### PR TITLE
✨ SSA: Implement request caching

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -86,6 +86,7 @@ type KubeadmControlPlaneReconciler struct {
 	// support SSA. This flag should be dropped after all affected tests are migrated
 	// to envtest.
 	disableInPlacePropagation bool
+	ssaCache                  ssa.Cache
 }
 
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -113,6 +114,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("kubeadm-control-plane-controller")
+	r.ssaCache = ssa.NewCache()
 
 	if r.managementCluster == nil {
 		if r.Tracker == nil {

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1574,7 +1574,7 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 
 	// Run syncMachines to clean up managed fields and have proper field ownership
 	// for Machines, InfrastructureMachines and KubeadmConfigs.
-	reconciler := &KubeadmControlPlaneReconciler{Client: env}
+	reconciler := &KubeadmControlPlaneReconciler{Client: env, ssaCache: ssa.NewCache()}
 	g.Expect(reconciler.syncMachines(ctx, controlPlane)).To(Succeed())
 
 	// The inPlaceMutatingMachine should have cleaned up managed fields.

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -305,12 +306,8 @@ func (r *KubeadmControlPlaneReconciler) updateExternalObject(ctx context.Context
 	// Update annotations
 	updatedObject.SetAnnotations(kcp.Spec.MachineTemplate.ObjectMeta.Annotations)
 
-	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
-		client.FieldOwner(kcpManagerName),
-	}
-	if err := r.Client.Patch(ctx, updatedObject, client.Apply, patchOptions...); err != nil {
-		return errors.Wrapf(err, "failed to update %s", klog.KObj(obj))
+	if err := ssa.Patch(ctx, r.Client, kcpManagerName, updatedObject); err != nil {
+		return errors.Wrapf(err, "failed to update %s", obj.GetObjectKind().GroupVersionKind().Kind)
 	}
 	return nil
 }
@@ -320,12 +317,8 @@ func (r *KubeadmControlPlaneReconciler) createMachine(ctx context.Context, kcp *
 	if err != nil {
 		return errors.Wrap(err, "failed to create Machine: failed to compute desired Machine")
 	}
-	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
-		client.FieldOwner(kcpManagerName),
-	}
-	if err := r.Client.Patch(ctx, machine, client.Apply, patchOptions...); err != nil {
-		return errors.Wrap(err, "failed to create Machine: apply failed")
+	if err := ssa.Patch(ctx, r.Client, kcpManagerName, machine); err != nil {
+		return errors.Wrap(err, "failed to create Machine")
 	}
 	// Remove the annotation tracking that a remediation is in progress (the remediation completed when
 	// the replacement machine has been created above).
@@ -342,12 +335,10 @@ func (r *KubeadmControlPlaneReconciler) updateMachine(ctx context.Context, machi
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to update Machine: failed to compute desired Machine")
 	}
-	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
-		client.FieldOwner(kcpManagerName),
-	}
-	if err := r.Client.Patch(ctx, updatedMachine, client.Apply, patchOptions...); err != nil {
-		return nil, errors.Wrap(err, "failed to update Machine: apply failed")
+
+	err = ssa.Patch(ctx, r.Client, kcpManagerName, updatedMachine, ssa.WithCachingProxy{Cache: r.ssaCache, Original: machine})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to update Machine")
 	}
 	return updatedMachine, nil
 }

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
@@ -58,6 +59,10 @@ import (
 const (
 	// controllerName defines the controller used when creating clients.
 	controllerName = "machine-controller"
+
+	// machineManagerName is the manager name used for Server-Side-Apply (SSA) operations
+	// in the Machine controller.
+	machineManagerName = "capi-machine"
 )
 
 var (
@@ -91,6 +96,7 @@ type Reconciler struct {
 	// nodeDeletionRetryTimeout determines how long the controller will retry deleting a node
 	// during a single reconciliation.
 	nodeDeletionRetryTimeout time.Duration
+	ssaCache                 ssa.Cache
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -134,6 +140,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	r.externalTracker = external.ObjectTracker{
 		Controller: controller,
 	}
+	r.ssaCache = ssa.NewCache()
 	return nil
 }
 

--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -33,6 +33,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -124,13 +125,10 @@ func (r *Reconciler) reconcileNode(ctx context.Context, cluster *clusterv1.Clust
 		}
 	}
 
-	options := []client.PatchOption{
-		client.FieldOwner("capi-machine"),
-		client.ForceOwnership,
-	}
-	nodePatch := unstructuredNode(node.Name, node.UID, getManagedLabels(machine.Labels))
-	if err := remoteClient.Patch(ctx, nodePatch, client.Apply, options...); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to apply patch label to the node")
+	updatedNode := unstructuredNode(node.Name, node.UID, getManagedLabels(machine.Labels))
+	err = ssa.Patch(ctx, remoteClient, machineManagerName, updatedNode, ssa.WithCachingProxy{Cache: r.ssaCache, Original: node})
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to apply labels to Node")
 	}
 
 	// Do the remaining node health checks, then set the node health to true if all checks pass.

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -726,8 +727,9 @@ func TestReconcileRequest(t *testing.T) {
 			).WithIndex(&corev1.Node{}, index.NodeProviderIDField, index.NodeByProviderID).Build()
 
 			r := &Reconciler{
-				Client:  clientFake,
-				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				Client:   clientFake,
+				Tracker:  remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				ssaCache: ssa.NewCache(),
 			}
 
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&tc.machine)})
@@ -972,8 +974,9 @@ func TestMachineConditions(t *testing.T) {
 				Build()
 
 			r := &Reconciler{
-				Client:  clientFake,
-				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				Client:   clientFake,
+				Tracker:  remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				ssaCache: ssa.NewCache(),
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&machine)})

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -70,6 +70,7 @@ type Reconciler struct {
 	WatchFilterValue string
 
 	recorder record.EventRecorder
+	ssaCache ssa.Cache
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -106,6 +107,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	}
 
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")
+	r.ssaCache = ssa.NewCache()
 	return nil
 }
 

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -40,6 +40,8 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/mdutil"
+	"sigs.k8s.io/cluster-api/internal/util/hash"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -153,11 +155,8 @@ func (r *Reconciler) updateMachineSet(ctx context.Context, deployment *clusterv1
 	}
 
 	// Update the MachineSet to propagate in-place mutable fields from the MachineDeployment.
