### PR TITLE
:seedling:  Add weekly test-release action

### DIFF
--- a/.github/workflows/lint-docs-weekly.yml
+++ b/.github/workflows/lint-docs-weekly.yml
@@ -2,7 +2,8 @@ name: Weekly check all Markdown links
 
 on:
   schedule:
-    - cron: "0 12 * * 4"
+    # Cron for every Monday at 12:00 UTC.
+    - cron: "0 12 * * 1"
 
 # Remove all permissions from GITHUB_TOKEN except metadata.
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Calculate go version
-        id: vars
-        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+        run: echo "go_version=$(make go-version)" >> $GITHUB_ENV
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
         with:
-          go-version: ${{ steps.vars.outputs.go_version }}
+          go-version: ${{ env.go_version }}
       - name: generate release artifacts
         run: |
           make release

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,6 +2,7 @@ name: scan-images
 
 on:
   schedule:
+    # Cron for every Monday at 12:00 UTC.
     - cron: "0 12 * * 1"
 
 # Remove all permissions from GITHUB_TOKEN except metadata.

--- a/.github/workflows/test-release-weekly.yml
+++ b/.github/workflows/test-release-weekly.yml
@@ -1,0 +1,40 @@
+name: Release test
+
+# Note: This workflow does not build for releases. It attempts to build release binaries daily to ensure the repo
+# is in a good state.
+
+on:
+  schedule:
+    # Cron for every day at 12:00 UTC.
+    - cron: "0 12 * * *"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  weekly-test-release:
+    name: Test release
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ main, release-1.3, release-1.2 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+      - name: Set env
+        run:  echo "RELEASE_TAG=v9.9.9-fake" >> $GITHUB_ENV
+      - name: Set fake tag for release
+        run: |
+          git tag ${{ env.RELEASE_TAG }}
+      - name: Calculate go version
+        run: echo "go_version=$(make go-version)" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # tag=v3.5.0
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Test release
+        run: |
+          make release


### PR DESCRIPTION
Add a weekly action to ensure the release process is working to regularly check the codebase is in a good-enough state to release.

This would catch issues like #8199 which are release-blocking but may not be known ahead of release time.
