### PR TITLE
🐛 IPAM Webhook allows empty gateway for IPv6 Address

### DIFF
--- a/exp/ipam/internal/webhooks/ipaddress_test.go
+++ b/exp/ipam/internal/webhooks/ipaddress_test.go
@@ -91,6 +91,38 @@ func TestIPAddressValidateCreate(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "a valid IPv6 Address with no gateway should be accepted",
+			ip: getAddress(true, func(addr *ipamv1.IPAddress) {
+				addr.Spec.Gateway = ""
+			}),
+			extraObjs: []client.Object{claim},
+			expectErr: false,
+		},
+		{
+			name: "an IPv4 Address with no gateway should be rejected",
+			ip: getAddress(false, func(addr *ipamv1.IPAddress) {
+				addr.Spec.Gateway = ""
+			}),
+			extraObjs: []client.Object{claim},
+			expectErr: true,
+		},
+		{
+			name: "a valid IPv4 Address with valid IPv6 gateway should be rejected",
+			ip: getAddress(false, func(addr *ipamv1.IPAddress) {
+				addr.Spec.Gateway = "42::ffff"
+			}),
+			extraObjs: []client.Object{claim},
+			expectErr: true,
+		},
+		{
+			name: "a valid IPv6 Address with valid IPv4 gateway should be rejected",
+			ip: getAddress(true, func(addr *ipamv1.IPAddress) {
+				addr.Spec.Gateway = "10.0.0.254"
+			}),
+			extraObjs: []client.Object{claim},
+			expectErr: true,
+		},
+		{
 			name: "a prefix that is negative should be rejected",
 			ip: getAddress(false, func(addr *ipamv1.IPAddress) {
 				addr.Spec.Prefix = -1


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

IPv6 default routes can be acquired through Router Advertisements, therefore empty gateway should be permitted. This PR continues to require gateway for IPv4. We also added validation to ensure the gateway family matches the address family.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

