### PR TITLE
 :sparkles: Handle variable definition conflicts for external variables

### DIFF
--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -19,6 +19,8 @@ package clusterclass
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -213,12 +215,10 @@ func (r *Reconciler) reconcileExternalReferences(ctx context.Context, clusterCla
 
 func (r *Reconciler) reconcileVariables(ctx context.Context, clusterClass *clusterv1.ClusterClass) error {
 	errs := []error{}
-	uniqueVars := map[string]bool{}
-	allVars := []clusterv1.ClusterClassStatusVariable{}
+	allVariableDefinitions := map[string]*clusterv1.ClusterClassStatusVariable{}
 	// Add inline variable definitions to the ClusterClass status.
 	for _, variable := range clusterClass.Spec.Variables {
-		uniqueVars[variable.Name] = true
-		allVars = append(allVars, statusVariableFromClusterClassVariable(variable, clusterv1.VariableDefinitionFromInline))
+		allVariableDefinitions[variable.Name] = addNewStatusVariable(variable, clusterv1.VariableDefinitionFromInline)
 	}
 
 	// If RuntimeSDK is enabled call the DiscoverVariables hook for all associated Runtime Extensions and add the variables
@@ -242,14 +242,23 @@ func (r *Reconciler) reconcileVariables(ctx context.Context, clusterClass *clust
 				continue
 			}
 			if resp.Variables != nil {
+				uniqueNamesForPatch := sets.Set[string]{}
 				for _, variable := range resp.Variables {
-					// TODO: Variables should be validated and deduplicated based on their provided definition.
-					if _, ok := uniqueVars[variable.Name]; ok {
-						errs = append(errs, errors.Errorf("duplicate variable name %s discovered in patch: %s", variable.Name, patch.Name))
+					// Ensure a patch doesn't define multiple variables with the same name.
+					if uniqueNamesForPatch.Has(variable.Name) {
+						errs = append(errs, errors.Errorf("variable %q is defined multiple times in variable discovery response from patch %q", variable.Name, patch.Name))
 						continue
 					}
-					uniqueVars[variable.Name] = true
-					allVars = append(allVars, statusVariableFromClusterClassVariable(variable, patch.Name))
+					uniqueNamesForPatch.Insert(variable.Name)
+
+					// If a variable of the same name already exists in allVariableDefinitions add the new definition to the existing list.
+					if _, ok := allVariableDefinitions[variable.Name]; ok {
+						allVariableDefinitions[variable.Name] = addDefinitionToExistingStatusVariable(variable, patch.Name, allVariableDefinitions[variable.Name])
+						continue
+					}
+
+					// Add the new variable to the list.
+					allVariableDefinitions[variable.Name] = addNewStatusVariable(variable, patch.Name)
 				}
 			}
 		}
@@ -260,10 +269,22 @@ func (r *Reconciler) reconcileVariables(ctx context.Context, clusterClass *clust
 			"VariableDiscovery failed: %s", kerrors.NewAggregate(errs))
 		return errors.Wrapf(kerrors.NewAggregate(errs), "failed to discover variables for ClusterClass %s", clusterClass.Name)
 	}
-	clusterClass.Status.Variables = allVars
+
+	statusVarList := []clusterv1.ClusterClassStatusVariable{}
+	for _, variable := range allVariableDefinitions {
+		statusVarList = append(statusVarList, *variable)
+	}
+	// Alphabetically sort the variables by name. This ensures no unnecessary updates to the ClusterClass status.
+	// Note: Definitions in `statusVarList[i].Definitions` have a stable order as they are added in a deterministic order
+	// and are always held in an array.
+	sort.SliceStable(statusVarList, func(i, j int) bool {
+		return statusVarList[i].Name < statusVarList[j].Name
+	})
+	clusterClass.Status.Variables = statusVarList
 	conditions.MarkTrue(clusterClass, clusterv1.ClusterClassVariablesReconciledCondition)
 	return nil
 }
