### PR TITLE
:seedling:  replacing DeepEqual with cmp Diff in tests

### DIFF
--- a/exp/addons/api/v1alpha3/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1alpha3/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/api/v1alpha3/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1alpha3/clusterresourcesetbinding_types_test.go
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/api/v1alpha4/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1alpha4/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/api/v1alpha4/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1alpha4/clusterresourcesetbinding_types_test.go
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
@@ -207,7 +207,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -207,7 +207,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if diff := cmp.Diff(b.ResourceRef, tt.resourceBinding.ResourceRef); diff == "" {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1210,8 +1210,8 @@ func Test_aggregateResponses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			aggregateSuccessfulResponses(tt.aggregateResponse, tt.responses)
 
-			if !reflect.DeepEqual(tt.aggregateResponse, tt.want) {
-				t.Errorf("aggregateSuccessfulResponses() got = %v, want %v", tt.aggregateResponse, tt.want)
+			if diff := cmp.Diff(tt.aggregateResponse, tt.want); diff != "" {
+				t.Errorf("aggregateSuccessfulResponses() got = %v, want %v, diff = %v", tt.aggregateResponse, tt.want, diff)
 			}
 		})
 	}

--- a/internal/topology/variables/schema_test.go
+++ b/internal/topology/variables/schema_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package variables
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -196,8 +196,8 @@ func Test_convertToAPIExtensionsJSONSchemaProps(t *testing.T) {
 				}
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("convertToAPIExtensionsJSONSchemaProps() got = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("convertToAPIExtensionsJSONSchemaProps() got = %v, want %v, diff %v", got, tt.want, diff)
 			}
 		})
 	}

--- a/util/conditions/compare.go
+++ b/util/conditions/compare.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Check(actual interface{}, expected interface{}) (result bool, err error) {
+	defer func() error {
+		if recover() != nil {
+			log.Printf("panic occured got %v expected %v", actual, expected)
+			err = fmt.Errorf("panic occured got %v expected %v", actual, expected)
+		}
+		return nil
+	}()
+	diff := cmp.Diff(actual, expected)
+	if diff == "" {
+		return true, err
+	}
+	log.Printf("mismatch of objects actual %v expected %v diff %v", actual, expected, diff)
+	return false, err
+}

