### PR TITLE
:bug: Update kindnetd and kindest/haproxy

### DIFF
--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: kindnet
       containers:
         - name: kindnet-cni
-          image: kindest/kindnetd:v20221004-44d545d1
+          image: kindest/kindnetd:v20230330-48f316cd
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/infrastructure/docker/internal/loadbalancer/const.go
+++ b/test/infrastructure/docker/internal/loadbalancer/const.go
@@ -24,7 +24,7 @@ const (
 	DefaultImageRepository = "kindest"
 
 	// DefaultImageTag is the loadbalancer image tag.
-	DefaultImageTag = "v20230227-d46f45b6"
+	DefaultImageTag = "v20230330-2f738c2"
 
 	// ConfigPath is the path to the config file in the image.
 	ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Update to the latest released versions of Kind's associated images. This brings in a change to fix a longstanding issue with the loadbalancer used in CAPD.

/area dependency
Fixes #8257 
