### PR TITLE
🌱 test/e2e: disable rollout check for ClusterClass-based cluster in clusterctl ugprade tests II

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -446,7 +446,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		// TODO(sbueringer) Only run this test for non-ClusterClass Clusters.
 		// Currently the Cluster topology controller triggers a rollout after upgrade.
 		// We are actively working on fixing it.
-		if workloadCluster.Spec.Topology != nil {
+		if workloadCluster.Spec.Topology == nil {
 			// After the upgrade check that there were no unexpected rollouts.
 			log.Logf("Verify there are no unexpected rollouts")
 			Consistently(func() bool {


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
:/ 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