--- a/util/conditions/compare.go
+++ b/util/conditions/compare.go
@@ -18,23 +18,25 @@ package conditions
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func Check(actual interface{}, expected interface{}) (result bool, err error) {
-	defer func() error {
+// Check compares the actual and expected values provided using the
+// cmp package and handles panic errors in case of comparison.
+func Check(actual interface{}, expected interface{}) (result bool, diff string, err error) {
+	result = true
+	defer func() {
 		if recover() != nil {
-			log.Printf("panic occured got %v expected %v", actual, expected)
-			err = fmt.Errorf("panic occured got %v expected %v", actual, expected)
+			err = fmt.Errorf("panic occurred got %v expected %v", actual, expected)
 		}
-		return nil
 	}()
-	diff := cmp.Diff(actual, expected)
-	if diff == "" {
-		return true, err
+	diff = cmp.Diff(actual, expected)
+	if err != nil {
+		return !result, "", err
 	}
-	log.Printf("mismatch of objects actual %v expected %v diff %v", actual, expected, diff)
-	return false, err
+	if diff != "" {
+		return !result, diff, nil
+	}
+	return result, diff, nil
 }

--- a/util/conditions/compare_test.go
+++ b/util/conditions/compare_test.go
@@ -21,7 +21,8 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	unstructv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -154,7 +155,7 @@ func TestCompareConditions(t *testing.T) {
 		},
 		{
 			name: "with similar unstructed object",
-			actual: &unstructured.Unstructured{
+			actual: &unstructv1.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "GenericBootstrapConfig",
 					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
@@ -168,7 +169,7 @@ func TestCompareConditions(t *testing.T) {
 					},
 				},
 			},
-			expected: &unstructured.Unstructured{
+			expected: &unstructv1.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "GenericBootstrapConfig",
 					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
@@ -186,7 +187,7 @@ func TestCompareConditions(t *testing.T) {
 		},
 		{
 			name: "with unsimilar dataSecretName type object",
-			actual: &unstructured.Unstructured{
+			actual: &unstructv1.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "GenericBootstrapConfig",
 					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
@@ -200,7 +201,7 @@ func TestCompareConditions(t *testing.T) {
 					},
 				},
 			},
-			expected: &unstructured.Unstructured{
+			expected: &unstructv1.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "GenericBootstrapConfig",
 					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
@@ -218,7 +219,7 @@ func TestCompareConditions(t *testing.T) {
 		},
 		{
 			name: "with unsimilar types",
-			actual: &unstructured.Unstructured{
+			actual: &unstructv1.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "GenericBootstrapConfig",
 					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
@@ -254,7 +255,7 @@ func TestCompareConditions(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			result, _ := Check(tc.actual, tc.expected)
+			result, _, _ := Check(tc.actual, tc.expected)
 			g.Expect(result).To(Equal(tc.expectMatch))
 		})
 	}

--- a/util/conditions/compare_test.go
+++ b/util/conditions/compare_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestCompareConditions(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actual      interface{}
+		expected    interface{}
+		expectMatch bool
+	}{
+		{
+			name:        "with similar strings",
+			actual:      "testing compare function",
+			expected:    "testing compare function",
+			expectMatch: true,
+		},
+		{
+			name:        "with non similar strings",
+			actual:      "testing compare function",
+			expected:    "testing compare functions",
+			expectMatch: false,
+		},
+		{
+			name: "with similar clusterv1 cluster object",
+			actual: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expected: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with unsimilar clusterv1 cluster name object",
+			actual: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test1",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expected: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test2",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with unsimilar clusterv1 cluster conditions object",
+			actual: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test1",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expected: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test1",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*FalseCondition(clusterv1.ControlPlaneInitializedCondition, "", clusterv1.ConditionSeverityInfo, ""),
+					},
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with similar unstructed object",
+			actual: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "GenericBootstrapConfig",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "test-namespace",
+					},
+					"status": map[string]interface{}{
+						"ready":          true,
+						"dataSecretName": "data",
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "GenericBootstrapConfig",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "test-namespace",
+					},
+					"status": map[string]interface{}{
+						"ready":          true,
+						"dataSecretName": "data",
+					},
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with unsimilar dataSecretName type object",
+			actual: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "GenericBootstrapConfig",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "test-namespace",
+					},
+					"status": map[string]interface{}{
+						"ready":          true,
+						"dataSecretName": "data1",
+					},
+				},
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "GenericBootstrapConfig",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "test-namespace",
+					},
+					"status": map[string]interface{}{
+						"ready":          true,
+						"dataSecretName": "data2",
+					},
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with unsimilar types",
+			actual: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "GenericBootstrapConfig",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-bootstrap-",
+						"namespace":    "test-namespace",
+					},
+					"status": map[string]interface{}{
+						"ready":          true,
+						"dataSecretName": "data",
+					},
+				},
+			},
+			expected: &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Cluster",
+					APIVersion: clusterv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test",
+					Namespace:    "test-namespace",
+				},
+				Status: clusterv1.ClusterStatus{
+					InfrastructureReady: false,
+					Conditions: clusterv1.Conditions{
+						*TrueCondition(clusterv1.ControlPlaneInitializedCondition),
+					},
+				},
+			},
+			expectMatch: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result, _ := Check(tc.actual, tc.expected)
+			g.Expect(result).To(Equal(tc.expectMatch))
+		})
+	}
+}

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -107,7 +107,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				result, diff, _ := conditions.Check(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.GetOwnerReferences(), objAfter.GetOwnerReferences(), diff)
+				}
 				return result
 			}, timeout).Should(BeTrue())
 		})