-	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
-		client.FieldOwner(machineDeploymentManagerName),
-	}
-	if err := r.Client.Patch(ctx, updatedMS, client.Apply, patchOptions...); err != nil {
+	err = ssa.Patch(ctx, r.Client, machineDeploymentManagerName, updatedMS, ssa.WithCachingProxy{Cache: r.ssaCache, Original: ms})
+	if err != nil {
 		r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedUpdate", "Failed to update MachineSet %s: %v", klog.KObj(updatedMS), err)
 		return nil, errors.Wrapf(err, "failed to update MachineSet %s", klog.KObj(updatedMS))
 	}
@@ -178,11 +177,7 @@ func (r *Reconciler) createMachineSetAndWait(ctx context.Context, deployment *cl
 	}
 
 	// Create the MachineSet.
-	patchOptions := []client.PatchOption{
-		client.ForceOwnership,
-		client.FieldOwner(machineDeploymentManagerName),
-	}
-	if err = r.Client.Patch(ctx, newMS, client.Apply, patchOptions...); err != nil {
+	if err := ssa.Patch(ctx, r.Client, machineDeploymentManagerName, newMS); err != nil {
 		r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedCreate", "Failed to create MachineSet %s: %v", klog.KObj(newMS), err)
 		return nil, errors.Wrapf(err, "failed to create new MachineSet %s", klog.KObj(newMS))
 	}
@@ -237,7 +232,7 @@ func (r *Reconciler) computeDesiredMachineSet(deployment *clusterv1.MachineDeplo
 		// As a result, we use the hash of the machine template while ignoring all in-place mutable fields, i.e. the
 		// machine template with only fields that could trigger a rollout for the machine-template-hash, making it
 		// independent of the changes to any in-place mutable fields.
-		templateHash, err := mdutil.ComputeSpewHash(mdutil.MachineTemplateDeepCopyRolloutFields(&deployment.Spec.Template))
+		templateHash, err := hash.Compute(mdutil.MachineTemplateDeepCopyRolloutFields(&deployment.Spec.Template))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to compute desired MachineSet: failed to compute machine template hash")
 		}

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -19,13 +19,10 @@ package mdutil
 
 import (
 	"fmt"
-	"hash"
-	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -686,33 +683,6 @@ func CloneSelectorAndAddLabel(selector *metav1.LabelSelector, labelKey, labelVal
 	}
 
 	return newSelector
-}
-
-// SpewHashObject writes specified object to hash using the spew library
-// which follows pointers and prints actual values of the nested objects
-// ensuring the hash does not change when a pointer changes.
-func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
-	hasher.Reset()
-	printer := spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
-	}
-
-	if _, err := printer.Fprintf(hasher, "%#v", objectToWrite); err != nil {
-		return fmt.Errorf("failed to write object to hasher")
-	}
-	return nil
-}
-
-// ComputeSpewHash computes the hash of a MachineTemplateSpec using the spew library.
-func ComputeSpewHash(objectToWrite interface{}) (uint32, error) {
-	machineTemplateSpecHasher := fnv.New32a()
-	if err := SpewHashObject(machineTemplateSpecHasher, objectToWrite); err != nil {
-		return 0, err
-	}
-	return machineTemplateSpecHasher.Sum32(), nil
 }
 
 // GetDeletingMachineCount gets the number of machines that are in the process of being deleted

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -2245,7 +2245,7 @@ func TestGetMaxUnhealthy(t *testing.T) {
 func ownerReferenceForCluster(ctx context.Context, g *WithT, c *clusterv1.Cluster) metav1.OwnerReference {
 	// Fetch the cluster to populate the UID
 	cc := &clusterv1.Cluster{}
-	g.Expect(env.GetClient().Get(ctx, util.ObjectKey(c), cc)).To(Succeed())
+	g.Expect(env.Get(ctx, util.ObjectKey(c), cc)).To(Succeed())
 
 	return metav1.OwnerReference{
 		APIVersion: clusterv1.GroupVersion.String(),

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -1175,7 +1175,7 @@ func TestMachineSetReconciler_syncMachines(t *testing.T) {
 
 	// Run syncMachines to clean up managed fields and have proper field ownership
 	// for Machines, InfrastructureMachines and BootstrapConfigs.
-	reconciler := &Reconciler{Client: env}
+	reconciler := &Reconciler{Client: env, ssaCache: ssa.NewCache()}
 	g.Expect(reconciler.syncMachines(ctx, ms, machines)).To(Succeed())
 
 	// The inPlaceMutatingMachine should have cleaned up managed fields.

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/hooks"
 	tlog "sigs.k8s.io/cluster-api/internal/log"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/internal/webhooks"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -118,7 +119,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	r.patchEngine = patches.NewEngine(r.RuntimeClient)
 	r.recorder = mgr.GetEventRecorderFor("topology/cluster")
 	if r.patchHelperFactory == nil {
-		r.patchHelperFactory = serverSideApplyPatchHelperFactory(r.Client)
+		r.patchHelperFactory = serverSideApplyPatchHelperFactory(r.Client, ssa.NewCache())
 	}
 	return nil
 }
@@ -394,9 +395,9 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Clu
 }
 
 // serverSideApplyPatchHelperFactory makes use of managed fields provided by server side apply and is used by the controller.
-func serverSideApplyPatchHelperFactory(c client.Client) structuredmerge.PatchHelperFactoryFunc {
+func serverSideApplyPatchHelperFactory(c client.Client, ssaCache ssa.Cache) structuredmerge.PatchHelperFactoryFunc {
 	return func(ctx context.Context, original, modified client.Object, opts ...structuredmerge.HelperOption) (structuredmerge.PatchHelper, error) {
-		return structuredmerge.NewServerSidePatchHelper(ctx, original, modified, c, opts...)
+		return structuredmerge.NewServerSidePatchHelper(ctx, original, modified, c, ssaCache, opts...)
 	}
 }
 

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/hooks"
 	fakeruntimeclient "sigs.k8s.io/cluster-api/internal/runtime/client/fake"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 )
 
 var (
@@ -87,7 +88,7 @@ func TestReconcileShim(t *testing.T) {
 		r := Reconciler{
 			Client:             env,
 			APIReader:          env.GetAPIReader(),
-			patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+			patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 		}
 		err = r.reconcileClusterShim(ctx, s)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -130,7 +131,7 @@ func TestReconcileShim(t *testing.T) {
 		r := Reconciler{
 			Client:             env,
 			APIReader:          env.GetAPIReader(),
-			patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+			patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 		}
 		err = r.reconcileClusterShim(ctx, s)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -180,7 +181,7 @@ func TestReconcileShim(t *testing.T) {
 		r := Reconciler{
 			Client:             env,
 			APIReader:          env.GetAPIReader(),
-			patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+			patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 		}
 		err = r.reconcileClusterShim(ctx, s)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -231,7 +232,7 @@ func TestReconcileShim(t *testing.T) {
 		r := Reconciler{
 			Client:             env,
 			APIReader:          env.GetAPIReader(),
-			patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+			patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 		}
 		err = r.reconcileClusterShim(ctx, s)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -272,7 +273,7 @@ func TestReconcileShim(t *testing.T) {
 		r := Reconciler{
 			Client:             nil,
 			APIReader:          env.GetAPIReader(),
-			patchHelperFactory: serverSideApplyPatchHelperFactory(nil),
+			patchHelperFactory: serverSideApplyPatchHelperFactory(nil, ssa.NewCache()),
 		}
 		err = r.reconcileClusterShim(ctx, s)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -962,7 +963,7 @@ func TestReconcileCluster(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 			err = r.reconcileCluster(ctx, s)
@@ -1087,7 +1088,7 @@ func TestReconcileInfrastructureCluster(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 			err = r.reconcileInfrastructureCluster(ctx, s)
@@ -1341,7 +1342,7 @@ func TestReconcileControlPlane(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 
@@ -1601,7 +1602,7 @@ func TestReconcileControlPlaneMachineHealthCheck(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 
@@ -1850,7 +1851,7 @@ func TestReconcileMachineDeployments(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 			err = r.reconcileMachineDeployments(ctx, s)
@@ -2329,7 +2330,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 
@@ -2595,7 +2596,7 @@ func TestReconcileMachineDeploymentMachineHealthCheck(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 
@@ -2741,7 +2742,7 @@ func TestReconciler_reconcileMachineHealthCheck(t *testing.T) {
 
 			r := Reconciler{
 				Client:             env,
-				patchHelperFactory: serverSideApplyPatchHelperFactory(env),
+				patchHelperFactory: serverSideApplyPatchHelperFactory(env, ssa.NewCache()),
 				recorder:           env.GetEventRecorderFor("test"),
 			}
 			if tt.current != nil {

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -39,7 +39,7 @@ type serverSidePatchHelper struct {
 }
 
 // NewServerSidePatchHelper returns a new PatchHelper using server side apply.
-func NewServerSidePatchHelper(ctx context.Context, original, modified client.Object, c client.Client, opts ...HelperOption) (PatchHelper, error) {
+func NewServerSidePatchHelper(ctx context.Context, original, modified client.Object, c client.Client, ssaCache ssa.Cache, opts ...HelperOption) (PatchHelper, error) {
 	// Create helperOptions for filtering the original and modified objects to the desired intent.
 	helperOptions := newHelperOptions(modified, opts...)
 
@@ -99,6 +99,7 @@ func NewServerSidePatchHelper(ctx context.Context, original, modified client.Obj
 		var err error
 		hasChanges, hasSpecChanges, err = dryRunSSAPatch(ctx, &dryRunSSAPatchInput{
 			client:               c,
+			ssaCache:             ssaCache,
 			originalUnstructured: originalUnstructured,
 			modifiedUnstructured: modifiedUnstructured.DeepCopy(),
 			helperOptions:        helperOptions,

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
@@ -42,6 +42,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -72,7 +73,7 @@ func TestServerSideApply(t *testing.T) {
 		var original *unstructured.Unstructured
 		modified := obj.DeepCopy()
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache())
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -83,7 +84,7 @@ func TestServerSideApply(t *testing.T) {
 		var original *clusterv1.MachineDeployment
 		modified := obj.DeepCopy()
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache())
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -92,7 +93,7 @@ func TestServerSideApply(t *testing.T) {
 		g := NewWithT(t)
 
 		// Create a patch helper with original == nil and modified == obj, ensure this is detected as operation that triggers changes.
-		p0, err := NewServerSidePatchHelper(ctx, nil, obj.DeepCopy(), env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, nil, obj.DeepCopy(), env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -127,7 +128,7 @@ func TestServerSideApply(t *testing.T) {
 
 		// Create a patch helper for a modified object with no changes.
 		modified := obj.DeepCopy()
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -144,7 +145,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "status", "foo")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -161,7 +162,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "bar")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -178,7 +179,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		modified.SetLabels(map[string]string{"foo": "changed"})
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -195,7 +196,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		modified.SetAnnotations(map[string]string{"foo": "changed"})
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -219,7 +220,7 @@ func TestServerSideApply(t *testing.T) {
 			},
 		})
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -236,7 +237,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "foo")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -269,7 +270,7 @@ func TestServerSideApply(t *testing.T) {
 		//       it here to be able to verify that managed field changes are ignored. This is the same situation as when
 		//       other controllers update .status (that is ignored) and the ServerSidePatchHelper then ignores the corresponding
 		//       managed field changes.
-		p0, err := NewServerSidePatchHelper(ctx, original, original, env.GetClient(), IgnorePaths{{"spec", "foo"}, {"spec", "bar"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, original, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}, {"spec", "bar"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -285,7 +286,7 @@ func TestServerSideApply(t *testing.T) {
 		// Create a patch helper for a modified object with no changes to what previously applied by th topology manager.
 		modified := obj.DeepCopy()
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -332,7 +333,7 @@ func TestServerSideApply(t *testing.T) {
 		modified := obj.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "controlPlaneEndpoint", "host")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -370,7 +371,7 @@ func TestServerSideApply(t *testing.T) {
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "controlPlaneEndpoint", "host")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "bar")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -410,7 +411,7 @@ func TestServerSideApply(t *testing.T) {
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed", "spec", "controlPlaneEndpoint", "host")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modified.Object, "changed-by-topology-controller", "spec", "bar")).To(Succeed())
 
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), IgnorePaths{{"spec", "foo"}})
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache(), IgnorePaths{{"spec", "foo"}})
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -458,7 +459,7 @@ func TestServerSideApply(t *testing.T) {
 		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(original), original)).To(Succeed())
 
 		// Create a patch helper for a modified object with which has no changes.
-		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+		p0, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache())
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeFalse())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
@@ -480,7 +481,7 @@ func TestServerSideApply(t *testing.T) {
 		modified.SetUID("")
 
 		// Create a patch helper which should fail because original's real UID changed.
-		_, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+		_, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache())
 		g.Expect(err).To(HaveOccurred())
 	})
 	t.Run("Error on object which does not exist (anymore) but was expected to get updated", func(t *testing.T) {
@@ -497,7 +498,7 @@ func TestServerSideApply(t *testing.T) {
 		original.SetUID("does-not-exist")
 
 		// Create a patch helper which should fail because original does not exist.
-		_, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+		_, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssa.NewCache())
 		g.Expect(err).To(HaveOccurred())
 	})
 }
@@ -532,7 +533,7 @@ func TestServerSideApplyWithDefaulting(t *testing.T) {
 
 	// Setup webhook with the manager.
 	// Note: The webhooks is not active yet, as the MutatingWebhookConfiguration will be deployed later.
-	mutatingWebhookConfiguration, err := setupWebhookWithManager(ns)
+	defaulter, mutatingWebhookConfiguration, err := setupWebhookWithManager(ns)
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Calculate KubeadmConfigTemplate.
@@ -637,8 +638,11 @@ func TestServerSideApplyWithDefaulting(t *testing.T) {
 			// in multiple test runs, because after the first test run it has a resourceVersion set.
 			mutatingWebhookConfiguration := mutatingWebhookConfiguration.DeepCopy()
 
+			// Create a cache to cache SSA requests.
+			ssaCache := ssa.NewCache()
+
 			// Create the initial KubeadmConfigTemplate (with the old defaulting logic).
-			p0, err := NewServerSidePatchHelper(ctx, nil, kct.DeepCopy(), env.GetClient())
+			p0, err := NewServerSidePatchHelper(ctx, nil, kct.DeepCopy(), env.GetClient(), ssaCache)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(p0.HasChanges()).To(BeTrue())
 			g.Expect(p0.HasSpecChanges()).To(BeTrue())
@@ -689,7 +693,7 @@ func TestServerSideApplyWithDefaulting(t *testing.T) {
 			}
 
 			// Apply modified.
-			p0, err = NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
+			p0, err = NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssaCache)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(p0.HasChanges()).To(Equal(tt.expectChanges))
 			g.Expect(p0.HasSpecChanges()).To(Equal(tt.expectSpecChanges))
@@ -721,6 +725,58 @@ func TestServerSideApplyWithDefaulting(t *testing.T) {
 					g.Expect(specTemplateSpecFieldV1).ToNot(HaveKey("f:users"))
 				}
 			}, 2*time.Second).Should(Succeed())
+
+			if p0.HasChanges() {
+				// If there were changes the request should not be cached.
+				// Which means on the next call we should not hit the cache and thus
+				// send a request to the server.
+				// We verify this by checking the webhook call counter.
+
+				// Get original.
+				original = kct.DeepCopy()
+				g.Expect(env.Get(ctx, client.ObjectKeyFromObject(original), original))
+
+				countBefore := defaulter.Counter
+
+				// Apply modified again.
+				p0, err = NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssaCache)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				// Expect no changes.
+				g.Expect(p0.HasChanges()).To(BeFalse())
+				g.Expect(p0.HasSpecChanges()).To(BeFalse())
+				g.Expect(p0.Patch(ctx)).To(Succeed())
+
+				// Expect webhook to be called.
+				g.Expect(defaulter.Counter).To(Equal(countBefore+2),
+					"request should not have been cached and thus we expect the webhook to be called twice (once for original and once for modified)")
+
+				// Note: Now the request is also cached, which we verify below.
+			}
+
+			// If there were no changes the request is now cached.
+			// Which means on the next call we should only hit the cache and thus
+			// don't send a request to the server.
+			// We verify this by checking the webhook call counter.
+
+			// Get original.
+			original = kct.DeepCopy()
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(original), original))
+
+			countBefore := defaulter.Counter
+
+			// Apply modified again.
+			p0, err = NewServerSidePatchHelper(ctx, original, modified, env.GetClient(), ssaCache)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Expect no changes.
+			g.Expect(p0.HasChanges()).To(BeFalse())
+			g.Expect(p0.HasSpecChanges()).To(BeFalse())
+			g.Expect(p0.Patch(ctx)).To(Succeed())
+
+			// Expect webhook to not be called.
+			g.Expect(defaulter.Counter).To(Equal(countBefore),
+				"request should have been cached and thus the webhook not called")
 		})
 	}
 }
@@ -728,7 +784,7 @@ func TestServerSideApplyWithDefaulting(t *testing.T) {
 // setupWebhookWithManager configures the envtest manager / webhook server to serve the webhook.
 // It also calculates and returns the corresponding MutatingWebhookConfiguration.
 // Note: To activate the webhook, the MutatingWebhookConfiguration has to be deployed.
-func setupWebhookWithManager(ns *corev1.Namespace) (*admissionv1.MutatingWebhookConfiguration, error) {
+func setupWebhookWithManager(ns *corev1.Namespace) (*KubeadmConfigTemplateTestDefaulter, *admissionv1.MutatingWebhookConfiguration, error) {
 	webhookServer := env.Manager.GetWebhookServer()
 
 	// Calculate webhook host and path.
@@ -741,13 +797,14 @@ func setupWebhookWithManager(ns *corev1.Namespace) (*admissionv1.MutatingWebhook
 
 	// Serve KubeadmConfigTemplateTestDefaulter on the webhook server.
 	// Note: This should only ever be called once with the same path, otherwise we get a panic.
+	defaulter := &KubeadmConfigTemplateTestDefaulter{}
 	webhookServer.Register(webhookPath,
-		admission.WithCustomDefaulter(&bootstrapv1.KubeadmConfigTemplate{}, &KubeadmConfigTemplateTestDefaulter{}))
+		admission.WithCustomDefaulter(&bootstrapv1.KubeadmConfigTemplate{}, defaulter))
 
 	// Calculate the MutatingWebhookConfiguration
 	caBundle, err := os.ReadFile(filepath.Join(webhookServer.CertDir, webhookServer.CertName))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sideEffectNone := admissionv1.SideEffectClassNone
@@ -785,19 +842,22 @@ func setupWebhookWithManager(ns *corev1.Namespace) (*admissionv1.MutatingWebhook
 			},
 		},
 	}
-	return webhookConfig, nil
+	return defaulter, webhookConfig, nil
 }
 
 var _ webhook.CustomDefaulter = &KubeadmConfigTemplateTestDefaulter{}
 
 type KubeadmConfigTemplateTestDefaulter struct {
+	Counter int
 }
 
-func (d KubeadmConfigTemplateTestDefaulter) Default(_ context.Context, obj runtime.Object) error {
+func (d *KubeadmConfigTemplateTestDefaulter) Default(_ context.Context, obj runtime.Object) error {
 	kct, ok := obj.(*bootstrapv1.KubeadmConfigTemplate)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
 	}
+
+	d.Counter++
 
 	defaultKubeadmConfigTemplate(kct)
 	return nil

--- a/internal/util/hash/hash.go
+++ b/internal/util/hash/hash.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hash provides utils to calculate hashes.
+package hash
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// Compute computes the hash of an object using the spew library.
+// Note: spew follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func Compute(obj interface{}) (uint32, error) {
+	hasher := fnv.New32a()
+
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+
+	if _, err := printer.Fprintf(hasher, "%#v", obj); err != nil {
+		return 0, fmt.Errorf("failed to calculate hash")
+	}
+
+	return hasher.Sum32(), nil
+}

--- a/internal/util/ssa/cache.go
+++ b/internal/util/ssa/cache.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	"sigs.k8s.io/cluster-api/internal/util/hash"
+)
+
+const (
+	// ttl is the duration for which we keep the keys in the cache.
+	ttl = 10 * time.Minute
+
+	// expirationInterval is the interval in which we will remove expired keys
+	// from the cache.
+	expirationInterval = 10 * time.Hour
+)
+
+// Cache caches SSA request results.
+// Specifically we only use it to cache that a certain request
+// doesn't have to be repeated anymore because there was no diff.
+type Cache interface {
+	// Add adds the given key to the Cache.
+	// Note: keys expire after the ttl.
+	Add(key string)
+
+	// Has checks if the given key (still) exists in the Cache.
+	// Note: keys expire after the ttl.
+	Has(key string) bool
+}
+
+// NewCache creates a new cache.
+func NewCache() Cache {
+	r := &ssaCache{
+		Store: cache.NewTTLStore(func(obj interface{}) (string, error) {
+			// We only add strings to the cache, so it's safe to cast to string.
+			return obj.(string), nil
+		}, ttl),
+	}
+	go func() {
+		for {
+			// Call list to clear the cache of expired items.
+			// We have to do this periodically as the cache itself only expires
+			// items lazily. If we don't do this the cache grows indefinitely.
+			r.List()
+
+			time.Sleep(expirationInterval)
+		}
+	}()
+	return r
+}
+
+type ssaCache struct {
+	cache.Store
+}
+
+// Add adds the given key to the Cache.
+// Note: keys expire after the ttl.
+func (r *ssaCache) Add(key string) {
+	// Note: We can ignore the error here because by only allowing strings
+	// and providing the corresponding keyFunc ourselves we can guarantee that
+	// the error never occurs.
+	_ = r.Store.Add(key)
+}
+
+// Has checks if the given key (still) exists in the Cache.
+// Note: keys expire after the ttl.
+func (r *ssaCache) Has(key string) bool {
+	// Note: We can ignore the error here because GetByKey never returns an error.
+	_, exists, _ := r.Store.GetByKey(key)
+	return exists
+}
+
+// ComputeRequestIdentifier computes a request identifier for the cache.
+// The identifier is unique for a specific request to ensure we don't have to re-run the request
+// once we found out that it would not produce a diff.
+// The identifier consists of: gvk, namespace, name and resourceVersion of the original object and a hash of the modified
+// object. This ensures that we re-run the request as soon as either original or modified changes.
+func ComputeRequestIdentifier(scheme *runtime.Scheme, original, modified client.Object) (string, error) {
+	modifiedObjectHash, err := hash.Compute(modified)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to calculate request identifier: failed to compute hash for modified object")
+	}
+
+	gvk, err := apiutil.GVKForObject(original, scheme)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to calculate request identifier: failed to get GroupVersionKind of original object %s", klog.KObj(original))
+	}
+
+	return fmt.Sprintf("%s.%s.%s.%d", gvk.String(), klog.KObj(original), original.GetResourceVersion(), modifiedObjectHash), nil
+}

--- a/internal/util/ssa/patch.go
+++ b/internal/util/ssa/patch.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// Option is the interface for configuration that modifies Options for a patch request.
+type Option interface {
+	// ApplyToOptions applies this configuration to the given Options.
+	ApplyToOptions(*Options)
+}
+
+// WithCachingProxy enables caching for the patch request.
+// The original and modified object will be used to generate an
+// identifier for the request.
+// The cache will be used to cache the result of the request.
+type WithCachingProxy struct {
+	Cache    Cache
+	Original client.Object
+}
+
+// ApplyToOptions applies WithCachingProxy to the given Options.
+func (w WithCachingProxy) ApplyToOptions(in *Options) {
+	in.WithCachingProxy = true
+	in.Cache = w.Cache
+	in.Original = w.Original
+}
+
+// Options contains the options for the Patch func.
+type Options struct {
+	WithCachingProxy bool
+	Cache            Cache
+	Original         client.Object
+}
+
+// Patch executes an SSA patch.
+// If WithCachingProxy is set and the request didn't change the object
+// we will cache this result, so subsequent calls don't have to run SSA again.
+func Patch(ctx context.Context, c client.Client, fieldManager string, modified client.Object, opts ...Option) error {
+	// Calculate the options.
+	options := &Options{}
+	for _, opt := range opts {
+		opt.ApplyToOptions(options)
+	}
+
+	var requestIdentifier string
+	var err error
+	if options.WithCachingProxy {
+		// Check if the request is cached.
+		requestIdentifier, err = ComputeRequestIdentifier(c.Scheme(), options.Original, modified)
+		if err != nil {
+			return errors.Wrapf(err, "failed to apply object")
+		}
+		if options.Cache.Has(requestIdentifier) {
+			// If the request is cached return the original object.
+			if err := c.Scheme().Convert(options.Original, modified, ctx); err != nil {
+				return errors.Wrapf(err, "failed to write original into modified object")
+			}
+			return nil
+		}
+	}
+
+	gvk, err := apiutil.GVKForObject(modified, c.Scheme())
+	if err != nil {
+		return errors.Wrapf(err, "failed to apply object: failed to get GroupVersionKind of modified object %s", klog.KObj(modified))
+	}
+
+	patchOptions := []client.PatchOption{
+		client.ForceOwnership,
+		client.FieldOwner(fieldManager),
+	}
+	if err := c.Patch(ctx, modified, client.Apply, patchOptions...); err != nil {
+		return errors.Wrapf(err, "failed to apply %s %s", gvk.Kind, klog.KObj(modified))
+	}
+
+	if options.WithCachingProxy {
+		// If the SSA call did not update the object, add the request to the cache.
+		if options.Original.GetResourceVersion() == modified.GetResourceVersion() {
+			options.Cache.Add(requestIdentifier)
+		}
+	}
+
+	return nil
+}

--- a/internal/util/ssa/patch_test.go
+++ b/internal/util/ssa/patch_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/internal/test/builder"
+)
+
+func TestPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	// Create a namespace for running the test
+	ns, err := env.CreateNamespace(ctx, "ssa")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Build the test object to work with.
+	initialObject := builder.TestInfrastructureCluster(ns.Name, "obj1").WithSpecFields(map[string]interface{}{
+		"spec.controlPlaneEndpoint.host": "1.2.3.4",
+		"spec.controlPlaneEndpoint.port": int64(1234),
+		"spec.foo":                       "bar",
+	}).Build()
+
+	fieldManager := "test-manager"
+	ssaCache := NewCache()
+
+	// Create the object
+	createObject := initialObject.DeepCopy()
+	g.Expect(Patch(ctx, env.GetClient(), fieldManager, createObject)).To(Succeed())
+
+	// Update the object and verify that the request was not cached as the object was changed.
+	// Get the original object.
+	originalObject := initialObject.DeepCopy()
+	g.Expect(env.Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+	// Modify the object
+	modifiedObject := initialObject.DeepCopy()
+	g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
+	// Compute request identifier, so we can later verify that the update call was not cached.
+	requestIdentifier, err := ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedObject)
+	g.Expect(err).ToNot(HaveOccurred())
+	// Update the object
+	g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+	// Verify that request was not cached (as it changed the object)
+	g.Expect(ssaCache.Has(requestIdentifier)).To(BeFalse())
+
+	// Repeat the same update and verify that the request was cached as the object was not changed.
+	// Get the original object.
+	originalObject = initialObject.DeepCopy()
+	g.Expect(env.Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+	// Modify the object
+	modifiedObject = initialObject.DeepCopy()
+	g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
+	// Compute request identifier, so we can later verify that the update call was cached.
+	requestIdentifier, err = ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedObject)
+	g.Expect(err).ToNot(HaveOccurred())
+	// Update the object
+	g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+	// Verify that request was cached (as it did not change the object)
+	g.Expect(ssaCache.Has(requestIdentifier)).To(BeTrue())
+}

--- a/internal/util/ssa/suite_test.go
+++ b/internal/util/ssa/suite_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"os"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+var (
+	ctx        = ctrl.SetupSignalHandler()
+	fakeScheme = runtime.NewScheme()
+	env        *envtest.Environment
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(fakeScheme)
+	_ = clusterv1.AddToScheme(fakeScheme)
+	_ = apiextensionsv1.AddToScheme(fakeScheme)
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In recent weeks we added in-place propagation across a few controllers and we introduced an additional SSA dryrun in our Cluster topology controller. Basically on every reconcile we run SSA against the apiserver.

Now it's time to optimize the amounts of SSA calls to avoid overloading the apiserver.

This PR implements caching for SSA requests. The high-level idea is that once we know for a given original and modified object that the request doesn't lead to any changes, we cache this information for 10 minutes.

SSA will only be executed again once either original or modified objects change or the 10 minutes are over.

Some data:
![Screenshot 2023-03-01 at 06 12 29](https://user-images.githubusercontent.com/4662360/222051315-19810da8-e945-4bb6-982d-698efc33ecfa.png)

The first two are ~ quickstart cluster creations with ClusterClass & caching => ~ 148 Patch calls
The last one is the same without caching => ~ 310 Patch calls until the cluster exists and then just continuous calls.

This PR currently contains caching for:
* Cluster topology SSA
* MachineDeployment => MachineSet
* MachineSet => Machine, InfraMachine, BootstrapConfig
* KCP => Machine, InfraMachine, BootstrapConfig
* Machine => Node

The difference should be even bigger once we implemented KCP reconciliation with SSA.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8146
