### PR TITLE
🐛 Add a check that replicas are set in the MachinePool spec

### DIFF
--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -116,6 +116,12 @@ func (r *MachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	if mp.Spec.Replicas == nil {
+		err := errors.Errorf("machinepool %s doesn't have replicas set", mp.Name)
+		log.Error(err, "Failed to find replicas in the MachinePool spec.", mp.Name)
+		return ctrl.Result{}, err
+	}
+
 	log = log.WithValues("Cluster", klog.KRef(mp.ObjectMeta.Namespace, mp.Spec.ClusterName))
 	ctx = ctrl.LoggerInto(ctx, log)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Now, if for some reason replicas are not set, controller starts to panic during [phases reconciliation](https://github.com/kubernetes-sigs/cluster-api/blob/main/exp/internal/controllers/machinepool_controller_phases.go#L67), and the pod goes into CrashLoopBackoff mode.

To prevent this, we add a check to verify that replicas value is not nil. It allows the controller to write a log message, return an error, and start reconciliation again.

