### PR TITLE
🌱 Add release notes pr statistics

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -204,6 +204,13 @@ func run() int {
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Printf("Changes since %v\n---\n", commitRange)
 
+	fmt.Printf("## :chart_with_upwards_trend: Fun stats\n")
+	fmt.Printf("- %d new commits merged\n", len(commits))
+	fmt.Printf("- %d breaking changes :warning:\n", len(merges[warning]))
+	fmt.Printf("- %d feature additions ✨\n", len(merges[features]))
+	fmt.Printf("- %d bugs fixed 🐛\n", len(merges[bugs]))
+	fmt.Println()
+
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
 		if len(mergeslice) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Automates the fun stats section of the weekly and release notes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

cc @joekr @sayantani11 @VibhorChinda 
