### PR TITLE
:book: Make beta + rc tag names less specific in docs

### DIFF
--- a/docs/release/releases/release-1.4.md
+++ b/docs/release/releases/release-1.4.md
@@ -15,11 +15,11 @@ The following table shows the preliminary dates for the `v1.4` release cycle.
 | *v1.2.x & v1.3.x released*                           | Release Lead | Tuesday 31st January 2023  | week 9   |
 | v1.4.0-beta.0 released                               | Release Lead | Tuesday 28th February 2023 | week 13  |
 | *v1.2.x & v1.3.x released*                           | Release Lead | Tuesday 28th February 2023 | week 13  |
-| v1.4.0-beta.1 released                               | Release Lead | Tuesday 7th March 2023     | week 14  |
+| v1.4.0-beta.x released                               | Release Lead | Tuesday 7th March 2023     | week 14  |
 | release-1.4 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 14th March 2023    | week 15  |
 | v1.4.0-rc.0 released                                 | Release Lead | Tuesday 14th March 2023    | week 15  |
 | release-1.4 jobs created                             | CI Manager   | Tuesday 14th March 2023    | week 15  |
-| v1.4.0-rc.1 released                                 | Release Lead | Tuesday 21st March 2023    | week 16  |
+| v1.4.0-rc.x released                                 | Release Lead | Tuesday 21st March 2023    | week 16  |
 | **v1.4.0 released**                                  | Release Lead | Tuesday 28th March 2023    | week 17  |
 | *v1.2.x & v1.3.x released*                           | Release Lead | Tuesday 28th March 2023    | week 17  |
 | Organize release retrospective                       | Release Lead | TBC                        | week 17  |

--- a/docs/release/releases/release-1.5.md
+++ b/docs/release/releases/release-1.5.md
@@ -13,11 +13,11 @@ The following table shows the preliminary dates for the `v1.5` release cycle.
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 30th May 2023      | week 9   |
 | v1.5.0-beta.0 released                               | Release Lead | Tuesday 27th June 2023     | week 13  |
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 27th June 2023     | week 13  |
-| v1.5.0-beta.1 released                               | Release Lead | Tuesday 4th July 2023      | week 14  |
+| v1.5.0-beta.x released                               | Release Lead | Tuesday 4th July 2023      | week 14  |
 | release-1.5 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 11th July 2023     | week 15  |
 | v1.5.0-rc.0 released                                 | Release Lead | Tuesday 11th July 2023     | week 15  |
 | release-1.5 jobs created                             | CI Manager   | Tuesday 11th July 2023     | week 15  |
-| v1.5.0-rc.1 released                                 | Release Lead | Tuesday 18th July 2023     | week 16  |
+| v1.5.0-rc.x released                                 | Release Lead | Tuesday 18th July 2023     | week 16  |
 | **v1.5.0 released**                                  | Release Lead | Tuesday 25th July 2023     | week 17  |
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 25th July 2023     | week 17  |
 | Organize release retrospective                       | Release Lead | TBC                        | week 17  |


### PR DESCRIPTION
Make the beta and release candidate tags expressed in the release timeline doc less specific. This allows for additional beta and rc releases during a release cycle where needed without any requirement to constantly update docs to keep them in sync with actual release dates.

/area release

