### PR TITLE
⚠️ in-place propagation from MD to MS

### DIFF
--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -54,8 +54,18 @@ const (
 	// proportions in case the deployment has surge replicas.
 	MaxReplicasAnnotation = "machinedeployment.clusters.x-k8s.io/max-replicas"
 
-	// MachineDeploymentUniqueLabel is the label applied to Machines
-	// in a MachineDeployment containing the hash of the template.
+	// MachineDeploymentUniqueLabel is used to uniquely identify the Machines of a MachineSet.
+	// The MachineDeployment controller will set this label on a MachineSet when it is created.
+	// The label is also applied to the Machines of the MachineSet and used in the MachineSet selector.
+	// Note: For the lifetime of the MachineSet the label's value has to stay the same, otherwise the
+	// MachineSet selector would no longer match its Machines.
+	// Note: In previous Cluster API versions (< v1.4.0), the label value was the hash of the full machine template.
+	// With the introduction of in-place mutation the machine template of the MachineSet can change.
+	// Because of that it is impossible that the label's value to always be the hash of the full machine template.
+	// (Because the hash changes when the machine template changes).
+	// As a result, we use the hash of the machine template while ignoring all in-place mutable fields, i.e. the
+	// machine template with only fields that could trigger a rollout for the machine-template-hash, making it
+	// independent of the changes to any in-place mutable fields.
 	MachineDeploymentUniqueLabel = "machine-template-hash"
 )
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -37,6 +37,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -49,6 +50,10 @@ var (
 	// machineDeploymentKind contains the schema.GroupVersionKind for the MachineDeployment type.
 	machineDeploymentKind = clusterv1.GroupVersion.WithKind("MachineDeployment")
 )
+
+// machineDeploymentManagerName is the manager name used for Server-Side-Apply (SSA) operations
+// in the MachineDeployment controller.
+const machineDeploymentManagerName = "capi-machinedeployment"
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
@@ -248,6 +253,19 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 		}
 	}
 
+	// Loop over all MachineSets and cleanup managed fields.
+	// We do this so that MachineSets that were created/patched before (< v1.4.0) the controller adopted
+	// Server-Side-Apply (SSA) can also work with SSA. Otherwise, fields would be co-owned by our "old" "manager" and
+	// "capi-machinedeployment" and then we would not be able to e.g. drop labels and annotations.
+	// Note: We are cleaning up managed fields for all MachineSets, so we're able to remove this code in a few
+	// Cluster API releases. If we do this only for selected MachineSets, we would have to keep this code forever.
+	for idx := range msList {
+		machineSet := msList[idx]
+		if err := ssa.CleanUpManagedFieldsForSSAAdoption(ctx, machineSet, machineDeploymentManagerName, r.Client); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to clean up managedFields of MachineSet %s", klog.KObj(machineSet))
+		}
+	}
+
 	if d.Spec.Paused {
 		return ctrl.Result{}, r.sync(ctx, d, msList)
 	}
@@ -302,7 +320,7 @@ func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, d *cluster
 			continue
 		}
 
