### PR TITLE
📖 Update `v1alpha3` and `v1alpha4` deprecation message

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/migrations/v1.3-to-v1.4.md
@@ -21,8 +21,8 @@ maintainers of providers and consumers of our Go API.
 ### Deprecation
 
 - The api versions `v1alpha3` and `v1alpha4` are deprecated and will be removed. 
-  - `v1alpha3` will be removed in v1.5 
-  - `v1alpha4` will be removed in v1.6
+  - `v1alpha3` will be removed in v1.6 
+  - `v1alpha4` will be removed in v1.7
 
   For more information please see [the note in the contributors guide](../../../CONTRIBUTING.md#removal-of-v1alpha3--v1alpha4-apiversions).
 

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -20,8 +20,8 @@ Also, this [guide](https://github.com/kubernetes/registry.k8s.io/tree/main/docs/
 <aside class="note">
 <h1>Deprecated API removal</h1>
 
-- API version v1alpha3 support will be removed in the upcoming release of v1.5
-- API version v1alpha4 support will be removed in the upcoming release of v1.6
+- API version v1alpha3 support will be removed in the upcoming release of v1.6
+- API version v1alpha4 support will be removed in the upcoming release of v1.7
 
 Review the [support-and-guarantees](./CONTRIBUTING.md#support-and-guarantees) section of the
 contributing guide for more details.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Based on https://github.com/kubernetes-sigs/cluster-api/issues/8038 it looks like the deprecation will occur on later releases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #8038 
