### PR TITLE
✨Implements Getter interface for IPAddressClaim object

### DIFF
--- a/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
@@ -55,6 +55,16 @@ type IPAddressClaim struct {
 	Status IPAddressClaimStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
+func (m *IPAddressClaim) GetConditions() clusterv1.Conditions {
+	return m.Status.Conditions
+}
+
+// SetConditions sets the conditions on this object.
+func (m *IPAddressClaim) SetConditions(conditions clusterv1.Conditions) {
+	m.Status.Conditions = conditions
+}
+
 // +kubebuilder:object:root=true
 
 // IPAddressClaimList is a list of IPAddressClaims.


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the `conditions.Getter` interface on the `IPAddressClaim` object.

**Which issue(s) this PR fixes**:
Fixes #8373 
