### PR TITLE
🌱 add MachineFinalizer during machine computation

### DIFF
--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -41,6 +41,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	machinecontroller "sigs.k8s.io/cluster-api/internal/controllers/machine"
 	machinesetcontroller "sigs.k8s.io/cluster-api/internal/controllers/machineset"
 	"sigs.k8s.io/cluster-api/internal/test/envtest"
 )
@@ -100,20 +101,28 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("unable to create unstructuredCachineClient: %v", err))
 		}
 
+		if err := (&machinecontroller.Reconciler{
+			Client:                    mgr.GetClient(),
+			UnstructuredCachingClient: unstructuredCachingClient,
+			APIReader:                 mgr.GetAPIReader(),
+			Tracker:                   tracker,
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
+		}
 		if err := (&machinesetcontroller.Reconciler{
 			Client:                    mgr.GetClient(),
 			UnstructuredCachingClient: unstructuredCachingClient,
 			APIReader:                 mgr.GetAPIReader(),
 			Tracker:                   tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start MMachineSetReconciler: %v", err))
+			panic(fmt.Sprintf("Failed to start MachineSetReconciler: %v", err))
 		}
 		if err := (&Reconciler{
 			Client:                    mgr.GetClient(),
 			UnstructuredCachingClient: unstructuredCachingClient,
 			APIReader:                 mgr.GetAPIReader(),
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start MMachineDeploymentReconciler: %v", err))
+			panic(fmt.Sprintf("Failed to start MachineDeploymentReconciler: %v", err))
 		}
 	}
 

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -604,6 +604,7 @@ func (r *Reconciler) computeDesiredMachine(machineSet *clusterv1.MachineSet, exi
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, machineSetKind)},
 			Labels:          map[string]string{},
 			Annotations:     map[string]string{},
+			Finalizers:      []string{clusterv1.MachineFinalizer},
 		},
 		Spec: *machineSet.Spec.Template.Spec.DeepCopy(),
 	}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -1598,6 +1598,7 @@ func TestComputeDesiredMachine(t *testing.T) {
 				clusterv1.MachineDeploymentNameLabel: "md1",
 			},
 			Annotations: map[string]string{"machine-annotation1": "machine-value1"},
+			Finalizers:  []string{clusterv1.MachineFinalizer},
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName:             "test-cluster",
@@ -1684,4 +1685,8 @@ func assertMachine(g *WithT, actualMachine *clusterv1.Machine, expectedMachine *
 	}
 	// Check Spec
 	g.Expect(actualMachine.Spec).Should(Equal(expectedMachine.Spec))
+	// Check Finalizer
+	if expectedMachine.Finalizers != nil {
+		g.Expect(actualMachine.Finalizers).Should(Equal(expectedMachine.Finalizers))
+	}
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds the `MachineFinalizer` during calculation of the `Machine` object so the finalizer is set on object creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8172
