### PR TITLE
🐛  Fix MachinePool node taint patching

### DIFF
--- a/internal/util/taints/taints_test.go
+++ b/internal/util/taints/taints_test.go
@@ -55,6 +55,16 @@ func TestRemoveNodeTaint(t *testing.T) {
 			wantTaints:   []corev1.Taint{taint2},
 			wantModified: false,
 		},
+		{
+			name: "drop last taint should return true",
+			node: &corev1.Node{Spec: corev1.NodeSpec{
+				Taints: []corev1.Taint{
+					taint1,
+				}}},
+			dropTaint:    taint1,
+			wantTaints:   []corev1.Taint{},
+			wantModified: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:  Fixes flake observed in CAPZ testing with CAPI v1.4.0 where MachinePool Nodes `{node.cluster.x-k8s.io/uninitialized: } ` taints don't get removed right away (~15 minute delay). The root cause is that we are escaping the second part of the `if annotations.AddAnnotations(node, desired) || taints.RemoveNodeTaint(node, clusterv1.NodeUninitializedTaint)` when the first part if true (see https://play.golang.com/p/i-6vDeSeeBE). This results in the controller returning no error without having patched the taints. Only after the resyncPeriod does the controller get requeued and Taints finally updated.

Credits to @nawazkh @willie-yao @jackfrancis for helping me find this 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/8442
