### PR TITLE
:sparkles: [kcp] Make networking.pod/service subnet fields mutable

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -121,6 +121,9 @@ const (
 	directory            = "directory"
 	preKubeadmCommands   = "preKubeadmCommands"
 	postKubeadmCommands  = "postKubeadmCommands"
+	networking           = "networking"
+	podSubnet            = "podSubnet"
+	serviceSubnet        = "serviceSubnet"
 	files                = "files"
 	users                = "users"
 	apiServer            = "apiServer"
@@ -146,6 +149,8 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, networking, podSubnet},
+		{spec, kubeadmConfigSpec, clusterConfiguration, networking, serviceSubnet},
 		{spec, kubeadmConfigSpec, clusterConfiguration, apiServer},
 		{spec, kubeadmConfigSpec, clusterConfiguration, apiServer, "*"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, controllerManager},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -653,6 +653,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	updateJoinConfigurationSkipPhases := before.DeepCopy()
 	updateJoinConfigurationSkipPhases.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases = []string{"addon/kube-proxy"}
 
+	updateNetworkingPodSubnet := before.DeepCopy()
+	updateNetworkingPodSubnet.Spec.KubeadmConfigSpec.ClusterConfiguration.Networking.PodSubnet = "100.64.0.0/16"
+
+	updateNetworkingServiceSubnet := before.DeepCopy()
+	updateNetworkingServiceSubnet.Spec.KubeadmConfigSpec.ClusterConfiguration.Networking.ServiceSubnet = "10.254.0.0/16"
+
 	updateDiskSetup := before.DeepCopy()
 	updateDiskSetup.Spec.KubeadmConfigSpec.DiskSetup = &bootstrapv1.DiskSetup{
 		Filesystems: []bootstrapv1.Filesystem{
@@ -974,6 +980,18 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       updateJoinConfigurationSkipPhases,
+		},
+		{
+			name:      "should allow changes to clusterConfiguration.networking.podSubnet",
+			expectErr: false,
+			before:    before,
+			kcp:       updateNetworkingPodSubnet,
+		},
+		{
+			name:      "should allow changes to clusterConfiguration.networking.serviceSubnet",
+			expectErr: false,
+			before:    before,
+			kcp:       updateNetworkingServiceSubnet,
 		},
 		{
 			name:      "should allow changes to diskSetup",


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Users might need to change pod or service CIDR on an already provisioned cluster. In this commit, we make these fields mutable to enable such kind of operation to take place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/6951 (partially)
