### PR TITLE
🐛 Add condition getter and setter on IPAddressClaim

### DIFF
--- a/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
@@ -55,6 +55,16 @@ type IPAddressClaim struct {
 	Status IPAddressClaimStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
+func (i *IPAddressClaim) GetConditions() clusterv1.Conditions {
+	return i.Status.Conditions
+}
+
+// SetConditions sets the conditions on this object.
+func (i *IPAddressClaim) SetConditions(conditions clusterv1.Conditions) {
+	i.Status.Conditions = conditions
+}
+
 // +kubebuilder:object:root=true
 
 // IPAddressClaimList is a list of IPAddressClaims.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add condition getter and setter which are missing on the IPAddressClaim experimental API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/8373
