### PR TITLE
:seedling: Make IPAddressClaim.Status.AddressRef optional

### DIFF
--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
@@ -127,8 +127,6 @@ spec:
                   - type
                   type: object
                 type: array
-            required:
-            - addressRef
             type: object
         type: object
     served: true

--- a/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
@@ -32,7 +32,8 @@ type IPAddressClaimSpec struct {
 // IPAddressClaimStatus is the observed status of a IPAddressClaim.
 type IPAddressClaimStatus struct {
 	// AddressRef is a reference to the address that was created for this claim.
-	AddressRef corev1.LocalObjectReference `json:"addressRef"`
+	// +optional
+	AddressRef corev1.LocalObjectReference `json:"addressRef,omitempty"`
 
 	// Conditions summarises the current state of the IPAddressClaim
 	// +optional


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR makes the `addressRef` on the IPAddressClaim status optional. This allows us to set the `condition` on the IPAddressClaim status without setting the `addressRef` in the case of failure to allocate an IPAddress.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This is related to #8424.