-		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
+		// Attempt to adopt MachineSet if it meets previous conditions and it has no controller references.
 		if metav1.GetControllerOf(ms) == nil {
 			if err := r.adoptOrphan(ctx, d, ms); err != nil {
 				log.Error(err, "Failed to adopt MachineSet into MachineDeployment")

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -91,7 +91,7 @@ func (r *Reconciler) reconcileNewMachineSet(ctx context.Context, allMSs []*clust
 		return r.scaleMachineSet(ctx, newMS, *(deployment.Spec.Replicas), deployment)
 	}
 
-	newReplicasCount, err := mdutil.NewMSNewReplicas(deployment, allMSs, newMS)
+	newReplicasCount, err := mdutil.NewMSNewReplicas(deployment, allMSs, *newMS.Spec.Replicas)
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -20,19 +20,23 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strconv"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/mdutil"
@@ -86,173 +90,284 @@ func (r *Reconciler) getAllMachineSetsAndSyncRevision(ctx context.Context, d *cl
 	return newMS, allOldMSs, nil
 }
 
-// Returns a machine set that matches the intent of the given deployment. Returns nil if the new machine set doesn't exist yet.
-// 1. Get existing new MS (the MS that the given deployment targets, whose machine template is the same as deployment's).
-// 2. If there's existing new MS, update its revision number if it's smaller than (maxOldRevision + 1), where maxOldRevision is the max revision number among all old MSes.
-// 3. If there's no existing new MS and createIfNotExisted is true, create one with appropriate revision number (maxOldRevision + 1) and replicas.
-// Note that the machine-template-hash will be added to adopted MSes and machines.
-func (r *Reconciler) getNewMachineSet(ctx context.Context, d *clusterv1.MachineDeployment, msList, oldMSs []*clusterv1.MachineSet, createIfNotExisted bool) (*clusterv1.MachineSet, error) {
-	log := ctrl.LoggerFrom(ctx)
+// Returns a MachineSet that matches the intent of the given MachineDeployment.
+// If there does not exist such a MachineSet and createIfNotExisted is true, create a new MachineSet.
+// If there is already such a MachineSet, update it to propagate in-place mutable fields from the MachineDeployment.
+func (r *Reconciler) getNewMachineSet(ctx context.Context, d *clusterv1.MachineDeployment, msList, oldMSs []*clusterv1.MachineSet, createIfNotExists bool) (*clusterv1.MachineSet, error) {
+	// Try to find a MachineSet which matches the MachineDeployments intent, while ignore diffs between
+	// the in-place mutable fields.
+	// If we find a matching MachineSet we just update it to propagate any changes to the in-place mutable
+	// fields and thus we do not trigger an unnecessary rollout (i.e. create a new MachineSet).
+	// If we don't find a matching MachineSet, we need a rollout and thus create a new MachineSet.
+	// Note: The in-place mutable fields can be just updated inline, because they do not affect the actual machines
+	// themselves (i.e. the infrastructure and the software running on the Machines not the Machine object).
+	matchingMS := mdutil.FindNewMachineSet(d, msList)
 
-	existingNewMS := mdutil.FindNewMachineSet(d, msList)
-
-	// Calculate the max revision number among all old MSes
-	maxOldRevision := mdutil.MaxRevision(oldMSs, log)
-
-	// Calculate revision number for this new machine set
-	newRevision := strconv.FormatInt(maxOldRevision+1, 10)
-
-	// Latest machine set exists. We need to sync its annotations (includes copying all but
-	// annotationsToSkip from the parent deployment, and update revision, desiredReplicas,
-	// and maxReplicas) and also update the revision annotation in the deployment with the
-	// latest revision.
-	if existingNewMS != nil {
-		msCopy := existingNewMS.DeepCopy()
-		patchHelper, err := patch.NewHelper(msCopy, r.Client)
+	// If there is a MachineSet that matches the intent of the MachineDeployment, update the MachineSet
+	// to propagate all in-place mutable fields from MachineDeployment to the MachineSet.
+	if matchingMS != nil {
+		updatedMS, err := r.updateMachineSet(ctx, d, matchingMS, oldMSs)
 		if err != nil {
 			return nil, err
 		}
 
-		// Set existing new machine set's annotation
-		annotationsUpdated := mdutil.SetNewMachineSetAnnotations(d, msCopy, newRevision, true, log)
-
-		minReadySecondsNeedsUpdate := msCopy.Spec.MinReadySeconds != *d.Spec.MinReadySeconds
-		deletePolicyNeedsUpdate := d.Spec.Strategy.RollingUpdate.DeletePolicy != nil && msCopy.Spec.DeletePolicy != *d.Spec.Strategy.RollingUpdate.DeletePolicy
-		if annotationsUpdated || minReadySecondsNeedsUpdate || deletePolicyNeedsUpdate {
-			msCopy.Spec.MinReadySeconds = *d.Spec.MinReadySeconds
-
-			if deletePolicyNeedsUpdate {
-				msCopy.Spec.DeletePolicy = *d.Spec.Strategy.RollingUpdate.DeletePolicy
-			}
-
-			return nil, patchHelper.Patch(ctx, msCopy)
-		}
-
-		// Apply revision annotation from existingNewMS if it is missing from the deployment.
+		// Ensure MachineDeployment has the latest MachineSet revision in its revision annotation.
 		err = r.updateMachineDeployment(ctx, d, func(innerDeployment *clusterv1.MachineDeployment) {
-			mdutil.SetDeploymentRevision(d, msCopy.Annotations[clusterv1.RevisionAnnotation])
+			mdutil.SetDeploymentRevision(d, updatedMS.Annotations[clusterv1.RevisionAnnotation])
 		})
-		return msCopy, err
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to update revision annotation on MachineDeployment")
+		}
+		return updatedMS, nil
 	}
 
-	if !createIfNotExisted {
+	if !createIfNotExists {
 		return nil, nil
 	}
 
-	// new MachineSet does not exist, create one.
-	newMSTemplate := *d.Spec.Template.DeepCopy()
-	hash, err := mdutil.ComputeSpewHash(&newMSTemplate)
+	// Create a new MachineSet and wait until the new MachineSet exists in the cache.
+	newMS, err := r.createMachineSetAndWait(ctx, d, oldMSs)
 	if err != nil {
 		return nil, err
 	}
-	machineTemplateSpecHash := fmt.Sprintf("%d", hash)
-	newMSTemplate.Labels = mdutil.CloneAndAddLabel(d.Spec.Template.Labels,
-		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
 
-	// Add machineTemplateHash label to selector.
-	newMSSelector := mdutil.CloneSelectorAndAddLabel(&d.Spec.Selector,
-		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
-
-	minReadySeconds := int32(0)
-	if d.Spec.MinReadySeconds != nil {
-		minReadySeconds = *d.Spec.MinReadySeconds
+	// Ensure MachineDeployment has the latest MachineSet revision in its revision annotation.
+	err = r.updateMachineDeployment(ctx, d, func(innerDeployment *clusterv1.MachineDeployment) {
+		mdutil.SetDeploymentRevision(d, newMS.Annotations[clusterv1.RevisionAnnotation])
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update revision annotation on MachineDeployment")
 	}
 
-	// Create new MachineSet
-	newMS := clusterv1.MachineSet{
+	return newMS, nil
+}
+
+// updateMachineSet updates an existing MachineSet to propagate in-place mutable fields from the MachineDeployment.
+func (r *Reconciler) updateMachineSet(ctx context.Context, deployment *clusterv1.MachineDeployment, ms *clusterv1.MachineSet, oldMSs []*clusterv1.MachineSet) (*clusterv1.MachineSet, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Compute the desired MachineSet.
+	updatedMS, err := r.computeDesiredMachineSet(deployment, ms, oldMSs, log)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update MachineSet %q", klog.KObj(ms))
+	}
+
+	// Update the MachineSet to propagate in-place mutable fields from the MachineDeployment.
+	patchOptions := []client.PatchOption{
+		client.ForceOwnership,
+		client.FieldOwner(machineDeploymentManagerName),
+	}
+	if err := r.Client.Patch(ctx, updatedMS, client.Apply, patchOptions...); err != nil {
+		r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedUpdate", "Failed to update MachineSet %s: %v", klog.KObj(updatedMS), err)
+		return nil, errors.Wrapf(err, "failed to update MachineSet %s", klog.KObj(updatedMS))
+	}
+
+	log.V(4).Info("Updated MachineSet", "MachineSet", klog.KObj(updatedMS))
+	return updatedMS, nil
+}
+
+// createMachineSetAndWait creates a new MachineSet with the desired intent of the MachineDeployment.
+// It waits for the cache to be updated with the newly created MachineSet.
+func (r *Reconciler) createMachineSetAndWait(ctx context.Context, deployment *clusterv1.MachineDeployment, oldMSs []*clusterv1.MachineSet) (*clusterv1.MachineSet, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Compute the desired MachineSet.
+	newMS, err := r.computeDesiredMachineSet(deployment, nil, oldMSs, log)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create new MachineSet")
+	}
+
+	// Create the MachineSet.
+	patchOptions := []client.PatchOption{
+		client.ForceOwnership,
+		client.FieldOwner(machineDeploymentManagerName),
+	}
+	if err = r.Client.Patch(ctx, newMS, client.Apply, patchOptions...); err != nil {
+		r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedCreate", "Failed to create MachineSet %s: %v", klog.KObj(newMS), err)
+		return nil, errors.Wrapf(err, "failed to create new MachineSet %s", klog.KObj(newMS))
+	}
+	log.V(4).Info("Created new MachineSet", "MachineSet", klog.KObj(newMS))
+	r.recorder.Eventf(deployment, corev1.EventTypeNormal, "SuccessfulCreate", "Created MachineSet %s", klog.KObj(newMS))
+
+	// Keep trying to get the MachineSet. This will force the cache to update and prevent any future reconciliation of
+	// the MachineDeployment to reconcile with an outdated list of MachineSets which could lead to unwanted creation of
+	// a duplicate MachineSet.
+	var pollErrors []error
+	if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+		ms := &clusterv1.MachineSet{}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(newMS), ms); err != nil {
+			// Do not return error here. Continue to poll even if we hit an error
+			// so that we avoid existing because of transient errors like network flakes.
+			// Capture all the errors and return the aggregate error if the poll fails eventually.
+			pollErrors = append(pollErrors, err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, errors.Wrapf(kerrors.NewAggregate(pollErrors), "failed to get the MachineSet %s after creation", klog.KObj(newMS))
+	}
+	return newMS, nil
+}
+
+// computeDesiredMachineSet computes the desired MachineSet.
+// This MachineSet will be used during reconciliation to:
+// * create a MachineSet
+// * update an existing MachineSet
+// Because we are using Server-Side-Apply we always have to calculate the full object.
+// There are small differences in how we calculate the MachineSet depending on if it
+// is a create or update. Example: for a new MachineSet we have to calculate a new name,
+// while for an existing MachineSet we have to use the name of the existing MachineSet.
+func (r *Reconciler) computeDesiredMachineSet(deployment *clusterv1.MachineDeployment, existingMS *clusterv1.MachineSet, oldMSs []*clusterv1.MachineSet, log logr.Logger) (*clusterv1.MachineSet, error) {
+	var name string
+	var uid types.UID
+	var finalizers []string
+	var uniqueIdentifierLabelValue string
+	var machineTemplateSpec clusterv1.MachineSpec
+	var replicas int32
+	var err error
+
+	// For a new MachineSet:
+	// * compute a new uniqueIdentifier, a new MachineSet name, finalizers, replicas and
+	//   machine template spec (take the one from MachineDeployment)
+	if existingMS == nil {
+		// Note: In previous Cluster API versions (< v1.4.0), the label value was the hash of the full machine
+		// template. With the introduction of in-place mutation the machine template of the MachineSet can change.
+		// Because of that it is impossible that the label's value to always be the hash of the full machine template.
+		// (Because the hash changes when the machine template changes).
+		// As a result, we use the hash of the machine template while ignoring all in-place mutable fields, i.e. the
+		// machine template with only fields that could trigger a rollout for the machine-template-hash, making it
+		// independent of the changes to any in-place mutable fields.
+		templateHash, err := mdutil.ComputeSpewHash(mdutil.MachineTemplateDeepCopyRolloutFields(&deployment.Spec.Template))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to compute desired MachineSet: failed to compute machine template hash")
+		}
+		uniqueIdentifierLabelValue = fmt.Sprintf("%d", templateHash)
+
+		name = computeNewMachineSetName(deployment.Name+"-", apirand.SafeEncodeString(uniqueIdentifierLabelValue))
+
+		// Add foregroundDeletion finalizer to MachineSet if the MachineDeployment has it.
+		if sets.New[string](deployment.Finalizers...).Has(metav1.FinalizerDeleteDependents) {
+			finalizers = []string{metav1.FinalizerDeleteDependents}
+		}
+
+		replicas, err = mdutil.NewMSNewReplicas(deployment, oldMSs, 0)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to compute desired MachineSet")
+		}
+
+		machineTemplateSpec = *deployment.Spec.Template.Spec.DeepCopy()
+	} else {
+		// For updating an existing MachineSet:
+		// * get the uniqueIdentifier from labels of the existingMS
+		// * use name, uid, finalizers, replicas and machine template spec from existingMS.
+		// Note: We use the uid, to ensure that the Server-Side-Apply only updates existingMS.
+		// Note: We carry over those fields because we don't want to mutate them for an existingMS.
+		var uniqueIdentifierLabelExists bool
+		uniqueIdentifierLabelValue, uniqueIdentifierLabelExists = existingMS.Labels[clusterv1.MachineDeploymentUniqueLabel]
+		if !uniqueIdentifierLabelExists {
+			return nil, errors.Errorf("failed to compute desired MachineSet: failed to get unique identifier from %q annotation",
+				clusterv1.MachineDeploymentUniqueLabel)
+		}
+
+		name = existingMS.Name
+		uid = existingMS.UID
+
+		// Keep foregroundDeletion finalizer if the existingMS has it.
+		// Note: This case is a little different from the create case. In the update case we preserve
+		// the finalizer on the MachineSet if it already exists. Because of SSA we should not build
+		// the finalizer information from the MachineDeployment when updating a MachineSet because that could lead
+		// to dropping the finalizer from the MachineSet if it is dropped from the MachineDeployment.
+		// We should not drop the finalizer on the MachineSet if the finalizer is dropped form the MachineDeployment.
+		if sets.New[string](existingMS.Finalizers...).Has(metav1.FinalizerDeleteDependents) {
+			finalizers = []string{metav1.FinalizerDeleteDependents}
+		}
+
+		replicas = *existingMS.Spec.Replicas
+
+		machineTemplateSpec = *existingMS.Spec.Template.Spec.DeepCopy()
+	}
+
+	// Construct the basic MachineSet.
+	desiredMS := &clusterv1.MachineSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineSet",
+		},
 		ObjectMeta: metav1.ObjectMeta{
-			// Make the name deterministic, to ensure idempotence
-			Name:      d.Name + "-" + apirand.SafeEncodeString(machineTemplateSpecHash),
-			Namespace: d.Namespace,
-			Labels:    make(map[string]string),
-			// Note: by setting the ownerRef on creation we signal to the MachineSet controller that this is not a stand-alone MachineSet.
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, machineDeploymentKind)},
+			Name:      name,
+			Namespace: deployment.Namespace,
+			// Note: By setting the ownerRef on creation we signal to the MachineSet controller that this is not a stand-alone MachineSet.
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(deployment, machineDeploymentKind)},
+			UID:             uid,
+			Finalizers:      finalizers,
 		},
 		Spec: clusterv1.MachineSetSpec{
-			ClusterName:     d.Spec.ClusterName,
-			Replicas:        new(int32),
-			MinReadySeconds: minReadySeconds,
-			Selector:        *newMSSelector,
-			Template:        newMSTemplate,
+			Replicas:    &replicas,
+			ClusterName: deployment.Spec.ClusterName,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: machineTemplateSpec,
+			},
 		},
 	}
 
