### PR TITLE
:bug: Update kindnetd and kindest/haproxy

### DIFF
--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: kindnet
       containers:
         - name: kindnet-cni
-          image: kindest/kindnetd:v20221004-44d545d1
+          image: kindest/kindnetd:v20230330-48f316cd
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/infrastructure/docker/internal/third_party/forked/loadbalancer/const.go
+++ b/test/infrastructure/docker/internal/third_party/forked/loadbalancer/const.go
@@ -23,7 +23,7 @@ const Image = "haproxy"
 const DefaultImageRepository = "kindest"
 
 // DefaultImageTag defines the loadbalancer image tag
-const DefaultImageTag = "v20210715-a6da3463"
+const DefaultImageTag = "v20230330-2f738c2"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Manual cherry-pick of: https://github.com/kubernetes-sigs/cluster-api/pull/8469

Update to the latest released versions of Kind's associated images. This brings in a change to fix a longstanding issue with the loadbalancer used in CAPD.

/area dependency
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/8257
