### PR TITLE
✨ clusterctl: add flag --show-machinehealthchecks to describe cluster

### DIFF
--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -425,7 +425,7 @@ var moveTests = []struct {
 		fields: moveTestsFields{
 			objs: func() []client.Object {
 				objs := test.NewFakeClusterClass("ns1", "class1").Objs()
-				objs = append(objs, test.NewFakeCluster("ns1", "foo").WithTopologyClass("class1").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "foo").WithTopology("class1").Objs()...)
 				return deduplicateObjects(objs)
 			}(),
 		},
@@ -452,8 +452,8 @@ var moveTests = []struct {
 			objs: func() []client.Object {
 				objs := test.NewFakeClusterClass("ns1", "class1").Objs()
 				objs = append(objs, test.NewFakeClusterClass("ns1", "class2").Objs()...)
-				objs = append(objs, test.NewFakeCluster("ns1", "foo1").WithTopologyClass("class1").Objs()...)
-				objs = append(objs, test.NewFakeCluster("ns1", "foo2").WithTopologyClass("class2").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "foo1").WithTopology("class1").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "foo2").WithTopology("class2").Objs()...)
 				return deduplicateObjects(objs)
 			}(),
 		},
@@ -486,8 +486,8 @@ var moveTests = []struct {
 		fields: moveTestsFields{
 			objs: func() []client.Object {
 				objs := test.NewFakeClusterClass("ns1", "class1").Objs()
-				objs = append(objs, test.NewFakeCluster("ns1", "foo1").WithTopologyClass("class1").Objs()...)
-				objs = append(objs, test.NewFakeCluster("ns1", "foo2").WithTopologyClass("class1").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "foo1").WithTopology("class1").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "foo2").WithTopology("class1").Objs()...)
 				return deduplicateObjects(objs)
 			}(),
 		},

