### PR TITLE
:bug: Automatically delete machines marked for deletion

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -99,6 +99,10 @@ const (
 	// when KCP or a machineset scales down. This annotation is given top priority on all delete policies.
 	DeleteMachineAnnotation = "cluster.x-k8s.io/delete-machine"
 
+	// MarkedForDeleteMachineAnnotation marks control plane and worker nodes that will be deleted as soon as possible.
+	// No deletion priority is considered, and all machines are deleted while respecting standard machine deletion procedures, such as node drains.
+	MarkedForDeleteMachineAnnotation = "cluster.x-k8s.io/machine-marked-for-delete"
+
 	// TemplateClonedFromNameAnnotation is the infrastructure machine annotation that stores the name of the infrastructure template resource
 	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
 	TemplateClonedFromNameAnnotation = "cluster.x-k8s.io/cloned-from-name"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR is a sister PR to a change in Cluster Autoscaler. This is to handle an edge case where nodes that fail to join a cluster cause Cluster Autoscaler to downscale desired replica counts below what is necessary to schedule all pods in the cluster.

https://github.com/kubernetes/autoscaler/pull/5538

Please see the linked for detailed context on the Cluster Autoscaler changes.

TLDR: We want to support a method for Cluster Autoscaler to delete nodes that isn't based around downscaling desired replica counts, in order for it to cancel nodes that exceed its max-node-provision-time.

**Which issue(s) this PR fixes**:
Fixes this Cluster Autoscaler issue.
https://github.com/kubernetes/autoscaler/issues/5465
