### PR TITLE
🐛 Add soft ownership from clusters to ClusterResourceSetBinding

### DIFF
--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1099,6 +1099,7 @@ func (f *FakeClusterResourceSet) Objs() []client.Object {
 				Namespace: cluster.Namespace,
 			},
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
+				ClusterName: cluster.Name,
 				Bindings: []*addonsv1.ResourceSetBinding{
 					{
 						ClusterResourceSetName: crs.Name,
@@ -1118,14 +1119,6 @@ func (f *FakeClusterResourceSet) Objs() []client.Object {
 		})
 
 		objs = append(objs, binding)
-
-		// binding are owned by the Cluster / ownership set by the ClusterResourceSet controller
-		binding.SetOwnerReferences(append(binding.OwnerReferences, metav1.OwnerReference{
-			APIVersion: cluster.APIVersion,
-			Kind:       cluster.Kind,
-			Name:       cluster.Name,
-			UID:        cluster.UID,
-		}))
 
 		resourceSetBinding := addonsv1.ResourceSetBinding{
 			ClusterResourceSetName: crs.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/pull/7680 removed the owner reference from cluster to ClusterResourceSetBinding, replacing it with a spec.ClusterName field

However, we did not fix the fake objects used for validating clusterctl move accordingly, and thus even if unit tests for move were passing, we are seeking flakiness in CI because there is no more a deterministic order between Cluster and ClusterResourceSetBinding (see details in the attached issue).

This PR fixes this issue by introducing soft ownership from clusters to ClusterResourceSetBinding; It also fixes the softOwnership test that was not really up to date with what the function is currently doing.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/8316
