### PR TITLE
📖 : Add beta testing tasks to release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -42,6 +42,7 @@ Week 13:
 * [ ] [Release Lead] [Cut the v1.4.0-beta.0 release](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#repeatedly-cut-a-release)
 * [ ] [Release Lead] [Cut the v1.3.3 release](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#repeatedly-cut-a-release)
 * [ ] [Release Lead] [Create a new GitHub milestone for the next release](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#create-a-new-github-milestone-for-the-next-release)
+* [ ] [Communications Manager] [Communicate beta to providers](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#communicate-beta-to-providers)
 
 Week 14:
 * [ ] [Release Lead] [Cut the v1.4.0-beta.1 release](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#repeatedly-cut-a-release)

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -39,6 +39,7 @@ This document details the responsibilities and tasks for each role in the releas
       - [Change production branch in Netlify to the new release branch](#change-production-branch-in-netlify-to-the-new-release-branch)
       - [Update clusterctl links in the quickstart](#update-clusterctl-links-in-the-quickstart)
       - [Continuously: Communicate key dates to the community](#continuously-communicate-key-dates-to-the-community)
+      - [Communicate beta to providers](#communicate-beta-to-providers)
   - [CI Signal/Bug Triage/Automation Manager](#ci-signalbug-triageautomation-manager)
     - [Responsibilities](#responsibilities-2)
     - [Tasks](#tasks-2)
@@ -372,6 +373,30 @@ Stakeholders are: (TBD)
 * Contributors to core Cluster API
 * Provider implementers
 * ...
+
+#### Communicate beta to providers
+
+The goal of this task is to inform all providers that a new beta.0 version a release is out and that it should be tested. We want to prevent issues where providers don't have enough time to test before a new version of CAPI is released. This stems from a previous issue we are trying to avoid: https://github.com/kubernetes-sigs/cluster-api/issues/8498
+
+We should inform at least the following providers via a new issue on their respective repos that a new version of CAPI is being released (provide the release date) and that the beta.0 version is ready for them to test.
+
+ - Addon provider helm: https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/issues/new
+ - AWS: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/new
+ - Azure: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/new
+ - Cloudstack: https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/issues/new
+ - Digital Ocean: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/issues/new
+ - GCP: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/new
+ - Kubemark: https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/issues/new
+ - Kubevirt: https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/new
+ - IBMCloud: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/new
+ - Nested: https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/new
+ - OCI: https://github.com/oracle/cluster-api-provider-oci/issues/new
+ - Openstack: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/new
+ - Operator: https://github.com/kubernetes-sigs/cluster-api-operator/issues/new
+ - Packet: https://github.com/kubernetes-sigs/cluster-api-provider-packet/issues/new
+ - vSphere: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/new
+
+TODO: Right now we don't have a template for this message but the Comms Team will provide one later. 
 
 ## CI Signal/Bug Triage/Automation Manager
 

--- a/docs/release/releases/release-1.5.md
+++ b/docs/release/releases/release-1.5.md
@@ -12,6 +12,7 @@ The following table shows the preliminary dates for the `v1.5` release cycle.
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 2nd May 2023       | week 5   |
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 30th May 2023      | week 9   |
 | v1.5.0-beta.0 released                               | Release Lead | Tuesday 27th June 2023     | week 13  |
+| Communicate beta to providers                        | Comms Manager| Tuesday 27th June 2023     | week 13  |
 | *v1.3.x & v1.4.x released*                           | Release Lead | Tuesday 27th June 2023     | week 13  |
 | v1.5.0-beta.x released                               | Release Lead | Tuesday 4th July 2023      | week 14  |
 | release-1.5 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 11th July 2023     | week 15  |


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As discussed in https://github.com/kubernetes-sigs/cluster-api/issues/8498#issuecomment-1503860857 we want to inform providers when a new beta.0 has been released. This will help 1) inform the providers of the upcoming release and 2) let them know a new version is ready to test. The beta.0 release should give the providers about a month of testing before the next minor release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #8498
