### PR TITLE
🐛 Add node watcher to MachinePool controller

### DIFF
--- a/api/v1beta1/index/index.go
+++ b/api/v1beta1/index/index.go
@@ -41,5 +41,15 @@ func AddDefaultIndexes(ctx context.Context, mgr ctrl.Manager) error {
 		}
 	}
 
+	if feature.Gates.Enabled(feature.MachinePool) {
+		if err := ByMachinePoolNode(ctx, mgr); err != nil {
+			return err
+		}
+
+		if err := ByMachinePoolProviderID(ctx, mgr); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/api/v1beta1/index/machinepool.go
+++ b/api/v1beta1/index/machinepool.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package index
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+)
+
+const (
+	// MachinePoolNodeNameField is used by the MachinePool Controller to index MachinePools by Node name, and add a watch on Nodes.
+	MachinePoolNodeNameField = "status.nodeRefs.name"
+
+	// MachinePoolProviderIDField is used to index MachinePools by ProviderID. It's useful to find MachinePools
+	// in a management cluster from Nodes in a workload cluster.
+	MachinePoolProviderIDField = "spec.providerIDList"
+)
+
+// ByMachinePoolNode adds the machinepool node name index to the
+// managers cache.
+func ByMachinePoolNode(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(ctx, &expv1.MachinePool{},
+		MachinePoolNodeNameField,
+		MachinePoolByNodeName,
+	); err != nil {
+		return errors.Wrap(err, "error setting index field")
+	}
+
+	return nil
+}
+
+// MachinePoolByNodeName contains the logic to index MachinePools by Node name.
+func MachinePoolByNodeName(o client.Object) []string {
+	machinepool, ok := o.(*expv1.MachinePool)
+	if !ok {
+		panic(fmt.Sprintf("Expected a MachinePool but got a %T", o))
+	}
+
+	if len(machinepool.Status.NodeRefs) == 0 {
+		return nil
+	}
+
+	nodeNames := make([]string, 0, len(machinepool.Status.NodeRefs))
+	for _, ref := range machinepool.Status.NodeRefs {
+		nodeNames = append(nodeNames, ref.Name)
+	}
+	return nodeNames
+}
+
+// ByMachinePoolProviderID adds the machinepool providerID index to the
+// managers cache.
+func ByMachinePoolProviderID(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(ctx, &expv1.MachinePool{},
+		MachinePoolProviderIDField,
+		machinePoolByProviderID,
+	); err != nil {
+		return errors.Wrap(err, "error setting index field")
+	}
+
+	return nil
+}
+
+func machinePoolByProviderID(o client.Object) []string {
+	machinepool, ok := o.(*expv1.MachinePool)
+	if !ok {
+		panic(fmt.Sprintf("Expected a MachinePool but got a %T", o))
+	}
+
+	if len(machinepool.Spec.ProviderIDList) == 0 {
+		return nil
+	}
+
+	providerIDs := make([]string, 0, len(machinepool.Spec.ProviderIDList))
+	for _, id := range machinepool.Spec.ProviderIDList {
+		providerID, err := noderefutil.NewProviderID(id)
+		if err != nil {
+			// Failed to create providerID, skipping.
+			continue
+		}
+		providerIDs = append(providerIDs, providerID.IndexKey())
+	}
+
+	return providerIDs
+}

--- a/api/v1beta1/index/machinepool_test.go
+++ b/api/v1beta1/index/machinepool_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package index
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
+	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+)
+
+func TestIndexMachinePoolByNodeName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name:     "when the machinepool has no NodeRef",
+			object:   &expv1.MachinePool{},
+			expected: []string{},
+		},
+		{
+			name: "when the machinepool has valid NodeRefs",
+			object: &expv1.MachinePool{
+				Status: expv1.MachinePoolStatus{
+					NodeRefs: []corev1.ObjectReference{
+						{
+							Name: "node1",
+						},
+						{
+							Name: "node2",
+						},
+					},
+				},
+			},
+			expected: []string{"node1", "node2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := MachinePoolByNodeName(tc.object)
+			g.Expect(got).To(ConsistOf(tc.expected))
+		})
+	}
+}
+
+func TestIndexMachinePoolByProviderID(t *testing.T) {
+	g := NewWithT(t)
+	validProviderID, err := noderefutil.NewProviderID("aws://region/zone/1")
+	g.Expect(err).ToNot(HaveOccurred())
+	otherValidProviderID, err := noderefutil.NewProviderID("aws://region/zone/2")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	testCases := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name:     "MachinePool has no providerID",
+			object:   &expv1.MachinePool{},
+			expected: nil,
+		},
+		{
+			name: "MachinePool has invalid providerID",
+			object: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					ProviderIDList: []string{"invalid"},
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "MachinePool has valid providerIDs",
+			object: &expv1.MachinePool{
+				Spec: expv1.MachinePoolSpec{
+					ProviderIDList: []string{validProviderID.String(), otherValidProviderID.String()},
+				},
+			},
+			expected: []string{validProviderID.IndexKey(), otherValidProviderID.IndexKey()},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := machinePoolByProviderID(tc.object)
+			g.Expect(got).To(BeEquivalentTo(tc.expected))
+		})
+	}
+}

--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	machinepool "sigs.k8s.io/cluster-api/exp/internal/controllers"
 )
 
@@ -30,6 +31,7 @@ import (
 type MachinePoolReconciler struct {
 	Client    client.Client
 	APIReader client.Reader
+	Tracker   *remote.ClusterCacheTracker
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -39,6 +41,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	return (&machinepool.MachinePoolReconciler{
 		Client:           r.Client,
 		APIReader:        r.APIReader,
+		Tracker:          r.Tracker,
 		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/main.go
+++ b/main.go
@@ -462,6 +462,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		if err := (&expcontrollers.MachinePoolReconciler{
 			Client:           mgr.GetClient(),
 			APIReader:        mgr.GetAPIReader(),
+			Tracker:          tracker,
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(machinePoolConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachinePool")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Since CAPI v1.4.0, the MachinePool controller drops the `node.cluster.x-k8s.io/uninitialized` taint from nodes as soon as the providerID gets added to the node by the cloud-controller-manager and CAPI is able to match the node with a MachinePool. However, it is currently not watching Nodes (unlike the Machine controller) which can cause delays in the taint being dropped on MachinePool nodes, which in turn causes the Node to not become schedulable until 10-15 minutes after the node is `Ready`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8442 
