### PR TITLE
📖 book: extend next steps of quick start

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1567,7 +1567,9 @@ kind delete cluster
 
 ## Next steps
 
-See the [clusterctl] documentation for more detail about clusterctl supported actions.
+- Create a second workload cluster. Simply follow the steps outlined above, but remember to provide a different name for your second workload cluster.
+- Deploy applications to your workload cluster. Use the [CNI deployment steps](#deploy-a-cni-solution) for pointers.
+- See the [clusterctl] documentation for more detail about clusterctl supported actions.
 
 <!-- links -->
 [Experimental Features]: ../tasks/experimental-features/experimental-features.md


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
in quick start there was info for first cluster but second cluster info was missing I have just added that. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8152