-	// Set the labels from newMSTemplate as top-level labels for the new MS.
-	// Note: We can't just set `newMSTemplate.Labels` directly and thus "share" the labels map between top-level and
-	// .spec.template.metadata.labels. This would mean that adding the MachineDeploymentNameLabel later top-level
-	// would also add the label to .spec.template.metadata.labels.
-	for k, v := range newMSTemplate.Labels {
-		newMS.Labels[k] = v
+	// Set the in-place mutable fields.
+	// When we create a new MachineSet we will just create the MachineSet with those fields.
+	// When we update an existing MachineSet will we update the fields on the existing MachineSet (in-place mutate).
+
+	// Set labels and .spec.template.labels.
+	desiredMS.Labels = mdutil.CloneAndAddLabel(deployment.Spec.Template.Labels,
+		clusterv1.MachineDeploymentUniqueLabel, uniqueIdentifierLabelValue)
+	// Always set the MachineDeploymentNameLabel.
+	// Note: If a client tries to create a MachineDeployment without a selector, the MachineDeployment webhook
+	// will add this label automatically. But we want this label to always be present even if the MachineDeployment
+	// has a selector which doesn't include it. Therefore, we have to set it here explicitly.
+	desiredMS.Labels[clusterv1.MachineDeploymentNameLabel] = deployment.Name
+	desiredMS.Spec.Template.Labels = mdutil.CloneAndAddLabel(deployment.Spec.Template.Labels,
+		clusterv1.MachineDeploymentUniqueLabel, uniqueIdentifierLabelValue)
+
+	// Set selector.
+	desiredMS.Spec.Selector = *mdutil.CloneSelectorAndAddLabel(&deployment.Spec.Selector, clusterv1.MachineDeploymentUniqueLabel, uniqueIdentifierLabelValue)
+
+	// Set annotations and .spec.template.annotations.
+	if desiredMS.Annotations, err = mdutil.ComputeMachineSetAnnotations(log, deployment, oldMSs, existingMS); err != nil {
+		return nil, errors.Wrap(err, "failed to compute desired MachineSet: failed to compute annotations")
 	}
+	desiredMS.Spec.Template.Annotations = cloneStringMap(deployment.Spec.Template.Annotations)
 
-	// Enforce that the MachineDeploymentNameLabel label is set
-	// Note: the MachineDeploymentNameLabel is added by the default webhook to MachineDeployment.spec.template.labels if spec.selector is empty.
-	newMS.Labels[clusterv1.MachineDeploymentNameLabel] = d.Name
+	// Set all other in-place mutable fields.
+	desiredMS.Spec.MinReadySeconds = pointer.Int32Deref(deployment.Spec.MinReadySeconds, 0)
+	desiredMS.Spec.DeletePolicy = pointer.StringDeref(deployment.Spec.Strategy.RollingUpdate.DeletePolicy, "")
+	desiredMS.Spec.Template.Spec.NodeDrainTimeout = deployment.Spec.Template.Spec.NodeDrainTimeout
+	desiredMS.Spec.Template.Spec.NodeDeletionTimeout = deployment.Spec.Template.Spec.NodeDeletionTimeout
+	desiredMS.Spec.Template.Spec.NodeVolumeDetachTimeout = deployment.Spec.Template.Spec.NodeVolumeDetachTimeout
 
-	if d.Spec.Strategy.RollingUpdate.DeletePolicy != nil {
-		newMS.Spec.DeletePolicy = *d.Spec.Strategy.RollingUpdate.DeletePolicy
+	return desiredMS, nil
+}
+
+// cloneStringMap clones a string map.
+func cloneStringMap(in map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range in {
+		out[k] = v
 	}
+	return out
+}
 
-	// Add foregroundDeletion finalizer to MachineSet if the MachineDeployment has it
-	finalizerSet := sets.Set[string]{}.Insert(d.Finalizers...)
-	if finalizerSet.Has(metav1.FinalizerDeleteDependents) {
-		controllerutil.AddFinalizer(&newMS, metav1.FinalizerDeleteDependents)
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
+
+// computeNewMachineSetName generates a new name for the MachineSet just like
+// the upstream SimpleNameGenerator.
+// Note: We had to extract the logic as we want to use the MachineSet name suffix as
+// unique identifier for the MachineSet.
+func computeNewMachineSetName(base, suffix string) string {
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
 	}
-
-	allMSs := append(oldMSs, &newMS)
-	newReplicasCount, err := mdutil.NewMSNewReplicas(d, allMSs, &newMS)
-	if err != nil {
-		return nil, err
-	}
-
-	*(newMS.Spec.Replicas) = newReplicasCount
-
-	// Set new machine set's annotation
-	mdutil.SetNewMachineSetAnnotations(d, &newMS, newRevision, false, log)
-	// Create the new MachineSet. If it already exists, then we need to check for possible
-	// hash collisions. If there is any other error, we need to report it in the status of
-	// the Deployment.
-	alreadyExists := false
-	err = r.Client.Create(ctx, &newMS)
-	createdMS := &newMS
-	switch {
-	// We may end up hitting this due to a slow cache or a fast resync of the Deployment.
-	case apierrors.IsAlreadyExists(err):
-		alreadyExists = true
-
-		ms := &clusterv1.MachineSet{}
-		msErr := r.Client.Get(ctx, client.ObjectKey{Namespace: newMS.Namespace, Name: newMS.Name}, ms)
-		if msErr != nil {
-			return nil, msErr
-		}
-
-		// If the Deployment owns the MachineSet and the MachineSet's MachineTemplateSpec is semantically
-		// deep equal to the MachineTemplateSpec of the Deployment, it's the Deployment's new MachineSet.
-		// Otherwise, this is a hash collision and we need to increment the collisionCount field in
-		// the status of the Deployment and requeue to try the creation in the next sync.
-		controllerRef := metav1.GetControllerOf(ms)
-		if controllerRef != nil && controllerRef.UID == d.UID && mdutil.EqualMachineTemplate(&d.Spec.Template, &ms.Spec.Template) {
-			createdMS = ms
-			break
-		}
-
-		return nil, err
-	case err != nil:
-		log.Error(err, "Failed to create new MachineSet", "MachineSet", klog.KObj(&newMS))
-		r.recorder.Eventf(d, corev1.EventTypeWarning, "FailedCreate", "Failed to create MachineSet %q: %v", newMS.Name, err)
-		return nil, err
-	}
-
-	if !alreadyExists {
-		log.V(4).Info("Created new MachineSet", "MachineSet", klog.KObj(createdMS))
-		r.recorder.Eventf(d, corev1.EventTypeNormal, "SuccessfulCreate", "Created MachineSet %q", newMS.Name)
-	}
-
-	err = r.updateMachineDeployment(ctx, d, func(innerDeployment *clusterv1.MachineDeployment) {
-		mdutil.SetDeploymentRevision(d, newRevision)
-	})
-
-	return createdMS, err
+	return fmt.Sprintf("%s%s", base, suffix)
 }
 
 // scale scales proportionally in order to mitigate risk. Otherwise, scaling up can increase the size

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -19,6 +19,7 @@ package mdutil
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/klog/v2/klogr"
+	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -76,175 +78,209 @@ func generateDeployment(image string) clusterv1.MachineDeployment {
 			Annotations: make(map[string]string),
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
-			Replicas: func(i int32) *int32 { return &i }(1),
+			Replicas: pointer.Int32(3),
 			Selector: metav1.LabelSelector{MatchLabels: machineLabels},
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels: machineLabels,
 				},
-				Spec: clusterv1.MachineSpec{},
+				Spec: clusterv1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Second},
+				},
 			},
 		},
 	}
 }
 
