### PR TITLE
[WIP] [DNR] 🐛 POC: Migrate MachineSets to new unique label

### DIFF
--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -57,6 +57,13 @@ const (
 	// MachineDeploymentUniqueLabel is the label applied to Machines
 	// in a MachineDeployment containing the hash of the template.
 	MachineDeploymentUniqueLabel = "machine-template-hash"
+
+	// MachineSetUniqueIdentifierLabel is used to uniquely identify the Machines of a MachineSet.
+	// The MachineDeployment controller will set this label on a MachineSet when it is created.
+	// The label is also applied to the Machines of the MachineSet and used in the MachineSet selector.
+	// Note: For the lifetime of the MachineSet the label's value has to stay the same, otherwise the
+	// MachineSet selector would no longer match its Machines.
+	MachineSetUniqueIdentifierLabel = "machine.clusters.x-k8s.io/unique-id"
 )
 
 // ANCHOR: MachineDeploymentSpec

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker.go
@@ -73,7 +73,7 @@ func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployme
 	}
 	// Copy template into the machinedeployment (excluding the hash)
 	revMSTemplate := *msForRevision.Spec.Template.DeepCopy()
-	delete(revMSTemplate.Labels, clusterv1.MachineDeploymentUniqueLabel)
+	delete(revMSTemplate.Labels, clusterv1.MachineSetUniqueIdentifierLabel)
 
 	d.Spec.Template = revMSTemplate
 	return patchHelper.Patch(ctx, d)

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -147,11 +147,11 @@ func (r *Reconciler) getNewMachineSet(ctx context.Context, d *clusterv1.MachineD
 	}
 	machineTemplateSpecHash := fmt.Sprintf("%d", hash)
 	newMSTemplate.Labels = mdutil.CloneAndAddLabel(d.Spec.Template.Labels,
-		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
+		clusterv1.MachineSetUniqueIdentifierLabel, machineTemplateSpecHash)
 
 	// Add machineTemplateHash label to selector.
 	newMSSelector := mdutil.CloneSelectorAndAddLabel(&d.Spec.Selector,
-		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
+		clusterv1.MachineSetUniqueIdentifierLabel, machineTemplateSpecHash)
 
 	minReadySeconds := int32(0)
 	if d.Spec.MinReadySeconds != nil {

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -377,8 +377,8 @@ func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) b
 	// 1. The hash result would be different upon machineTemplateSpec API changes
 	//    (e.g. the addition of a new field will cause the hash code to change)
 	// 2. The deployment template won't have hash labels
-	delete(t1Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
-	delete(t2Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
+	delete(t1Copy.Labels, clusterv1.MachineSetUniqueIdentifierLabel)
+	delete(t2Copy.Labels, clusterv1.MachineSetUniqueIdentifierLabel)
 
 	// Remove the version part from the references APIVersion field,
 	// for more details see issue #2183 and #2140.

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -106,62 +106,62 @@ func TestEqualMachineTemplate(t *testing.T) {
 	}{
 		{
 			Name:     "Same spec, same labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
 			Expected: true,
 		},
 		{
 			Name:     "Same spec, only machine-template-hash label value is different",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2", "something": "else"}),
 			Expected: true,
 		},
 		{
 			Name:     "Same spec, the former doesn't have machine-template-hash label",
 			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2", "something": "else"}),
 			Expected: true,
 		},
 		{
 			Name:     "Same spec, the former doesn't have machine-template-hash label",
 			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2", "something": "else"}),
 			Expected: true,
 		},
 		{
 			Name:     "Same spec, the label is different, the former doesn't have machine-template-hash label, same number of labels",
 			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2"}),
 			Expected: false,
 		},
 		{
 			Name:     "Same spec, the label is different, the latter doesn't have machine-template-hash label, same number of labels",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1"}),
 			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
 			Expected: false,
 		},
 		{
 			Name:     "Same spec, the label is different, and the machine-template-hash label value is the same",
-			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
 			Expected: false,
 		},
 		{
 			Name:     "Different spec, same labels",
-			Former:   generateMachineTemplateSpec(map[string]string{"former": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"latter": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Former:   generateMachineTemplateSpec(map[string]string{"former": "value"}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"latter": "value"}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
 			Expected: false,
 		},
 		{
 			Name:     "Different spec, different machine-template-hash label value",
-			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2", "something": "else"}),
 			Expected: false,
 		},
 		{
 			Name:     "Different spec, the former doesn't have machine-template-hash label",
 			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{"something": "else"}),
-			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineSetUniqueIdentifierLabel: "value-2", "something": "else"}),
 			Expected: false,
 		},
 		{
@@ -273,11 +273,11 @@ func TestFindNewMachineSet(t *testing.T) {
 
 	deployment := generateDeployment("nginx")
 	newMS := generateMS(deployment)
-	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
+	newMS.Labels[clusterv1.MachineSetUniqueIdentifierLabel] = "hash"
 	newMS.CreationTimestamp = later
 
 	newMSDup := generateMS(deployment)
-	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
+	newMSDup.Labels[clusterv1.MachineSetUniqueIdentifierLabel] = "different-hash"
 	newMSDup.CreationTimestamp = now
 
 	oldDeployment := generateDeployment("nginx")
@@ -331,11 +331,11 @@ func TestFindOldMachineSets(t *testing.T) {
 	deployment := generateDeployment("nginx")
 	newMS := generateMS(deployment)
 	*(newMS.Spec.Replicas) = 1
-	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
+	newMS.Labels[clusterv1.MachineSetUniqueIdentifierLabel] = "hash"
 	newMS.CreationTimestamp = later
 
 	newMSDup := generateMS(deployment)
-	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
+	newMSDup.Labels[clusterv1.MachineSetUniqueIdentifierLabel] = "different-hash"
 	newMSDup.CreationTimestamp = now
 
 	oldDeployment := generateDeployment("nginx")


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR is just a prototype to figure out and test if and how we can just migrate existing MachineSets and Machines to a new unique label. The plan is to test it via the clusterctl upgrade tests.

If we want to go down this path, this PR could be merged either before or after the in-place propagation PRs.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
