### PR TITLE
:book: Fix links in 0.3->0.4 migration guide

### DIFF
--- a/docs/book/src/developer/providers/migrations/v0.3-to-v0.4.md
+++ b/docs/book/src/developer/providers/migrations/v0.3-to-v0.4.md
@@ -74,7 +74,7 @@ instances of the same provider, each one with its own set of credentials while w
 Starting from v1alpha4 instead we are going require that an infrastructure provider should manage different credentials,
 each one of them corresponding to an infrastructure tenant.
 
-see [Multi-tenancy](../architecture/controllers/multi-tenancy.md) and [Support multiple instances](../architecture/controllers/support-multiple-instances.md) for
+see [Multi-tenancy](../../architecture/controllers/multi-tenancy.md) and [Support multiple instances](../../architecture/controllers/support-multiple-instances.md) for
 more details.
 
 Specific changes related to this topic will be detailed in this document.
@@ -336,7 +336,7 @@ have to be adjusted accordingly.
 - `spec.nodeDrainTimeout` has been moved to `spec.machineTemplate.nodeDrainTimeout`.
 
 ## Required spec and status fields for Control Planes using 'version' for ClusterClass support
-ControlPlane implementations using version must now [include a 'version' field as defined below in both its spec and its status](../architecture/controllers/control-plane.md#required-spec-fields-for-implementations-using-version).
+ControlPlane implementations using version must now [include a 'version' field as defined below in both its spec and its status](../../architecture/controllers/control-plane.md#required-spec-fields-for-implementations-using-version).
 
  `spec.version` - is a string representing the Kubernetes version to be used
   by the control plane machines. The value must be a valid semantic version;
@@ -348,7 +348,7 @@ ControlPlane implementations using version must now [include a 'version' field a
 Please note that implementing these fields are a requirement for a control plane provider to be used with ClusterClass and managed topologies.
 
 ## Required spec fields for Control Planes using 'Machines' for ClusterClass support
-ControlPlane implementations that use an underlying MachineInfrastructure must now [include a 'machineTemplate' as defined below, with subordinate fields, in its Spec.](../architecture/controllers/control-plane.md#required-spec-fields-for-implementations-using-machines)
+ControlPlane implementations that use an underlying MachineInfrastructure must now [include a 'machineTemplate' as defined below, with subordinate fields, in its Spec.](../../architecture/controllers/control-plane.md#required-spec-fields-for-implementations-using-machines)
 
 
  `machineTemplate` - is a struct containing details of the control plane

--- a/docs/book/src/tasks/upgrading-cluster-api-versions.md
+++ b/docs/book/src/tasks/upgrading-cluster-api-versions.md
@@ -35,5 +35,5 @@ You should now be able to manage your resources using the `v1alpha4` version of 
 <!-- links -->
 [components]: ../reference/glossary.md#provider-components
 [management cluster]: ../reference/glossary.md#management-cluster
-[Cluster API v1alpha3 compared to v1alpha4 section]: ../developer/providers/v0.3-to-v0.4.md
-[Cluster API v1alpha4 compared to v1beta1 section]: ../developer/providers/v0.4-to-v1.0.md
+[Cluster API v1alpha3 compared to v1alpha4 section]: ../developer/providers/migrations/v0.3-to-v0.4.md
+[Cluster API v1alpha4 compared to v1beta1 section]: ../developer/providers/migrations/v0.4-to-v1.0.md


### PR DESCRIPTION
Fix broken links found in the weekly markdown link scan.

/kind documentation