-func generateMachineTemplateSpec(annotations, labels map[string]string) clusterv1.MachineTemplateSpec {
-	return clusterv1.MachineTemplateSpec{
-		ObjectMeta: clusterv1.ObjectMeta{
-			Annotations: annotations,
-			Labels:      labels,
+func TestMachineSetsByDecreasingReplicas(t *testing.T) {
+	t0 := time.Now()
+	t1 := t0.Add(1 * time.Minute)
+	msAReplicas1T0 := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: t0},
+			Name:              "ms-a",
 		},
-		Spec: clusterv1.MachineSpec{},
+		Spec: clusterv1.MachineSetSpec{
+			Replicas: pointer.Int32(1),
+		},
+	}
+
+	msAAReplicas3T0 := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: t0},
+			Name:              "ms-aa",
+		},
+		Spec: clusterv1.MachineSetSpec{
+			Replicas: pointer.Int32(3),
+		},
+	}
+
+	msBReplicas1T0 := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: t0},
+			Name:              "ms-b",
+		},
+		Spec: clusterv1.MachineSetSpec{
+			Replicas: pointer.Int32(1),
+		},
+	}
+
+	msAReplicas1T1 := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Time{Time: t1},
+			Name:              "ms-a",
+		},
+		Spec: clusterv1.MachineSetSpec{
+			Replicas: pointer.Int32(1),
+		},
+	}
+
+	tests := []struct {
+		name        string
+		machineSets []*clusterv1.MachineSet
+		want        []*clusterv1.MachineSet
+	}{
+		{
+			name:        "machine set with higher replicas should be lower in the list",
+			machineSets: []*clusterv1.MachineSet{msAReplicas1T0, msAAReplicas3T0},
+			want:        []*clusterv1.MachineSet{msAAReplicas3T0, msAReplicas1T0},
+		},
+		{
+			name:        "MachineSet created earlier should be lower in the list if replicas are the same",
+			machineSets: []*clusterv1.MachineSet{msAReplicas1T1, msAReplicas1T0},
+			want:        []*clusterv1.MachineSet{msAReplicas1T0, msAReplicas1T1},
+		},
+		{
+			name:        "MachineSet with lower name should be lower in the list if the replicas and creationTimestamp are same",
+			machineSets: []*clusterv1.MachineSet{msBReplicas1T0, msAReplicas1T0},
+			want:        []*clusterv1.MachineSet{msAReplicas1T0, msBReplicas1T0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// sort the machine sets and verify the sorted list
+			g := NewWithT(t)
+			sort.Sort(MachineSetsByDecreasingReplicas(tt.machineSets))
+			g.Expect(tt.machineSets).To(Equal(tt.want))
+		})
 	}
 }
 
 func TestEqualMachineTemplate(t *testing.T) {
+	machineTemplate := &clusterv1.MachineTemplateSpec{
+		ObjectMeta: clusterv1.ObjectMeta{
+			Labels:      map[string]string{"l1": "v1"},
+			Annotations: map[string]string{"a1": "v1"},
+		},
+		Spec: clusterv1.MachineSpec{
+			NodeDrainTimeout:        &metav1.Duration{Duration: 10 * time.Second},
+			NodeDeletionTimeout:     &metav1.Duration{Duration: 10 * time.Second},
+			NodeVolumeDetachTimeout: &metav1.Duration{Duration: 10 * time.Second},
+			InfrastructureRef: corev1.ObjectReference{
+				Name:       "infra1",
+				Namespace:  "default",
+				Kind:       "InfrastructureMachine",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					Name:       "bootstrap1",
+					Namespace:  "default",
+					Kind:       "BootstrapConfig",
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				},
+			},
+		},
+	}
+
+	machineTemplateWithEmptyLabels := machineTemplate.DeepCopy()
+	machineTemplateWithEmptyLabels.Labels = map[string]string{}
+
+	machineTemplateWithDifferentLabels := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentLabels.Labels = map[string]string{"l2": "v2"}
+
+	machineTemplateWithEmptyAnnotations := machineTemplate.DeepCopy()
+	machineTemplateWithEmptyAnnotations.Annotations = map[string]string{}
+
+	machineTemplateWithDifferentAnnotations := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentAnnotations.Annotations = map[string]string{"a2": "v2"}
+
+	machineTemplateWithDifferentInPlaceMutableSpecFields := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentInPlaceMutableSpecFields.Spec.NodeDrainTimeout = &metav1.Duration{Duration: 20 * time.Second}
+	machineTemplateWithDifferentInPlaceMutableSpecFields.Spec.NodeDeletionTimeout = &metav1.Duration{Duration: 20 * time.Second}
+	machineTemplateWithDifferentInPlaceMutableSpecFields.Spec.NodeVolumeDetachTimeout = &metav1.Duration{Duration: 20 * time.Second}
+
+	machineTemplateWithDifferentInfraRef := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentInfraRef.Spec.InfrastructureRef.Name = "infra2"
+
+	machineTemplateWithDifferentInfraRefAPIVersion := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentInfraRefAPIVersion.Spec.InfrastructureRef.APIVersion = "infrastructure.cluster.x-k8s.io/v1beta2"
+
+	machineTemplateWithDifferentBootstrapConfigRef := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentBootstrapConfigRef.Spec.Bootstrap.ConfigRef.Name = "bootstrap2"
+
+	machineTemplateWithDifferentBootstrapConfigRefAPIVersion := machineTemplate.DeepCopy()
+	machineTemplateWithDifferentBootstrapConfigRefAPIVersion.Spec.Bootstrap.ConfigRef.APIVersion = "bootstrap.cluster.x-k8s.io/v1beta2"
+
 	tests := []struct {
 		Name           string
-		Former, Latter clusterv1.MachineTemplateSpec
+		Former, Latter *clusterv1.MachineTemplateSpec
 		Expected       bool
 	}{
 		{
-			Name:     "Same spec, same labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Name:     "Same spec, except latter does not have labels",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithEmptyLabels,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, only machine-template-hash label value is different",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Name:     "Same spec, except latter has different labels",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentLabels,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, the former doesn't have machine-template-hash label",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Name:     "Same spec, except latter does not have annotations",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithEmptyAnnotations,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, the former doesn't have machine-template-hash label",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Name:     "Same spec, except latter has different annotations",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentAnnotations,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, the label is different, the former doesn't have machine-template-hash label, same number of labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2"}),
-			Expected: false,
-		},
-		{
-			Name:     "Same spec, the label is different, the latter doesn't have machine-template-hash label, same number of labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Expected: false,
-		},
-		{
-			Name:     "Same spec, the label is different, and the machine-template-hash label value is the same",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Expected: false,
-		},
-		{
-			Name:     "Different spec, same labels",
-			Former:   generateMachineTemplateSpec(map[string]string{"former": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"latter": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Expected: false,
-		},
-		{
-			Name:     "Different spec, different machine-template-hash label value",
-			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
-			Expected: false,
-		},
-		{
-			Name:     "Different spec, the former doesn't have machine-template-hash label",
-			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
-			Expected: false,
-		},
-		{
-			Name:     "Different spec, different labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"nothing": "else"}),
-			Expected: false,
-		},
-		{
-			Name: "Same spec, except for references versions",
-			Former: clusterv1.MachineTemplateSpec{
-				ObjectMeta: clusterv1.ObjectMeta{
-					Labels: map[string]string{},
-				},
-				Spec: clusterv1.MachineSpec{
-					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
-							Kind:       "MachineBootstrap",
-						},
-					},
-					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
-						Kind:       "MachineInfrastructure",
-					},
-				},
-			},
-			Latter: clusterv1.MachineTemplateSpec{
-				ObjectMeta: clusterv1.ObjectMeta{
-					Labels: map[string]string{},
-				},
-				Spec: clusterv1.MachineSpec{
-					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "MachineBootstrap",
-						},
-					},
-					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-						Kind:       "MachineInfrastructure",
-					},
-				},
-			},
+			Name:     "Spec changes, latter has different in-place mutable spec fields",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentInPlaceMutableSpecFields,
 			Expected: true,
 		},
 		{
-			Name: "Same spec, bootstrap references are different kinds",
-			Former: clusterv1.MachineTemplateSpec{
-				ObjectMeta: clusterv1.ObjectMeta{
-					Labels: map[string]string{},
-				},
-				Spec: clusterv1.MachineSpec{
-					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
-							Kind:       "MachineBootstrap1",
-						},
-					},
-					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
-						Kind:       "MachineInfrastructure",
-					},
-				},
-			},
-			Latter: clusterv1.MachineTemplateSpec{
-				ObjectMeta: clusterv1.ObjectMeta{
-					Labels: map[string]string{},
-				},
-				Spec: clusterv1.MachineSpec{
-					Bootstrap: clusterv1.Bootstrap{
-						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "MachineBootstrap2",
-						},
-					},
-					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-						Kind:       "MachineInfrastructure",
-					},
-				},
-			},
+			Name:     "Spec changes, latter has different InfrastructureRef",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentInfraRef,
 			Expected: false,