+
 func reconcileConditions(clusterClass *clusterv1.ClusterClass, outdatedRefs map[*corev1.ObjectReference]*corev1.ObjectReference) {
 	if len(outdatedRefs) > 0 {
 		var msg []string
@@ -288,10 +309,9 @@ func reconcileConditions(clusterClass *clusterv1.ClusterClass, outdatedRefs map[
 	)
 }
 
-func statusVariableFromClusterClassVariable(variable clusterv1.ClusterClassVariable, from string) clusterv1.ClusterClassStatusVariable {
-	return clusterv1.ClusterClassStatusVariable{
-		Name: variable.Name,
-		// TODO: In a future iteration this should be true where definitions are equal.
+func addNewStatusVariable(variable clusterv1.ClusterClassVariable, from string) *clusterv1.ClusterClassStatusVariable {
+	return &clusterv1.ClusterClassStatusVariable{
+		Name:                variable.Name,
 		DefinitionsConflict: false,
 		Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 			{
@@ -300,6 +320,26 @@ func statusVariableFromClusterClassVariable(variable clusterv1.ClusterClassVaria
 				Schema:   variable.Schema,
 			},
 		}}
+}
+
+func addDefinitionToExistingStatusVariable(variable clusterv1.ClusterClassVariable, from string, existingVariable *clusterv1.ClusterClassStatusVariable) *clusterv1.ClusterClassStatusVariable {
+	combinedVariable := existingVariable.DeepCopy()
+	newVariableDefinition := clusterv1.ClusterClassStatusVariableDefinition{
+		From:     from,
+		Required: variable.Required,
+		Schema:   variable.Schema,
+	}
+	combinedVariable.Definitions = append(existingVariable.Definitions, newVariableDefinition)
+
+	// If the new definition is different from any existing definition, set DefinitionsConflict to true.
+	// If definitions already conflict, no need to check.
+	if !combinedVariable.DefinitionsConflict {
+		currentDefinition := combinedVariable.Definitions[0]
+		if !(currentDefinition.Required == newVariableDefinition.Required && reflect.DeepEqual(currentDefinition.Schema, newVariableDefinition.Schema)) {
+			combinedVariable.DefinitionsConflict = true
+		}
+	}
+	return combinedVariable
 }
 
 func refString(ref *corev1.ObjectReference) string {

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1114,7 +1115,7 @@ func TestReconciler_DefaultCluster(t *testing.T) {
 				Build(),
 			wantCluster: clusterBuilder.DeepCopy().
 				WithTopology(topologyBase.DeepCopy().WithVariables(
-					clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-east"`)}}).
+					clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-east"`)}, DefinitionFrom: ""}).
 					Build()).
 				Build(),
 		},
@@ -1234,7 +1235,7 @@ func TestReconciler_DefaultCluster(t *testing.T) {
 			got := &clusterv1.Cluster{}
 			g.Expect(fakeClient.Get(ctx, client.ObjectKey{Name: tt.initialCluster.Name, Namespace: tt.initialCluster.Namespace}, got)).To(Succeed())
 			// Compare the spec of the two clusters to ensure that variables are defaulted correctly.
-			g.Expect(reflect.DeepEqual(got.Spec, tt.wantCluster.Spec)).To(BeTrue())
+			g.Expect(reflect.DeepEqual(got.Spec, tt.wantCluster.Spec)).To(BeTrue(), cmp.Diff(got.Spec, tt.wantCluster.Spec))
 		})
 	}
 }

--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -30,54 +30,51 @@ import (
 )
 
 // DefaultClusterVariables defaults ClusterVariables.
-func DefaultClusterVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
-	return defaultClusterVariables(clusterVariables, clusterClassVariables, true, fldPath)
+func DefaultClusterVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
+	return defaultClusterVariables(values, definitions, true, fldPath)
 }
 
 // DefaultMachineDeploymentVariables defaults MachineDeploymentVariables.
-func DefaultMachineDeploymentVariables(machineDeploymentVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
-	return defaultClusterVariables(machineDeploymentVariables, clusterClassVariables, false, fldPath)
+func DefaultMachineDeploymentVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
+	return defaultClusterVariables(values, definitions, false, fldPath)
 }
 
 // defaultClusterVariables defaults variables.
 // If they do not exist yet, they are created if createVariables is set.
-func defaultClusterVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, createVariables bool, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
+func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, createVariables bool, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
 	var allErrs field.ErrorList
 
-	// Build maps for easier and faster access.
-	clusterVariablesMap := getClusterVariablesMap(clusterVariables)
-	clusterClassVariablesMap := getClusterClassVariablesMap(clusterClassVariables)
-
-	// Validate that all variables in the Cluster are defined in the ClusterClass.
-	// Note: If we don't validate this, we would get a nil pointer dereference below.
-	allErrs = append(allErrs, validateClusterVariablesDefined(clusterVariables, clusterClassVariablesMap, fldPath)...)
-	if len(allErrs) > 0 {
-		return nil, allErrs
+	// Get a map of ClusterVariable values. This function validates that:
+	// - variables are not defined more than once in Cluster spec.
+	// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
+	valuesIndex, err := newValuesIndex(values)
+	if err != nil {
+		return nil, append(allErrs, field.Invalid(fldPath, values,
+			fmt.Sprintf("cluster variables not valid: %s", err)))
 	}
 
-	// allVariables is used to get a full correctly ordered list of variables.
-	allVariables := []string{}
-	// Add any ClusterVariables that already exist.
-	for _, variable := range clusterVariables {
-		allVariables = append(allVariables, variable.Name)
-	}
-	// Add variables from the ClusterClass, which currently don't exist on the Cluster.
-	for _, variable := range clusterClassVariables {
-		// Continue if the ClusterClass variable already exists.
-		if _, ok := clusterVariablesMap[variable.Name]; ok {
+	// Get an index for each variable name and definition.
+	defIndex := newDefinitionsIndex(definitions)
+
+	// Get a deterministically ordered list of all variables defined in both the Cluster and the ClusterClass.
+	// Note: If the order is not deterministic variables would be continuously rewritten to the Cluster.
+	allVariables := getAllVariables(values, valuesIndex, definitions)
+
+	// Default all variables.
+	defaultedValues := []clusterv1.ClusterVariable{}
+	for _, variable := range allVariables {
+		// Get the variable definition from the ClusterClass. If the variable is not defined add an error.
+		definition, err := defIndex.get(variable.Name, variable.DefinitionFrom)
+		if err != nil {
+			allErrs = append(allErrs, field.Required(fldPath, err.Error()))
 			continue
 		}
 
-		allVariables = append(allVariables, variable.Name)
-	}
+		// Get the current value of the variable if it is defined in the Cluster spec.
+		currentValue := getCurrentValue(variable, valuesIndex)
 
-	// Default all variables.
-	defaultedClusterVariables := []clusterv1.ClusterVariable{}
-	for i, variableName := range allVariables {
-		clusterClassVariable := clusterClassVariablesMap[variableName]
-		clusterVariable := clusterVariablesMap[variableName]
-
-		defaultedClusterVariable, errs := defaultClusterVariable(clusterVariable, clusterClassVariable, fldPath.Index(i), createVariables)
+		// Default the variable.
+		defaultedValue, errs := defaultValue(currentValue, definition, fldPath, createVariables)
 		if len(errs) > 0 {
 			allErrs = append(allErrs, errs...)
 			continue
@@ -86,46 +83,55 @@ func defaultClusterVariables(clusterVariables []clusterv1.ClusterVariable, clust
 		// Continue if there is no defaulted variable.
 		// NOTE: This happens when the variable doesn't exist on the CLuster before and
 		// there is no top-level default value.
-		if defaultedClusterVariable == nil {
+		if defaultedValue == nil {
 			continue
 		}
-
-		defaultedClusterVariables = append(defaultedClusterVariables, *defaultedClusterVariable)
+		defaultedValues = append(defaultedValues, *defaultedValue)
 	}
 
 	if len(allErrs) > 0 {
 		return nil, allErrs
 	}
-
-	return defaultedClusterVariables, nil
+	return defaultedValues, nil
 }
 
-// defaultClusterVariable defaults a clusterVariable based on the default value in the clusterClassVariable.
-func defaultClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterClassVariable *clusterv1.ClusterClassVariable, fldPath *field.Path, createVariable bool) (*clusterv1.ClusterVariable, field.ErrorList) {
-	if clusterVariable == nil {
+// getCurrentValue returns the value of a variable for its definitionFrom, or for an empty definitionFrom if it exists.
+func getCurrentValue(variable clusterv1.ClusterVariable, valuesMap map[string]map[string]clusterv1.ClusterVariable) *clusterv1.ClusterVariable {
+	// If the value is set in the Cluster spec get the value.
+	if valuesForName, ok := valuesMap[variable.Name]; ok {
+		if value, ok := valuesForName[variable.DefinitionFrom]; ok {
+			return &value
+		}
+	}
+	return nil
+}
+
+// defaultValue defaults a clusterVariable based on the default value in the clusterClassVariable.
+func defaultValue(currentValue *clusterv1.ClusterVariable, definition *statusVariableDefinition, fldPath *field.Path, createVariable bool) (*clusterv1.ClusterVariable, field.ErrorList) {
+	if currentValue == nil {
 		// Return if the variable does not exist yet and createVariable is false.
 		if !createVariable {
 			return nil, nil
 		}
 		// Return if the variable does not exist yet and there is no top-level default value.
-		if clusterClassVariable.Schema.OpenAPIV3Schema.Default == nil {
+		if definition.Schema.OpenAPIV3Schema.Default == nil {
 			return nil, nil
 		}
 	}
 
 	// Convert schema to Kubernetes APIExtensions schema.
-	apiExtensionsSchema, errs := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema, field.NewPath("schema"))
+	apiExtensionsSchema, errs := convertToAPIExtensionsJSONSchemaProps(&definition.Schema.OpenAPIV3Schema, field.NewPath("schema"))
 	if len(errs) > 0 {
 		return nil, field.ErrorList{field.Invalid(fldPath, "",
-			fmt.Sprintf("invalid schema in ClusterClass for variable %q: error to convert schema %v", clusterClassVariable.Name, errs))}
+			fmt.Sprintf("invalid schema in ClusterClass for variable %q: error to convert schema %v", definition.Name, errs))}
 	}
 
 	var value interface{}
 	// If the variable already exists, parse the current value.
-	if clusterVariable != nil && len(clusterVariable.Value.Raw) > 0 {
-		if err := json.Unmarshal(clusterVariable.Value.Raw, &value); err != nil {
+	if currentValue != nil && len(currentValue.Value.Raw) > 0 {
+		if err := json.Unmarshal(currentValue.Value.Raw, &value); err != nil {
 			return nil, field.ErrorList{field.Invalid(fldPath, "",
-				fmt.Sprintf("failed to unmarshal variable value %q: %v", string(clusterVariable.Value.Raw), err))}
+				fmt.Sprintf("failed to unmarshal variable %q value %q: %v", currentValue.Name, string(currentValue.Value.Raw), err))}
 		}
 	}
 
@@ -133,7 +139,7 @@ func defaultClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterC
 	// so we wrap the schema and the variable in objects.
 	// <variable-name>: <variable-value>
 	wrappedVariable := map[string]interface{}{
-		clusterClassVariable.Name: value,
+		definition.Name: value,
 	}
 	// type: object
 	// properties:
@@ -141,7 +147,7 @@ func defaultClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterC
 	wrappedSchema := &apiextensions.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensions.JSONSchemaProps{
-			clusterClassVariable.Name: *apiExtensionsSchema,
+			definition.Name: *apiExtensionsSchema,
 		},
 	}
 
@@ -149,20 +155,69 @@ func defaultClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterC
 	ss, err := structuralschema.NewStructural(wrappedSchema)
 	if err != nil {
 		return nil, field.ErrorList{field.Invalid(fldPath, "",
-			fmt.Sprintf("failed defaulting variable %q: %v", clusterVariable.Name, err))}
+			fmt.Sprintf("failed defaulting variable %q: %v", currentValue.Name, err))}
 	}
 	structuraldefaulting.Default(wrappedVariable, ss)
 
 	// Marshal the defaulted value.
-	defaultedVariableValue, err := json.Marshal(wrappedVariable[clusterClassVariable.Name])
+	defaultedVariableValue, err := json.Marshal(wrappedVariable[definition.Name])
 	if err != nil {
 		return nil, field.ErrorList{field.Invalid(fldPath, "",
-			fmt.Sprintf("failed to marshal default value of variable %q: %v", clusterClassVariable.Name, err))}
+			fmt.Sprintf("failed to marshal default value of variable %q: %v", definition.Name, err))}
 	}
-	return &clusterv1.ClusterVariable{
-		Name: clusterClassVariable.Name,
+	v := &clusterv1.ClusterVariable{
+		Name: definition.Name,
 		Value: apiextensionsv1.JSON{
 			Raw: defaultedVariableValue,
 		},
-	}, nil
+		DefinitionFrom: definition.From,
+	}
+
+	return v, nil
+}
+
+// getAllVariables returns a correctly ordered list of all variables defined in the ClusterClass and the Cluster.
+func getAllVariables(values []clusterv1.ClusterVariable, valuesIndex map[string]map[string]clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable) []clusterv1.ClusterVariable {
+	// allVariables is used to get a full correctly ordered list of variables.
+	allVariables := []clusterv1.ClusterVariable{}
+	uniqueVariableDefinitions := map[string]bool{}
+
+	// Add any values that already exist.
+	allVariables = append(allVariables, values...)
+
+	// Add variables from the ClusterClass, which currently don't exist on the Cluster.
+	for _, variable := range definitions {
+		for _, definition := range variable.Definitions {
+			definitionFrom := definition.From
+
+			// 1) If there is a value in the Cluster with this definitionFrom or with an empty definitionFrom this variable does not need to be defaulted.
+			if _, ok := valuesIndex[variable.Name]; ok {
+				if _, ok := valuesIndex[variable.Name][definitionFrom]; ok {
+					continue
+				}
+				if _, ok := valuesIndex[variable.Name][emptyDefinitionFrom]; ok {
+					continue
+				}
+			}
+
+			// 2) If the definition has no conflicts and no variable of the same name is defined in the Cluster set the definitionFrom to emptyDefinitionFrom.
+			if !variable.DefinitionsConflict && len(valuesIndex[variable.Name]) == 0 {
+				definitionFrom = emptyDefinitionFrom
+			}
+
+			// 3) If a variable with this name and definition has been added already, continue.
+			// This prevents adding the same variable multiple times where the variable is defaulted with an emptyDefinitionFrom.
+			if _, ok := uniqueVariableDefinitions[definitionFrom+variable.Name]; ok {
+				continue
+			}
+
+			// Otherwise add the variable to the list.
+			allVariables = append(allVariables, clusterv1.ClusterVariable{
+				Name:           variable.Name,
+				DefinitionFrom: definitionFrom,
+			})
+			uniqueVariableDefinitions[definitionFrom+variable.Name] = true
+		}
+	}
+	return allVariables
 }

--- a/internal/topology/variables/cluster_variable_defaulting_test.go
+++ b/internal/topology/variables/cluster_variable_defaulting_test.go
@@ -28,17 +28,17 @@ import (
 
 func Test_DefaultClusterVariables(t *testing.T) {
 	tests := []struct {
-		name                  string
-		clusterClassVariables []clusterv1.ClusterClassVariable
-		clusterVariables      []clusterv1.ClusterVariable
-		createVariables       bool
-		want                  []clusterv1.ClusterVariable
-		wantErr               bool
+		name            string
+		definitions     []clusterv1.ClusterClassStatusVariable
+		values          []clusterv1.ClusterVariable
+		createVariables bool
+		want            []clusterv1.ClusterVariable
+		wantErr         bool
 	}{
 		{
-			name:                  "Return error if variable is not defined in ClusterClass",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{},
-			clusterVariables: []clusterv1.ClusterVariable{
+			name:        "Return error if variable is not defined in ClusterClass",
+			definitions: []clusterv1.ClusterClassStatusVariable{},
+			values: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
@@ -51,51 +51,75 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		},
 		{
 			name: "Default one variable of each valid type",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "location",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "string",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+					Name: "location",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "string",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+								},
+							},
 						},
 					},
 				},
 
 				{
-					Name:     "count",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "number",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+					Name: "count",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "number",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "correct",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "boolean",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+					Name: "correct",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "boolean",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+								},
+							},
 						},
 					},
 				},
 			},
