### PR TITLE
🌱 Removed Link in Roadmap.md and re-phrased the text.

### DIFF
--- a/docs/book/src/roadmap.md
+++ b/docs/book/src/roadmap.md
@@ -1,3 +1,3 @@
 # Cluster API Roadmap
 
-You can find the Cluster API roadmap discussion at [GitHub](https://github.com/kubernetes-sigs/cluster-api/discussions/5556). Please feel free to participate!
+The Cluster API roadmap discussion will take place during the weekly office hours.


### PR DESCRIPTION
Removed link to roadmap discussion from the book and,
Replaced the text :
From,
You can find the Cluster API roadmap discussion at https://github.com/kubernetes-sigs/cluster-api/discussions/5556. Please feel free to participate!
to
The Cluster API roadmap discussion will take place during the weekly office hours.

Fixes #8451 