### PR TITLE
🌱 Bump golangci-lint to 1.52.1 and fix findings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,5 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.4.0
         with:
-          version: v1.51.2
+          version: v1.52.1
           working-directory: ${{matrix.working-directory}}

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -226,7 +226,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		// No new machine should be created.
 		// Note: expected length is 0 because no machine is created and hence no machine is on the API server.
 		// Other machines are in-memory only during the test.
-		g.Expect(controlPlaneMachines.Items).To(HaveLen(0))
+		g.Expect(controlPlaneMachines.Items).To(BeEmpty())
 
 		endMachines := collections.FromMachineList(controlPlaneMachines)
 		for _, m := range endMachines {

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -394,7 +394,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
-			g.Expect(machine.Status.Addresses).To(HaveLen(0))
+			g.Expect(machine.Status.Addresses).To(BeEmpty())
 			// Verify that the LastUpdated timestamp was updated
 			g.Expect(machine.Status.LastUpdated).NotTo(BeNil())
 			g.Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())

--- a/internal/controllers/topology/cluster/conditions.go
+++ b/internal/controllers/topology/cluster/conditions.go
@@ -103,19 +103,19 @@ func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluste
 
 		switch {
 		case s.UpgradeTracker.ControlPlane.PendingUpgrade:
-			msgBuilder.WriteString(fmt.Sprintf("Control plane upgrade to %s on hold.", s.Blueprint.Topology.Version))
+			fmt.Fprintf(msgBuilder, "Control plane upgrade to %s on hold.", s.Blueprint.Topology.Version)
 			reason = clusterv1.TopologyReconciledControlPlaneUpgradePendingReason
 		case s.UpgradeTracker.MachineDeployments.PendingUpgrade():
-			msgBuilder.WriteString(fmt.Sprintf("MachineDeployment(s) %s upgrade to version %s on hold.",
+			fmt.Fprintf(msgBuilder, "MachineDeployment(s) %s upgrade to version %s on hold.",
 				computeMachineDeploymentNameList(s.UpgradeTracker.MachineDeployments.PendingUpgradeNames()),
 				s.Blueprint.Topology.Version,
-			))
+			)
 			reason = clusterv1.TopologyReconciledMachineDeploymentsUpgradePendingReason
 		case s.UpgradeTracker.MachineDeployments.DeferredUpgrade():
-			msgBuilder.WriteString(fmt.Sprintf("MachineDeployment(s) %s upgrade to version %s deferred.",
+			fmt.Fprintf(msgBuilder, "MachineDeployment(s) %s upgrade to version %s deferred.",
 				computeMachineDeploymentNameList(s.UpgradeTracker.MachineDeployments.DeferredUpgradeNames()),
 				s.Blueprint.Topology.Version,
-			))
+			)
 			reason = clusterv1.TopologyReconciledMachineDeploymentsUpgradeDeferredReason
 		}
 
@@ -128,15 +128,15 @@ func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluste
 			if err != nil {
 				return errors.Wrap(err, "failed to get control plane spec version")
 			}
-			msgBuilder.WriteString(fmt.Sprintf(" Control plane is upgrading to version %s", *cpVersion))
+			fmt.Fprintf(msgBuilder, " Control plane is upgrading to version %s", *cpVersion)
 
 		case s.UpgradeTracker.ControlPlane.IsScaling:
 			msgBuilder.WriteString(" Control plane is reconciling desired replicas")
 
 		case s.Current.MachineDeployments.IsAnyRollingOut():
-			msgBuilder.WriteString(fmt.Sprintf(" MachineDeployment(s) %s are rolling out",
+			fmt.Fprintf(msgBuilder, " MachineDeployment(s) %s are rolling out",
 				computeMachineDeploymentNameList(s.UpgradeTracker.MachineDeployments.RolloutNames()),
-			))
+			)
 		}
 
 		conditions.Set(

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -527,7 +527,7 @@ func ScaleAndWaitMachineDeploymentTopology(ctx context.Context, input ScaleAndWa
 	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling ScaleAndWaitMachineDeployment")
 	Expect(input.Cluster).ToNot(BeNil(), "Invalid argument. input.Cluster can't be nil when calling ScaleAndWaitMachineDeployment")
 	Expect(input.Cluster.Spec.Topology.Workers).ToNot(BeNil(), "Invalid argument. input.Cluster must have MachineDeployment topologies")
-	Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments) >= 1).To(BeTrue(), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")
+	Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments)).NotTo(BeEmpty(), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")
 
 	mdTopology := input.Cluster.Spec.Topology.Workers.MachineDeployments[0]
 	log.Logf("Scaling machine deployment topology %s from %d to %d replicas", mdTopology.Name, *mdTopology.Replicas, input.Replicas)

--- a/test/framework/namespace_helpers.go
+++ b/test/framework/namespace_helpers.go
@@ -147,13 +147,13 @@ func WatchNamespaceEvents(ctx context.Context, input WatchNamespaceEventsInput) 
 	_, err = eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			e := obj.(*corev1.Event)
-			_, _ = f.WriteString(fmt.Sprintf("[New Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
-				klog.KObj(e), e.InvolvedObject.APIVersion, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message, e))
+			_, _ = fmt.Fprintf(f, "[New Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
+				klog.KObj(e), e.InvolvedObject.APIVersion, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message, e)
 		},
 		UpdateFunc: func(_, obj interface{}) {
 			e := obj.(*corev1.Event)
-			_, _ = f.WriteString(fmt.Sprintf("[Updated Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
-				klog.KObj(e), e.InvolvedObject.APIVersion, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message, e))
+			_, _ = fmt.Fprintf(f, "[Updated Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
+				klog.KObj(e), e.InvolvedObject.APIVersion, e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Message, e)
 		},
 		DeleteFunc: func(obj interface{}) {},
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

