### PR TITLE
🐛 clusterctl: return early if release for latest tag does not exist yet

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/client/repository/repository_github_test.go
@@ -441,6 +441,15 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 		fmt.Fprint(w, "v0.3.1\n")
 	})
 
+	// setup an handler for returning 4 fake releases but no actual tagged release
+	muxGoproxy.HandleFunc("/github.com/o/r2/@v/list", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "v0.5.0\n")
+		fmt.Fprint(w, "v0.4.0\n")
+		fmt.Fprint(w, "v0.3.2\n")
+		fmt.Fprint(w, "v0.3.1\n")
+	})
+
 	configVariablesClient := test.NewFakeVariableClient()
 
 	type field struct {
@@ -480,6 +489,15 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 			contract: "foo",
 			wantErr:  false,
 		},
+		{
+			name: "Return 404 if there is no release for the tag",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://github.com/o/r2/releases/v0.99.0/path", clusterctlv1.CoreProviderType),
+			},
+			want:     "0.99.0",
+			contract: "v1alpha4",
+			wantErr:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -514,6 +532,11 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 		fmt.Fprint(w, "v0.4.3-alpha\n") // prerelease
 		fmt.Fprint(w, "foo\n")          // no semantic version tag
 	})
+	// And also expose a release for them
+	muxGoproxy.HandleFunc("/api.github.com/repos/o/r1/releases/tags/v0.4.2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "{}\n")
+	})
 
 	// Setup a handler for returning no releases.
 	muxGoproxy.HandleFunc("/github.com/o/r2/@v/list", func(w http.ResponseWriter, r *http.Request) {
@@ -543,7 +566,7 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 		{
 			name: "Get latest release, ignores pre-release version",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.4.2/path", clusterctlv1.CoreProviderType),
 			},
 			want:    "v0.4.2",
 			wantErr: false,
@@ -559,7 +582,7 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 		{
 			name: "Falls back to latest prerelease when no official release present",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r3/releases/latest/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r3/releases/v0.1.0-alpha.2/path", clusterctlv1.CoreProviderType),
 			},
 			want:    "v0.1.0-alpha.2",
 			wantErr: false,
@@ -619,7 +642,7 @@ func Test_gitHubRepository_getLatestPatchRelease(t *testing.T) {
 		{
 			name: "Get latest patch release, no Major/Minor specified",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v1.3.2/path", clusterctlv1.CoreProviderType),
 			},
 			minor:   nil,
 			major:   nil,
@@ -629,7 +652,7 @@ func Test_gitHubRepository_getLatestPatchRelease(t *testing.T) {
 		{
 			name: "Get latest patch release, for Major 0 and Minor 3",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.3.2/path", clusterctlv1.CoreProviderType),
 			},
 			major:   &major0,
 			minor:   &minor3,
@@ -639,7 +662,7 @@ func Test_gitHubRepository_getLatestPatchRelease(t *testing.T) {
 		{
 			name: "Get latest patch release, for Major 0 and Minor 4",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.4.0/path", clusterctlv1.CoreProviderType),
 			},
 			major:   &major0,
 			minor:   &minor4,

--- a/cmd/clusterctl/client/repository/repository_versions.go
+++ b/cmd/clusterctl/client/repository/repository_versions.go
@@ -39,11 +39,16 @@ func latestContractRelease(repo Repository, contract string) (string, error) {
 	}
 	// Attempt to check if the latest release satisfies the API Contract
 	// This is a best-effort attempt to find the latest release for an older API contract if it's not the latest release.
-	// If an error occurs, we just return the latest release.
 	file, err := repo.GetFile(latest, metadataFile)
+	// If an error occurs, we just return the latest release.
 	if err != nil {
+		if errors.Is(err, errNotFound) {
+			// If it was ErrNotFound, then there is no release yet for the resolved tag.
+			// Ref: https://github.com/kubernetes-sigs/cluster-api/issues/7889
+			return "", err
+		}
 		// if we can't get the metadata file from the release, we return latest.
-		return latest, nil //nolint:nilerr
+		return latest, nil
 	}
 	latestMetadata := &clusterctlv1.Metadata{}
 	codecFactory := serializer.NewCodecFactory(scheme.Scheme)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds the ability to detect a 404 error from the github client and handle the error differently than just bubbling up the usual error message.

It now also does not retry fetching the release on 404 errors and immediately returns instead.

Old output was (after 1m timeout):

> Error: failed to get provider components for the "cluster-api" provider: failed to read "core-components.yaml" from provider's repository "cluster-api": failed to get GitHub release v1.3.6: failed to read release "v1.3.6": GET https://api.github.com/repos/kubernetes-sigs/cluster-api/releases/tags/v1.3.6: 404 Not Found []

New output is:

> Error: failed to get provider components for the "cluster-api" provider: failed to get repository client for the CoreProvider with name cluster-api: error creating the GitHub repository client: failed to get latest release: release does not exist yet, consider setting "GOPROXY=off" as workaround: failed to get GitHub release v1.3.6: 404 Not Found

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially fixing #7889