+		},
+		{
+			Name:     "Spec changes, latter has different Bootstrap.ConfigRef",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentBootstrapConfigRef,
+			Expected: false,
+		},
+		{
+			Name:     "Same spec, except latter has different InfrastructureRef APIVersion",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentInfraRefAPIVersion,
+			Expected: true,
+		},
+		{
+			Name:     "Same spec, except latter has different Bootstrap.ConfigRef APIVersion",
+			Former:   machineTemplate,
+			Latter:   machineTemplateWithDifferentBootstrapConfigRefAPIVersion,
+			Expected: true,
 		},
 	}
 
@@ -260,32 +296,26 @@ func TestEqualMachineTemplate(t *testing.T) {
 				g.Expect(t2.Labels).NotTo(BeNil())
 			}
 
-			runTest(&test.Former, &test.Latter)
+			runTest(test.Former, test.Latter)
 			// Test the same case in reverse order
-			runTest(&test.Latter, &test.Former)
+			runTest(test.Latter, test.Former)
 		})
 	}
 }
 
 func TestFindNewMachineSet(t *testing.T) {
-	now := metav1.Now()
-	later := metav1.Time{Time: now.Add(time.Minute)}
-
 	deployment := generateDeployment("nginx")
-	newMS := generateMS(deployment)
-	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
-	newMS.CreationTimestamp = later
 
-	newMSDup := generateMS(deployment)
-	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
-	newMSDup.CreationTimestamp = now
+	matchingMS := generateMS(deployment)
 
-	oldDeployment := generateDeployment("nginx")
-	oldMS := generateMS(oldDeployment)
-	oldMS.Spec.Template.Annotations = map[string]string{
-		"old": "true",
-	}
-	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
+	matchingMSHigherReplicas := generateMS(deployment)
+	matchingMSHigherReplicas.Spec.Replicas = pointer.Int32(2)
+
+	matchingMSDiffersInPlaceMutableFields := generateMS(deployment)
+	matchingMSDiffersInPlaceMutableFields.Spec.Template.Spec.NodeDrainTimeout = &metav1.Duration{Duration: 20 * time.Second}
+
+	oldMS := generateMS(deployment)
+	oldMS.Spec.Template.Spec.InfrastructureRef.Name = "changed-infra-ref"
 
 	tests := []struct {
 		Name       string
@@ -294,19 +324,25 @@ func TestFindNewMachineSet(t *testing.T) {
 		expected   *clusterv1.MachineSet
 	}{
 		{
-			Name:       "Get new MachineSet with the same template as Deployment spec but different machine-template-hash value",
+			Name:       "Get the MachineSet with the MachineTemplate that matches the intent of the MachineDeployment",
 			deployment: deployment,
-			msList:     []*clusterv1.MachineSet{&newMS, &oldMS},
-			expected:   &newMS,
+			msList:     []*clusterv1.MachineSet{&oldMS, &matchingMS},
+			expected:   &matchingMS,
 		},
 		{
-			Name:       "Get the oldest new MachineSet when there are more than one MachineSet with the same template",
+			Name:       "Get the MachineSet with the higher replicas if multiple MachineSets match the desired intent on the MachineDeployment",
 			deployment: deployment,
-			msList:     []*clusterv1.MachineSet{&newMS, &oldMS, &newMSDup},
-			expected:   &newMSDup,
+			msList:     []*clusterv1.MachineSet{&oldMS, &matchingMS, &matchingMSHigherReplicas},
+			expected:   &matchingMSHigherReplicas,
 		},
 		{
-			Name:       "Get nil new MachineSet",
+			Name:       "Get the MachineSet with the MachineTemplate that matches the desired intent on the MachineDeployment, except differs in in-place mutable fields",
+			deployment: deployment,
+			msList:     []*clusterv1.MachineSet{&oldMS, &matchingMSDiffersInPlaceMutableFields},
+			expected:   &matchingMSDiffersInPlaceMutableFields,
+		},
+		{
+			Name:       "Get nil if no MachineSet matches the desired intent of the MachineDeployment",
 			deployment: deployment,
 			msList:     []*clusterv1.MachineSet{&oldMS},
 			expected:   nil,
@@ -324,34 +360,22 @@ func TestFindNewMachineSet(t *testing.T) {
 }
 
 func TestFindOldMachineSets(t *testing.T) {
-	now := metav1.Now()
-	later := metav1.Time{Time: now.Add(time.Minute)}
-	before := metav1.Time{Time: now.Add(-time.Minute)}
-
 	deployment := generateDeployment("nginx")
-	newMS := generateMS(deployment)
-	*(newMS.Spec.Replicas) = 1
-	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
-	newMS.CreationTimestamp = later
 
-	newMSDup := generateMS(deployment)
-	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
-	newMSDup.CreationTimestamp = now
+	newMS := generateMS(deployment)
+	newMS.Name = "aa"
+	newMS.Spec.Replicas = pointer.Int32(1)
+
+	newMSHigherReplicas := generateMS(deployment)
+	newMSHigherReplicas.Spec.Replicas = pointer.Int32(2)
+
+	newMSHigherName := generateMS(deployment)
+	newMSHigherName.Spec.Replicas = pointer.Int32(1)
+	newMSHigherName.Name = "ab"
 
 	oldDeployment := generateDeployment("nginx")
+	oldDeployment.Spec.Template.Spec.InfrastructureRef.Name = "changed-infra-ref"
 	oldMS := generateMS(oldDeployment)
-	oldMS.Spec.Template.Annotations = map[string]string{
-		"old": "true",
-	}
-	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
-	oldMS.CreationTimestamp = before
-
-	oldDeployment = generateDeployment("nginx")
-	oldDeployment.Spec.Selector.MatchLabels["old-label"] = "old-value"
-	oldDeployment.Spec.Template.Labels["old-label"] = "old-value"
-	oldMSwithOldLabel := generateMS(oldDeployment)
-	oldMSwithOldLabel.Status.FullyLabeledReplicas = *(oldMSwithOldLabel.Spec.Replicas)
-	oldMSwithOldLabel.CreationTimestamp = before
 
 	tests := []struct {
 		Name            string
@@ -375,24 +399,24 @@ func TestFindOldMachineSets(t *testing.T) {
 			expectedRequire: nil,
 		},
 		{
-			Name:            "Get old MachineSets with two new MachineSets, only the oldest new MachineSet is seen as new MachineSet",
+			Name:            "Get old MachineSets with two new MachineSets, only the MachineSet with higher replicas is seen as new MachineSet",
 			deployment:      deployment,
-			msList:          []*clusterv1.MachineSet{&oldMS, &newMS, &newMSDup},
+			msList:          []*clusterv1.MachineSet{&oldMS, &newMS, &newMSHigherReplicas},
 			expected:        []*clusterv1.MachineSet{&oldMS, &newMS},
 			expectedRequire: []*clusterv1.MachineSet{&newMS},
+		},
+		{
+			Name:            "Get old MachineSets with two new MachineSets, when replicas are matching only the MachineSet with lower name is seen as new MachineSet",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&oldMS, &newMS, &newMSHigherName},
+			expected:        []*clusterv1.MachineSet{&oldMS, &newMSHigherName},
+			expectedRequire: []*clusterv1.MachineSet{&newMSHigherName},
 		},
 		{
 			Name:            "Get empty old MachineSets",
 			deployment:      deployment,
 			msList:          []*clusterv1.MachineSet{&newMS},
 			expected:        []*clusterv1.MachineSet{},
-			expectedRequire: nil,
-		},
-		{
-			Name:            "Get old MachineSets after label changed in MachineDeployments",
-			deployment:      deployment,
-			msList:          []*clusterv1.MachineSet{&newMS, &oldMSwithOldLabel},
-			expected:        []*clusterv1.MachineSet{&oldMSwithOldLabel},
 			expectedRequire: nil,
 		},
 	}
@@ -562,7 +586,7 @@ func TestNewMSNewReplicas(t *testing.T) {
 				}(test.maxSurge),
 			}
 			*(newRC.Spec.Replicas) = test.newMSReplicas
-			ms, err := NewMSNewReplicas(&newDeployment, []*clusterv1.MachineSet{&rs5}, &newRC)
+			ms, err := NewMSNewReplicas(&newDeployment, []*clusterv1.MachineSet{&rs5}, *newRC.Spec.Replicas)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(ms).To(Equal(test.expected))
 		})
@@ -716,24 +740,10 @@ func TestMaxUnavailable(t *testing.T) {
 func TestAnnotationUtils(t *testing.T) {
 	// Setup
 	tDeployment := generateDeployment("nginx")
+	tDeployment.Spec.Replicas = pointer.Int32(1)
 	tMS := generateMS(tDeployment)
-	tDeployment.Annotations[clusterv1.RevisionAnnotation] = "999"
-	logger := klogr.New()
 
-	// Test Case 1: Check if anotations are copied properly from deployment to MS
-	t.Run("SetNewMachineSetAnnotations", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// Try to set the increment revision from 1 through 20
-		for i := 0; i < 20; i++ {
-			nextRevision := fmt.Sprintf("%d", i+1)
-			SetNewMachineSetAnnotations(&tDeployment, &tMS, nextRevision, true, logger)
-			// Now the MachineSets Revision Annotation should be i+1
-			g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.RevisionAnnotation, nextRevision))
-		}
-	})
-
-	// Test Case 2:  Check if annotations are set properly
+	// Test Case 1:  Check if annotations are set properly
 	t.Run("SetReplicasAnnotations", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -742,7 +752,7 @@ func TestAnnotationUtils(t *testing.T) {
 		g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.MaxReplicasAnnotation, "11"))
 	})
 
