### PR TITLE
⚠️ in-place propagation from MS to Machines

### DIFF
--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,8 +34,10 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 )
 
 var _ reconcile.Reconciler = &Reconciler{}
@@ -71,6 +74,8 @@ func TestMachineSetReconciler(t *testing.T) {
 		namespace, testCluster := setup(t, g)
 		defer teardown(t, g, namespace, testCluster)
 
+		duration10m := &metav1.Duration{Duration: 10 * time.Minute}
+		duration5m := &metav1.Duration{Duration: 5 * time.Minute}
 		replicas := int32(2)
 		version := "v1.14.2"
 		instance := &clusterv1.MachineSet{
@@ -114,6 +119,9 @@ func TestMachineSetReconciler(t *testing.T) {
 							Kind:       "GenericInfrastructureMachineTemplate",
 							Name:       "ms-template",
 						},
+						NodeDrainTimeout:        duration10m,
+						NodeDeletionTimeout:     duration10m,
+						NodeVolumeDetachTimeout: duration10m,
 					},
 				},
 			},
@@ -285,6 +293,30 @@ func TestMachineSetReconciler(t *testing.T) {
 			fakeBootstrapRefReady(*m.Spec.Bootstrap.ConfigRef, bootstrapResource, g)
 			fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource, g)
 		}
+
+		// Verify that in-place mutable fields propagate form MachineSet to Machines.
+		t.Log("Updating NodeDrainTimeout on MachineSet")
+		patchHelper, err := patch.NewHelper(instance, env)
+		g.Expect(err).Should(BeNil())
+		instance.Spec.Template.Spec.NodeDrainTimeout = duration5m
+		g.Expect(patchHelper.Patch(ctx, instance)).Should(Succeed())
+
+		t.Log("Verifying new NodeDrainTimeout value is set on Machines")
+		g.Eventually(func() bool {
+			if err := env.List(ctx, machines, client.InNamespace(namespace.Name)); err != nil {
+				return false
+			}
+			// All the machines should have the new NodeDrainTimeoutValue
+			for _, m := range machines.Items {
+				if m.Spec.NodeDrainTimeout == nil {
+					return false
+				}
+				if m.Spec.NodeDrainTimeout.Duration != duration5m.Duration {
+					return false
+				}
+			}
+			return true
+		}, timeout).Should(BeTrue(), "machine should have the updated NodeDrainTimeout value")
 
 		// Try to delete 1 machine and check the MachineSet scales back up.
 		machineToBeDeleted := machines.Items[0]
@@ -918,4 +950,363 @@ func TestMachineSetReconciler_updateStatusResizedCondition(t *testing.T) {
 			g.Expect(gotCond.Message).To(Equal(tc.expectedMessage))
 		})
 	}
