### PR TITLE
:bug: Fix git config in release-binary builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -924,6 +924,7 @@ release-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:$(GO_VERSION) \
+		git config --global --add safe.directory /workspace; \
 		go build -a -trimpath -ldflags "$(LDFLAGS) -extldflags '-static'" \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY)) $(BUILD_PATH)
 


### PR DESCRIPTION
This change fixes a build error in CAPI for release binaries. 

When trying to cut a tag for CAPI release v1.4.0 we saw the following error:

> cd /workspace; git status --porcelain
> fatal: detected dubious ownership in repository at '/workspace'
> To add an exception for this directory, call:        git config --global --add safe.directory /workspace
> error obtaining VCS status: exit status 128
>         Use -buildvcs=false to disable VCS stamping.
> make: *** [Makefile:919: release-binary] Error 1

This seems to be down to ownership of the directories in the golang container and git being careful about which directories it allows. 

I'm still trying to get to the bottom of this issue, but this change seems low impact and should fix the error in the short term to unblock a release.