-	// Test Case 3:  Check if annotations reflect deployments state
+	// Test Case 2:  Check if annotations reflect deployments state
 	tMS.Annotations[clusterv1.DesiredReplicasAnnotation] = "1"
 	tMS.Status.AvailableReplicas = 1
 	tMS.Spec.Replicas = new(int32)
@@ -753,6 +763,151 @@ func TestAnnotationUtils(t *testing.T) {
 
 		g.Expect(IsSaturated(&tDeployment, &tMS)).To(BeTrue())
 	})
+}
+
+func TestComputeMachineSetAnnotations(t *testing.T) {
+	deployment := generateDeployment("nginx")
+	deployment.Spec.Replicas = pointer.Int32(3)
+	maxSurge := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(0)
+	deployment.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{
+		Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+		RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+			MaxSurge:       &maxSurge,
+			MaxUnavailable: &maxUnavailable,
+		},
+	}
+	deployment.Annotations = map[string]string{
+		corev1.LastAppliedConfigAnnotation: "last-applied-configuration",
+		"key1":                             "value1",
+	}
+
+	tests := []struct {
+		name       string
+		deployment *clusterv1.MachineDeployment
+		oldMSs     []*clusterv1.MachineSet
+		ms         *clusterv1.MachineSet
+		want       map[string]string
+		wantErr    bool
+	}{
+		{
+			name:       "Calculating annotations for a new MachineSet",
+			deployment: &deployment,
+			oldMSs:     nil,
+			ms:         nil,
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "1",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Calculating annotations for a new MachineSet - old MSs exist",
+			deployment: &deployment,
+			oldMSs:     []*clusterv1.MachineSet{machineSetWithRevisionAndHistory("1", "")},
+			ms:         nil,
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "2",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Calculating annotations for a existing MachineSet",
+			deployment: &deployment,
+			oldMSs:     nil,
+			ms:         machineSetWithRevisionAndHistory("1", ""),
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "1",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Calculating annotations for a existing MachineSet - old MSs exist",
+			deployment: &deployment,
+			oldMSs: []*clusterv1.MachineSet{
+				machineSetWithRevisionAndHistory("1", ""),
+				machineSetWithRevisionAndHistory("2", ""),
+			},
+			ms: machineSetWithRevisionAndHistory("1", ""),
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "3",
+				clusterv1.RevisionHistoryAnnotation: "1",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Calculating annotations for a existing MachineSet - old MSs exist - existing revision is greater",
+			deployment: &deployment,
+			oldMSs: []*clusterv1.MachineSet{
+				machineSetWithRevisionAndHistory("1", ""),
+				machineSetWithRevisionAndHistory("2", ""),
+			},
+			ms: machineSetWithRevisionAndHistory("4", ""),
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "4",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Calculating annotations for a existing MachineSet - old MSs exist - ms already has revision history",
+			deployment: &deployment,
+			oldMSs: []*clusterv1.MachineSet{
+				machineSetWithRevisionAndHistory("3", ""),
+				machineSetWithRevisionAndHistory("4", ""),
+			},
+			ms: machineSetWithRevisionAndHistory("2", "1"),
+			want: map[string]string{
+				"key1":                              "value1",
+				clusterv1.RevisionAnnotation:        "5",
+				clusterv1.RevisionHistoryAnnotation: "1,2",
+				clusterv1.DesiredReplicasAnnotation: "3",
+				clusterv1.MaxReplicasAnnotation:     "4",
+			},
+			wantErr: false,
+		},
+	}
+
+	log := klogr.New()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := ComputeMachineSetAnnotations(log, tt.deployment, tt.oldMSs, tt.ms)
+			if tt.wantErr {
+				g.Expect(err).ShouldNot(BeNil())
+			} else {
+				g.Expect(err).Should(BeNil())
+				g.Expect(got).Should(Equal(tt.want))
+			}
+		})
+	}
+}
+
+func machineSetWithRevisionAndHistory(revision string, revisionHistory string) *clusterv1.MachineSet {
+	ms := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				clusterv1.RevisionAnnotation: revision,
+			},
+		},
+	}
+	if revisionHistory != "" {
+		ms.Annotations[clusterv1.RevisionHistoryAnnotation] = revisionHistory
+	}
+	return ms
 }
 
 func TestReplicasAnnotationsNeedUpdate(t *testing.T) {

--- a/internal/util/ssa/managedfields.go
+++ b/internal/util/ssa/managedfields.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to Server-Side-Apply.
+package ssa
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// CleanUpManagedFieldsForSSAAdoption deletes the managedFields entries on the object that belong to "manager" (Operation=Update)
+// if there is no field yet that is managed by `ssaManager`.
+// It adds an "empty" entry in managedFields of the object if no field is currently managed by `ssaManager`.
+//
+// In previous versions of Cluster API (< v1.4.0) we were writing objects with Create and Patch which resulted in fields
+// being owned by the "manager". After switching to Server-Side-Apply (SSA), fields will be owned by `ssaManager`.
+//
+// If we want to be able to drop fields that were previously owned by the "manager" we have to ensure that
+// fields are not co-owned by "manager" and `ssaManager`. Otherwise, when we drop the fields with SSA
+// (i.e. `ssaManager`) the fields would remain as they are still owned by "manager".
+// The following code will do a one-time update on the managed fields to drop all entries for "manager".
+// We won't do this on subsequent reconciles. This case will be identified by checking if `ssaManager` owns any fields.
+// Dropping all existing "manager" entries (which could also be from other controllers) is safe, as we assume that if
+// other controllers are still writing fields on the object they will just do it again and thus gain ownership again.
+func CleanUpManagedFieldsForSSAAdoption(ctx context.Context, obj client.Object, ssaManager string, c client.Client) error {
+	// Return if `ssaManager` already owns any fields.
+	if hasFieldsManagedBy(obj, ssaManager) {
+		return nil
+	}
+
+	// Since there is no field managed by `ssaManager` it means that
+	// this is the first time this object is being processed after the controller calling this function
+	// started to use SSA patches.
+	// It is required to clean-up managedFields from entries created by the regular patches.
+	// This will ensure that `ssaManager` will be able to modify the fields that
+	// were originally owned by "manager".
+	base := obj.DeepCopyObject().(client.Object)
+
+	// Remove managedFieldEntry for manager=manager and operation=update to prevent having two managers holding values.
+	originalManagedFields := obj.GetManagedFields()
+	managedFields := make([]metav1.ManagedFieldsEntry, 0, len(originalManagedFields))
+	for i := range originalManagedFields {
+		if originalManagedFields[i].Manager == "manager" &&
+			originalManagedFields[i].Operation == metav1.ManagedFieldsOperationUpdate {
+			continue
+		}
+		managedFields = append(managedFields, originalManagedFields[i])
+	}
+
+	// Add a seeding managedFieldEntry for SSA executed by the management controller, to prevent SSA to create/infer
+	// a default managedFieldEntry when the first SSA is applied.
+	// More specifically, if an existing object doesn't have managedFields when applying the first SSA the API server
+	// creates an entry with operation=Update (kind of guessing where the object comes from), but this entry ends up
+	// acting as a co-ownership and we want to prevent this.
+	// NOTE: fieldV1Map cannot be empty, so we add metadata.name which will be cleaned up at the first SSA patch.
+	fieldV1Map := map[string]interface{}{
+		"f:metadata": map[string]interface{}{
+			"f:name": map[string]interface{}{},
+		},
+	}
+	fieldV1, err := json.Marshal(fieldV1Map)
+	if err != nil {
+		return errors.Wrap(err, "failed to create seeding fieldV1Map for cleaning up legacy managed fields")
+	}
+	now := metav1.Now()
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return errors.Wrapf(err, "failed to get GroupVersionKind of object %s", klog.KObj(obj))
+	}
+	managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+		Manager:    ssaManager,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		APIVersion: gvk.GroupVersion().String(),
+		Time:       &now,
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+	})
+
+	obj.SetManagedFields(managedFields)
+
+	return c.Patch(ctx, obj, client.MergeFrom(base))
+}
+
+// hasFieldsManagedBy returns true if any of the fields in obj are managed by manager.
+func hasFieldsManagedBy(obj client.Object, manager string) bool {
+	managedFields := obj.GetManagedFields()
+	for _, mf := range managedFields {
+		if mf.Manager == manager {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/ssa/managedfields_test.go
+++ b/internal/util/ssa/managedfields_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to ssa.
+package ssa
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCleanUpManagedFieldsForSSAAdoption(t *testing.T) {
+	ctx := context.Background()
+
+	ssaManager := "ssa-manager"
+	classicManager := "manager"
+
+	objWithoutAnyManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlyClassicManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   classicManager,
+				Operation: metav1.ManagedFieldsOperationUpdate,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlySSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   ssaManager,
+				Operation: metav1.ManagedFieldsOperationApply,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithClassicManagerAndSSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   classicManager,
+					Operation: metav1.ManagedFieldsOperationUpdate,
+				},
+				{
+					Manager:   ssaManager,
+					Operation: metav1.ManagedFieldsOperationApply,
+				},
+			},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+
+	tests := []struct {
+		name                       string
+		obj                        client.Object
+		wantEntryForClassicManager bool
+	}{
+		{
+			name:                       "should add an entry for ssaManager if it does not have one",
+			obj:                        objWithoutAnyManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should add an entry for ssaManager and drop entry for classic manager if it exists",
+			obj:                        objWithOnlyClassicManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry for ssa-manager if it already has one (no-op)",
+			obj:                        objWithOnlySSAManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry with ssa-manager if it already has one - should not drop other manager entries (no-op)",
+			obj:                        objWithClassicManagerAndSSAManager,
+			wantEntryForClassicManager: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
+			g.Expect(CleanUpManagedFieldsForSSAAdoption(ctx, tt.obj, ssaManager, fakeClient)).Should(Succeed())
+			g.Expect(tt.obj.GetManagedFields()).Should(
+				ContainElement(MatchManagedFieldsEntry(ssaManager, metav1.ManagedFieldsOperationApply)))
+			if tt.wantEntryForClassicManager {
+				g.Expect(tt.obj.GetManagedFields()).Should(
+					ContainElement(MatchManagedFieldsEntry(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			} else {
+				g.Expect(tt.obj.GetManagedFields()).ShouldNot(
+					ContainElement(MatchManagedFieldsEntry(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			}
+		})
+	}
+}

--- a/internal/util/ssa/matchers.go
+++ b/internal/util/ssa/matchers.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MatchManagedFieldsEntry is a gomega Matcher to check if a ManagedFieldsEntry has the given name and operation.
+func MatchManagedFieldsEntry(manager string, operation metav1.ManagedFieldsOperationType) types.GomegaMatcher {
+	return &managedFieldMatcher{
+		manager:   manager,
+		operation: operation,
+	}
+}
+
+type managedFieldMatcher struct {
+	manager   string
+	operation metav1.ManagedFieldsOperationType
+}
+
+func (mf *managedFieldMatcher) Match(actual interface{}) (bool, error) {
+	managedFieldsEntry, ok := actual.(metav1.ManagedFieldsEntry)
+	if !ok {
+		return false, fmt.Errorf("expecting metav1.ManagedFieldsEntry got %T", actual)
+	}
+
+	return managedFieldsEntry.Manager == mf.manager && managedFieldsEntry.Operation == mf.operation, nil
+}
+
+func (mf *managedFieldMatcher) FailureMessage(actual interface{}) string {
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldsEntry to match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
+}
+
+func (mf *managedFieldMatcher) NegatedFailureMessage(actual interface{}) string {
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldsEntry to not match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR implements the in-place propagation behavior for MachineDeployments.
The PR contains the following features:
- Changes to in-place propagation fields in MachineDeployment will not trigger a MachineSet rollout
- Changes to in-place propagation fields in MachineDeployment are synced to the target MachineSet
   - Example: A user can change`md.spec.template.metadata.labels` without triggering a rollout and the changes will be passed down to the target MachineSet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of https://github.com/kubernetes-sigs/cluster-api/issues/7731