+}
+
+func TestMachineSetReconciler_syncMachines(t *testing.T) {
+	setup := func(t *testing.T, g *WithT) (*corev1.Namespace, *clusterv1.Cluster) {
+		t.Helper()
+
+		t.Log("Creating the namespace")
+		ns, err := env.CreateNamespace(ctx, "test-machine-set-reconciler-sync-machines")
+		g.Expect(err).To(BeNil())
+
+		t.Log("Creating the Cluster")
+		cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: ns.Name, Name: testClusterName}}
+		g.Expect(env.Create(ctx, cluster)).To(Succeed())
+
+		t.Log("Creating the Cluster Kubeconfig Secret")
+		g.Expect(env.CreateKubeconfigSecret(ctx, cluster)).To(Succeed())
+
+		return ns, cluster
+	}
+
+	teardown := func(t *testing.T, g *WithT, ns *corev1.Namespace, cluster *clusterv1.Cluster) {
+		t.Helper()
+
+		t.Log("Deleting the Cluster")
+		g.Expect(env.Delete(ctx, cluster)).To(Succeed())
+		t.Log("Deleting the namespace")
+		g.Expect(env.Delete(ctx, ns)).To(Succeed())
+	}
+
+	g := NewWithT(t)
+	namespace, testCluster := setup(t, g)
+	defer teardown(t, g, namespace, testCluster)
+
+	replicas := int32(2)
+	version := "v1.25.3"
+	duration10s := &metav1.Duration{Duration: 10 * time.Second}
+	ms := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "abc-123-ms-uid",
+			Name:      "ms-1",
+			Namespace: namespace.Name,
+			Labels: map[string]string{
+				"label-1": "true",
+			},
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName: testCluster.Name,
+			Replicas:    &replicas,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"machine-set-matching-label": "true",
+				},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{
+						"machine-set-matching-label": "true",
+					},
+					Annotations: map[string]string{
+						"annotation-1": "true",
+						"precedence":   "MachineSet",
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: testCluster.Name,
+					Version:     &version,
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+							Kind:       "GenericBootstrapConfigTemplate",
+							Name:       "ms-template",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+						Kind:       "GenericInfrastructureMachineTemplate",
+						Name:       "ms-template",
+					},
+					NodeDrainTimeout:        duration10s,
+					NodeDeletionTimeout:     duration10s,
+					NodeVolumeDetachTimeout: duration10s,
+				},
+			},
+		},
+	}
+
+	inPlaceMutatingMachine := &clusterv1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Machine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "abc-123-uid",
+			Name:      "in-place-mutating-machine",
+			Namespace: namespace.Name,
+			Labels:    map[string]string{},
+			Annotations: map[string]string{
+				// This will be overwritten with the annotation from the MachineSet
+				"precedence": "Machine",
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: testClusterName,
+			InfrastructureRef: corev1.ObjectReference{
+				Namespace: namespace.Name,
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.String("machine-bootstrap-secret"),
+			},
+		},
+	}
+	g.Expect(env.Create(ctx, inPlaceMutatingMachine, client.FieldOwner("manager"))).To(Succeed())
+
+	deletingMachine := &clusterv1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Machine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			UID:         "abc-123-uid",
+			Name:        "deleting-machine",
+			Namespace:   namespace.Name,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+			Finalizers:  []string{"testing-finalizer"},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: testClusterName,
+			InfrastructureRef: corev1.ObjectReference{
+				Namespace: namespace.Name,
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.String("machine-bootstrap-secret"),
+			},
+		},
+	}
+	g.Expect(env.Create(ctx, deletingMachine, client.FieldOwner("manager"))).To(Succeed())
+	// Delete the machine to put it in the deleting state
+	g.Expect(env.Delete(ctx, deletingMachine)).To(Succeed())
+	// Wait till the machine is marked for deletion
+	g.Eventually(func() bool {
+		if err := env.Get(ctx, client.ObjectKeyFromObject(deletingMachine), deletingMachine); err != nil {
+			return false
+		}
+		return !deletingMachine.DeletionTimestamp.IsZero()
+	}, timeout).Should(BeTrue())
+
+	machines := []*clusterv1.Machine{inPlaceMutatingMachine, deletingMachine}
+
+	// Sync the Machines.
+	reconciler := &Reconciler{Client: env}
+	g.Expect(reconciler.syncMachines(ctx, ms, machines)).To(Succeed())
+
+	// The in-place mutating machine should have:
+	// - clean-up managed fields
+	// - updated in-place propagating values
+	updatedInPlaceMutatingMachine := inPlaceMutatingMachine.DeepCopy()
+	g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(updatedInPlaceMutatingMachine), updatedInPlaceMutatingMachine))
+
+	// Verify ManagedFields
+	g.Expect(updatedInPlaceMutatingMachine.ManagedFields).Should(
+		ContainElement(ssa.MatchManagedFieldsEntry(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
+		"in-place mutable machine should contain an entry for SSA manager",
+	)
+	g.Expect(updatedInPlaceMutatingMachine.ManagedFields).ShouldNot(
+		ContainElement(ssa.MatchManagedFieldsEntry("manager", metav1.ManagedFieldsOperationUpdate)),
+		"in-place mutable machine should not contain an entry for old manager",
+	)
+
+	// Verify in-place mutable fields have been updated.
+	// Verify Labels
+	g.Expect(updatedInPlaceMutatingMachine.Labels).Should(HaveKeyWithValue("machine-set-matching-label", "true"))
+	// Verify Annotations
+	g.Expect(updatedInPlaceMutatingMachine.Annotations).Should(HaveKeyWithValue("annotation-1", "true"))
+	g.Expect(updatedInPlaceMutatingMachine.Annotations).Should(HaveKeyWithValue("precedence", "MachineSet"))
+	// Verify Node timeout values
+	g.Expect(updatedInPlaceMutatingMachine.Spec.NodeDrainTimeout).Should(And(
+		Not(BeNil()),
+		HaveValue(Equal(*ms.Spec.Template.Spec.NodeDrainTimeout)),
+	))
+	g.Expect(updatedInPlaceMutatingMachine.Spec.NodeDeletionTimeout).Should(And(
+		Not(BeNil()),
+		HaveValue(Equal(*ms.Spec.Template.Spec.NodeDeletionTimeout)),
+	))
+	g.Expect(updatedInPlaceMutatingMachine.Spec.NodeVolumeDetachTimeout).Should(And(
+		Not(BeNil()),
+		HaveValue(Equal(*ms.Spec.Template.Spec.NodeDrainTimeout)),
+	))
+
+	// Wait to ensure Machine is not updated.
+	// Verify that the machine stays the same consistently.
+	g.Consistently(func(g Gomega) {
+		// The deleting machine should not change.
+		updatedDeletingMachine := deletingMachine.DeepCopy()
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(updatedDeletingMachine), updatedDeletingMachine))
+
+		// Verify ManagedFields
+		g.Expect(updatedDeletingMachine.ManagedFields).ShouldNot(
+			ContainElement(ssa.MatchManagedFieldsEntry(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
+			"deleting machine should not contain an entry for SSA manager",
+		)
+		g.Expect(updatedDeletingMachine.ManagedFields).Should(
+			ContainElement(ssa.MatchManagedFieldsEntry("manager", metav1.ManagedFieldsOperationUpdate)),
+			"in-place mutable machine should still contain an entry for old manager",
+		)
+
+		// Verify in-place mutable fields are still the same.
+		g.Expect(updatedDeletingMachine.Labels).Should(Equal(deletingMachine.Labels))
+		g.Expect(updatedDeletingMachine.Annotations).Should(Equal(deletingMachine.Annotations))
+		g.Expect(updatedDeletingMachine.Spec.NodeDrainTimeout).Should(Equal(deletingMachine.Spec.NodeDrainTimeout))
+		g.Expect(updatedDeletingMachine.Spec.NodeDeletionTimeout).Should(Equal(deletingMachine.Spec.NodeDeletionTimeout))
+		g.Expect(updatedDeletingMachine.Spec.NodeVolumeDetachTimeout).Should(Equal(deletingMachine.Spec.NodeVolumeDetachTimeout))
+	}, 5*time.Second).Should(Succeed())
+}
+
+func TestComputeDesiredMachine(t *testing.T) {
+	duration5s := &metav1.Duration{Duration: 5 * time.Second}
+	duration10s := &metav1.Duration{Duration: 10 * time.Second}
+
+	infraRef := corev1.ObjectReference{
+		Kind:       "GenericInfrastructureMachineTemplate",
+		Name:       "infra-template-1",
+		APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+	}
+	bootstrapRef := corev1.ObjectReference{
+		Kind:       "GenericBootstrapConfigTemplate",
+		Name:       "bootstrap-template-1",
+		APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+	}
+
+	ms := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "ms1",
+			Labels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: "md1",
+			},
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName:     "test-cluster",
+			Replicas:        pointer.Int32(3),
+			MinReadySeconds: 10,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"k1": "v1"},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels:      map[string]string{"machine-label1": "machine-value1"},
+					Annotations: map[string]string{"machine-annotation1": "machine-value1"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Version:           pointer.String("v1.25.3"),
+					InfrastructureRef: infraRef,
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &bootstrapRef,
+					},
+					NodeDrainTimeout:        duration10s,
+					NodeVolumeDetachTimeout: duration10s,
+					NodeDeletionTimeout:     duration10s,
+				},
+			},
+		},
+	}
+
+	skeletonMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Labels: map[string]string{
+				"machine-label1":                     "machine-value1",
+				clusterv1.MachineSetNameLabel:        "ms1",
+				clusterv1.MachineDeploymentNameLabel: "md1",
+			},
+			Annotations: map[string]string{"machine-annotation1": "machine-value1"},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName:             "test-cluster",
+			Version:                 pointer.String("v1.25.3"),
+			NodeDrainTimeout:        duration10s,
+			NodeVolumeDetachTimeout: duration10s,
+			NodeDeletionTimeout:     duration10s,
+		},
+	}
+
+	// Creating a new Machine
+	expectedNewMachine := skeletonMachine.DeepCopy()
+
+	// Updating an existing Machine
+	existingMachine := skeletonMachine.DeepCopy()
+	existingMachine.Name = "exiting-machine-1"
+	existingMachine.UID = "abc-123-existing-machine-1"
+	existingMachine.Labels = nil
+	existingMachine.Annotations = nil
+	existingMachine.Spec.InfrastructureRef = corev1.ObjectReference{
+		Kind:       "GenericInfrastructureMachine",
+		Name:       "infra-machine-1",
+		APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+	}
+	existingMachine.Spec.Bootstrap.ConfigRef = &corev1.ObjectReference{
+		Kind:       "GenericBootstrapConfig",
+		Name:       "bootstrap-config-1",
+		APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+	}
+	existingMachine.Spec.NodeDrainTimeout = duration5s
+	existingMachine.Spec.NodeDeletionTimeout = duration5s
+	existingMachine.Spec.NodeVolumeDetachTimeout = duration5s
+
+	expectedUpdatedMachine := skeletonMachine.DeepCopy()
+	expectedUpdatedMachine.Name = existingMachine.Name
+	expectedUpdatedMachine.UID = existingMachine.UID
+	expectedUpdatedMachine.Spec.InfrastructureRef = *existingMachine.Spec.InfrastructureRef.DeepCopy()
+	expectedUpdatedMachine.Spec.Bootstrap.ConfigRef = existingMachine.Spec.Bootstrap.ConfigRef.DeepCopy()
+
+	tests := []struct {
+		name            string
+		existingMachine *clusterv1.Machine
+		want            *clusterv1.Machine
+	}{
+		{
+			name:            "creating a new Machine",
+			existingMachine: nil,
+			want:            expectedNewMachine,
+		},
+		{
+			name:            "updating an existing Machine",
+			existingMachine: existingMachine,
+			want:            expectedUpdatedMachine,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := (&Reconciler{}).computeDesiredMachine(ms, tt.existingMachine)
+			assertMachine(g, got, tt.want)
+		})
+	}
+}
+
+func assertMachine(g *WithT, actualMachine *clusterv1.Machine, expectedMachine *clusterv1.Machine) {
+	// Check Name
+	if expectedMachine.Name != "" {
+		g.Expect(actualMachine.Name).Should(Equal(expectedMachine.Name))
+	}
+	// Check UID
+	if expectedMachine.UID != "" {
+		g.Expect(actualMachine.UID).Should(Equal(expectedMachine.UID))
+	}
+	// Check Namespace
+	g.Expect(actualMachine.Namespace).Should(Equal(expectedMachine.Namespace))
+	// Check Labels
+	for k, v := range expectedMachine.Labels {
+		g.Expect(actualMachine.Labels).Should(HaveKeyWithValue(k, v))
+	}
+	// Check Annotations
+	for k, v := range expectedMachine.Annotations {
+		g.Expect(actualMachine.Annotations).Should(HaveKeyWithValue(k, v))
+	}
+	// Check Spec
+	g.Expect(actualMachine.Spec).Should(Equal(expectedMachine.Spec))
 }

