### PR TITLE
[release-1.4] 📖 Update versions doc with k8s v1.27 notes

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -24,10 +24,10 @@ When a new Kubernetes minor release is available, we will try to support it in a
 the corresponding required changes in Cluster API are too invasive we won't backport the support and users have to wait 
 for the next Cluster API minor release.
 
-For example, Cluster API v1.4.0 would support the following Kubernetes versions:
-* v1.23.x to v1.26.x for the management cluster
-* v1.21.x to v1.26.x for the workload cluster
-* When Kubernetes 1.27 is released, it will be supported in v1.4.x (but not in v1.3.x)
+For example, Cluster API v1.5.0 would support the following Kubernetes versions:
+* v1.24.x to v1.27.x for the management cluster
+* v1.22.x to v1.27.x for the workload cluster
+* When Kubernetes 1.28 is released, it will be supported in v1.5.x (but not in v1.4.x)
 
 Support in this context means that we:
 * maintain corresponding code paths
@@ -72,17 +72,18 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)    |
-|-------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.18  | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.19  | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.20  | ✓                    | ✓                 | ✓                 |                   |
-| Kubernetes v1.21  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.22  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.23* | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.24  | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.25  |                      | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.26  |                      | ✓                 | ✓                 | ✓                 |
+|                   | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)          |
+|-------------------|----------------------|-------------------|-------------------|-------------------------|
+| Kubernetes v1.18  | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.19  | ✓                    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.20  | ✓                    | ✓                 | ✓                 |                         |
+| Kubernetes v1.21  | ✓                    | ✓                 | ✓                 | ✓ (only workload)       |
+| Kubernetes v1.22  | ✓                    | ✓                 | ✓                 | ✓ (only workload)       | 
+| Kubernetes v1.23* | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.24  | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.25  |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.26  |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.27  |                      |                   |                   | ✓ (from v1.4.2 release) |
 
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
@@ -94,33 +95,36 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)     |
-|------------------------------------|----------------------|-------------------|-------------------|--------------------|
-| Kubernetes v1.18 + kubeadm/v1beta2 | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                    |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                    | ✓ (only workload) | ✓ (only workload) |                    |
-| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                    | ✓                 | ✓                 |                    |
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                    | ✓                 | ✓                 | ✓  (only workload) |
-| Kubernetes v1.22 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓  (only workload) |
-| Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓                  |
-| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓                  |
-| Kubernetes v1.25 + kubeadm/v1beta3 |                      | ✓                 | ✓                 | ✓                  |
-| Kubernetes v1.26 + kubeadm/v1beta3 |                      | ✓                 | ✓                 | ✓                  |
+|                                    | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)          |
+|------------------------------------|----------------------|-------------------|-------------------|-------------------------|
+| Kubernetes v1.18 + kubeadm/v1beta2 | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                    | ✓                 | ✓                 |                         |
+| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                    | ✓                 | ✓                 | ✓ (only workload)       |
+| Kubernetes v1.22 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓ (only workload)       |
+| Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.25 + kubeadm/v1beta3 |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.26 + kubeadm/v1beta3 |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.27 + kubeadm/v1beta3 |                      |                   |                   | ✓ (from v1.4.2 release) |
+
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)    |
-|----------------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.18 + etcd/v3 | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                 | ✓                 |                   |
-| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.22 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.23 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.25 + etcd/v3 |                      | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.26 + etcd/v3 |                      | ✓                 | ✓                 | ✓                 |
+|                            | v1.1 (v1beta1) (EOL) | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)          |
+|----------------------------|----------------------|-------------------|-------------------|-------------------------|
+| Kubernetes v1.18 + etcd/v3 | ✓ (only workload)    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                         |
+| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                 | ✓                 |                         |
+| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload)       |
+| Kubernetes v1.22 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload)       |
+| Kubernetes v1.23 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.25 + etcd/v3 |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.26 + etcd/v3 |                      | ✓                 | ✓                 | ✓                       |
+| Kubernetes v1.27 + etcd/v3 |                      |                   |                   | ✓ (from v1.4.2 release) |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
@@ -141,6 +145,9 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 | v1.4 (v1beta1)       | v1.10.1                         |
 
 #### Kubernetes version specific notes
+
+**1.27**:
+* No specific notes
 
 **1.26**:
 * No specific notes


### PR DESCRIPTION
Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)

(cherry picked from commit af03bdd9d68918ff37113cb5764975a6394ef811)

**What this PR does / why we need it**:
Manually cherry-picks #https://github.com/kubernetes-sigs/cluster-api/pull/8520 considering [this comment](https://github.com/kubernetes-sigs/cluster-api/pull/8520#issuecomment-1506923176) from original PR and assumes support for v1.27 will start from v1.4.2. This will be on hold until 1.4.x release out with 1.27 support and will be left as is or updated accordingly

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/8459

cc @kubernetes-sigs/cluster-api-release-team 

/hold