-			clusterVariables: []clusterv1.ClusterVariable{},
-			createVariables:  true,
+			values:          []clusterv1.ClusterVariable{},
+			createVariables: true,
 			want: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
@@ -125,50 +149,67 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		},
 		{
 			name: "Don't default variable if variable creation is disabled",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
 						},
 					},
 				},
 			},
-			clusterVariables: []clusterv1.ClusterVariable{},
-			createVariables:  false,
-			want:             []clusterv1.ClusterVariable{},
+			values:          []clusterv1.ClusterVariable{},
+			createVariables: false,
+			want:            []clusterv1.ClusterVariable{},
 		},
 		{
 			name: "Don't default variables that are set",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "correct",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "boolean",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+					Name: "correct",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "boolean",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+								},
+							},
 						},
 					},
 				},
 			},
-			clusterVariables: []clusterv1.ClusterVariable{
+			values: []clusterv1.ClusterVariable{
 				{
 					Name: "correct",
-
 					// Value is set here and shouldn't be defaulted.
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`false`),
@@ -193,29 +234,40 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		},
 		{
 			name: "Don't add variables that have no default schema",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "correct",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "boolean",
+					Name: "correct",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "boolean",
+								},
+							},
 						},
 					},
 				},
 			},
-			clusterVariables: []clusterv1.ClusterVariable{},
-			createVariables:  true,
+			values:          []clusterv1.ClusterVariable{},
+			createVariables: true,
 			want: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
@@ -225,12 +277,378 @@ func Test_DefaultClusterVariables(t *testing.T) {
 				},
 			},
 		},