--- a/internal/util/ssa/managedfields.go
+++ b/internal/util/ssa/managedfields.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to Server-Side-Apply.
+package ssa
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// CleanUpManagedFieldsForSSAAdoption deletes the managedFields entries on the object that belong to "manager" (Operation=Update)
+// if there is no field yet that is managed by `ssaManager`.
+// It adds an "empty" entry in managedFields of the object if no field is currently managed by `ssaManager`.
+//
+// In previous versions of Cluster API (< v1.4.0) we were writing objects with Create and Patch which resulted in fields
+// being owned by the "manager". After switching to Server-Side-Apply (SSA), fields will be owned by `ssaManager`.
+//
+// If we want to be able to drop fields that were previously owned by the "manager" we have to ensure that
+// fields are not co-owned by "manager" and `ssaManager`. Otherwise, when we drop the fields with SSA
+// (i.e. `ssaManager`) the fields would remain as they are still owned by "manager".
+// The following code will do a one-time update on the managed fields to drop all entries for "manager".
+// We won't do this on subsequent reconciles. This case will be identified by checking if `ssaManager` owns any fields.
+// Dropping all existing "manager" entries (which could also be from other controllers) is safe, as we assume that if
+// other controllers are still writing fields on the object they will just do it again and thus gain ownership again.
+func CleanUpManagedFieldsForSSAAdoption(ctx context.Context, obj client.Object, ssaManager string, c client.Client) error {
+	// Return if `ssaManager` already owns any fields.
+	if hasFieldsManagedBy(obj, ssaManager) {
+		return nil
+	}
+
+	// Since there is no field managed by `ssaManager` it means that
+	// this is the first time this object is being processed after the controller calling this function
+	// started to use SSA patches.
+	// It is required to clean-up managedFields from entries created by the regular patches.
+	// This will ensure that `ssaManager` will be able to modify the fields that
+	// were originally owned by "manager".
+	base := obj.DeepCopyObject().(client.Object)
+
+	// Remove managedFieldEntry for manager=manager and operation=update to prevent having two managers holding values.
+	originalManagedFields := obj.GetManagedFields()
+	managedFields := make([]metav1.ManagedFieldsEntry, 0, len(originalManagedFields))
+	for i := range originalManagedFields {
+		if originalManagedFields[i].Manager == "manager" &&
+			originalManagedFields[i].Operation == metav1.ManagedFieldsOperationUpdate {
+			continue
+		}
+		managedFields = append(managedFields, originalManagedFields[i])
+	}
+
+	// Add a seeding managedFieldEntry for SSA executed by the management controller, to prevent SSA to create/infer
+	// a default managedFieldEntry when the first SSA is applied.
+	// More specifically, if an existing object doesn't have managedFields when applying the first SSA the API server
+	// creates an entry with operation=Update (kind of guessing where the object comes from), but this entry ends up
+	// acting as a co-ownership and we want to prevent this.
+	// NOTE: fieldV1Map cannot be empty, so we add metadata.name which will be cleaned up at the first SSA patch.
+	fieldV1Map := map[string]interface{}{
+		"f:metadata": map[string]interface{}{
+			"f:name": map[string]interface{}{},
+		},
+	}
+	fieldV1, err := json.Marshal(fieldV1Map)
+	if err != nil {
+		return errors.Wrap(err, "failed to create seeding fieldV1Map for cleaning up legacy managed fields")
+	}
+	now := metav1.Now()
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return errors.Wrapf(err, "failed to get GroupVersionKind of object %s", klog.KObj(obj))
+	}
+	managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+		Manager:    ssaManager,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		APIVersion: gvk.GroupVersion().String(),
+		Time:       &now,
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+	})
+
+	obj.SetManagedFields(managedFields)
+
+	return c.Patch(ctx, obj, client.MergeFrom(base))
+}
+
+// hasFieldsManagedBy returns true if any of the fields in obj are managed by manager.
+func hasFieldsManagedBy(obj client.Object, manager string) bool {
+	managedFields := obj.GetManagedFields()
+	for _, mf := range managedFields {
+		if mf.Manager == manager {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/ssa/managedfields_test.go
+++ b/internal/util/ssa/managedfields_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to ssa.
+package ssa
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCleanUpManagedFieldsForSSAAdoption(t *testing.T) {
+	ctx := context.Background()
+
+	ssaManager := "ssa-manager"
+	classicManager := "manager"
+
+	objWithoutAnyManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlyClassicManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   classicManager,
+				Operation: metav1.ManagedFieldsOperationUpdate,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlySSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   ssaManager,
+				Operation: metav1.ManagedFieldsOperationApply,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithClassicManagerAndSSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   classicManager,
+					Operation: metav1.ManagedFieldsOperationUpdate,
+				},
+				{
+					Manager:   ssaManager,
+					Operation: metav1.ManagedFieldsOperationApply,
+				},
+			},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+
+	tests := []struct {
+		name                       string
+		obj                        client.Object
+		wantEntryForClassicManager bool
+	}{
+		{
+			name:                       "should add an entry for ssaManager if it does not have one",
+			obj:                        objWithoutAnyManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should add an entry for ssaManager and drop entry for classic manager if it exists",
+			obj:                        objWithOnlyClassicManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry for ssa-manager if it already has one (no-op)",
+			obj:                        objWithOnlySSAManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry with ssa-manager if it already has one - should not drop other manager entries (no-op)",
+			obj:                        objWithClassicManagerAndSSAManager,
+			wantEntryForClassicManager: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
+			g.Expect(CleanUpManagedFieldsForSSAAdoption(ctx, tt.obj, ssaManager, fakeClient)).Should(Succeed())
+			g.Expect(tt.obj.GetManagedFields()).Should(
+				ContainElement(MatchManagedFieldsEntry(ssaManager, metav1.ManagedFieldsOperationApply)))
+			if tt.wantEntryForClassicManager {
+				g.Expect(tt.obj.GetManagedFields()).Should(
+					ContainElement(MatchManagedFieldsEntry(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			} else {
+				g.Expect(tt.obj.GetManagedFields()).ShouldNot(
+					ContainElement(MatchManagedFieldsEntry(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			}
+		})
+	}
+}

--- a/internal/util/ssa/matchers.go
+++ b/internal/util/ssa/matchers.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MatchManagedFieldsEntry is a gomega Matcher to check if a ManagedFieldsEntry has the given name and operation.
+func MatchManagedFieldsEntry(manager string, operation metav1.ManagedFieldsOperationType) types.GomegaMatcher {
+	return &managedFieldMatcher{
+		manager:   manager,
+		operation: operation,
+	}
+}
+
+type managedFieldMatcher struct {
+	manager   string
+	operation metav1.ManagedFieldsOperationType
+}
+
+func (mf *managedFieldMatcher) Match(actual interface{}) (bool, error) {
+	managedFieldsEntry, ok := actual.(metav1.ManagedFieldsEntry)
+	if !ok {
+		return false, fmt.Errorf("expecting metav1.ManagedFieldsEntry got %T", actual)
+	}
+
+	return managedFieldsEntry.Manager == mf.manager && managedFieldsEntry.Operation == mf.operation, nil
+}
+
+func (mf *managedFieldMatcher) FailureMessage(actual interface{}) string {
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldsEntry to match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
+}
+
+func (mf *managedFieldMatcher) NegatedFailureMessage(actual interface{}) string {
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldsEntry to not match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR implements the in-place propagation behavior for MachineSets. Changes to in-place propagation fields in MachineSet are synced to the target Machines.

**Follow-up work:**
- https://github.com/kubernetes-sigs/cluster-api/pull/8060)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of https://github.com/kubernetes-sigs/cluster-api/issues/7731
