### PR TITLE
🌱 Switch cloudbuild.yaml to e2 machine type

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -3,7 +3,7 @@
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
     entrypoint: make

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
     entrypoint: make


### PR DESCRIPTION
**What this PR does / why we need it**:
n1 machine times are old and e2 are going to be cheaper.

Reference https://github.com/kubernetes/k8s.io/issues/5059