+		// Variables with multiple non-conflicting definitions.
+		{
+			name: "Don't default if a value is set with empty definitionFrom",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+							Required: true,
+							From:     "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					// This variable does not have definitionConflicts. An unset definitionFrom is valid.
+				},
+			},
+			createVariables: true,
+			want: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						// Expect value set in Cluster.
+						Raw: []byte(`2`),
+					},
+				},
+			},
+		},
+		{
+			name: "Default many non-conflicting variables to one value in Cluster",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+
+							Required: true,
+							From:     "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+
+							Required: true,
+							From:     "otherpatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			values:          []clusterv1.ClusterVariable{},
+			createVariables: true,
+			want: []clusterv1.ClusterVariable{
+				{
+					// As this variable is non-conflicting it can be set only once in the Cluster through defaulting.
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+				},
+			},
+		},
+		{
+			name: "Default many non-conflicting definitions to many values in Cluster when some values are set with definitionFrom",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+							Required: true,
+							From:     "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				// The variable is set with definitionFrom for one of two definitions.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				},
+			},
+			createVariables: true,
+			want: []clusterv1.ClusterVariable{
+				// Expect the value in the Cluster to be retained.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				},
+				// Expect defaulting for the definition with no value in the Cluster.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+		},
+		// Variables with conflicting definitions.
+		{
+			name: "Default many conflicting definitions to many values in Cluster",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+							// Variable isn't required, but should still be defaulted according to its schema.
+							Required: false,
+							From:     "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`2`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			values:          []clusterv1.ClusterVariable{},
+			createVariables: true,
+			want: []clusterv1.ClusterVariable{
+				// As this variable has conflicting definitions expect one value in the Cluster
+				// for each "DefinitionFrom".
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+		},
+		{
+			name: "Default many conflicting definitions to many values in Cluster when some values are set with definitionFrom",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+								},
+							},
+						},
+						{
+							// Variable isn't required, but should still be defaulted according to its schema.
+							Required: false,
+							From:     "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`2`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`3`),
+					},
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				},
+			},
+			createVariables: true,
+			want: []clusterv1.ClusterVariable{
+				// As this variable has conflicting definitions expect one value in the Cluster
+				// for each "DefinitionFrom" and retain values set in Cluster.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`3`),
+					},
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+		},
+		{
+			name:    "Error if a value is set with empty and non-empty definitionFrom.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: "somepatch",
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: clusterv1.VariableDefinitionFromInline,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					// Mix of empty and non-empty definitionFrom is not valid.
+					DefinitionFrom: "",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+		},
+		{
+			name:    "Error if a value is set twice with the same definitionFrom.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: "somepatch",
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: clusterv1.VariableDefinitionFromInline,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				// Identical definitionFrom and name for two different values.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			vars, errList := defaultClusterVariables(tt.clusterVariables, tt.clusterClassVariables, tt.createVariables,
+			vars, errList := defaultClusterVariables(tt.values, tt.definitions, tt.createVariables,
 				field.NewPath("spec", "topology", "variables"))
 
 			if tt.wantErr {
@@ -247,20 +665,22 @@ func Test_DefaultClusterVariable(t *testing.T) {
 	tests := []struct {
 		name                 string
 		clusterVariable      *clusterv1.ClusterVariable
-		clusterClassVariable *clusterv1.ClusterClassVariable
+		clusterClassVariable *statusVariableDefinition
 		createVariable       bool
 		want                 *clusterv1.ClusterVariable
 		wantErr              bool
 	}{
 		{
 			name: "Default new integer variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "integer",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "cpu",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "integer",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+						},
 					},
 				},
 			},
@@ -274,13 +694,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default new integer variable if variable creation is disabled",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "integer",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "cpu",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "integer",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+						},
 					},
 				},
 			},
@@ -289,13 +711,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing integer variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "integer",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "cpu",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "integer",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+						},
 					},
 				},
 			},
@@ -315,13 +739,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new string variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "location",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "string",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "location",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+						},
 					},
 				},
 			},
@@ -335,13 +761,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing string variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "location",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "string",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "location",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+						},
 					},
 				},
 			},
@@ -361,13 +789,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new number variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "number",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "cpu",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "number",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+						},
 					},
 				},
 			},
@@ -381,13 +811,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing number variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "number",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "cpu",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "number",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+						},
 					},
 				},
 			},
@@ -407,13 +839,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new boolean variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "correct",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "boolean",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "correct",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "boolean",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+						},
 					},
 				},
 			},
@@ -427,13 +861,15 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing boolean variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "correct",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "boolean",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "correct",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "boolean",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+						},
 					},
 				},
 			},
@@ -453,22 +889,24 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new object variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "object",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-						Properties: map[string]clusterv1.JSONSchemaProps{
-							"enabled": {
-								Type: "boolean",
-							},
-							"url": {
-								Type: "string",
-							},
-							"noProxy": {
-								Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "object",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
+							Properties: map[string]clusterv1.JSONSchemaProps{
+								"enabled": {
+									Type: "boolean",
+								},
+								"url": {
+									Type: "string",
+								},
+								"noProxy": {
+									Type: "string",
+								},
 							},
 						},
 					},
@@ -484,23 +922,25 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default new object variable if there is no top-level default",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type: "object",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type: "object",
 
-						Properties: map[string]clusterv1.JSONSchemaProps{
-							"enabled": {
-								Type:    "boolean",
-								Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
-							},
-							"url": {
-								Type: "string",
-							},
-							"noProxy": {
-								Type: "string",
+							Properties: map[string]clusterv1.JSONSchemaProps{
+								"enabled": {
+									Type:    "boolean",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
+								},
+								"url": {
+									Type: "string",
+								},
+								"noProxy": {
+									Type: "string",
+								},
 							},
 						},
 					},
@@ -511,22 +951,24 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing object variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "object",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-						Properties: map[string]clusterv1.JSONSchemaProps{
-							"enabled": {
-								Type: "boolean",
-							},
-							"url": {
-								Type: "string",
-							},
-							"noProxy": {
-								Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "object",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
+							Properties: map[string]clusterv1.JSONSchemaProps{
+								"enabled": {
+									Type: "boolean",
+								},
+								"url": {
+									Type: "string",
+								},
+								"noProxy": {
+									Type: "string",
+								},
 							},
 						},
 					},
@@ -548,23 +990,26 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default nested fields of existing object variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "object",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-						Properties: map[string]clusterv1.JSONSchemaProps{
-							"enabled": {
-								Type: "boolean",
-							},
-							"url": {
-								Type:    "string",
-								Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-							},
-							"noProxy": {
-								Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "object",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
+							Properties: map[string]clusterv1.JSONSchemaProps{
+								"enabled": {
+									Type: "boolean",
+								},
+								"url": {
+									Type:    "string",
+									Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+								},
+								"noProxy": {
+									Type: "string",
+								},
 							},
 						},
 					},
@@ -586,25 +1031,27 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new map variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type:    "object",
-						Default: &apiextensionsv1.JSON{Raw: []byte(`{"proxy":{"enabled":false}}`)},
-						AdditionalProperties: &clusterv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type:    "string",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-								},
-								"noProxy": {
-									Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "object",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`{"proxy":{"enabled":false}}`)},
+							AdditionalProperties: &clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type:    "string",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -621,24 +1068,26 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default nested fields of existing map variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "httpProxy",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type: "object",
-						AdditionalProperties: &clusterv1.JSONSchemaProps{
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "httpProxy",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type: "object",
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type:    "string",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-								},
-								"noProxy": {
-									Type: "string",
+							AdditionalProperties: &clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type:    "string",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -661,24 +1110,26 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new array variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "testVariable",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type: "array",
-						Items: &clusterv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "testVariable",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type: "array",
+							Items: &clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type: "string",
+									},
 								},
 							},
+							Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 						},
-						Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 					},
 				},
 			},
@@ -692,24 +1143,27 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing array variable",
-			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "testVariable",
-				Required: true,
-				Schema: clusterv1.VariableSchema{
-					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-						Type: "array",
-						Items: &clusterv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type: "string",
+			clusterClassVariable: &statusVariableDefinition{
+				Name: "testVariable",
+				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type: "array",
+							Items: &clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type: "string",
+									},
 								},
 							},
+							Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 						},
-						Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 					},
 				},
 			},
@@ -732,7 +1186,7 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			defaultedVariable, errList := defaultClusterVariable(tt.clusterVariable, tt.clusterClassVariable,
+			defaultedVariable, errList := defaultValue(tt.clusterVariable, tt.clusterClassVariable,
 				field.NewPath("spec", "topology", "variables").Index(0), tt.createVariable)
 
 			if tt.wantErr {
@@ -744,4 +1198,145 @@ func Test_DefaultClusterVariable(t *testing.T) {
 			g.Expect(defaultedVariable).To(Equal(tt.want))
 		})
 	}
