### PR TITLE
:bug: Fix flake in machine phases test

### DIFF
--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -139,7 +139,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		}, 10*time.Second).Should(BeTrue())
 
 		// Wait until InfraMachine has the ownerReference.
-		g.Eventually(func() bool {
+		g.Eventually(func(g Gomega) bool {
 			if err := env.Get(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
 				return false
 			}


### PR DESCRIPTION
Fix for a flake in the machine phases test. The eventually call was using the wrong gomega matcher which made it fail the first time around.

/area testing