### PR TITLE
✨ SSA: improve request caching

### DIFF
--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -306,7 +306,7 @@ func (r *KubeadmControlPlaneReconciler) updateExternalObject(ctx context.Context
 	// Update annotations
 	updatedObject.SetAnnotations(kcp.Spec.MachineTemplate.ObjectMeta.Annotations)
 
-	if err := ssa.Patch(ctx, r.Client, kcpManagerName, updatedObject); err != nil {
+	if err := ssa.Patch(ctx, r.Client, kcpManagerName, updatedObject, ssa.WithCachingProxy{Cache: r.ssaCache, Original: obj}); err != nil {
 		return errors.Wrapf(err, "failed to update %s", obj.GetObjectKind().GroupVersionKind().Kind)
 	}
 	return nil

--- a/internal/util/ssa/patch_test.go
+++ b/internal/util/ssa/patch_test.go
@@ -18,11 +18,15 @@ package ssa
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 )
 
@@ -33,47 +37,135 @@ func TestPatch(t *testing.T) {
 	ns, err := env.CreateNamespace(ctx, "ssa")
 	g.Expect(err).ToNot(HaveOccurred())
 
-	// Build the test object to work with.
-	initialObject := builder.TestInfrastructureCluster(ns.Name, "obj1").WithSpecFields(map[string]interface{}{
-		"spec.controlPlaneEndpoint.host": "1.2.3.4",
-		"spec.controlPlaneEndpoint.port": int64(1234),
-		"spec.foo":                       "bar",
-	}).Build()
+	t.Run("Test patch with unstructured", func(t *testing.T) {
+		// Build the test object to work with.
+		initialObject := builder.TestInfrastructureCluster(ns.Name, "obj1").WithSpecFields(map[string]interface{}{
+			"spec.controlPlaneEndpoint.host": "1.2.3.4",
+			"spec.controlPlaneEndpoint.port": int64(1234),
+			"spec.foo":                       "bar",
+		}).Build()
 
-	fieldManager := "test-manager"
-	ssaCache := NewCache()
+		fieldManager := "test-manager"
+		ssaCache := NewCache()
 
-	// Create the object
-	createObject := initialObject.DeepCopy()
-	g.Expect(Patch(ctx, env.GetClient(), fieldManager, createObject)).To(Succeed())
+		// 1. Create the object
+		createObject := initialObject.DeepCopy()
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, createObject)).To(Succeed())
 
-	// Update the object and verify that the request was not cached as the object was changed.
-	// Get the original object.
-	originalObject := initialObject.DeepCopy()
-	g.Expect(env.Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
-	// Modify the object
-	modifiedObject := initialObject.DeepCopy()
-	g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
-	// Compute request identifier, so we can later verify that the update call was not cached.
-	requestIdentifier, err := ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedObject)
-	g.Expect(err).ToNot(HaveOccurred())
-	// Update the object
-	g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
-	// Verify that request was not cached (as it changed the object)
-	g.Expect(ssaCache.Has(requestIdentifier)).To(BeFalse())
+		// 2. Update the object and verify that the request was not cached as the object was changed.
+		// Get the original object.
+		originalObject := initialObject.DeepCopy()
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+		// Modify the object
+		modifiedObject := initialObject.DeepCopy()
+		g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
+		// Compute request identifier, so we can later verify that the update call was not cached.
+		modifiedUnstructured, err := prepareModified(env.Scheme(), modifiedObject)
+		g.Expect(err).ToNot(HaveOccurred())
+		requestIdentifier, err := ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedUnstructured)
+		g.Expect(err).ToNot(HaveOccurred())
+		// Update the object
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+		// Verify that request was not cached (as it changed the object)
+		g.Expect(ssaCache.Has(requestIdentifier)).To(BeFalse())
 
-	// Repeat the same update and verify that the request was cached as the object was not changed.
-	// Get the original object.
-	originalObject = initialObject.DeepCopy()
-	g.Expect(env.Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
-	// Modify the object
-	modifiedObject = initialObject.DeepCopy()
-	g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
-	// Compute request identifier, so we can later verify that the update call was cached.
-	requestIdentifier, err = ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedObject)
-	g.Expect(err).ToNot(HaveOccurred())
-	// Update the object
-	g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
-	// Verify that request was cached (as it did not change the object)
-	g.Expect(ssaCache.Has(requestIdentifier)).To(BeTrue())
+		// 3. Repeat the same update and verify that the request was cached as the object was not changed.
+		// Get the original object.
+		originalObject = initialObject.DeepCopy()
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+		// Modify the object
+		modifiedObject = initialObject.DeepCopy()
+		g.Expect(unstructured.SetNestedField(modifiedObject.Object, "baz", "spec", "foo")).To(Succeed())
+		// Compute request identifier, so we can later verify that the update call was cached.
+		modifiedUnstructured, err = prepareModified(env.Scheme(), modifiedObject)
+		g.Expect(err).ToNot(HaveOccurred())
+		requestIdentifier, err = ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedUnstructured)
+		g.Expect(err).ToNot(HaveOccurred())
+		// Update the object
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+		// Verify that request was cached (as it did not change the object)
+		g.Expect(ssaCache.Has(requestIdentifier)).To(BeTrue())
+	})
+
+	t.Run("Test patch with Machine", func(t *testing.T) {
+		// Build the test object to work with.
+		initialObject := &clusterv1.Machine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Machine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "machine-1",
+				Namespace: ns.Name,
+				Labels: map[string]string{
+					"label": "labelValue",
+				},
+				Annotations: map[string]string{
+					"annotation": "annotationValue",
+				},
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName:      "cluster-1",
+				Version:          pointer.String("v1.25.0"),
+				NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Second},
+				Bootstrap: clusterv1.Bootstrap{
+					DataSecretName: pointer.String("data-secret"),
+				},
+			},
+		}
+		fieldManager := "test-manager"
+		ssaCache := NewCache()
+
+		// 1. Create the object
+		createObject := initialObject.DeepCopy()
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, createObject)).To(Succeed())
+		// Note: We have to patch the status here to explicitly set these two status fields.
+		// If we don't do it the Machine defaulting webhook will try to set the two fields to false.
+		// For an unknown reason this will happen with the 2nd update call (3.) below and not before.
+		// This means that this call would unexpectedly not cache the object because the resourceVersion
+		// is changed because the fields are set.
+		// It's unclear why those status fields are not already set during create (1.) or the first update (2.)
+		// (the webhook is returning patches for the two fields in those requests as well).
+		// To further investigate this behavior it would be necessary to debug the kube-apiserver.
+		// Fortunately, in reality this is not an issue as the fields will be set sooner or later and then
+		// the requests are cached.
+		createObjectWithStatus := createObject.DeepCopy()
+		createObjectWithStatus.Status.BootstrapReady = false
+		createObjectWithStatus.Status.InfrastructureReady = false
+		g.Expect(env.Status().Patch(ctx, createObjectWithStatus, client.MergeFrom(createObject)))
+
+		// 2. Update the object and verify that the request was not cached as the object was changed.
+		// Get the original object.
+		originalObject := initialObject.DeepCopy()
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+		// Modify the object
+		modifiedObject := initialObject.DeepCopy()
+		modifiedObject.Spec.NodeDrainTimeout = &metav1.Duration{Duration: 5 * time.Second}
+		// Compute request identifier, so we can later verify that the update call was not cached.
+		modifiedUnstructured, err := prepareModified(env.Scheme(), modifiedObject)
+		g.Expect(err).ToNot(HaveOccurred())
+		requestIdentifier, err := ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedUnstructured)
+		g.Expect(err).ToNot(HaveOccurred())
+		// Update the object
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+		// Verify that request was not cached (as it changed the object)
+		g.Expect(ssaCache.Has(requestIdentifier)).To(BeFalse())
+
+		// 3. Repeat the same update and verify that the request was cached as the object was not changed.
+		// Get the original object.
+		originalObject = initialObject.DeepCopy()
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(originalObject), originalObject))
+		// Modify the object
+		modifiedObject = initialObject.DeepCopy()
+		modifiedObject.Spec.NodeDrainTimeout = &metav1.Duration{Duration: 5 * time.Second}
+		// Compute request identifier, so we can later verify that the update call was cached.
+		modifiedUnstructured, err = prepareModified(env.Scheme(), modifiedObject)
+		g.Expect(err).ToNot(HaveOccurred())
+		requestIdentifier, err = ComputeRequestIdentifier(env.GetScheme(), originalObject, modifiedUnstructured)
+		g.Expect(err).ToNot(HaveOccurred())
+		// Update the object
+		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+		// Verify that request was cached (as it did not change the object)
+		g.Expect(ssaCache.Has(requestIdentifier)).To(BeTrue())
+	})
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR further improves SSA request caching:
1. caching was not used when writing KubeadmConfig / InfraMachine in KCP
2. caching was not always effective as in some cases we continuously tried to write fields like creationTimestamp. In those cases the resourceVersion was continuously changed and thus the request was not cached.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8146
