### PR TITLE
:book: Fix broken links in migrations guides

### DIFF
--- a/docs/book/src/developer/providers/migrations/v0.4-to-v1.0.md
+++ b/docs/book/src/developer/providers/migrations/v0.4-to-v1.0.md
@@ -69,7 +69,7 @@ Users relying on custom upgrades procedures should ensure a migration to v1alpha
 Otherwise, your controller might end up with multiple running instances that each acquired leadership through different resource locks during upgrades and thus act on the same resources concurrently.
 
 
-[cluster-contract]: ./cluster-infrastructure.md
-[machine-contract]: ./machine-infrastructure.md
-[metadata-propagation]: ../../developer/architecture/controllers/metadata-propagation.md
+[cluster-contract]: ./../cluster-infrastructure.md
+[machine-contract]: ./../machine-infrastructure.md
+[metadata-propagation]: ../../../developer/architecture/controllers/metadata-propagation.md
 [capv-ipam]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1210

--- a/docs/book/src/developer/providers/migrations/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/migrations/v1.0-to-v1.1.md
@@ -56,7 +56,7 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
 * ClusterClass:
     * `clusterctl` is now able to handle cluster templates with ClusterClasses ([PR](https://github.com/kubernetes-sigs/cluster-api/pull/5351)).
-      Please check out the corresponding documentation in [clusterctl provider contract](../../clusterctl/provider-contract.md#clusterclass-definitions)
+      Please check out the corresponding documentation in [clusterctl provider contract](../../../clusterctl/provider-contract.md#clusterclass-definitions)
       If you have any further questions about writing ClusterClasses, please let us know.
     * e2e tests:
         * `QuickStartSpec` is now able to test clusters using ClusterClass. Please see this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5423) for an example on how to use it.

--- a/docs/book/src/developer/providers/migrations/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/migrations/v1.2-to-v1.3.md
@@ -41,7 +41,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 - A new timeout `nodeVolumeDetachTimeout` has been introduced that defines how long the controller will spend on waiting for all volumes to be detached.
 The default value is 0, meaning that the volume can be detached without any time limitations.
 - A new annotation `machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach` has been introduced that allows explicitly skip the waiting for node volume detaching.
-- A new annotation `"cluster.x-k8s.io/replicas-managed-by"` has been introduced to indicate that a MachinePool's replica enforcement is delegated to an external autoscaler (not managed by Cluster API). For more information see the documentation [here](../architecture/controllers/machine-pool.md#externally-managed-autoscaler).
+- A new annotation `"cluster.x-k8s.io/replicas-managed-by"` has been introduced to indicate that a MachinePool's replica enforcement is delegated to an external autoscaler (not managed by Cluster API). For more information see the documentation [here](../../architecture/controllers/machine-pool.md#externally-managed-autoscaler).
 - The `Path` func in the `sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository.Overrider` interface has been adjusted to also return an error.
 
 ### Other
@@ -55,8 +55,8 @@ The default value is 0, meaning that the volume can be detached without any time
   * the default test timeout has been [changed to 1h](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)
   * the `--junit-report` argument [replaces JUnit custom reporter](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#improved-reporting-infrastructure) code
   * see the ["Update tests to Ginkgo v2" PR](https://github.com/kubernetes-sigs/cluster-api/pull/6906) for a reference example
-- Cluster API introduced new [logging guidelines](../../developer/logging.md). All reconcilers in the core repository were updated
-  to [log the entire object hierarchy](../../developer/logging.md#keyvalue-pairs). It would be great if providers would be adjusted
+- Cluster API introduced new [logging guidelines](../../../developer/logging.md). All reconcilers in the core repository were updated
+  to [log the entire object hierarchy](../../../developer/logging.md#keyvalue-pairs). It would be great if providers would be adjusted
   as well to make it possible to cross-reference log entries across providers (please see CAPD for an infra provider reference implementation).
 - The `CreateLogFile` function and `CreateLogFileInput` struct in the E2E test framework for clusterctl has been renamed to `OpenLogFile` and `OpenLogFileInput` because the function will now append to the logfile instead of truncating the content.
 - The `Move` function in E2E test framework for clusterctl has been modified to:

--- a/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
@@ -23,7 +23,7 @@ maintainers of providers and consumers of our Go API.
   - `v1alpha3` will be removed in v1.5 
   - `v1alpha4` will be removed in v1.6
 
-  For more information please see [the note in the contributors guide](../../CONTRIBUTING.md#removal-of-v1alpha3--v1alpha4-apiversions).
+  For more information please see [the note in the contributors guide](../../../CONTRIBUTING.md#removal-of-v1alpha3--v1alpha4-apiversions).
 
 ### Removals
 


### PR DESCRIPTION
Fix a number of broken links in the contribution guides.

 These link issues were introduced by https://github.com/kubernetes-sigs/cluster-api/pull/8383, but I'm not sure why the link checker didn't catch them at that point.


