### PR TITLE
🐛 test/e2e: use topology cluster-template for clusterctl upgrade mgmt cluster 

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -39,6 +39,8 @@ var _ = Describe("When testing clusterctl upgrades (v0.3=>current)", func() {
 			UpgradeClusterctlVariables: map[string]string{
 				"CLUSTER_TOPOLOGY": "false",
 			},
+			MgmtFlavor:     "topology",
+			WorkloadFlavor: "",
 		}
 	})
 })
@@ -54,6 +56,8 @@ var _ = Describe("When testing clusterctl upgrades (v0.4=>current)", func() {
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1alpha4",
 			InitWithKubernetesVersion: "v1.23.13",
+			MgmtFlavor:                "topology",
+			WorkloadFlavor:            "",
 		}
 	})
 })
@@ -78,6 +82,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.23.13",
+			MgmtFlavor:                        "topology",
+			WorkloadFlavor:                    "",
 		}
 	})
 })
@@ -102,6 +108,10 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
+			// TODO(sbueringer) The topology flavor enables PSA.
+			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
+			//MgmtFlavor:                        "topology",
+			WorkloadFlavor: "",
 		}
 	})
 })
@@ -126,7 +136,10 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>cur
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
-			WorkloadFlavor:                    "topology",
+			// TODO(sbueringer) The topology flavor enables PSA.
+			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
+			//MgmtFlavor:                        "topology",
+			WorkloadFlavor: "topology",
 		}
 	})
 })
@@ -142,6 +155,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.26.0",
+			MgmtFlavor:                "topology",
+			WorkloadFlavor:            "",
 		}
 	})
 })
@@ -157,6 +172,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.26.0",
+			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 		}
 	})


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This should make the v0.3, v0.4 & v1.0 clusterctl upgrades more stable.

Currently they are using the default flavor. But the default flavor is not setting the cgroupDriver to cgroupfs for Kubernetes < 1.24.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
