### PR TITLE
🐛 mark false on kubeadmcontrolplane.status.conditions.available if kubeadm init failed 

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/condition_consts.go
+++ b/controlplane/kubeadm/api/v1beta1/condition_consts.go
@@ -44,6 +44,9 @@ const (
 	// WaitingForKubeadmInitReason (Severity=Info) documents a KubeadmControlPlane object waiting for the first
 	// control plane instance to complete the kubeadm init operation.
 	WaitingForKubeadmInitReason = "WaitingForKubeadmInit"
+
+	// KubeadmInitFailedReason (Severity=Error) documents kubeadm init operation of the first cp node failed.
+	KubeadmInitFailedReason = "KubeadmInitFailed"
 )
 
 const (

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -107,9 +107,14 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	kcp.Status.UnavailableReplicas = replicas - status.ReadyNodes
 
 	// This only gets initialized once and does not change if the kubeadm config map goes away.
-	if status.HasKubeadmConfig {
-		kcp.Status.Initialized = true
-		conditions.MarkTrue(kcp, controlplanev1.AvailableCondition)
+	if !kcp.Status.Initialized {
+		if status.HasKubeadmConfig {
+			kcp.Status.Initialized = true
+			conditions.MarkTrue(kcp, controlplanev1.AvailableCondition)
+		} else {
+			kcp.Status.Initialized = false
+			conditions.MarkFalse(kcp, controlplanev1.AvailableCondition, controlplanev1.KubeadmInitFailedReason, clusterv1.ConditionSeverityError, "")
+		}
 	}
 
 	if kcp.Status.ReadyReplicas > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will make kubeadmcontrolplane controller marks its available condition false if kubeadm init failed at the very first node and `kubeadm-config` couldn't be retrieved(we assume that the first cp node initalization will create `kubeadm-config` configmap).

Sometimes, kubeadm init didn't go well for unexpected reasons.
At this moment, the controller does not provide enough clue why control plane provisioning is stuck.
```yaml
  conditions:
  - lastTransitionTime: "2023-04-14T00:56:00Z"
    message: Scaling up control plane to 5 replicas (actual 1)
    reason: ScalingUp
    severity: Warning
    status: "False"
    type: Ready
  - lastTransitionTime: "2023-04-14T00:56:00Z"
    reason: WaitingForKubeadmInit
    severity: Info
    status: "False"
    type: Available
  - lastTransitionTime: "2023-04-14T00:56:00Z"
    status: "True"
    type: CertificatesAvailable
  - lastTransitionTime: "2023-04-14T01:03:36Z"
    status: "True"
    type: MachinesReady
  - lastTransitionTime: "2023-04-14T00:56:00Z"
    message: Scaling up control plane to 5 replicas (actual 1)
    reason: ScalingUp
    severity: Warning
    status: "False"
    type: Resized
```