### PR TITLE
🌱 CAPD: drop kubectl from image

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -111,14 +111,6 @@ providers = {
             "third_party",
         ],
         "label": "CAPD",
-        # Add kubectl to the docker image, CAPD manager requires it.
-        "additional_docker_helper_commands": "RUN curl -LO https://dl.k8s.io/release/{KUBE}/bin/linux/{ARCH}/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/bin/kubectl".format(
-            ARCH = os_arch,
-            KUBE = kubernetes_version,
-        ),
-        "additional_docker_build_commands": """
-COPY --from=tilt-helper /usr/bin/kubectl /usr/bin/kubectl
-""",
     },
     "test-extension": {
         "context": "test/extension",  # NOTE: this should be kept in sync with corresponding setting in tilt-prepare

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
@@ -32,10 +33,6 @@ ENV GOPROXY=$goproxy
 
 # Gets additional CAPD dependencies
 WORKDIR /tmp
-
-RUN curl -LO "https://dl.k8s.io/release/v1.26.0/bin/linux/${ARCH}/kubectl" && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/bin/kubectl
 
 WORKDIR /workspace
 COPY go.mod go.mod
@@ -77,6 +74,5 @@ FROM gcr.io/distroless/static:latest-${ARCH}
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Drop kubectl from the CAPD image.
(kubectl should not be used anymore since we're setting the providerID of nodes with the regular client)

This will speed up CAPD image builds (also in TIlt :))

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