@@ -542,7 +545,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(obj.Finalizers, objAfter.Finalizers)
+				result, diff, _ := conditions.Check(obj.Finalizers, objAfter.Finalizers)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Finalizers, objAfter.Finalizers, diff)
+				}
 				return result
 			}, timeout).Should(BeTrue())
 		})
@@ -626,7 +632,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
+				result, diff, _ := conditions.Check(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef, diff)
+				}
 				return objAfter.Spec.Paused && result
 			}, timeout).Should(BeTrue())
 		})
@@ -665,7 +674,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(objAfter.Status, obj.Status)
+				result, diff, _ := conditions.Check(objAfter.Status, obj.Status)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Status, objAfter.Status, diff)
+				}
 				return result
 			}, timeout).Should(BeTrue())
 		})
@@ -715,7 +727,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				result, diff, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Spec, objAfter.Spec, diff)
+				}
 				return obj.Status.InfrastructureReady == objAfter.Status.InfrastructureReady &&
 					conditions.IsTrue(objAfter, clusterv1.ReadyCondition) &&
 					result
@@ -773,7 +788,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				result, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				result, diff, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Spec, objAfter.Spec, diff)
+				}
 				return result &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())
@@ -822,8 +840,14 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				specResult, _ := conditions.Check(obj.Spec, objAfter.Spec)
-				statusResult, _ := conditions.Check(obj.Status, objAfter.Status)
+				specResult, diff, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Spec, objAfter.Spec, diff)
+				}
+				statusResult, diff, _ := conditions.Check(obj.Status, objAfter.Status)
+				if diff != "" {
+					t.Logf("mismatch of objects actual %v expected %v diff %v", obj.Status, objAfter.Status, diff)
+				}
 				return specResult && statusResult &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package patch
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,7 +107,8 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				return reflect.DeepEqual(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				result, _ := conditions.Check(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				return result
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -542,8 +542,8 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-
-				return reflect.DeepEqual(obj.Finalizers, objAfter.Finalizers)
+				result, _ := conditions.Check(obj.Finalizers, objAfter.Finalizers)
+				return result
 			}, timeout).Should(BeTrue())
 		})
 
@@ -626,9 +626,8 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-
-				return objAfter.Spec.Paused &&
-					reflect.DeepEqual(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
+				result, _ := conditions.Check(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
+				return objAfter.Spec.Paused && result
 			}, timeout).Should(BeTrue())
 		})
 
@@ -666,7 +665,8 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				return reflect.DeepEqual(objAfter.Status, obj.Status)
+				result, _ := conditions.Check(objAfter.Status, obj.Status)
+				return result
 			}, timeout).Should(BeTrue())
 		})
 
@@ -715,10 +715,10 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-
+				result, _ := conditions.Check(obj.Spec, objAfter.Spec)
 				return obj.Status.InfrastructureReady == objAfter.Status.InfrastructureReady &&
 					conditions.IsTrue(objAfter, clusterv1.ReadyCondition) &&
-					reflect.DeepEqual(obj.Spec, objAfter.Spec)
+					result
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -773,8 +773,8 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-
-				return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
+				result, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				return result &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())
 		})
@@ -822,9 +822,9 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-
-				return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
-					reflect.DeepEqual(obj.Status, objAfter.Status) &&
+				specResult, _ := conditions.Check(obj.Spec, objAfter.Spec)
+				statusResult, _ := conditions.Check(obj.Status, objAfter.Status)
+				return specResult && statusResult &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())
 		})


### PR DESCRIPTION
wrapper function to compare cmp diff in case panic occurs with log

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
replaces reflect.DeepEqual with go-cmp diff function and also creates a wrapper function to perform comparisons that handles panics which can be used for non testing code as suggested in issue discussion. Tests for the same written
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8186 
