### PR TITLE
🌱 Add area/dependency label for dependabot when bumping gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,4 +27,5 @@ updates:
   commit-message:
     prefix: ":seedling:"
   labels:
+    - "area/dependency"
     - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding area/dependency label for dependabot when it bumps gomod. 

I think it fits and since there are a few prs from dependabot it's nice to catch it asap.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partof #8263

cc @joekr 
