### PR TITLE
:seedling: Update kind to v1.18.0

### DIFF
--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -14,7 +14,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 
 - sigs.k8s.io/controller-runtime: v0.12.x => v0.13.x
 - sigs.k8s.io/controller-tools: v0.9.x => v0.10.x
-- sigs.k8s.io/kind: v0.14.x => v0.17.x
+- sigs.k8s.io/kind: v0.14.x => v0.18.x
 - k8s.io/*: v0.24.x => v0.25.x (derived from controller-runtime)
 - github.com/onsi/ginkgo: v1.x => v2.x (derived from controller-runtime)
 - k8s.io/kubectl: v0.24.x => 0.25.x

--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -11,6 +11,7 @@ maintainers of providers and consumers of our Go API.
 
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
+- sigs.k8s.io/kind: v0.17.x => v0.18.x
 - sigs.k8s.io/controller-runtime: v0.13.x => v0.14.x
 - sigs.k8s.io/controller-tools: v0.10.x => v0.11.x
 - github.com/joelanford/go-apidiff: 0.5.0 => 0.6.0

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -46,7 +46,7 @@ a target [management cluster] on the selected [infrastructure provider].
 
    [kind] is not designed for production use.
 
-   **Minimum [kind] supported version**: v0.17.0
+   **Minimum [kind] supported version**: v0.18.0
 
    **Help with common issues can be found in the [Troubleshooting Guide](./troubleshooting.md).**
 

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -26,7 +26,7 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 GOPATH_BIN="$(go env GOPATH)/bin"
-MINIMUM_KIND_VERSION=v0.17.0
+MINIMUM_KIND_VERSION=v0.18.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.14.5
-	sigs.k8s.io/kind v0.17.0
+	sigs.k8s.io/kind v0.18.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -970,8 +970,8 @@ sigs.k8s.io/controller-runtime v0.14.5 h1:6xaWFqzT5KuAQ9ufgUaj1G/+C4Y1GRkhrxl+BJ
 sigs.k8s.io/controller-runtime v0.14.5/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kind v0.17.0 h1:CScmGz/wX66puA06Gj8OZb76Wmk7JIjgWf5JDvY7msM=
-sigs.k8s.io/kind v0.17.0/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
+sigs.k8s.io/kind v0.18.0 h1:ahgZdVV1pdhXlYe1f+ztISakT23KdrBl/NFY9JMygzs=
+sigs.k8s.io/kind v0.18.0/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=


### PR DESCRIPTION
Update kind to v0.18.0.

Release notes: https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0

/area dependency

