### PR TITLE
[release-1.3] 🌱 test/e2e: use topology flavor for workload clusters in clusterctl upgrade test

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -73,19 +73,17 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
 			// use the latest version for the contract (which is v1.3.0 for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.8",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.8"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.8"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.8"},
+			InitWithCoreProvider:            "cluster-api:v1.2.12",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.12"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.12"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.12"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
-			// TODO(sbueringer) The topology flavor enables PSA.
-			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
-			//MgmtFlavor:                        "topology",
-			WorkloadFlavor: "",
+			MgmtFlavor:                        "topology",
+			WorkloadFlavor:                    "",
 		}
 	})
 })
@@ -101,19 +99,17 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>cur
 			InitWithBinary:        "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
 			// We have to pin the providers because with `InitWithProvidersContract` the test would
 			// use the latest version for the contract (which is v1.3.0 for v1beta1).
-			InitWithCoreProvider:            "cluster-api:v1.2.8",
-			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.8"},
-			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.8"},
-			InitWithInfrastructureProviders: []string{"docker:v1.2.8"},
+			InitWithCoreProvider:            "cluster-api:v1.2.12",
+			InitWithBootstrapProviders:      []string{"kubeadm:v1.2.12"},
+			InitWithControlPlaneProviders:   []string{"kubeadm:v1.2.12"},
+			InitWithInfrastructureProviders: []string{"docker:v1.2.12"},
 			// We have to set this to an empty array as clusterctl v1.2 doesn't support
 			// runtime extension providers. If we don't do this the test will automatically
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithKubernetesVersion:         "v1.26.0",
-			// TODO(sbueringer) The topology flavor enables PSA.
-			// CAPD will only work with PSA after we have a release with https://github.com/kubernetes-sigs/cluster-api/pull/8313.
-			//MgmtFlavor:                        "topology",
-			WorkloadFlavor: "topology",
+			MgmtFlavor:                        "topology",
+			WorkloadFlavor:                    "topology",
 		}
 	})
 })

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -49,8 +49,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v0.4/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/core-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -87,8 +87,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v0.4/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/bootstrap-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -125,8 +125,8 @@ providers:
       new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v0.4/metadata.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/control-plane-components.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -165,8 +165,8 @@ providers:
     files:
     - sourcePath: "../data/shared/v0.4/metadata.yaml"
     - sourcePath: "../data/infrastructure-docker/v0.4/cluster-template.yaml"
-  - name: v1.2.8 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.8/infrastructure-components-development.yaml"
+  - name: v1.2.12 # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.12/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:


### PR DESCRIPTION
…rade test

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/8311#discussion_r1141596306

To be honest not sure if we need this, but let's clean it up at least for consistency with other tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
