### PR TITLE
 📖 Fix a typo

### DIFF
--- a/docs/book/src/clusterctl/commands/move.md
+++ b/docs/book/src/clusterctl/commands/move.md
@@ -52,7 +52,7 @@ while doing the move operation, and possible race conditions happening while the
 remediating etc. has never been investigated nor addressed.
 
 In order to avoid further confusion about this point, `clusterctl backup` and `clusterctl restore` commands have been
-removed because they were built on top of `clusterctl move` logic and they were sharing he same limitations.
+removed because they were built on top of `clusterctl move` logic and they were sharing the same limitations.
 User can use `clusterctl move --to-directory` and `clusterctl move --from-directory` instead; this will hopefully
 make it clear those operation have the same limitations of the move command.
 


### PR DESCRIPTION
There is typo in documentation of `clusterctl move` command. It should be `the` instead of `he`.
