### PR TITLE
:seedling: Disable fail-fast by default for e2e tests

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -54,7 +54,7 @@ kind:prepullAdditionalImages
 # Configure e2e tests
 export GINKGO_NODES=3
 export GINKGO_NOCOLOR=true
-export GINKGO_ARGS="${GINKGO_ARGS:-"--fail-fast"}"
+export GINKGO_ARGS="${GINKGO_ARGS:-""}"
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=false


### PR DESCRIPTION
Set `fail-fast=false` for e2e test jobs by default. This will give better test coverage by running more tests so more than one failure at a time can surface. 

Context: https://github.com/kubernetes-sigs/cluster-api/pull/8365#issuecomment-1519808239