### PR TITLE
:bug: remove duplicate fix for btrfs/zfs support

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -52,7 +52,6 @@ const (
 
 	btrfsStorage = "btrfs"
 	zfsStorage   = "zfs"
-	xfsStorage   = "xfs"
 )
 
 type dockerRuntime struct {
@@ -446,15 +445,6 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 	}
 	containerConfig.Env = envVars
 
-	// handle Docker on Btrfs or ZFS
-	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
-	if d.mountDevMapper(info) {
-		runConfig.Mounts = append(runConfig.Mounts, Mount{
-			Source: "/dev/mapper",
-			Target: "/dev/mapper",
-		})
-	}
-
 	configureVolumes(runConfig, &containerConfig, &hostConfig)
 	configurePortMappings(runConfig.PortMappings, &containerConfig, &hostConfig)
 
@@ -691,28 +681,6 @@ func (d *dockerRuntime) usernsRemap(info dockersystem.Info) bool {
 		}
 	}
 	return false
-}
-
-// mountDevMapper checks if the Docker storage driver is Btrfs or ZFS
-// or if the backing filesystem is Btrfs.
-func (d *dockerRuntime) mountDevMapper(info dockersystem.Info) bool {
-	storage := ""
-	storage = strings.ToLower(strings.TrimSpace(info.Driver))
-	if storage == btrfsStorage || storage == zfsStorage || storage == "devicemapper" {
-		return true
-	}
-
-	// check the backing file system
-	// docker info -f '{{json .DriverStatus  }}'
-	// [["Backing Filesystem","extfs"],["Supports d_type","true"],["Native Overlay Diff","true"]]
-	for _, item := range info.DriverStatus {
-		if item[0] == "Backing Filesystem" {
-			storage = strings.ToLower(item[1])
-			break
-		}
-	}
-
-	return storage == btrfsStorage || storage == zfsStorage || storage == xfsStorage
 }
 
 // rootless: use fuse-overlayfs by default


### PR DESCRIPTION
If btrfs or zfs is used CAPD adds the /dev/mapper mount twice. This PR ensures we only do it once.

xref to where kind implements this:  https://github.com/kubernetes-sigs/kind/pull/1464


<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8317