+}
+
+func Test_getAllVariables(t *testing.T) {
+	g := NewWithT(t)
+	t.Run("Expect values to be correctly consolidated in allVariables", func(t *testing.T) {
+		expectedValues := []clusterv1.ClusterVariable{
+			// var1 has a value with no DefinitionFrom set and only one definition. It should be retained as is.
+			{
+				Name: "var1",
+			},
+
+			// var2 has a value with DefinitionFrom "inline". It has a second definition with DefinitionFrom "somepatch".
+			// The value for the first definition should be retained and a value for the second definition should be added.
+			{
+				Name:           "var2",
+				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+			},
+			{
+				Name:           "var2",
+				DefinitionFrom: "somepatch",
+			},
+
+			// var3 had no values. It has two conflicting definitions. A value for each definition should be added.
+			{
+				Name:           "var3",
+				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+			},
+			{
+				Name:           "var3",
+				DefinitionFrom: "somepatch",
+			},
+
+			// var4 had no values. It has two non-conflicting definitions. A single value with emptyDefinitionFrom should
+			// be added.
+			{
+				Name:           "var4",
+				DefinitionFrom: emptyDefinitionFrom,
+			},
+		}
+
+		values := []clusterv1.ClusterVariable{
+			{
+				Name: "var1",
+			},
+			{
+				Name:           "var2",
+				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+			},
+		}
+		definitions := []clusterv1.ClusterClassStatusVariable{
+			{
+				Name: "var1",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: false,
+						From:     clusterv1.VariableDefinitionFromInline,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "var2",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						From:     clusterv1.VariableDefinitionFromInline,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+					{
+						Required: true,
+						From:     "somepatch",
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:                "var3",
+				DefinitionsConflict: true,
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: false,
+						From:     clusterv1.VariableDefinitionFromInline,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+					{
+						Required: true,
+						From:     "somepatch",
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "var4",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						From:     clusterv1.VariableDefinitionFromInline,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+					{
+						Required: true,
+						From:     "somepatch",
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valuesIndex, err := newValuesIndex(values)
+		g.Expect(err).To(BeNil())
+		got := getAllVariables(values, valuesIndex, definitions)
+		g.Expect(got).To(Equal(expectedValues))
+	})
 }

--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -30,99 +30,108 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// ValidateClusterVariables validates ClusterVariables.
-func ValidateClusterVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
-	return validateClusterVariables(clusterVariables, clusterClassVariables, true, fldPath)
+// ValidateClusterVariables validates ClusterVariables based on the definitions in ClusterClass `.status.variables`.
+func ValidateClusterVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, fldPath *field.Path) field.ErrorList {
+	return validateClusterVariables(values, definitions, true, fldPath)
 }
 
 // ValidateMachineDeploymentVariables validates ValidateMachineDeploymentVariables.
-func ValidateMachineDeploymentVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
-	return validateClusterVariables(clusterVariables, clusterClassVariables, false, fldPath)
+func ValidateMachineDeploymentVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, fldPath *field.Path) field.ErrorList {
+	return validateClusterVariables(values, definitions, false, fldPath)
 }
 
-// validateClusterVariables validates variables via the schemas in the corresponding clusterClassVariable.
-func validateClusterVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, validateRequired bool, fldPath *field.Path) field.ErrorList {
+// validateClusterVariables validates variable values according to the corresponding definition.
+func validateClusterVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, validateRequired bool, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	// Build maps for easier and faster access.
-	clusterVariablesMap := getClusterVariablesMap(clusterVariables)
-	clusterClassVariablesMap := getClusterClassVariablesMap(clusterClassVariables)
+	// Get a map of ClusterVariable values. This function validates that:
+	// - variables are not defined more than once in Cluster spec.
+	// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
+	valuesMap, err := newValuesIndex(values)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath, values, fmt.Sprintf("cluster variables not valid: %s", err)))
+	}
 
-	// Validate:
-	// * required variables from the ClusterClass exist on the Cluster.
-	// * all variables in the Cluster are defined in the ClusterClass.
+	// Get an index of definitions for each variable name and definition from the ClusterClass variable.
+	defIndex := newDefinitionsIndex(definitions)
+
+	// Required variables definitions must exist as values on the Cluster.
 	if validateRequired {
-		allErrs = append(allErrs, validateRequiredClusterVariables(clusterVariablesMap, clusterClassVariablesMap, fldPath)...)
-	}
-	allErrs = append(allErrs, validateClusterVariablesDefined(clusterVariables, clusterClassVariablesMap, fldPath)...)
-	if len(allErrs) > 0 {
-		return allErrs
+		allErrs = append(allErrs, validateRequiredVariables(valuesMap, defIndex, fldPath)...)
 	}
 