--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -41,6 +41,9 @@ type DescribeClusterOptions struct {
 	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.
 	ShowMachineSets bool
 
+	// ShowMachineHealthChecks instructs the discovery process to include machine health checks in the ObjectTree.
+	ShowMachineHealthChecks bool
+
 	// ShowClusterResourceSets instructs the discovery process to include cluster resource sets in the ObjectTree.
 	ShowClusterResourceSets bool
 
@@ -92,6 +95,7 @@ func (c *clusterctlClient) DescribeCluster(options DescribeClusterOptions) (*tre
 		ShowOtherConditions:     options.ShowOtherConditions,
 		ShowMachineSets:         options.ShowMachineSets,
 		ShowClusterResourceSets: options.ShowClusterResourceSets,
+		ShowMachineHealthChecks: options.ShowMachineHealthChecks,
 		ShowTemplates:           options.ShowTemplates,
 		AddTemplateVirtualNode:  options.AddTemplateVirtualNode,
 		Echo:                    options.Echo,

--- a/cmd/clusterctl/client/tree/annotations.go
+++ b/cmd/clusterctl/client/tree/annotations.go
@@ -51,7 +51,7 @@ const (
 	GroupItemsSeparator = ", "
 
 	// ObjectZOrderAnnotation contains an integer that defines the sorting of child objects when the object tree is printed.
-	// Objects are sorted by their z-order from highest to lowest, and then by their name in alphaebetical order if the
+	// Objects are sorted by their z-order from highest to lowest, and then by their name in alphabetical order if the
 	// z-order is the same. Objects with no z-order set are assumed to have a default z-order of 0.
 	ObjectZOrderAnnotation = "tree.cluster.x-k8s.io.io/z-order"
 )

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -41,6 +41,9 @@ type ObjectTreeOptions struct {
 	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.
 	ShowMachineSets bool
 
+	// ShowMachineHealthChecks instructs the discovery process to include machine health checks in the ObjectTree.
+	ShowMachineHealthChecks bool
+
 	// ShowClusterResourceSets instructs the discovery process to include cluster resource sets in the ObjectTree.
 	ShowClusterResourceSets bool
 
@@ -83,7 +86,7 @@ func NewObjectTree(root client.Object, options ObjectTreeOptions) *ObjectTree {
 	}
 }
 
-// Add a object to the object tree.
+// Add an object to the object tree.
 func (od ObjectTree) Add(parent, obj client.Object, opts ...AddObjectOption) (added bool, visible bool) {
 	if parent == nil || obj == nil {
 		return false, false

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -60,6 +60,7 @@ type describeClusterOptions struct {
 	showOtherConditions     string
 	showMachineSets         bool
 	showClusterResourceSets bool
+	showMachineHealthChecks bool
 	showTemplates           bool
 	echo                    bool
 	grouping                bool
@@ -86,6 +87,9 @@ var describeClusterClusterCmd = &cobra.Command{
 
 		# Describe the cluster named test-1 showing all the conditions for a specific machine.
 		clusterctl describe cluster test-1 --show-conditions Machine/m1
+
+		# Describe the cluster named test-1 showing all machine health checks.
+		clusterctl describe cluster test-1 --show-machinehealthchecks
 
 		# Describe the cluster named test-1 disabling automatic grouping of objects with the same ready condition
 		# e.g. un-group all the machines with Ready=true instead of showing a single group node.
@@ -114,6 +118,8 @@ func init() {
 	describeClusterClusterCmd.Flags().StringVarP(&dc.namespace, "namespace", "n", "",
 		"The namespace where the workload cluster is located. If unspecified, the current namespace will be used.")
 
+	describeClusterClusterCmd.Flags().BoolVar(&dc.showMachineHealthChecks, "show-machinehealthchecks", false,
+		"Show MachineHealthChecks.")
 	describeClusterClusterCmd.Flags().StringVar(&dc.showOtherConditions, "show-conditions", "",
 		"list of comma separated kind or kind/name for which the command should show all the object's conditions (use 'all' to show conditions for everything).")
 	describeClusterClusterCmd.Flags().BoolVar(&dc.showMachineSets, "show-machinesets", false,
@@ -157,6 +163,7 @@ func runDescribeCluster(cmd *cobra.Command, name string) error {
 		ClusterName:             name,
 		ShowOtherConditions:     dc.showOtherConditions,
 		ShowClusterResourceSets: dc.showClusterResourceSets,
+		ShowMachineHealthChecks: dc.showMachineHealthChecks,
 		ShowTemplates:           dc.showTemplates,
 		ShowMachineSets:         dc.showMachineSets,
 		AddTemplateVirtualNode:  true,

--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -57,6 +57,7 @@ maintainers of providers and consumers of our Go API.
 
 ### Other
 
+- clusterctl describe cluster command now has a --show-machinehealthchecks flag.
 - clusterctl now emits an error for provider CRDs which don't comply with the CRD naming conventions. This warning can be skipped for resources not referenced by Cluster API
   core resources via the `clusterctl.cluster.x-k8s.io/skip-crd-name-preflight-check` annotation. The contracts specify:
   > The CRD name must have the format produced by sigs.k8s.io/cluster-api/util/contract.CalculateCRDName(Group, Kind)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a flag `--show-machinehealthchecks` to show machine health checks belonging to a cluster.

Example invocation
```
./bin/clusterctl --kubeconfig-context capi-1 -n foo-1 describe cluster foo-1-cluster --show-machinehealthchecks
NAME                                                               READY  SEVERITY  REASON  SINCE  MESSAGE 
Cluster/foo-1-cluster                                             True                     4d2h            
├─ClusterInfrastructure - OpenStackCluster/foo-1-os-cluster                                                
├─ControlPlane - KubeadmControlPlane/foo-1-kubeadm-control-plane  True                     4d2h            
│ └─Machine/foo-1-kubeadm-control-plane-2q8fn                     True                     4d2h            
├─MachineHealthCheck                                                                                        
│ └─MachineHealthCheck/foo-1-worker-small-unhealthy                                                        
└─Workers                                                                                                   
  └─MachineDeployment/foo-1-worker-small                          True                     4d2h            
    └─Machine/foo-1-worker-small-7d45bd89d7-bkcp7                 True                     4d2h          
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7222
