### PR TITLE
🌱 Fix spelling mistake in clusterctl comment

### DIFF
--- a/cmd/clusterctl/client/tree/annotations.go
+++ b/cmd/clusterctl/client/tree/annotations.go
@@ -51,7 +51,7 @@ const (
 	GroupItemsSeparator = ", "
 
 	// ObjectZOrderAnnotation contains an integer that defines the sorting of child objects when the object tree is printed.
-	// Objects are sorted by their z-order from highest to lowest, and then by their name in alphaebetical order if the
+	// Objects are sorted by their z-order from highest to lowest, and then by their name in alphabetical order if the
 	// z-order is the same. Objects with no z-order set are assumed to have a default z-order of 0.
 	ObjectZOrderAnnotation = "tree.cluster.x-k8s.io.io/z-order"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a minor spelling mistake in a clusterctl comment.

Main purpose is to test the area label assignment. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