-	// Validate all variables from the Cluster.
-	for i := range clusterVariables {
-		clusterVariable := clusterVariables[i]
-
-		// Get schema.
-		// Nb. We already validated above in validateClusterVariablesDefined that there is a
-		// corresponding ClusterClass variable, so we don't have to check it again.
-		clusterClassVariable := clusterClassVariablesMap[clusterVariable.Name]
-
-		allErrs = append(allErrs, ValidateClusterVariable(&clusterVariable, clusterClassVariable, fldPath.Index(i))...)
-	}
-	return allErrs
-}
-
-// validateRequiredClusterVariables validates all required variables from the ClusterClass exist in the Cluster.
-func validateRequiredClusterVariables(clusterVariables map[string]*clusterv1.ClusterVariable, clusterClassVariables map[string]*clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
-	var allErrs field.ErrorList
-
-	for variableName, clusterClassVariable := range clusterClassVariables {
-		if !clusterClassVariable.Required {
+	for _, value := range values {
+		// Values must have an associated definition and must have a non-empty definitionFrom if there are conflicting definitions.
+		definition, err := defIndex.get(value.Name, value.DefinitionFrom)
+		if err != nil {
+			allErrs = append(allErrs, field.Required(fldPath, err.Error())) // TODO: consider if to add ClusterClass name
 			continue
 		}
 
-		if _, ok := clusterVariables[variableName]; !ok {
-			allErrs = append(allErrs, field.Required(fldPath,
-				fmt.Sprintf("required variable with name %q must be defined", variableName))) // TODO: consider if to use "Clusters with ClusterClass %q must have a variable with name %q"
-		}
+		// Values must be valid according to the schema in their definition.
+		allErrs = append(allErrs, ValidateClusterVariable(value.DeepCopy(), &clusterv1.ClusterClassVariable{
+			Name:     value.Name,
+			Required: definition.Required,
+			Schema:   definition.Schema,
+		}, fldPath)...)
 	}
 
 	return allErrs
 }
 
-// validateClusterVariablesDefined validates all variables from the Cluster are defined in the ClusterClass.
-func validateClusterVariablesDefined(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables map[string]*clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
+// validateRequiredVariables validates all required variables from the ClusterClass exist in the Cluster.
+func validateRequiredVariables(values map[string]map[string]clusterv1.ClusterVariable, definitions definitionsIndex, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	for i, clusterVariable := range clusterVariables {
-		if _, ok := clusterClassVariables[clusterVariable.Name]; !ok {
-			return field.ErrorList{field.Invalid(fldPath.Index(i).Child("name"), clusterVariable.Name,
-				fmt.Sprintf("variable with name %q is not defined in ClusterClass `status.variables`", clusterVariable.Name))} // TODO: consider if to add ClusterClass name
+	for name, definitionsForName := range definitions {
+		for _, def := range definitionsForName {
+			// Check the required value for the specific variable definition. If the variable is not required continue.
+			if !def.Required {
+				continue
+			}
+
+			// If there is no variable with this name defined in the Cluster add an error and continue.
+			valuesForName, found := values[name]
+			if !found {
+				allErrs = append(allErrs, field.Required(fldPath,
+					fmt.Sprintf("required variable with name %q must be defined", name))) // TODO: consider if to use "Clusters with ClusterClass %q must have a variable with name %q"
+				continue
+			}
+
+			// If there are no definition conflicts and the variable is set with an empty "DefinitionFrom" field return here.
+			// This is a valid way for users to define a required value for variables across all variable definitions.
+			if _, ok := valuesForName[emptyDefinitionFrom]; ok && !def.Conflicts {
+				continue
+			}
+
+			// If the variable is not set for the specific definitionFrom add an error.
+			if _, ok := valuesForName[def.From]; !ok {
+				allErrs = append(allErrs, field.Required(fldPath,
+					fmt.Sprintf("required variable with name %q from %q must be defined", name, def.From))) // TODO: consider if to use "Clusters with ClusterClass %q must have a variable with name %q"
+			}
 		}
 	}
-
 	return allErrs
 }
 
 // ValidateClusterVariable validates a clusterVariable.
-func ValidateClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterClassVariable *clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
+func ValidateClusterVariable(value *clusterv1.ClusterVariable, definition *clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
 	// Parse JSON value.
 	var variableValue interface{}
 	// Only try to unmarshal the clusterVariable if it is not nil, otherwise the variableValue is nil.
 	// Note: A clusterVariable with a nil value is the result of setting the variable value to "null" via YAML.
-	if clusterVariable.Value.Raw != nil {
-		if err := json.Unmarshal(clusterVariable.Value.Raw, &variableValue); err != nil {
-			return field.ErrorList{field.Invalid(fldPath.Child("value"), string(clusterVariable.Value.Raw),
-				fmt.Sprintf("variable %q could not be parsed: %v", clusterVariable.Name, err))}
+	if value.Value.Raw != nil {
+		if err := json.Unmarshal(value.Value.Raw, &variableValue); err != nil {
+			return field.ErrorList{field.Invalid(fldPath.Child("value"), string(value.Value.Raw),
+				fmt.Sprintf("variable %q could not be parsed: %v", value.Name, err))}
 		}
 	}
 
 	// Convert schema to Kubernetes APIExtensions Schema.
-	apiExtensionsSchema, allErrs := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema, field.NewPath("schema"))
+	apiExtensionsSchema, allErrs := convertToAPIExtensionsJSONSchemaProps(&definition.Schema.OpenAPIV3Schema, field.NewPath("schema"))
 	if len(allErrs) > 0 {
 		return field.ErrorList{field.InternalError(fldPath,
-			fmt.Errorf("failed to convert schema definition for variable %q; ClusterClass should be checked: %v", clusterClassVariable.Name, allErrs))} // TODO: consider if to add ClusterClass name
+			fmt.Errorf("failed to convert schema definition for variable %q; ClusterClass should be checked: %v", definition.Name, allErrs))} // TODO: consider if to add ClusterClass name
 	}
 
 	// Create validator for schema.
@@ -131,7 +140,7 @@ func ValidateClusterVariable(clusterVariable *clusterv1.ClusterVariable, cluster
 	})
 	if err != nil {
 		return field.ErrorList{field.InternalError(fldPath,
-			fmt.Errorf("failed to create schema validator for variable %q; ClusterClass should be checked: %v", clusterVariable.Name, err))} // TODO: consider if to add ClusterClass name
+			fmt.Errorf("failed to create schema validator for variable %q; ClusterClass should be checked: %v", value.Name, err))} // TODO: consider if to add ClusterClass name
 	}
 
 	// Validate variable against the schema.
@@ -140,7 +149,7 @@ func ValidateClusterVariable(clusterVariable *clusterv1.ClusterVariable, cluster
 		return err
 	}
 
-	return validateUnknownFields(fldPath, clusterVariable, variableValue, apiExtensionsSchema)
+	return validateUnknownFields(fldPath, value, variableValue, apiExtensionsSchema)
 }
 
 // validateUnknownFields validates the given variableValue for unknown fields.
@@ -185,20 +194,4 @@ func validateUnknownFields(fldPath *field.Path, clusterVariable *clusterv1.Clust
 	}
 
 	return nil
-}
-
-func getClusterVariablesMap(clusterVariables []clusterv1.ClusterVariable) map[string]*clusterv1.ClusterVariable {
-	variablesMap := map[string]*clusterv1.ClusterVariable{}
-	for i := range clusterVariables {
-		variablesMap[clusterVariables[i].Name] = &clusterVariables[i]
-	}
-	return variablesMap
-}
-
-func getClusterClassVariablesMap(clusterClassVariables []clusterv1.ClusterClassVariable) map[string]*clusterv1.ClusterClassVariable {
-	variablesMap := map[string]*clusterv1.ClusterClassVariable{}
-	for i := range clusterClassVariables {
-		variablesMap[clusterClassVariables[i].Name] = &clusterClassVariables[i]
-	}
-	return variablesMap
 }

--- a/internal/topology/variables/cluster_variable_validation_test.go
+++ b/internal/topology/variables/cluster_variable_validation_test.go
@@ -29,51 +29,65 @@ import (
 
 func Test_ValidateClusterVariables(t *testing.T) {
 	tests := []struct {
-		name                  string
-		clusterClassVariables []clusterv1.ClusterClassVariable
-		clusterVariables      []clusterv1.ClusterVariable
-		validateRequired      bool
-		wantErr               bool
+		name             string
+		definitions      []clusterv1.ClusterClassStatusVariable
+		values           []clusterv1.ClusterVariable
+		validateRequired bool
+		wantErr          bool
 	}{
 		{
-			name: "Pass for a number of valid variables.",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			name: "Pass for a number of valid values.",
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Minimum: pointer.Int64(1),
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Minimum: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "zone",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:      "string",
-							MinLength: pointer.Int64(1),
+					Name: "zone",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:      "string",
+									MinLength: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "location",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "string",
-							Enum: []apiextensionsv1.JSON{
-								{Raw: []byte(`"us-east-1"`)},
-								{Raw: []byte(`"us-east-2"`)},
+					Name: "location",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+									Enum: []apiextensionsv1.JSON{
+										{Raw: []byte(`"us-east-1"`)},
+										{Raw: []byte(`"us-east-2"`)},
+									},
+								},
 							},
 						},
 					},
 				},
 			},
-
-			clusterVariables: []clusterv1.ClusterVariable{
+			values: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
@@ -96,32 +110,42 @@ func Test_ValidateClusterVariables(t *testing.T) {
 			validateRequired: true,
 		},
 		{
-			name: "Error if required ClusterClassVariable is not defined in ClusterVariables.",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			name:    "Error when no value for required definition.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Minimum: pointer.Int64(1),
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Minimum: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "zone",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:      "string",
-							MinLength: pointer.Int64(1),
+					Name: "zone",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:      "string",
+									MinLength: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 			},
-
-			clusterVariables: []clusterv1.ClusterVariable{
-				// cpu is missing in the ClusterVariables but is required in ClusterClassVariables.
+			values: []clusterv1.ClusterVariable{
+				// cpu is missing in the values but is required in definition.
 				{
 					Name: "zone",
 					Value: apiextensionsv1.JSON{
@@ -130,35 +154,44 @@ func Test_ValidateClusterVariables(t *testing.T) {
 				},
 			},
 			validateRequired: true,
-			wantErr:          true,
 		},
 		{
-			name: "Pass if required ClusterClassVariable is not defined in ClusterVariables but required validation is disabled.",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
+			name: "Pass if validateRequired='false' and no value for required definition.",
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Minimum: pointer.Int64(1),
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:    "integer",
+									Minimum: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 				{
-					Name:     "zone",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:      "string",
-							MinLength: pointer.Int64(1),
+					Name: "zone",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Required: true,
+							From:     clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type:      "string",
+									MinLength: pointer.Int64(1),
+								},
+							},
 						},
 					},
 				},
 			},
 
