### PR TITLE
:seedling: Allow overriding gingko args in e2e tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o pipefail
 
+
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}" || exit 1
 
@@ -53,7 +54,7 @@ kind:prepullAdditionalImages
 # Configure e2e tests
 export GINKGO_NODES=3
 export GINKGO_NOCOLOR=true
-export GINKGO_ARGS="--fail-fast" # Other ginkgo args that need to be appended to the command.
+export GINKGO_ARGS="${GINKGO_ARGS:-"--fail-fast"}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=false


### PR DESCRIPTION
Allow overriding the value of GINKGO_ARGS in the CI test script. This will allow us to disable fail-fast and give us full runs of e2e tests in the CI.

/area testing
