### PR TITLE
[release-1.2] 🌱 CAPD: set privileged PSA policy

### DIFF
--- a/test/infrastructure/docker/config/default/namespace.yaml
+++ b/test/infrastructure/docker/config/default/namespace.yaml
@@ -3,4 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    # CAPD requires the privileged policy because it needs to mount the docker socket using a hostPath.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
   name: system


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Manual cherry-pick of the CAPD change in #7446
