### PR TITLE
:bug: Replace fixed build uid with command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -926,7 +926,7 @@ release-binary: $(RELEASE_DIR)
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
 		-e GOCACHE=/tmp/ \
-		--user 1000:1000 \
+		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:$(GO_VERSION) \


### PR DESCRIPTION
Make the uid introduced in #8219 match the uid used by the user building the binary.

This should allow the release-binaries target to work on more systems.

/area clusterctl
