### PR TITLE
:book: update quickstart kustomize commands to target correct subdir

### DIFF
--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -114,8 +114,8 @@ make docker-push
 
 # Apply the manifests
 kustomize build config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
-kustomize build bootstrap/kubeadm/config | ./hack/tools/bin/envsubst | kubectl apply -f -
-kustomize build controlplane/kubeadm/config | ./hack/tools/bin/envsubst | kubectl apply -f -
+kustomize build bootstrap/kubeadm/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
+kustomize build controlplane/kubeadm/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
 kustomize build test/infrastructure/docker/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
 ```
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently the quickstart guide applies two of the `kustomize` commands to directories that do not contain the kustomization.yaml file, resulting in the following errors when you step through these commands:

```
 kustomize build bootstrap/kubeadm/config
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/stephen.cahill/cluster-api/bootstrap/kubeadm/config'
```

```
kustomize build controlplane/kubeadm/config
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/stephen.cahill/cluster-api/controlplane/kubeadm/config'
```

This PR updates the two commands to target the correct subdirectories for the commands to succeed.