### PR TITLE
:seedling: :book: move.md: Warning: Status get lost

### DIFF
--- a/docs/book/src/clusterctl/commands/move.md
+++ b/docs/book/src/clusterctl/commands/move.md
@@ -58,6 +58,16 @@ make it clear those operation have the same limitations of the move command.
 
 </aside>
 
+<aside class="note warning">
+
+<h1> Warning: Status subresource is never restored </h1>
+
+Every object's `Status` subresource, including every nested field (e.g. `Status.Conditions`), is never restored during a `move` operation. A `Status` subresource should never contain fields that cannot be recreated or derived from information in spec, metadata, or external systems.
+Provider implementers should not store non-ephemeral data in the `Status`. 
+`Status` should be able to be fully rebuilt by controllers by observing the current state of resources.
+
+</aside>
+
 ## Pivot
 
 Pivoting is a process for moving the provider components and declared Cluster API resources from a source management

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -466,6 +466,19 @@ exact move sequence to be executed by the user.
 Additionally, provider authors should be aware that `clusterctl move` assumes all the provider's Controllers respect the
 `Cluster.Spec.Paused` field introduced in the v1alpha3 Cluster API specification.
 
+<aside class="note warning">
+
+<h1> Warning: Status subresource is never restored </h1>
+
+Every object's `Status` subresource, including every nested field (e.g. `Status.Conditions`), is never 
+restored during a `move` operation. A `Status` subresource should never contain fields that cannot 
+be recreated or derived from information in spec, metadata, or external systems.
+
+Provider implementers should not store non-ephemeral data in the `Status`. 
+`Status` should be able to be fully rebuilt by controllers by observing the current state of resources.
+
+</aside>
+
 <!--LINKS-->
 [drone-envsubst]: https://github.com/drone/envsubst
 [issue 3418]: https://github.com/kubernetes-sigs/cluster-api/issues/3418


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add a warning to the docs of `move`, that the Status of CRDs gets lost during the move.

Feel free to update the wording completely without asking. I am not good at writing docs. Thank you.
