### PR TITLE
:seedling: Remove omitempty tag from definitionsConflict

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -577,7 +577,7 @@ type ClusterClassStatusVariable struct {
 
 	// DefinitionsConflict specifies whether or not there are conflicting definitions for a single variable name.
 	// +optional
-	DefinitionsConflict bool `json:"definitionsConflict,omitempty"`
+	DefinitionsConflict bool `json:"definitionsConflict"`
 
 	// Definitions is a list of definitions for a variable.
 	Definitions []ClusterClassStatusVariableDefinition `json:"definitions"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -487,6 +487,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterClassStatusVariable(ref com
 					"definitionsConflict": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DefinitionsConflict specifies whether or not there are conflicting definitions for a single variable name.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
DefinitionsConflict shows when a variable has conflicts in different definitions in the ClusterClass status.  This change makes `definitionsConflict` visible when it is false in order to signal clearly to the user that all variable definitions for a given name are equal.