### PR TITLE
🐛 use PreferNoSchedule uninitialized taint

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -148,12 +148,12 @@ const (
 
 // NodeUninitializedTaint can be added to Nodes at creation by the bootstrap provider, e.g. the
 // KubeadmBootstrap provider will add the taint.
-// This taint is used to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.
+// This taint is used try to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.
 // As of today the Node initialization consists of syncing labels from Machines to Nodes. Once the labels
 // have been initially synced the taint is removed from the Node.
 var NodeUninitializedTaint = corev1.Taint{
 	Key:    "node.cluster.x-k8s.io/uninitialized",
-	Effect: corev1.TaintEffectNoSchedule,
+	Effect: corev1.TaintEffectPreferNoSchedule,
 }
 
 const (

--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -125,8 +125,8 @@ A bootstrap provider's bootstrap data must create `/run/cluster-api/bootstrap-su
 
 ## Taint Nodes at creation
 
-A bootstrap provider can optionally taint nodes at creation with `node.cluster.x-k8s.io/uninitialized:NoSchedule`.
-This taint is used to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.
+A bootstrap provider can optionally taint nodes at creation with `node.cluster.x-k8s.io/uninitialized:PreferNoSchedule`.
+This taint is used to try to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.
 As of today the Node initialization consists of syncing labels from Machines to Nodes. Once the labels have been 
 initially synced the taint is removed form the Node.
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Set `node.cluster.x-k8s.io/uninitialized:PreferNoSchedule`. Use the softer scheduling rules to not block CPI from scheduling pods on the control plane nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8357
