### PR TITLE
:seedling: Update e2e upgrade test versions

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -96,7 +96,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 			SkipCleanup:           skipCleanup,
 			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.5/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
-			// use the latest version for the contract (which is v1.3.0 for v1beta1).
+			// use the latest version for the contract (which is v1.3.X for v1beta1).
 			InitWithCoreProvider:            "cluster-api:v1.0.5",
 			InitWithBootstrapProviders:      []string{"kubeadm:v1.0.5"},
 			InitWithControlPlaneProviders:   []string{"kubeadm:v1.0.5"},
@@ -131,13 +131,13 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
-			// use the latest version for the contract (which is v1.3.0 for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.8",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.8"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.8"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.8"},
+			// use the latest version for the contract (which is v1.3.X for v1beta1).
+			InitWithCoreProvider:            "cluster-api:v1.2.11",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.11"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.11"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.11"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
@@ -170,13 +170,13 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>cur
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
-			// use the latest version for the contract (which is v1.3.0 for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.8",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.8"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.8"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.8"},
+			// use the latest version for the contract (which is v1.3.X for v1beta1).
+			InitWithCoreProvider:            "cluster-api:v1.2.11",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.11"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.11"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.11"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
@@ -209,7 +209,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ArtifactFolder:            artifactFolder,
 			SkipCleanup:               skipCleanup,
-			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.26.0",
 			MgmtFlavor:                "topology",
@@ -237,7 +237,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			BootstrapClusterProxy:     bootstrapClusterProxy,
 			ArtifactFolder:            artifactFolder,
 			SkipCleanup:               skipCleanup,
-			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.26.0",
 			MgmtFlavor:                "topology",

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -58,8 +58,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/core-components.yaml"
+  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -67,8 +67,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.2/metadata.yaml"
-  - name: v1.3.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/core-components.yaml"
+  - name: v1.3.5 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -114,8 +114,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/bootstrap-components.yaml"
+  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -123,8 +123,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.2/metadata.yaml"
-  - name: v1.3.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/bootstrap-components.yaml"
+  - name: v1.3.5 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -170,8 +170,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/control-plane-components.yaml"
+  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -179,8 +179,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.2/metadata.yaml"
-  - name: v1.3.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/control-plane-components.yaml"
+  - name: v1.3.5 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -229,8 +229,8 @@ providers:
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
     - sourcePath: "../data/infrastructure-docker/v1.0/cluster-template.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/infrastructure-components-development.yaml"
+  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -241,8 +241,8 @@ providers:
     - sourcePath: "../data/infrastructure-docker/v1.2/cluster-template.yaml"
     - sourcePath: "../data/infrastructure-docker/v1.2/cluster-template-topology.yaml"
     - sourcePath: "../data/infrastructure-docker/v1.2/clusterclass-quick-start.yaml"
-  - name: v1.3.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/infrastructure-components-development.yaml"
+  - name: v1.3.5 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.5/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:


### PR DESCRIPTION
Update the versions of CAPI used in upgrade test to the latest available versions.

/area testing