-			clusterVariables: []clusterv1.ClusterVariable{
-				// cpu is missing in the ClusterVariables and is required in ClusterClassVariables,
+			values: []clusterv1.ClusterVariable{
+				// cpu is missing in the values and is required in definitions,
 				// but required validation is disabled.
 				{
 					Name: "zone",
@@ -170,61 +203,433 @@ func Test_ValidateClusterVariables(t *testing.T) {
 			validateRequired: false,
 		},
 		{
-			name: "Error if ClusterVariable defined which has no ClusterClassVariable definition.",
-			clusterClassVariables: []clusterv1.ClusterClassVariable{
-				{
-					Name:     "cpu",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Minimum: pointer.Int64(1),
-						},
-					},
-				},
-				{
-					Name:     "zone",
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:      "string",
-							MinLength: pointer.Int64(1),
-						},
-					},
-				},
-			},
-
-			clusterVariables: []clusterv1.ClusterVariable{
-				// location is defined here but not in the ClusterClassVariables
+			name:        "Error if value has no definition.",
+			wantErr:     true,
+			definitions: []clusterv1.ClusterClassStatusVariable{},
+			values: []clusterv1.ClusterVariable{
+				// location has a value but no definition.
 				{
 					Name: "location",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`"us-east-1"`),
 					},
 				},
+			},
+			validateRequired: true,
+		},
+		// Non-conflicting definition tests.
+		{
+			name: "Pass if a value with empty definitionFrom set for a non-conflicting definition",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     clusterv1.VariableDefinitionFromInline,
+							Required: true,
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     "somepatch",
+							Required: true,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
 				},
-
+			},
+			validateRequired: true,
+		},
+		{
+			name: "Pass when there is a separate value for each required definition with no definition conflicts.",
+			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name: "zone",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`"longerThanOneCharacter"`),
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     clusterv1.VariableDefinitionFromInline,
+							Required: true,
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     "somepatch",
+							Required: true,
+						},
 					},
 				},
 			},
+			values: []clusterv1.ClusterVariable{
+				// Each value is set individually.
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "inline",
+				},
+			},
 			validateRequired: true,
-			wantErr:          true,
+		},
+		{
+			name:    "Fail if value DefinitionFrom field does not match any definition.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							From: clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					// This definition does not exist.
+					DefinitionFrom: "non-existent-patch",
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name:    "Fail if a value is set twice with the same definitionFrom.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: "somepatch",
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name:    "Fail if a value is set with empty and non-empty definitionFrom.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: "somepatch",
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From: clusterv1.VariableDefinitionFromInline,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					// Mix of empty and non-empty definitionFrom is not valid.
+					DefinitionFrom: "",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`2`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name:    "Fail when values invalid by their definition schema.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							From: clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						{
+							From: "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "inline",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`"one"`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
+		},
+		// Conflicting definition tests.
+		{
+			name: "Pass with a value provided for each conflicting definition.",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							From: clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						{
+							From: "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`"one"`),
+					},
+					DefinitionFrom: "inline",
+				},
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name: "Pass if non-required definition value doesn't include definitionFrom for each required definition when definitions conflict.",
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					// There are conflicting definitions which means values should include a `definitionFrom` field.
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     "somepatch",
+							Required: true,
+						},
+						// This variable is not required so it does not need a value.
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     "anotherpatch",
+							Required: false,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name:    "Fail if value doesn't include definitionFrom when definitions conflict.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name: "cpu",
+					// There are conflicting definitions which means values should include a `definitionFrom` field.
+					DefinitionsConflict: true,
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+							From: clusterv1.VariableDefinitionFromInline,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						{
+							From: "somepatch",
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					// No definitionFrom
+				},
+			},
+			validateRequired: true,
+		},
+		{
+			name:    "Fail if value doesn't include definitionFrom for each required definition when definitions conflict.",
+			wantErr: true,
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:                "cpu",
+					DefinitionsConflict: true,
+					// There are conflicting definitions which means values should include a `definitionFrom` field.
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+						{
+
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+							From:     clusterv1.VariableDefinitionFromInline,
+							Required: true,
+						},
+						{
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "integer",
+								},
+							},
+							From:     "somepatch",
+							Required: true,
+						},
+					},
+				},
+			},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+					DefinitionFrom: "somepatch",
+				},
+			},
+			validateRequired: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			errList := validateClusterVariables(tt.clusterVariables, tt.clusterClassVariables,
+			errList := validateClusterVariables(tt.values, tt.definitions,
 				tt.validateRequired, field.NewPath("spec", "topology", "variables"))
 
 			if tt.wantErr {
@@ -263,7 +668,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if integer is above Maximum",
+			name:    "Error if integer is above Maximum",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "cpu",
 				Required: true,
@@ -280,10 +686,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`99`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if integer is below Minimum",
+			name:    "Error if integer is below Minimum",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "cpu",
 				Required: true,
@@ -300,11 +706,11 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`0`),
 				},
 			},
-			wantErr: true,
 		},
 
 		{
-			name: "Fails, expected integer got string",
+			name:    "Fails, expected integer got string",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "cpu",
 				Required: true,
@@ -321,7 +727,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`"1"`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid string",
@@ -343,7 +748,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if string doesn't match pattern ",
+			name:    "Error if string doesn't match pattern ",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "location",
 				Required: true,
@@ -360,10 +766,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`"000000a"`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if string doesn't match format ",
+			name:    "Error if string doesn't match format ",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "location",
 				Required: true,
@@ -380,7 +786,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`"not a URI"`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid enum string",
@@ -405,7 +810,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Fails, value does not match one of the enum string values",
+			name:    "Fails, value does not match one of the enum string values",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "location",
 				Required: true,
@@ -425,7 +831,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`"us-east-invalid"`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid enum integer",
@@ -450,7 +855,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Fails, value does not match one of the enum integer values",
+			name:    "Fails, value does not match one of the enum integer values",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "location",
 				Required: true,
@@ -470,7 +876,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`3`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid object",
@@ -496,7 +901,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if nested field is invalid",
+			name:    "Error if nested field is invalid",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "httpProxy",
 				Required: true,
@@ -517,10 +923,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"enabled":"not-a-bool"}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if object is a bool instead",
+			name:    "Error if object is a bool instead",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "httpProxy",
 				Required: true,
@@ -541,10 +947,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`"not-a-object"`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if object is missing required field",
+			name:    "Error if object is missing required field",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "httpProxy",
 				Required: true,
@@ -571,7 +977,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"enabled":"true"}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid object",
@@ -642,7 +1047,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Fails, value does not match one of the enum object values",
+			name:    "Fails, value does not match one of the enum object values",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "enumObject",
 				Required: true,
@@ -670,7 +1076,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"location": "us-east-2","url":"wrong-url"}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid map",
@@ -699,7 +1104,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if map is missing a required field",
+			name:    "Error if map is missing a required field",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "httpProxy",
 				Required: true,
@@ -727,7 +1133,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"proxy":{"enabled":false}}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid array",
@@ -755,7 +1160,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if array element is invalid",
+			name:    "Error if array element is invalid",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testArray",
 				Required: true,