While working with release notes I noticed a commit message about bumping golangci-lint to `1.52.0` but it actually bumps to `1.51.2`. This commit bumps to `1.52.1` and fixes the new findings.

New findings:
```
internal/controllers/machine/machine_controller_phases_test.go:397:4: ginkgo-linter: wrong length assertion; consider using `g.Expect(machine.Status.Addresses).To(BeEmpty())` instead (ginkgolinter)
                        g.Expect(machine.Status.Addresses).To(HaveLen(0))
                        ^
controlplane/kubeadm/internal/controllers/scale_test.go:229:3: ginkgo-linter: wrong length assertion; consider using `g.Expect(controlPlaneMachines.Items).To(BeEmpty())` instead (ginkgolinter)
                g.Expect(controlPlaneMachines.Items).To(HaveLen(0))
                ^
internal/controllers/topology/cluster/conditions.go:131:4: preferFprint: suggestion: fmt.Fprintf(msgBuilder, " Control plane is upgrading to version %s", *cpVersion) (gocritic)
                        msgBuilder.WriteString(fmt.Sprintf(" Control plane is upgrading to version %s", *cpVersion))
                        ^
internal/controllers/topology/cluster/conditions.go:137:4: preferFprint: suggestion: fmt.Fprintf(msgBuilder, " MachineDeployment(s) %s are rolling out",
                        <...>pgradeTracker.MachineDeployments.RolloutNames())) (gocritic)
                        msgBuilder.WriteString(fmt.Sprintf(" MachineDeployment(s) %s are rolling out",
                        ^
internal/controllers/topology/cluster/conditions.go:106:4: preferFprint: suggestion: fmt.Fprintf(msgBuilder, "Control plane upgrade to %s on hold.", s.Blueprint.Topology.Version) (gocritic)
                        msgBuilder.WriteString(fmt.Sprintf("Control plane upgrade to %s on hold.", s.Blueprint.Topology.Version))
                        ^
internal/controllers/topology/cluster/conditions.go:109:4: preferFprint: suggestion: fmt.Fprintf(msgBuilder, "MachineDeployment(s) %s upgrade to version %s <...>pgradeNames()),
                                s.Blueprint.Topology.Version) (gocritic)
                        msgBuilder.WriteString(fmt.Sprintf("MachineDeployment(s) %s upgrade to version %s on hold.",
                        ^
internal/controllers/topology/cluster/conditions.go:115:4: preferFprint: suggestion: fmt.Fprintf(msgBuilder, "MachineDeployment(s) %s upgrade to version %s <...>pgradeNames()),
                                s.Blueprint.Topology.Version) (gocritic)
                        msgBuilder.WriteString(fmt.Sprintf("MachineDeployment(s) %s upgrade to version %s deferred.",
                        ^


test/framework/namespace_helpers.go:150:11: preferFprint: suggestion: fmt.Fprintf(f, "[New Event] %s\n\tresource: %s/%s/%s\n\treason<...>d, e.InvolvedObject.Name, e.Reason, e.Message, e) (gocritic)
                        _, _ = f.WriteString(fmt.Sprintf("[New Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
                               ^
test/framework/namespace_helpers.go:155:11: preferFprint: suggestion: fmt.Fprintf(f, "[Updated Event] %s\n\tresource: %s/%s/%s\n\tre<...>d, e.InvolvedObject.Name, e.Reason, e.Message, e) (gocritic)
                        _, _ = f.WriteString(fmt.Sprintf("[Updated Event] %s\n\tresource: %s/%s/%s\n\treason: %s\n\tmessage: %s\n\tfull: %#v\n",
                               ^
test/framework/machinedeployment_helpers.go:530:2: ginkgo-linter: wrong comparison assertion; consider using `Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments)).To(BeNumerically(">=", 1), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")` instead (ginkgolinter)
        Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments) >= 1).To(BeTrue(), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")
        ^

test/framework/machinedeployment_helpers.go:530:2: ginkgo-linter: wrong length assertion; consider using `Expect(input.Cluster.Spec.Topology.Workers.MachineDeployments).ToNot(BeEmpty(), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")` instead (ginkgolinter)
        Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments)).To(BeNumerically(">=", 1), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")
        ^
```
