### PR TITLE
🐛 set uninitialized taint only on worker nodes

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver"
 	ignition "github.com/flatcar/ignition/config/v2_3"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -2190,112 +2189,6 @@ func TestKubeadmConfigReconciler_ResolveUsers(t *testing.T) {
 					g.Expect(user.Passwd).To(BeNil())
 				}
 			}
-		})
-	}
-}
-
-func TestAddNodeUninitializedTaint(t *testing.T) {
-	dummyTaint := corev1.Taint{
-		Key:    "dummy-taint",
-		Value:  "",
-		Effect: corev1.TaintEffectNoSchedule,
-	}
-
-	tests := []struct {
-		name              string
-		nodeRegistration  *bootstrapv1.NodeRegistrationOptions
-		kubernetesVersion semver.Version
-		isControlPlane    bool
-		wantTaints        []corev1.Taint
-	}{
-		{
-			name: "for control plane with version < v1.24.0, if taints is nil it should add the uninitialized and the master taint",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: nil,
-			},
-			kubernetesVersion: semver.MustParse("1.23.0"),
-			isControlPlane:    true,
-			wantTaints: []corev1.Taint{
-				oldControlPlaneTaint,
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name: "for control plane with version >= v1.24.0 and < v1.25.0, if taints is nil it should add the uninitialized, control-plane and the master taints",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: nil,
-			},
-			kubernetesVersion: semver.MustParse("1.24.5"),
-			isControlPlane:    true,
-			wantTaints: []corev1.Taint{
-				oldControlPlaneTaint,
-				controlPlaneTaint,
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name: "for control plane with version >= v1.25.0, if taints is nil it should add the uninitialized and the control-plane taint",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: nil,
-			},
-			kubernetesVersion: semver.MustParse("1.25.0"),
-			isControlPlane:    true,
-			wantTaints: []corev1.Taint{
-				controlPlaneTaint,
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name: "for control plane, if taints is not nil it should only add the uninitialized taint",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: []corev1.Taint{},
-			},
-			kubernetesVersion: semver.MustParse("1.26.0"),
-			isControlPlane:    true,
-			wantTaints: []corev1.Taint{
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name: "for control plane, if it already has some taints it should add the uninitialized taint",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: []corev1.Taint{dummyTaint},
-			},
-			kubernetesVersion: semver.MustParse("1.26.0"),
-			isControlPlane:    true,
-			wantTaints: []corev1.Taint{
-				dummyTaint,
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name:              "for worker, it should add the uninitialized taint",
-			nodeRegistration:  &bootstrapv1.NodeRegistrationOptions{},
-			kubernetesVersion: semver.MustParse("1.26.0"),
-			isControlPlane:    false,
-			wantTaints: []corev1.Taint{
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-		{
-			name: "for worker, if it already has some taints it should add the uninitialized taint",
-			nodeRegistration: &bootstrapv1.NodeRegistrationOptions{
-				Taints: []corev1.Taint{dummyTaint},
-			},
-			kubernetesVersion: semver.MustParse("1.26.0"),
-			isControlPlane:    false,
-			wantTaints: []corev1.Taint{
-				dummyTaint,
-				clusterv1.NodeUninitializedTaint,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			addNodeUninitializedTaint(tt.nodeRegistration, tt.isControlPlane, tt.kubernetesVersion)
-			g.Expect(tt.nodeRegistration.Taints).To(Equal(tt.wantTaints))
 		})
 	}
 }

--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -125,7 +125,7 @@ A bootstrap provider's bootstrap data must create `/run/cluster-api/bootstrap-su
 
 ## Taint Nodes at creation
 
-A bootstrap provider can optionally taint nodes at creation with `node.cluster.x-k8s.io/uninitialized:NoSchedule`.
+A bootstrap provider can optionally taint worker nodes at creation with `node.cluster.x-k8s.io/uninitialized:NoSchedule`.
 This taint is used to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.
 As of today the Node initialization consists of syncing labels from Machines to Nodes. Once the labels have been 
 initially synced the taint is removed form the Node.

--- a/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
+++ b/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
@@ -101,19 +101,22 @@ Kubernetes supports both equality and inequality requirements in label selection
 
 In an inequality based selection, the user wants to place a workload on node(s) that do not contain a specific label (e.g. Node.Labels not contain `my.prefix/foo=bar`). The case is potentially problematic because it relies on the absence of a label and this can occur if the pod scheduler runs during the delay interval.
 
-One way to address this is to use kubelet's `--register-with-taints` flag. Newly minted nodes can be tainted via the taint `node.cluster.x-k8s.io=uninitialized:NoSchedule`. Assuming workloads don't have this specific toleration, then nothing should be scheduled. KubeadmConfigTemplate provides the means to set taints on nodes (see  JoinConfiguration.NodeRegistration.Taints).
+One way to address this is to use kubelet's `--register-with-taints` flag. Newly minted nodes can be tainted via the taint `node.cluster.x-k8s.io/uninitialized:NoSchedule`. Assuming workloads don't have this specific toleration, then nothing should be scheduled. KubeadmConfigTemplate provides the means to set taints on nodes (see  JoinConfiguration.NodeRegistration.Taints).
 
 The process of tainting the nodes, can be carried out by the user and can be documented as follows:
 
 ```
 If you utilize inequality based selection for workload placement, to prevent unintended scheduling of pods during the initial node startup phase, it is recommend that you specify the following taint in your KubeadmConfigTemplate:
-`node.cluster.x-k8s.io=uninitialized:NoSchedule`
+`node.cluster.x-k8s.io/uninitialized:NoSchedule`
 ```
 
 After the node has come up and the machine controller has applied the labels, the machine controller will also remove this specific taint if it's present.
 
 During the implementation we will consider also automating the insertion of the taint via CABPK in order to simplify UX;
 in this case, the new behaviour should be documented in the contract as optional requirement for bootstrap providers.
+
+The `node.cluster.x-k8s.io/uninitialized:NoSchedule` taint should only be applied on the worker nodes. It should not be applied on the control plane nodes as it could prevent other components like CPI from initializing which will block cluster creation.
+
 
 ## Alternatives
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Apply the `node.cluster.x-k8s.io/uninitialized:NoSchedule` only to worker nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8357


/hold