### PR TITLE
:seedling: Rename md parameters for consistency

### DIFF
--- a/cmd/clusterctl/client/alpha/machinedeployment.go
+++ b/cmd/clusterctl/client/alpha/machinedeployment.go
@@ -118,7 +118,7 @@ func findMachineDeploymentRevision(toRevision int64, allMSs []*clusterv1.Machine
 }
 
 // getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
-func getMachineSetsForDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
+func getMachineSetsForDeployment(proxy cluster.Proxy, md *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
 	log := logf.Log
 	c, err := proxy.NewClient()
 	if err != nil {
@@ -126,7 +126,7 @@ func getMachineSetsForDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeploy
 	}
 	// List all MachineSets to find those we own but that no longer match our selector.
 	machineSets := &clusterv1.MachineSetList{}
-	if err := c.List(ctx, machineSets, client.InNamespace(d.Namespace)); err != nil {
+	if err := c.List(ctx, machineSets, client.InNamespace(md.Namespace)); err != nil {
 		return nil, err
 	}
 
@@ -135,12 +135,12 @@ func getMachineSetsForDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeploy
 		ms := &machineSets.Items[idx]
 
 		// Skip this MachineSet if its controller ref is not pointing to this MachineDeployment
-		if !metav1.IsControlledBy(ms, d) {
+		if !metav1.IsControlledBy(ms, md) {
 			log.V(5).Info("Skipping MachineSet, controller ref does not match MachineDeployment", "machineset", ms.Name)
 			continue
 		}
 
-		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
+		selector, err := metav1.LabelSelectorAsSelector(&md.Spec.Selector)
 		if err != nil {
 			log.V(5).Info("Skipping MachineSet, failed to get label selector from spec selector", "machineset", ms.Name)
 			continue

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker.go
@@ -47,7 +47,7 @@ func (r *rollout) ObjectRollbacker(proxy cluster.Proxy, ref corev1.ObjectReferen
 }
 
 // rollbackMachineDeployment will rollback to a previous MachineSet revision used by this MachineDeployment.
-func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployment, toRevision int64) error {
+func rollbackMachineDeployment(proxy cluster.Proxy, md *clusterv1.MachineDeployment, toRevision int64) error {
 	log := logf.Log
 	c, err := proxy.NewClient()
 	if err != nil {
@@ -57,7 +57,7 @@ func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployme
 	if toRevision < 0 {
 		return errors.Errorf("revision number cannot be negative: %v", toRevision)
 	}
-	msList, err := getMachineSetsForDeployment(proxy, d)
+	msList, err := getMachineSetsForDeployment(proxy, md)
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployme
 		return err
 	}
 	log.V(7).Info("Found revision", "revision", msForRevision)
-	patchHelper, err := patch.NewHelper(d, c)
+	patchHelper, err := patch.NewHelper(md, c)
 	if err != nil {
 		return err
 	}
@@ -75,6 +75,6 @@ func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployme
 	revMSTemplate := *msForRevision.Spec.Template.DeepCopy()
 	delete(revMSTemplate.Labels, clusterv1.MachineDeploymentUniqueLabel)
 
-	d.Spec.Template = revMSTemplate
-	return patchHelper.Patch(ctx, d)
+	md.Spec.Template = revMSTemplate
+	return patchHelper.Patch(ctx, md)
 }

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -172,9 +172,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	return result, err
 }
 
-func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, d *clusterv1.MachineDeployment, options ...patch.Option) error {
+func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, md *clusterv1.MachineDeployment, options ...patch.Option) error {
 	// Always update the readyCondition by summarizing the state of other conditions.
-	conditions.SetSummary(d,
+	conditions.SetSummary(md,
 		conditions.WithConditions(
 			clusterv1.MachineDeploymentAvailableCondition,
 		),
@@ -187,29 +187,29 @@ func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, d *c
 			clusterv1.MachineDeploymentAvailableCondition,
 		}},
 	)
-	return patchHelper.Patch(ctx, d, options...)
+	return patchHelper.Patch(ctx, md, options...)
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, d *clusterv1.MachineDeployment) (ctrl.Result, error) {
+func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, md *clusterv1.MachineDeployment) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(4).Info("Reconcile MachineDeployment")
 
 	// Reconcile and retrieve the Cluster object.
-	if d.Labels == nil {
-		d.Labels = make(map[string]string)
+	if md.Labels == nil {
+		md.Labels = make(map[string]string)
 	}
-	if d.Spec.Selector.MatchLabels == nil {
-		d.Spec.Selector.MatchLabels = make(map[string]string)
+	if md.Spec.Selector.MatchLabels == nil {
+		md.Spec.Selector.MatchLabels = make(map[string]string)
 	}
-	if d.Spec.Template.Labels == nil {
-		d.Spec.Template.Labels = make(map[string]string)
+	if md.Spec.Template.Labels == nil {
+		md.Spec.Template.Labels = make(map[string]string)
 	}
 
-	d.Labels[clusterv1.ClusterNameLabel] = d.Spec.ClusterName
+	md.Labels[clusterv1.ClusterNameLabel] = md.Spec.ClusterName
 
 	// Set the MachineDeployment as directly owned by the Cluster (if not already present).
-	if r.shouldAdopt(d) {
-		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{
+	if r.shouldAdopt(md) {
+		md.OwnerReferences = util.EnsureOwnerRef(md.OwnerReferences, metav1.OwnerReference{
 			APIVersion: clusterv1.GroupVersion.String(),
 			Kind:       "Cluster",
 			Name:       cluster.Name,
@@ -219,17 +219,17 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	}
 
 	// Make sure to reconcile the external infrastructure reference.
-	if err := reconcileExternalTemplateReference(ctx, r.Client, cluster, &d.Spec.Template.Spec.InfrastructureRef); err != nil {
+	if err := reconcileExternalTemplateReference(ctx, r.Client, cluster, &md.Spec.Template.Spec.InfrastructureRef); err != nil {
 		return ctrl.Result{}, err
 	}
 	// Make sure to reconcile the external bootstrap reference, if any.
-	if d.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
-		if err := reconcileExternalTemplateReference(ctx, r.Client, cluster, d.Spec.Template.Spec.Bootstrap.ConfigRef); err != nil {
+	if md.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
+		if err := reconcileExternalTemplateReference(ctx, r.Client, cluster, md.Spec.Template.Spec.Bootstrap.ConfigRef); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	msList, err := r.getMachineSetsForDeployment(ctx, d)
+	msList, err := r.getMachineSetsForDeployment(ctx, md)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -241,7 +241,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	// to all MachineSets created by a MachineDeployment or if a user manually removed the label.
 	for idx := range msList {
 		machineSet := msList[idx]
-		if name, ok := machineSet.Labels[clusterv1.MachineDeploymentNameLabel]; ok && name == d.Name {
+		if name, ok := machineSet.Labels[clusterv1.MachineDeploymentNameLabel]; ok && name == md.Name {
 			continue
 		}
 
@@ -249,7 +249,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to apply %s label to MachineSet %q", clusterv1.MachineDeploymentNameLabel, machineSet.Name)
 		}
-		machineSet.Labels[clusterv1.MachineDeploymentNameLabel] = d.Name
+		machineSet.Labels[clusterv1.MachineDeploymentNameLabel] = md.Name
 		if err := helper.Patch(ctx, machineSet); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to apply %s label to MachineSet %q", clusterv1.MachineDeploymentNameLabel, machineSet.Name)
 		}
@@ -268,35 +268,35 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 		}
 	}
 
-	if d.Spec.Paused {
-		return ctrl.Result{}, r.sync(ctx, d, msList)
+	if md.Spec.Paused {
+		return ctrl.Result{}, r.sync(ctx, md, msList)
 	}
 
-	if d.Spec.Strategy == nil {
+	if md.Spec.Strategy == nil {
 		return ctrl.Result{}, errors.Errorf("missing MachineDeployment strategy")
 	}
 
-	if d.Spec.Strategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType {
-		if d.Spec.Strategy.RollingUpdate == nil {
-			return ctrl.Result{}, errors.Errorf("missing MachineDeployment settings for strategy type: %s", d.Spec.Strategy.Type)
+	if md.Spec.Strategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType {
+		if md.Spec.Strategy.RollingUpdate == nil {
+			return ctrl.Result{}, errors.Errorf("missing MachineDeployment settings for strategy type: %s", md.Spec.Strategy.Type)
 		}
-		return ctrl.Result{}, r.rolloutRolling(ctx, d, msList)
+		return ctrl.Result{}, r.rolloutRolling(ctx, md, msList)
 	}
 
-	if d.Spec.Strategy.Type == clusterv1.OnDeleteMachineDeploymentStrategyType {
-		return ctrl.Result{}, r.rolloutOnDelete(ctx, d, msList)
+	if md.Spec.Strategy.Type == clusterv1.OnDeleteMachineDeploymentStrategyType {
+		return ctrl.Result{}, r.rolloutOnDelete(ctx, md, msList)
 	}
 
-	return ctrl.Result{}, errors.Errorf("unexpected deployment strategy type: %s", d.Spec.Strategy.Type)
+	return ctrl.Result{}, errors.Errorf("unexpected deployment strategy type: %s", md.Spec.Strategy.Type)
 }
 
 // getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
-func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, d *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
+func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, md *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// List all MachineSets to find those we own but that no longer match our selector.
 	machineSets := &clusterv1.MachineSetList{}
-	if err := r.Client.List(ctx, machineSets, client.InNamespace(d.Namespace)); err != nil {
+	if err := r.Client.List(ctx, machineSets, client.InNamespace(md.Namespace)); err != nil {
 		return nil, err
 	}
 
@@ -304,7 +304,7 @@ func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, d *cluster
 	for idx := range machineSets.Items {
 		ms := &machineSets.Items[idx]
 		log.WithValues("MachineSet", klog.KObj(ms))
-		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
+		selector, err := metav1.LabelSelectorAsSelector(&md.Spec.Selector)
 		if err != nil {
 			log.Error(err, "Skipping MachineSet, failed to get label selector from spec selector")
 			continue
@@ -317,23 +317,23 @@ func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, d *cluster
 		}
 
 		// Skip this MachineSet unless either selector matches or it has a controller ref pointing to this MachineDeployment
-		if !selector.Matches(labels.Set(ms.Labels)) && !metav1.IsControlledBy(ms, d) {
+		if !selector.Matches(labels.Set(ms.Labels)) && !metav1.IsControlledBy(ms, md) {
 			log.V(4).Info("Skipping MachineSet, label mismatch")
 			continue
 		}
 
 		// Attempt to adopt MachineSet if it meets previous conditions and it has no controller references.
 		if metav1.GetControllerOf(ms) == nil {
-			if err := r.adoptOrphan(ctx, d, ms); err != nil {
+			if err := r.adoptOrphan(ctx, md, ms); err != nil {
 				log.Error(err, "Failed to adopt MachineSet into MachineDeployment")
-				r.recorder.Eventf(d, corev1.EventTypeWarning, "FailedAdopt", "Failed to adopt MachineSet %q: %v", ms.Name, err)
+				r.recorder.Eventf(md, corev1.EventTypeWarning, "FailedAdopt", "Failed to adopt MachineSet %q: %v", ms.Name, err)
 				continue
 			}
 			log.Info("Adopted MachineSet into MachineDeployment")
-			r.recorder.Eventf(d, corev1.EventTypeNormal, "SuccessfulAdopt", "Adopted MachineSet %q", ms.Name)
+			r.recorder.Eventf(md, corev1.EventTypeNormal, "SuccessfulAdopt", "Adopted MachineSet %q", ms.Name)
 		}
 
-		if !metav1.IsControlledBy(ms, d) {
+		if !metav1.IsControlledBy(ms, md) {
 			continue
 		}
 

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -30,8 +30,8 @@ import (
 )
 
 // rolloutRolling implements the logic for rolling a new MachineSet.
-func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
-	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, d, msList, true)
+func (r *Reconciler) rolloutRolling(ctx context.Context, md *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
+	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, md, msList, true)
 	if err != nil {
 		return err
 	}
@@ -46,25 +46,25 @@ func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDep
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.
-	if err := r.reconcileNewMachineSet(ctx, allMSs, newMS, d); err != nil {
+	if err := r.reconcileNewMachineSet(ctx, allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
 	// Scale down, if we can.
-	if err := r.reconcileOldMachineSets(ctx, allMSs, oldMSs, newMS, d); err != nil {
+	if err := r.reconcileOldMachineSets(ctx, allMSs, oldMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if mdutil.DeploymentComplete(d, &d.Status) {
-		if err := r.cleanupDeployment(ctx, oldMSs, d); err != nil {
+	if mdutil.DeploymentComplete(md, &md.Status) {
+		if err := r.cleanupDeployment(ctx, oldMSs, md); err != nil {
 			return err
 		}
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
@@ -32,8 +32,8 @@ import (
 )
 
 // rolloutOnDelete implements the logic for the OnDelete MachineDeploymentStrategyType.
-func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
-	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, d, msList, true)
+func (r *Reconciler) rolloutOnDelete(ctx context.Context, md *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
+	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, md, msList, true)
 	if err != nil {
 		return err
 	}
@@ -48,25 +48,25 @@ func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDe
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.
-	if err := r.reconcileNewMachineSetOnDelete(ctx, allMSs, newMS, d); err != nil {
+	if err := r.reconcileNewMachineSetOnDelete(ctx, allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
 	// Scale down, if we can.
-	if err := r.reconcileOldMachineSetsOnDelete(ctx, oldMSs, allMSs, d); err != nil {
+	if err := r.reconcileOldMachineSetsOnDelete(ctx, oldMSs, allMSs, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if mdutil.DeploymentComplete(d, &d.Status) {
-		if err := r.cleanupDeployment(ctx, oldMSs, d); err != nil {
+	if mdutil.DeploymentComplete(md, &md.Status) {
+		if err := r.cleanupDeployment(ctx, oldMSs, md); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Update MachineDeployment parameter names (`d` -> `md`) to make them more consistent across the codebase.

/kind cleanup
/area code-organization

