### PR TITLE
:seedling: Rename internal/util/ssa util functions for better naming consistency

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/drop_diff_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/drop_diff_test.go
@@ -60,8 +60,8 @@ func Test_dropDiffForNotAllowedPaths(t *testing.T) {
 						"foo": "123-changed",
 					},
 				},
-				shouldDropDiffFunc: ssa.IsNotAllowedPath(
-					[]contract.Path{ // NOTE: we are dropping everything not in this list (IsNotAllowed)
+				shouldDropDiffFunc: ssa.IsPathNotAllowed(
+					[]contract.Path{ // NOTE: we are dropping everything not in this list (IsPathNotAllowed)
 						{"metadata", "labels"},
 						{"metadata", "annotations"},
 						{"spec"},
@@ -110,8 +110,8 @@ func Test_dropDiffForNotAllowedPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				shouldDropDiffFunc: ssa.IsNotAllowedPath(
-					[]contract.Path{ // NOTE: we are dropping everything not in this list (IsNotAllowed)
+				shouldDropDiffFunc: ssa.IsPathNotAllowed(
+					[]contract.Path{ // NOTE: we are dropping everything not in this list (IsPathNotAllowed)
 						{"metadata", "labels"},
 						{"metadata", "annotations"},
 						{"spec"},
@@ -146,8 +146,8 @@ func Test_dropDiffForNotAllowedPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				shouldDropDiffFunc: ssa.IsNotAllowedPath(
-					[]contract.Path{}, // NOTE: we are dropping everything not in this list (IsNotAllowed)
+				shouldDropDiffFunc: ssa.IsPathNotAllowed(
+					[]contract.Path{}, // NOTE: we are dropping everything not in this list (IsPathNotAllowed)
 				),
 			},
 			wantModified: map[string]interface{}{
@@ -194,7 +194,7 @@ func Test_dropDiffForIgnoredPaths(t *testing.T) {
 						},
 					},
 				},
-				shouldDropDiffFunc: ssa.IsIgnorePath(
+				shouldDropDiffFunc: ssa.IsPathIgnored(
 					[]contract.Path{
 						{"spec", "controlPlaneEndpoint"},
 					},
@@ -226,7 +226,7 @@ func Test_dropDiffForIgnoredPaths(t *testing.T) {
 						},
 					},
 				},
-				shouldDropDiffFunc: ssa.IsIgnorePath(
+				shouldDropDiffFunc: ssa.IsPathIgnored(
 					[]contract.Path{
 						{"spec", "controlPlaneEndpoint"},
 					},
@@ -251,7 +251,7 @@ func Test_dropDiffForIgnoredPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				shouldDropDiffFunc: ssa.IsIgnorePath(
+				shouldDropDiffFunc: ssa.IsPathIgnored(
 					[]contract.Path{
 						{"spec", "foo"},
 					},

--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -183,7 +183,7 @@ func cleanupManagedFieldsAndAnnotation(obj *unstructured.Unstructured) error {
 	ssa.FilterIntent(&ssa.FilterIntentInput{
 		Path:  contract.Path{},
 		Value: obj.Object,
-		ShouldFilter: ssa.IsIgnorePath([]contract.Path{
+		ShouldFilter: ssa.IsPathIgnored([]contract.Path{
 			{"metadata", "annotations", clusterv1.TopologyDryRunAnnotation},
 			// In case the ClusterClass we are reconciling is using not the latest apiVersion the conversion
 			// annotation might be added to objects. As we don't care about differences in conversion as we
@@ -220,7 +220,7 @@ func cleanupManagedFieldsAndAnnotation(obj *unstructured.Unstructured) error {
 		ssa.FilterIntent(&ssa.FilterIntentInput{
 			Path:  contract.Path{},
 			Value: fieldsV1,
-			ShouldFilter: ssa.IsIgnorePath([]contract.Path{
+			ShouldFilter: ssa.IsPathIgnored([]contract.Path{
 				{"f:metadata", "f:annotations", "f:" + clusterv1.TopologyDryRunAnnotation},
 				{"f:metadata", "f:annotations", "f:" + conversion.DataAnnotation},
 			}),

--- a/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
@@ -171,7 +171,7 @@ func applyOptions(in *applyOptionsInput) ([]byte, error) {
 			path:               contract.Path{},
 			original:           originalMap,
 			modified:           modifiedMap,
-			shouldDropDiffFunc: ssa.IsNotAllowedPath(in.options.allowedPaths),
+			shouldDropDiffFunc: ssa.IsPathNotAllowed(in.options.allowedPaths),
 		})
 	}
 
@@ -183,7 +183,7 @@ func applyOptions(in *applyOptionsInput) ([]byte, error) {
 			path:               contract.Path{},
 			original:           originalMap,
 			modified:           modifiedMap,
-			shouldDropDiffFunc: ssa.IsIgnorePath(in.options.ignorePaths),
+			shouldDropDiffFunc: ssa.IsPathIgnored(in.options.ignorePaths),
 		})
 	}
 

--- a/internal/util/ssa/filterintent.go
+++ b/internal/util/ssa/filterintent.go
@@ -41,7 +41,7 @@ func FilterObject(obj *unstructured.Unstructured, input *FilterObjectInput) {
 		FilterIntent(&FilterIntentInput{
 			Path:         contract.Path{},
 			Value:        obj.Object,
-			ShouldFilter: IsNotAllowedPath(input.AllowedPaths),
+			ShouldFilter: IsPathNotAllowed(input.AllowedPaths),
 		})
 	}
 
@@ -51,7 +51,7 @@ func FilterObject(obj *unstructured.Unstructured, input *FilterObjectInput) {
 		FilterIntent(&FilterIntentInput{
 			Path:         contract.Path{},
 			Value:        obj.Object,
-			ShouldFilter: IsIgnorePath(input.IgnorePaths),
+			ShouldFilter: IsPathIgnored(input.IgnorePaths),
 		})
 	}
 }
@@ -111,8 +111,8 @@ type FilterIntentInput struct {
 	ShouldFilter func(path contract.Path) bool
 }
 
-// IsAllowedPath returns true when the Path is one of the AllowedPaths.
-func IsAllowedPath(allowedPaths []contract.Path) func(path contract.Path) bool {
+// IsPathAllowed returns true when the Path is one of the AllowedPaths.
+func IsPathAllowed(allowedPaths []contract.Path) func(path contract.Path) bool {
 	return func(path contract.Path) bool {
 		for _, p := range allowedPaths {
 			// NOTE: we allow everything Equal or one IsParentOf one of the allowed paths.
@@ -126,16 +126,16 @@ func IsAllowedPath(allowedPaths []contract.Path) func(path contract.Path) bool {
 	}
 }
 
-// IsNotAllowedPath returns true when the Path is NOT one of the AllowedPaths.
-func IsNotAllowedPath(allowedPaths []contract.Path) func(path contract.Path) bool {
+// IsPathNotAllowed returns true when the Path is NOT one of the AllowedPaths.
+func IsPathNotAllowed(allowedPaths []contract.Path) func(path contract.Path) bool {
 	return func(path contract.Path) bool {
-		isAllowed := IsAllowedPath(allowedPaths)
+		isAllowed := IsPathAllowed(allowedPaths)
 		return !isAllowed(path)
 	}
 }
 
-// IsIgnorePath returns true when the Path is one of the IgnorePaths.
-func IsIgnorePath(ignorePaths []contract.Path) func(path contract.Path) bool {
+// IsPathIgnored returns true when the Path is one of the IgnorePaths.
+func IsPathIgnored(ignorePaths []contract.Path) func(path contract.Path) bool {
 	return func(path contract.Path) bool {
 		for _, p := range ignorePaths {
 			if path.Equal(p) {

--- a/internal/util/ssa/filterintent_test.go
+++ b/internal/util/ssa/filterintent_test.go
@@ -55,7 +55,7 @@ func Test_filterNotAllowedPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				ShouldFilter: IsNotAllowedPath(
+				ShouldFilter: IsPathNotAllowed(
 					[]contract.Path{ // NOTE: we are dropping everything not in this list
 						{"apiVersion"},
 						{"kind"},
@@ -96,7 +96,7 @@ func Test_filterNotAllowedPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				ShouldFilter: IsNotAllowedPath(
+				ShouldFilter: IsPathNotAllowed(
 					[]contract.Path{}, // NOTE: we are filtering out everything not in this list (everything)
 				),
 			},
@@ -135,7 +135,7 @@ func Test_filterIgnoredPaths(t *testing.T) {
 						},
 					},
 				},
-				ShouldFilter: IsIgnorePath(
+				ShouldFilter: IsPathIgnored(
 					[]contract.Path{
 						{"spec", "controlPlaneEndpoint"},
 					},
@@ -157,7 +157,7 @@ func Test_filterIgnoredPaths(t *testing.T) {
 						"foo": "123",
 					},
 				},
-				ShouldFilter: IsIgnorePath(
+				ShouldFilter: IsPathIgnored(
 					[]contract.Path{
 						{"spec", "foo"},
 					},
@@ -178,7 +178,7 @@ func Test_filterIgnoredPaths(t *testing.T) {
 						},
 					},
 				},
-				ShouldFilter: IsIgnorePath(
+				ShouldFilter: IsPathIgnored(
 					[]contract.Path{
 						{"spec", "bar", "foo"},
 					},

--- a/internal/util/ssa/managedfields.go
+++ b/internal/util/ssa/managedfields.go
@@ -74,7 +74,7 @@ func DropManagedFields(ctx context.Context, c client.Client, obj client.Object, 
 			FilterIntent(&FilterIntentInput{
 				Path:         contract.Path{},
 				Value:        fieldsV1,
-				ShouldFilter: IsIgnorePath(paths),
+				ShouldFilter: IsPathIgnored(paths),
 			})
 
 			fieldsV1Raw, err := json.Marshal(fieldsV1)

--- a/internal/util/ssa/matchers.go
+++ b/internal/util/ssa/matchers.go
@@ -92,7 +92,7 @@ func (fom *fieldOwnershipMatcher) Match(actual interface{}) (bool, error) {
 			FilterIntent(&FilterIntentInput{
 				Path:         contract.Path{},
 				Value:        fieldsV1,
-				ShouldFilter: IsNotAllowedPath([]contract.Path{fom.path}),
+				ShouldFilter: IsPathNotAllowed([]contract.Path{fom.path}),
 			})
 			return len(fieldsV1) > 0, nil
 		}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
 Renames `internal/util/ssa` util functions for better naming consistency

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8396
