### PR TITLE
[release-1.4] 🌱 test/e2e: use topology flavor for workload clusters in clusterctl upgrade test

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -134,22 +134,20 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
 			// use the latest version for the contract (which is v1.3.X for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.11",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.11"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.11"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.11"},
+			InitWithCoreProvider:            "cluster-api:v1.2.12",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.12"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.12"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.12"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
-			// TODO(sbueringer) The topology flavor enables PSA.
-			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
-			//MgmtFlavor:                        "topology",
-			WorkloadFlavor: "",
+			MgmtFlavor:                        "topology",
+			WorkloadFlavor:                    "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
@@ -173,22 +171,20 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>cur
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/clusterctl-{OS}-{ARCH}",
+			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
 			// use the latest version for the contract (which is v1.3.X for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.11",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.11"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.11"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.11"},
+			InitWithCoreProvider:            "cluster-api:v1.2.12",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.12"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.12"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.12"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
-			// TODO(sbueringer) The topology flavor enables PSA.
-			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
-			//MgmtFlavor:                        "topology",
-			WorkloadFlavor: "topology",
+			MgmtFlavor:                        "topology",
+			WorkloadFlavor:                    "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -58,8 +58,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/core-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -114,8 +114,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/bootstrap-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -170,8 +170,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
-  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/control-plane-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -229,8 +229,8 @@ providers:
     files:
     - sourcePath: "../data/shared/v1.0/metadata.yaml"
     - sourcePath: "../data/infrastructure-docker/v1.0/cluster-template.yaml"
-  - name: v1.2.11 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.11/infrastructure-components-development.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/8311#discussion_r1141596306

To be honest not sure if we need this, but let's clean it up at least for consistency with other tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
