### PR TITLE
🌱 test/extension: push to staging registry

### DIFF
--- a/test/extension/config/default/manager_pull_policy.yaml
+++ b/test/extension/config/default/manager_pull_policy.yaml
@@ -7,7 +7,4 @@ spec:
     spec:
       containers:
       - name: manager
-        # No image is currently published for the test extension.
-        # To run locally either pre-load the image onto the control-plane nodes or change the manager_image_patch.yaml
-        # image ref to a registry with an up-to-date test-extension image.
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR modifies our push targets to also push the test extension image to the staging repository (just like CAPD).

With this change it will be possible (again) to just run e2e tests locally without having to build the test extension every time.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
