### PR TITLE
📖 book: add missing apiversion deprecation to migration docs

### DIFF
--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -19,7 +19,11 @@ maintainers of providers and consumers of our Go API.
 
 ### Deprecation
 
--
+- The api versions `v1alpha3` and `v1alpha4` are deprecated and will be removed. 
+  - `v1alpha3` will be removed in v1.5 
+  - `v1alpha4` will be removed in v1.6
+
+  For more information, please see: https://release-1-4.cluster-api.sigs.k8s.io/contributing?highlight=v1alpha#removal-of-v1alpha3--v1alpha4-apiversions
 
 ### Removals
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The apiversion deprecations should also be in the migration docs. 

Should be cherry picked into 1.4 branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partof #8038

cc @sbueringer @killianmuldoon @ykakarap 
