### PR TITLE
🌱 [WIP] [DNR] Reproduce clusterctl upgrade e2e test flake

### DIFF
--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -17,26 +17,51 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 func (r *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
+		WithDefaulter(&KubeadmConfigTemplateWebhook{}).
 		Complete()
 }
 
+// KubeadmConfigTemplateWebhook implements a custom defaulting webhook for KubeadmConfigTemplate.
+// +kubebuilder:object:generate=false
+type KubeadmConfigTemplateWebhook struct{}
+
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &KubeadmConfigTemplate{}
+var _ webhook.CustomDefaulter = &KubeadmConfigTemplateWebhook{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (r *KubeadmConfigTemplate) Default() {
-	DefaultKubeadmConfigSpec(&r.Spec.Template.Spec)
+func (k KubeadmConfigTemplateWebhook) Default(ctx context.Context, raw runtime.Object) error {
+	obj, ok := raw.(*KubeadmConfigTemplate)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfigTemplate but got a %T", obj))
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
+	}
+
+	//
+	//if !topology.ShouldSkipDefaulting(req, obj) {
+	if req.UserInfo.Username != "kubernetes-admin" {
+		DefaultKubeadmConfigSpec(&obj.Spec.Template.Spec)
+	}
+
+	return nil
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -55,8 +55,6 @@ func (k KubeadmConfigTemplateWebhook) Default(ctx context.Context, raw runtime.O
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
 	}
 
-	//
-	//if !topology.ShouldSkipDefaulting(req, obj) {
 	if req.UserInfo.Username != "kubernetes-admin" {
 		DefaultKubeadmConfigSpec(&obj.Spec.Template.Spec)
 	}

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -29,6 +29,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -36,6 +37,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	logsjson "k8s.io/component-base/logs/json"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -152,6 +154,21 @@ func main() {
 	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if logOptions.Format == logsv1.JSONLogFormat {
+		log, flush := logsjson.NewJSONLogger(logOptions.Verbosity, zapcore.Lock(logsjson.AddNopSync(os.Stderr)), nil, &zapcore.EncoderConfig{
+			MessageKey: "msg",
+			CallerKey:  "caller",
+			NameKey:    "logger",
+			TimeKey:    "ts",
+			EncodeTime: func(_ time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				enc.AppendString(time.Now().Format("15:04:05.999Z07"))
+			},
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		})
+		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
 	}
 
 	// klog.Background will automatically use the right logger.

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -374,7 +374,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	}
 
 	// Control plane machines rollout due to configuration changes (e.g. upgrades) takes precedence over other operations.
-	needRollout := controlPlane.MachinesNeedingRollout()
+	needRollout := controlPlane.MachinesNeedingRollout(ctx)
 	switch {
 	case len(needRollout) > 0:
 		log.Info("Rolling out Control Plane machines", "needRollout", needRollout.Names())

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -54,7 +54,7 @@ func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Conte
 	}
 
 	bootstrapSpec := controlPlane.InitialControlPlaneConfig()
-	fd := controlPlane.NextFailureDomainForScaleUp()
+	fd := controlPlane.NextFailureDomainForScaleUp(ctx)
 	if err := r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, fd); err != nil {
 		logger.Error(err, "Failed to create initial control plane Machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "FailedInitialization", "Failed to create initial control plane Machine for cluster %s/%s control plane: %v", cluster.Namespace, cluster.Name, err)
@@ -75,7 +75,7 @@ func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context,
 
 	// Create the bootstrap configuration
 	bootstrapSpec := controlPlane.JoinControlPlaneConfig()
-	fd := controlPlane.NextFailureDomainForScaleUp()
+	fd := controlPlane.NextFailureDomainForScaleUp(ctx)
 	if err := r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, fd); err != nil {
 		logger.Error(err, "Failed to create additional control plane Machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "FailedScaleUp", "Failed to create additional control plane Machine for cluster %s/%s control plane: %v", cluster.Namespace, cluster.Name, err)

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -50,7 +50,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 		log.Error(err, "failed to initialize control plane")
 		return err
 	}
-	kcp.Status.UpdatedReplicas = int32(len(controlPlane.UpToDateMachines()))
+	kcp.Status.UpdatedReplicas = int32(len(controlPlane.UpToDateMachines(ctx)))
 
 	replicas := int32(len(ownedMachines))
 	desiredReplicas := *kcp.Spec.Replicas

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -29,6 +29,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -38,6 +39,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	logsjson "k8s.io/component-base/logs/json"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -160,6 +162,21 @@ func main() {
 	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if logOptions.Format == logsv1.JSONLogFormat {
+		log, flush := logsjson.NewJSONLogger(logOptions.Verbosity, zapcore.Lock(logsjson.AddNopSync(os.Stderr)), nil, &zapcore.EncoderConfig{
+			MessageKey: "msg",
+			CallerKey:  "caller",
+			NameKey:    "logger",
+			TimeKey:    "ts",
+			EncodeTime: func(_ time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				enc.AppendString(time.Now().Format("15:04:05.999Z07"))
+			},
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		})
+		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
 	}
 
 	// klog.Background will automatically use the right logger.

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
+	go.uber.org/zap v1.24.0
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,8 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
+require github.com/go-test/deep v1.1.0
+
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/flect v1.0.0 h1:eBFmskjXZgAOagiTXJH25Nt5sdFwNRcb8DKZsIsAUQI=
 github.com/gobuffalo/flect v1.0.0/go.mod h1:l9V6xSb4BlXwsxEMj3FVEub2nkdQjWhPvD8XTTlHPQc=
 github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -91,6 +91,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling")
 
 	clusterClass := &clusterv1.ClusterClass{}
 	if err := r.Client.Get(ctx, req.NamespacedName, clusterClass); err != nil {

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -466,6 +466,11 @@ func DefaultVariables(cluster *clusterv1.Cluster, clusterClass *clusterv1.Cluste
 		clusterClassStatusVariablesToVariables(clusterClass.Status.Variables),
 		field.NewPath("spec", "topology", "variables"))
 	if len(errs) > 0 {
+		ccJSON, err := json.Marshal(clusterClass)
+		if err != nil {
+			fmt.Printf("Debug: unexpected err:\n%v\n", err)
+		}
+		fmt.Printf("Debug:\n%v\n", string(ccJSON))
 		allErrs = append(allErrs, errs...)
 	} else {
 		cluster.Spec.Topology.Variables = defaultedVariables
@@ -510,13 +515,6 @@ func ValidateClusterForClusterClass(cluster *clusterv1.Cluster, clusterClass *cl
 		//TODO: Update this function to directly us ClusterClassStatusVariables to take care of multiple definitions per variable name.
 		clusterClassStatusVariablesToVariables(clusterClass.Status.Variables),
 		fldPath.Child("variables"))...)
-	if true || len(allErrs) > 0 {
-		ccJSON, err := json.Marshal(clusterClass)
-		if err != nil {
-			fmt.Printf("Debug: unexpected err:\n%v\n", err)
-		}
-		fmt.Printf("Debug:\n%v\n", ccJSON)
-	}
 
 	if cluster.Spec.Topology.Workers != nil {
 		for i, md := range cluster.Spec.Topology.Workers.MachineDeployments {

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -18,6 +18,7 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -509,6 +510,13 @@ func ValidateClusterForClusterClass(cluster *clusterv1.Cluster, clusterClass *cl
 		//TODO: Update this function to directly us ClusterClassStatusVariables to take care of multiple definitions per variable name.
 		clusterClassStatusVariablesToVariables(clusterClass.Status.Variables),
 		fldPath.Child("variables"))...)
+	if true || len(allErrs) > 0 {
+		ccJSON, err := json.Marshal(clusterClass)
+		if err != nil {
+			fmt.Printf("Debug: unexpected err:\n%v\n", err)
+		}
+		fmt.Printf("Debug:\n%v\n", ccJSON)
+	}
 
 	if cluster.Spec.Topology.Workers != nil {
 		for i, md := range cluster.Spec.Topology.Workers.MachineDeployments {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +38,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	logsjson "k8s.io/component-base/logs/json"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -215,6 +217,21 @@ func main() {
 	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if logOptions.Format == logsv1.JSONLogFormat {
+		log, flush := logsjson.NewJSONLogger(logOptions.Verbosity, zapcore.Lock(logsjson.AddNopSync(os.Stderr)), nil, &zapcore.EncoderConfig{
+			MessageKey: "msg",
+			CallerKey:  "caller",
+			NameKey:    "logger",
+			TimeKey:    "ts",
+			EncodeTime: func(_ time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				enc.AppendString(time.Now().Format("15:04:05.999Z07"))
+			},
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		})
+		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
 	}
 
 	// klog.Background will automatically use the right logger.

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -466,28 +466,30 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 					newMachines := names(postUpgradeMachineList).Difference(names(preUpgradeMachineList))
 					deletedMachines := names(preUpgradeMachineList).Difference(names(postUpgradeMachineList))
 
-					if len(newMachines) > 0 {
-						log.Logf("Detected new machines")
-						for _, obj := range postUpgradeMachineList.Items {
-							if newMachines.Has(obj.GetName()) {
-								resourceYAML, err := yaml.Marshal(obj)
-								Expect(err).ToNot(HaveOccurred())
-								log.Logf("New machine %s:\n%s", klog.KObj(&obj), resourceYAML)
-							}
-						}
-					}
-
-					if len(deletedMachines) > 0 {
-						log.Logf("Detected deleted machines")
-						for _, obj := range preUpgradeMachineList.Items {
-							if deletedMachines.Has(obj.GetName()) {
-								resourceYAML, err := yaml.Marshal(obj)
-								Expect(err).ToNot(HaveOccurred())
-								log.Logf("Deleted machine %s:\n%s", klog.KObj(&obj), resourceYAML)
-							}
+				if len(newMachines) > 0 {
+					log.Logf("Detected new machines")
+					for _, obj := range postUpgradeMachineList.Items {
+						obj := obj
+						if newMachines.Has(obj.GetName()) {
+							resourceYAML, err := yaml.Marshal(obj)
+							Expect(err).ToNot(HaveOccurred())
+							log.Logf("New machine %s:\n%s", klog.KObj(&obj), resourceYAML)
 						}
 					}
 				}
+
+				if len(deletedMachines) > 0 {
+					log.Logf("Detected deleted machines")
+					for _, obj := range preUpgradeMachineList.Items {
+						obj := obj
+						if deletedMachines.Has(obj.GetName()) {
+							resourceYAML, err := yaml.Marshal(obj)
+							Expect(err).ToNot(HaveOccurred())
+							log.Logf("Deleted machine %s:\n%s", klog.KObj(&obj), resourceYAML)
+						}
+					}
+				}
+			}
 
 				return matchUnstructuredLists(preUpgradeMachineList, postUpgradeMachineList)
 			}, "10m", "30s").Should(BeTrue(), "Machines should remain the same after the upgrade")

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -25,8 +25,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
+// These tests are run in e2e-main to ensure the bugs are fixed
 var _ = Describe("When testing clusterctl upgrades (v0.3=>current) [PR-Blocking]", func() {
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= 5; i++ {
 		Describe(strconv.Itoa(i), func() {
 			ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
 				return ClusterctlUpgradeSpecInput{
@@ -47,6 +48,45 @@ var _ = Describe("When testing clusterctl upgrades (v0.3=>current) [PR-Blocking]
 			})
 		})
 	}
+})
+var _ = Describe("When testing clusterctl upgrades (v1.3=>current) [PR-Blocking]", func() {
+	for i := 1; i <= 5; i++ {
+		Describe(strconv.Itoa(i), func() {
+			ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
+				return ClusterctlUpgradeSpecInput{
+					E2EConfig:                 e2eConfig,
+					ClusterctlConfigPath:      clusterctlConfigPath,
+					BootstrapClusterProxy:     bootstrapClusterProxy,
+					ArtifactFolder:            artifactFolder,
+					SkipCleanup:               skipCleanup,
+					InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
+					InitWithProvidersContract: "v1beta1",
+					InitWithKubernetesVersion: "v1.26.0",
+				}
+			})
+		})
+	}
+})
+
+// Everything else is run in e2e-full-main.
+var _ = Describe("When testing clusterctl upgrades (v0.3=>current)", func() {
+	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
+		return ClusterctlUpgradeSpecInput{
+			E2EConfig:                 e2eConfig,
+			ClusterctlConfigPath:      clusterctlConfigPath,
+			BootstrapClusterProxy:     bootstrapClusterProxy,
+			ArtifactFolder:            artifactFolder,
+			SkipCleanup:               skipCleanup,
+			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}",
+			InitWithProvidersContract: "v1alpha3",
+			// CAPI v0.3.x does not work on Kubernetes >= v1.22.
+			InitWithKubernetesVersion: "v1.21.12",
+			// CAPI does not work with Kubernetes < v1.22 if ClusterClass is enabled, so we have to disable it.
+			UpgradeClusterctlVariables: map[string]string{
+				"CLUSTER_TOPOLOGY": "false",
+			},
+		}
+	})
 })
 
 var _ = Describe("When testing clusterctl upgrades (v0.4=>current)", func() {

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -20,27 +20,33 @@ limitations under the License.
 package e2e
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("When testing clusterctl upgrades (v0.3=>current)", func() {
-	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
-		return ClusterctlUpgradeSpecInput{
-			E2EConfig:                 e2eConfig,
-			ClusterctlConfigPath:      clusterctlConfigPath,
-			BootstrapClusterProxy:     bootstrapClusterProxy,
-			ArtifactFolder:            artifactFolder,
-			SkipCleanup:               skipCleanup,
-			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}",
-			InitWithProvidersContract: "v1alpha3",
-			// CAPI v0.3.x does not work on Kubernetes >= v1.22.
-			InitWithKubernetesVersion: "v1.21.12",
-			// CAPI does not work with Kubernetes < v1.22 if ClusterClass is enabled, so we have to disable it.
-			UpgradeClusterctlVariables: map[string]string{
-				"CLUSTER_TOPOLOGY": "false",
-			},
-		}
-	})
+var _ = Describe("When testing clusterctl upgrades (v0.3=>current) [PR-Blocking]", func() {
+	for i := 1; i <= 10; i++ {
+		Describe(strconv.Itoa(i), func() {
+			ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
+				return ClusterctlUpgradeSpecInput{
+					E2EConfig:                 e2eConfig,
+					ClusterctlConfigPath:      clusterctlConfigPath,
+					BootstrapClusterProxy:     bootstrapClusterProxy,
+					ArtifactFolder:            artifactFolder,
+					SkipCleanup:               skipCleanup,
+					InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}",
+					InitWithProvidersContract: "v1alpha3",
+					// CAPI v0.3.x does not work on Kubernetes >= v1.22.
+					InitWithKubernetesVersion: "v1.21.12",
+					// CAPI does not work with Kubernetes < v1.22 if ClusterClass is enabled, so we have to disable it.
+					UpgradeClusterctlVariables: map[string]string{
+						"CLUSTER_TOPOLOGY": "false",
+					},
+				}
+			})
+		})
+	}
 })
 
 var _ = Describe("When testing clusterctl upgrades (v0.4=>current)", func() {

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-// These tests are run in e2e-main to ensure the bugs are fixed
+// These tests are run in e2e-main to ensure the bugs are fixed.
 var _ = Describe("When testing clusterctl upgrades (v0.3=>current) [PR-Blocking]", func() {
 	for i := 1; i <= 5; i++ {
 		Describe(strconv.Itoa(i), func() {

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
-var _ = Describe("When following the Cluster API quick-start", func() {
+var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
-var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", func() {
+var _ = Describe("When following the Cluster API quick-start", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -28,10 +28,12 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	logsjson "k8s.io/component-base/logs/json"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -116,6 +118,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	if logOptions.Format == logsv1.JSONLogFormat {
+		log, flush := logsjson.NewJSONLogger(logOptions.Verbosity, zapcore.Lock(logsjson.AddNopSync(os.Stderr)), nil, &zapcore.EncoderConfig{
+			MessageKey: "msg",
+			CallerKey:  "caller",
+			NameKey:    "logger",
+			TimeKey:    "ts",
+			EncodeTime: func(_ time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				enc.AppendString(time.Now().Format("15:04:05.999Z07"))
+			},
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		})
+		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
+	}
+	
 	// Add the klog logger in the context.
 	// NOTE: it is not mandatory to use contextual logging in custom RuntimeExtension, but it is recommended
 	// because it allows to use a log stored in the context across the entire chain of calls (without

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -132,7 +132,7 @@ func main() {
 		})
 		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
 	}
-	
+
 	// Add the klog logger in the context.
 	// NOTE: it is not mandatory to use contextual logging in custom RuntimeExtension, but it is recommended
 	// because it allows to use a log stored in the context across the entire chain of calls (without

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -273,6 +274,14 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 
 	log.Logf("Creating the workload cluster with name %q using the %q template (Kubernetes %s, %d control-plane machines, %d worker machines)",
 		input.ConfigCluster.ClusterName, valueOrDefault(input.ConfigCluster.Flavor), input.ConfigCluster.KubernetesVersion, *input.ConfigCluster.ControlPlaneMachineCount, *input.ConfigCluster.WorkerMachineCount)
+
+	// Ensure we have a Cluster for dump and cleanup steps in AfterEach even if ApplyClusterTemplateAndWait fails.
+	result.Cluster = &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      input.ConfigCluster.ClusterName,
+			Namespace: input.ConfigCluster.Namespace,
+		},
+	}
 
 	log.Logf("Getting the cluster template yaml")
 	workloadClusterTemplate := ConfigCluster(ctx, ConfigClusterInput{

--- a/test/go.mod
+++ b/test/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/vincent-petithory/dataurl v1.0.0
+	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.1
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
@@ -106,7 +107,6 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783 // indirect

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -140,7 +140,7 @@ func main() {
 		})
 		klog.SetLoggerWithOptions(log, klog.ContextualLogger(false), klog.FlushLogger(flush))
 	}
-	
+
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 

--- a/util/topology/topology.go
+++ b/util/topology/topology.go
@@ -29,17 +29,6 @@ import (
 // This ensures that the immutability check is skipped only when dry-running and when the operations has been invoked by the topology controller.
 // Instead, kubectl dry-run behavior remains consistent with the one user gets when doing kubectl apply (immutability is enforced).
 func ShouldSkipImmutabilityChecks(req admission.Request, obj metav1.Object) bool {
-	return isDryRun(req, obj)
-
-}
-
-// ShouldSkipDefaulting returns true if it is a dry-run request and the object
-// FIXME(sbueringer): also consider other func name
-func ShouldSkipDefaulting(req admission.Request, obj metav1.Object) bool {
-	return isDryRun(req, obj)
-}
-
-func isDryRun(req admission.Request, obj metav1.Object) bool {
 	// Check if the request is a dry-run
 	if req.DryRun == nil || !*req.DryRun {
 		return false

--- a/util/topology/topology.go
+++ b/util/topology/topology.go
@@ -29,6 +29,17 @@ import (
 // This ensures that the immutability check is skipped only when dry-running and when the operations has been invoked by the topology controller.
 // Instead, kubectl dry-run behavior remains consistent with the one user gets when doing kubectl apply (immutability is enforced).
 func ShouldSkipImmutabilityChecks(req admission.Request, obj metav1.Object) bool {
+	return isDryRun(req, obj)
+
+}
+
+// ShouldSkipDefaulting returns true if it is a dry-run request and the object
+// FIXME(sbueringer): also consider other func name
+func ShouldSkipDefaulting(req admission.Request, obj metav1.Object) bool {
+	return isDryRun(req, obj)
+}
+
+func isDryRun(req admission.Request, obj metav1.Object) bool {
 	// Check if the request is a dry-run
 	if req.DryRun == nil || !*req.DryRun {
 		return false


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently contains:
* Improve KCP logging
* Improve e2e test assertion
* Increase timeout for which Machines have to remain stable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
