### PR TITLE
:book: Fix broken link to kubectl install

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -52,6 +52,6 @@ chmod +x ./kubebuilder && sudo mv ./kubebuilder /usr/local/bin/kubebuilder
 {{#/tabs }}
 
 [kubebuilder-book]: https://book.kubebuilder.io/
-[kubectl-install]: http://kubernetes.io/docs/user-guide/prereqs/
+[kubectl-install]: https://kubernetes.io/docs/tasks/tools/#kubectl
 [install-kustomize]: https://kubectl.docs.kubernetes.io/installation/kustomize/
 [install-kubebuilder]:  https://book.kubebuilder.io/quick-start.html#installation


### PR DESCRIPTION
Fix broken link in the book to the Kubernetes kubectl install page.

Fixes test run https://github.com/kubernetes-sigs/cluster-api/actions/runs/4313798314
