### PR TITLE
🐛 ipam: fix gateway being required for IPAddress

### DIFF
--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
@@ -93,7 +93,6 @@ spec:
             required:
             - address
             - claimRef
-            - gateway
             - poolRef
             - prefix
             type: object

--- a/exp/ipam/api/v1alpha1/ipaddress_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddress_types.go
@@ -36,7 +36,8 @@ type IPAddressSpec struct {
 	Prefix int `json:"prefix"`
 
 	// Gateway is the network gateway of the network the address is from.
-	Gateway string `json:"gateway"`
+	// +optional
+	Gateway string `json:"gateway,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/exp/ipam/internal/webhooks/ipaddress.go
+++ b/exp/ipam/internal/webhooks/ipaddress.go
@@ -123,14 +123,15 @@ func (webhook *IPAddress) validate(ctx context.Context, ip *ipamv1.IPAddress) er
 			))
 	}
 
-	_, err = netip.ParseAddr(ip.Spec.Gateway)
-	if err != nil {
-		allErrs = append(allErrs,
-			field.Invalid(
-				specPath.Child("gateway"),
-				ip.Spec.Gateway,
-				"not a valid IP address",
-			))
+	if ip.Spec.Gateway != "" {
+		if _, err := netip.ParseAddr(ip.Spec.Gateway); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					specPath.Child("gateway"),
+					ip.Spec.Gateway,
+					"not a valid IP address",
+				))
+		}
 	}
 
 	if ip.Spec.PoolRef.APIGroup == nil {

--- a/exp/ipam/internal/webhooks/ipaddress_test.go
+++ b/exp/ipam/internal/webhooks/ipaddress_test.go
@@ -131,6 +131,14 @@ func TestIPAddressValidateCreate(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "an empty gateway should be allowed",
+			ip: getAddress(false, func(addr *ipamv1.IPAddress) {
+				addr.Spec.Gateway = ""
+			}),
+			extraObjs: []client.Object{claim},
+			expectErr: false,
+		},
+		{
 			name: "a pool reference that does not match the claim should be rejected",
 			ip: getAddress(false, func(addr *ipamv1.IPAddress) {
 				addr.Spec.PoolRef.Name = "nothing"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The validating webhook for IPAddress ensures that `.spec.gateway` is a valid IP address. This check fails if the field is empty, making it a required field. Since it is defined as `omitempty` it should be optional.

This PR wraps it with an is-empty check to allow the field to be empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
related to telekom/cluster-api-ipam-provider-in-cluster#70
Fixes #8536