### PR TITLE
🐛 ClusterClass: run dry-run on original and modified object

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -96,7 +96,7 @@ func NewServerSidePatchHelper(ctx context.Context, original, modified client.Obj
 		hasChanges, hasSpecChanges, err = dryRunSSAPatch(ctx, &dryRunSSAPatchInput{
 			client:               c,
 			originalUnstructured: originalUnstructured,
-			dryRunUnstructured:   modifiedUnstructured.DeepCopy(),
+			modifiedUnstructured: modifiedUnstructured.DeepCopy(),
 			helperOptions:        helperOptions,
 		})
 		if err != nil {

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -435,6 +435,21 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			input.PostUpgrade(managementClusterProxy)
 		}
 
+		// After the upgrade check that there were no unexpected rollouts.
+		log.Logf("Verify there are no unexpected rollouts")
+		Consistently(func() bool {
+			postUpgradeMachineList := &unstructured.UnstructuredList{}
+			postUpgradeMachineList.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("MachineList"))
+			err = managementClusterProxy.GetClient().List(
+				ctx,
+				postUpgradeMachineList,
+				client.InNamespace(testNamespace.Name),
+				client.MatchingLabels{clusterv1.ClusterNameLabel: workLoadClusterName},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			return matchUnstructuredLists(preUpgradeMachineList, postUpgradeMachineList)
+		}, "3m", "30s").Should(BeTrue(), "Machines should remain the same after the upgrade")
+
 		// After upgrading we are sure the version is the latest version of the API,
 		// so it is possible to use the standard helpers
 		workloadCluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
@@ -442,26 +457,6 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			Namespace: testNamespace.Name,
 			Name:      workLoadClusterName,
 		})
-
-		// TODO(sbueringer) Only run this test for non-ClusterClass Clusters.
-		// Currently the Cluster topology controller triggers a rollout after upgrade.
-		// We are actively working on fixing it.
-		if workloadCluster.Spec.Topology == nil {
-			// After the upgrade check that there were no unexpected rollouts.
-			log.Logf("Verify there are no unexpected rollouts")
-			Consistently(func() bool {
-				postUpgradeMachineList := &unstructured.UnstructuredList{}
-				postUpgradeMachineList.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("MachineList"))
-				err = managementClusterProxy.GetClient().List(
-					ctx,
-					postUpgradeMachineList,
-					client.InNamespace(testNamespace.Name),
-					client.MatchingLabels{clusterv1.ClusterNameLabel: workLoadClusterName},
-				)
-				Expect(err).NotTo(HaveOccurred())
-				return matchUnstructuredLists(preUpgradeMachineList, postUpgradeMachineList)
-			}, "3m", "30s").Should(BeTrue(), "Machines should remain the same after the upgrade")
-		}
 
 		if workloadCluster.Spec.Topology != nil {
 			// Cluster is using ClusterClass, scale up via topology.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
