### PR TITLE
docs: fix clusterctl alpha rollout typo

### DIFF
--- a/docs/book/src/tasks/upgrading-clusters.md
+++ b/docs/book/src/tasks/upgrading-clusters.md
@@ -63,7 +63,7 @@ The rollout can be triggered by running the following command:
 
 ```shell
 # Trigger a KubeadmControlPlane rollout.
-clusterctl alpha rollout restart kubeadmcontrollplane/my-kcp
+clusterctl alpha rollout restart kubeadmcontrolplane/my-kcp
 
 # Trigger a MachineDeployment rollout.
 clusterctl alpha rollout restart machinedeployment/my-md-0


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fix a double "l" typo in the command documentation.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
