### PR TITLE
⚠️ Use k8s v1.27.0 in quickstart docs and CAPD

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -28,7 +28,7 @@ changes should be cherry-picked to all release series that will support the new 
   * Ensure the latest available kind version is used (including the latest images for this kind release)
   * Verify the quickstart manually
   * Prior art: #7156
-  * bump `InitWithKubernetesVersion` in `clusterctl_upgrade_test.go`
+  * bump `InitWithKubernetesVersion` and `WorkloadKubernetesVersion` in `clusterctl_upgrade_test.go`
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
   * For the main branch and the release branch of the latest supported Cluster API minor release:
     * Add new periodic upgrade job.

--- a/Tiltfile
+++ b/Tiltfile
@@ -4,7 +4,7 @@ envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
 default_build_engine = "docker"
-kubernetes_version = "v1.26.0"
+kubernetes_version = "v1.27.0"
 
 if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
     fail("Required command '" + kubectl_cmd + "' not found in PATH")

--- a/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
@@ -75,7 +75,7 @@ maintainers of providers and consumers of our Go API.
   For more information, please see: https://github.com/kubernetes/enhancements/issues/2845
 - A new `KCPRemediationSpec` test has been added providing better test coverage for KCP remediation most common use cases. As a consequence `MachineRemediationSpec` has been renamed to `MachineDeploymentRemediationSpec` and now only tests remediation of worker machines (NOTE: we plan to improve this test as well in a future iteration).
 - Package `test/infrastructure/docker/internal/third_party/forked/loadbalancer` has been moved to `test/infrastructure/docker/internal/loadbalancer` to allow it to diverge from the upstream Kind package.
