### PR TITLE
:seedling: Set fail-fast: false for weekly md link check

### DIFF
--- a/.github/workflows/lint-docs-weekly.yml
+++ b/.github/workflows/lint-docs-weekly.yml
@@ -11,6 +11,7 @@ jobs:
   markdown-link-check:
     name: Broken Links
     strategy:
+      fail-fast: false
       matrix:
         branch: [ main, release-1.3, release-1.2 ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently the weekly lint checker fails if one job, i.e. link checking for one branch, fails. This change should give results from all jobs, with any failure still reporting as a failure for the run.

