### PR TITLE
📖Fix remediation test doc issue in v1.3 to v1.4 upgrade docs

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
@@ -73,8 +73,7 @@ maintainers of providers and consumers of our Go API.
   Please note that the following logging flags have been removed: (in `component-base`, but this affects all CAPI controllers): `--add-dir-header`, `--alsologtostderr`, `--log-backtrace-at`,
   `--log-dir`, `--log-file`, `--log-file-max-size`, `--logtostderr`, `--one-output`, `--skip-headers`, `--skip-log-headers` and `--stderrthreshold`.
   For more information, please see: https://github.com/kubernetes/enhancements/issues/2845
-- A new `KCPRemediationSpec` test has been added providing better test coverage for KCP remediation most common use cases. As a consequence `MachineRemediationSpec` now only tests remediation of
-  worker machines (NOTE: we plan to improve this test as well in a future iteration).
+- A new `KCPRemediationSpec` test has been added providing better test coverage for KCP remediation most common use cases. As a consequence `MachineRemediationSpec` has been renamed to `MachineDeploymentRemediationSpec` and now only tests remediation of worker machines (NOTE: we plan to improve this test as well in a future iteration).
 - Package `test/infrastructure/docker/internal/third_party/forked/loadbalancer` has been moved to `test/infrastructure/docker/internal/loadbalancer` to allow it to diverge from the upstream Kind package.
 - 
 ### Suggested changes for providers


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes a documentation error in the v1.3 to v1.4 upgrade docs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8499 