-- 
+
 ### Suggested changes for providers
 
 - Providers should add an explicit security context to their controllers deployment, see [#7831](https://github.com/kubernetes-sigs/cluster-api/pull/7831) for reference.

--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -30,6 +30,7 @@ maintainers of providers and consumers of our Go API.
 ### Other
 
 - clusterctl move is adding the new annotation `clusterctl.cluster.x-k8s.io/delete-for-move` before object deletion.
+- Providers running CAPI release-0.3 clusterctl upgrade tests should set `WorkloadKubernetesVersion` field to the maximum workload cluster kubernetes version supported by the old providers in `ClusterctlUpgradeSpecInput`. For more information, please see: https://github.com/kubernetes-sigs/cluster-api/pull/8518#issuecomment-1508064859 
 
 ### Suggested changes for providers
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -325,7 +325,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: default
-  KUBERNETES_VERSION: v1.26.0
+  KUBERNETES_VERSION: v1.27.0
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 3
 ```

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1215,7 +1215,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.26.0 \
+  --kubernetes-version v1.27.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1227,7 +1227,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.26.0
+export KUBERNETES_VERSION=1.27.0
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -1258,7 +1258,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.26.0 \
+  --kubernetes-version v1.27.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1308,6 +1308,13 @@ You can also get an "at glance" view of the cluster and its resources by running
 clusterctl describe cluster capi-quickstart
 ```
 
+and see an output similar to this:
+
+```bash
+NAME              PHASE         AGE   VERSION
+capi-quickstart   Provisioned   8s    v1.27.0
+```
+
 To verify the first control plane is up:
 
 ```bash
@@ -1318,7 +1325,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.26.0
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.27.0
 ```
 
 <aside class="note warning">
@@ -1537,13 +1544,13 @@ let's check the status using `kubectl get nodes`:
 kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
-NAME                                          STATUS   ROLES           AGE   VERSION
-capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.26.0
-capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.26.0
-capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.26.0
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.26.0
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.26.0
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.26.0
+NAME                                          STATUS   ROLES           AGE    VERSION
+capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.27.0
+capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.27.0
+capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.27.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.27.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.27.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.27.0
 ```
 
 {{#/tab }}

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -110,7 +110,7 @@ This comes down to changing occurrences of the old version to the new version, e
          we use in the clusterctl upgrade tests (as of today `cluster-template` and `cluster-template-topology`).
       2. Remove old folders that are not used anymore (for `v1.4` we don't have to remove any).
    5. Modify the test specs in `test/e2e/clusterctl_upgrade_test.go` (according to the versions we want to test described above).
-      Please note that `InitWithKubernetesVersion` should be the highest mgmt cluster version supported by the respective Cluster API version.
+      Please note that both `InitWithKubernetesVersion` and `WorkloadKubernetesVersion` should be the highest mgmt cluster version supported by the respective Cluster API version.
 2. Update `create-local-repository.py` and `tools/tilt-prepare/main.go`: `v1.3.99` => `v1.4.99`.
 3. Make sure all tests are green (also run `pull-cluster-api-e2e-full-main` and `pull-cluster-api-e2e-workload-upgrade-1-23-latest-main`).
 

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -105,6 +105,8 @@ type ClusterctlUpgradeSpecInput struct {
 	MgmtFlavor                  string
 	CNIManifestPath             string
 	WorkloadFlavor              string
+	// WorkloadKubernetesVersion is Kubernetes version used to create the workload cluster, e.g. `v1.25.0`
+	WorkloadKubernetesVersion string
 	// Custom providers can be specified to upgrade to a pre-release or a custom version instead of upgrading to the latest using contact
 	CoreProvider              string
 	BootstrapProviders        []string
@@ -328,7 +330,10 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		// so we are getting a template using the downloaded version of clusterctl, applying it, and wait for machines to be provisioned.
 
 		workLoadClusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-		kubernetesVersion := input.E2EConfig.GetVariable(KubernetesVersion)
+		kubernetesVersion := input.WorkloadKubernetesVersion
+		if kubernetesVersion == "" {
+			kubernetesVersion = input.E2EConfig.GetVariable(KubernetesVersion)
+		}
 		controlPlaneMachineCount := pointer.Int64(1)
 		workerMachineCount := pointer.Int64(1)
 

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -209,7 +209,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.4=>current)", func() {
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.26.0",
+			InitWithKubernetesVersion: "v1.27.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -237,7 +237,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.4=>cur
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.26.0",
+			InitWithKubernetesVersion: "v1.27.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -36,7 +36,8 @@ var _ = Describe("When testing clusterctl upgrades (v0.3=>current)", func() {
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1alpha3",
 			// CAPI v0.3.x does not work on Kubernetes >= v1.22.
-			InitWithKubernetesVersion: "v1.21.12",
+			InitWithKubernetesVersion: "v1.21.14",
+			WorkloadKubernetesVersion: "v1.22.17",
 			// CAPI does not work with Kubernetes < v1.22 if ClusterClass is enabled, so we have to disable it.
 			UpgradeClusterctlVariables: map[string]string{
 				"CLUSTER_TOPOLOGY": "false",
@@ -68,7 +69,8 @@ var _ = Describe("When testing clusterctl upgrades (v0.4=>current)", func() {
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1alpha4",
-			InitWithKubernetesVersion: "v1.23.13",
+			InitWithKubernetesVersion: "v1.23.17",
+			WorkloadKubernetesVersion: "v1.23.17",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -105,7 +107,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
-			InitWithKubernetesVersion:         "v1.23.13",
+			InitWithKubernetesVersion:         "v1.23.17",
+			WorkloadKubernetesVersion:         "v1.23.17",
 			MgmtFlavor:                        "topology",
 			WorkloadFlavor:                    "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -143,7 +146,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithProvidersContract:         "v1beta1",
-			InitWithKubernetesVersion:         "v1.26.0",
+			InitWithKubernetesVersion:         "v1.26.3",
+			WorkloadKubernetesVersion:         "v1.26.3",
 			MgmtFlavor:                        "topology",
 			WorkloadFlavor:                    "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -181,7 +185,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithProvidersContract:         "v1beta1",
-			InitWithKubernetesVersion:         "v1.26.0",
+			InitWithKubernetesVersion:         "v1.26.3",
+			WorkloadKubernetesVersion:         "v1.26.3",
 			MgmtFlavor:                        "topology",
 			WorkloadFlavor:                    "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -210,6 +215,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.4=>current)", func() {
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.27.0",
+			WorkloadKubernetesVersion: "v1.27.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -238,6 +244,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.4=>cur
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			InitWithKubernetesVersion: "v1.27.0",
+			WorkloadKubernetesVersion: "v1.27.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -323,12 +323,12 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.26.0"
-  KUBERNETES_VERSION: "v1.26.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.6-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.27.0"
+  KUBERNETES_VERSION: "v1.27.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.3"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.27.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.7-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.26.0"
+	DefaultNodeImageVersion = "v1.27.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.26.0
+  version: v1.27.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.26.0
+      version: v1.27.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.26.0
+  version: v1.27.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.26.0
+      version: v1.27.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.26.0
+  version: v1.27.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.26.0
+      version: v1.27.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.26.0
+  version: v1.27.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.26.0
+      version: v1.27.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.26.0"
+	defaultImageTag  = "v1.27.0"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)

**What this PR does / why we need it**:
Bumps k8s version to v1.27.0 in Quickstart docs and CAPD. 

**NOTE**: 

- etcd version is bumped to` 3.5.7-0` following the [kubeadm](https://github.com/kubernetes/kubernetes/blob/release-1.27/cmd/kubeadm/app/constants/constants.go#L311-L312)
-  COREDNS_VERSION is bumped to `v1.10.1` following the [kubeadm](https://github.com/kubernetes/kubernetes/blob/c3e3ff989ac9abfb0dc3b958fcb698fcce952f8c/cmd/kubeadm/app/constants/constants.go#L348)
- new field called: `WorkloadKubernetesVersion` was introduced to `ClusterctlUpgradeSpecInput`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of: #8459 

cc @kubernetes-sigs/cluster-api-release-team 
