### PR TITLE
:bug: update TopologyReconciled condition on cluster deletion

### DIFF
--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -164,12 +164,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	// In case the object is deleted, the managed topology stops to reconcile;
-	// (the other controllers will take care of deletion).
-	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, cluster)
-	}
-
 	patchHelper, err := patch.NewHelper(cluster, r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -195,6 +189,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			return
 		}
 	}()
+
+	// In case the object is deleted, the managed topology stops to reconcile;
+	// (the other controllers will take care of deletion).
+	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, cluster)
+	}
 
 	// Handle normal reconciliation loop.
 	return r.reconcile(ctx, s)

--- a/internal/controllers/topology/cluster/conditions.go
+++ b/internal/controllers/topology/cluster/conditions.go
@@ -43,6 +43,19 @@ func (r *Reconciler) reconcileConditions(s *scope.Scope, cluster *clusterv1.Clus
 //     In such a case, since some of the component's spec would be adrift from the topology the
 //     topology cannot be considered fully reconciled.
 func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluster *clusterv1.Cluster, reconcileErr error) error {
+	// Mark TopologyReconciled as false due to cluster deletion.
+	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
+		conditions.Set(
+			cluster,
+			conditions.FalseCondition(
+				clusterv1.TopologyReconciledCondition,
+				clusterv1.DeletedReason,
+				clusterv1.ConditionSeverityInfo,
+				"",
+			),
+		)
+		return nil
+	}
 	// If an error occurred during reconciliation set the TopologyReconciled condition to false.
 	// Add the error message from the reconcile function to the message of the condition.
 	if reconcileErr != nil {

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -39,6 +39,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 
+	deletionTime := metav1.Unix(0, 0)
 	tests := []struct {
 		name                 string
 		reconcileErr         error
@@ -584,6 +585,17 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				HookResponseTracker: scope.NewHookResponseTracker(),
 			},
 			wantConditionStatus: corev1.ConditionTrue,
+		},
+		{
+			name: "should set the TopologyReconciledCondition to False if the cluster has been deleted",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &deletionTime,
+				},
+			},
+			wantConditionStatus:  corev1.ConditionFalse,
+			wantConditionReason:  clusterv1.DeletedReason,
+			wantConditionMessage: "",
 		},
 	}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Sets `TopologyReconciled` status condition to `False` on cluster deletion 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7926