@@ -778,10 +1184,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`["enumValue1","enumValueInvalid"]`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if array is too large",
+			name:    "Error if array is too large",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testArray",
 				Required: true,
@@ -801,10 +1207,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`["value1","value2","value3","value4"]`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if array is too small",
+			name:    "Error if array is too small",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testArray",
 				Required: true,
@@ -824,10 +1230,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`["value1","value2"]`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if array contains duplicate values",
+			name:    "Error if array contains duplicate values",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testArray",
 				Required: true,
@@ -847,7 +1253,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`["value1","value1"]`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid array object",
@@ -875,7 +1280,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Fails, value does not match one of the enum array values",
+			name:    "Fails, value does not match one of the enum array values",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "enumArray",
 				Required: true,
@@ -898,7 +1304,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`["7","8","9"]`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid object with x-kubernetes-preserve-unknown-fields",
@@ -926,7 +1331,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if undefined field",
+			name:    "Error if undefined field",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testObject",
 				Required: true,
@@ -948,10 +1354,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"knownProperty":false,"unknownProperty":true}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if undefined field with different casing",
+			name:    "Error if undefined field with different casing",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testObject",
 				Required: true,
@@ -973,7 +1379,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"KnownProperty":false}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid nested object with x-kubernetes-preserve-unknown-fields",
@@ -1027,7 +1432,8 @@ func Test_ValidateClusterVariable(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if undefined field nested",
+			name:    "Error if undefined field nested",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testObject",
 				Required: true,
@@ -1054,10 +1460,10 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"test": {"knownProperty":false,"unknownProperty":true}}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
-			name: "Error if undefined field nested and x-kubernetes-preserve-unknown-fields one level above",
+			name:    "Error if undefined field nested and x-kubernetes-preserve-unknown-fields one level above",
+			wantErr: true,
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "testObject",
 				Required: true,
@@ -1085,7 +1491,6 @@ func Test_ValidateClusterVariable(t *testing.T) {
 					Raw: []byte(`{"test": {"knownProperty":false,"unknownProperty":true}}`),
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "Valid object with mid-level unknown fields",

--- a/internal/topology/variables/utils.go
+++ b/internal/topology/variables/utils.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package variables
+
+import (
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+const (
+	// emptyDefinitionFrom is the definitionFrom value used when none is supplied by the user.
+	emptyDefinitionFrom = ""
+)
+
+// newValuesIndex return a map of ClusterVariable values per name and definitionsFrom.
+// This function validates that:
+// - variables are not defined more than once in Cluster spec/
+// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
+func newValuesIndex(values []clusterv1.ClusterVariable) (map[string]map[string]clusterv1.ClusterVariable, error) {
+	valuesMap := map[string]map[string]clusterv1.ClusterVariable{}
+	errs := []error{}
+	for _, value := range values {
+		c := value
+		_, ok := valuesMap[c.Name]
+		if !ok {
+			valuesMap[c.Name] = map[string]clusterv1.ClusterVariable{}
+		}
+		// Check that the variable has not been defined more than once with the same definitionFrom.
+		if _, ok := valuesMap[c.Name][c.DefinitionFrom]; ok {
+			errs = append(errs, errors.Errorf("variable %q from %q is defined more than once", c.Name, c.DefinitionFrom))
+			continue
+		}
+		// Add the variable.
+		valuesMap[c.Name][c.DefinitionFrom] = c
+	}
+	if len(errs) > 0 {
+		return nil, kerrors.NewAggregate(errs)
+	}
+	// Validate that the variables do not have incompatible values in their `definitionFrom` fields.
+	if err := validateValuesDefinitionFrom(valuesMap); err != nil {
+		return nil, err
+	}
+
+	return valuesMap, nil
+}
+
+// validateValuesDefinitionFrom validates that variables are not defined with both an empty DefinitionFrom and a
+// non-empty DefinitionFrom.
+func validateValuesDefinitionFrom(values map[string]map[string]clusterv1.ClusterVariable) error {
+	var errs []error
+	for name, valuesForName := range values {
+		for _, value := range valuesForName {
+			// Append an error if the value has a non-empty definitionFrom but there's also a value with
+			// an empty DefinitionFrom.
+			if _, ok := valuesForName[emptyDefinitionFrom]; ok && value.DefinitionFrom != emptyDefinitionFrom {
+				errs = append(errs, errors.Errorf("variable %q is defined with a mix of empty and non-empty values for definitionFrom", name))
+				break // No need to check other values for this variable.
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return kerrors.NewAggregate(errs)
+	}
+	return nil
+}
+
+type statusVariableDefinition struct {
+	*clusterv1.ClusterClassStatusVariableDefinition
+	Name      string
+	Conflicts bool
+}
+
+type definitionsIndex map[string]map[string]*statusVariableDefinition
+
+// newDefinitionsIndex returns a definitionsIndex with ClusterClassStatusVariable definitions by name and definition.From.
+// This index has special handling for variables with no definition conflicts in the `get` method.
+func newDefinitionsIndex(definitions []clusterv1.ClusterClassStatusVariable) definitionsIndex {
+	i := definitionsIndex{}
+	for _, def := range definitions {
+		i.store(def)
+	}
+	return i
+}
+func (i definitionsIndex) store(definition clusterv1.ClusterClassStatusVariable) {
+	for _, d := range definition.Definitions {
+		if _, ok := i[definition.Name]; !ok {
+			i[definition.Name] = map[string]*statusVariableDefinition{}
+		}
+		i[definition.Name][d.From] = &statusVariableDefinition{
+			Name:                                 definition.Name,
+			Conflicts:                            definition.DefinitionsConflict,
+			ClusterClassStatusVariableDefinition: d.DeepCopy(),
+		}
+	}
+}
+
+// get returns a statusVariableDefinition for a given name and definitionFrom. If the definition has no conflicts it can
+// be retrieved using an emptyDefinitionFrom.
+// Return an error if the definition is not found or if the definitionFrom is empty and there are conflicts in the definitions.
+func (i definitionsIndex) get(name, definitionFrom string) (*statusVariableDefinition, error) {
+	// If no variable with this name exists return an error.
+	if _, ok := i[name]; !ok {
+		return nil, errors.Errorf("no definitions found for variable %q", name)
+	}
+
+	// If the definition exists for the specific definitionFrom, return it.
+	if def, ok := i[name][definitionFrom]; ok {
+		return def, nil
+	}
+
+	// If definitionFrom is empty and there are no conflicts return a definition with an emptyDefinitionFrom.
+	if definitionFrom == emptyDefinitionFrom {
+		for _, def := range i[name] {
+			if !def.Conflicts {
+				return &statusVariableDefinition{
+					Name:      def.Name,
+					Conflicts: def.Conflicts,
+					ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+						// Return the definition with an empty definitionFrom. This ensures when a user gets
+						// a definition with an emptyDefinitionFrom, the return value also has emptyDefinitionFrom.
+						// This is used in variable defaulting to ensure variables that only need one value for multiple
+						// definitions have an emptyDefinitionFrom.
+						From:     emptyDefinitionFrom,
+						Required: def.Required,
+						Schema:   def.Schema,
+					},
+				}, nil
+			}
+			return nil, errors.Errorf("variable %q has conflicting definitions. It requires a non-empty `definitionFrom`", name)
+		}
+	}
+	return nil, errors.Errorf("no definitions found for variable %q from %q", name, definitionFrom)
+}


### PR DESCRIPTION
Add handling for conflicting definitions in variables defined in the ClusterClass and external patches. This change includes:
- Comparing variables and signalling which variables conflict in the ClusterClass status
- Validation and Defaulting of variables based on the appropriate definiton where conflicts exist 
- Validating that Cluster's define a `DefinitionFrom` field when there are conflicting variables

Part of #7985 
