### PR TITLE
:book: Fix http link in book

### DIFF
--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -23,7 +23,7 @@ maintainers of providers and consumers of our Go API.
   - `v1alpha3` will be removed in v1.5 
   - `v1alpha4` will be removed in v1.6
 
-  For more information, please see: https://release-1-4.cluster-api.sigs.k8s.io/contributing?highlight=v1alpha#removal-of-v1alpha3--v1alpha4-apiversions
+  For more information please see [the note in the contributors guide](../../CONTRIBUTING.md#removal-of-v1alpha3--v1alpha4-apiversions).
 
 ### Removals
 


### PR DESCRIPTION
Update a link in the implementers guide to use internal markdown-based linking instead of http based linking. This will make the link more resilient to change in future.
