### PR TITLE
🌱 KCP: improve error log on scale up when Machine doesn't have a nodeRef

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2321,6 +2321,10 @@ func createMachineNodePair(name string, cluster *clusterv1.Cluster, kcp *control
 }
 
 func setMachineHealthy(m *clusterv1.Machine) {
+	m.Status.NodeRef = &corev1.ObjectReference{
+		Kind: "Node",
+		Name: "node-1",
+	}
 	conditions.MarkTrue(m, controlplanev1.MachineAPIServerPodHealthyCondition)
 	conditions.MarkTrue(m, controlplanev1.MachineControllerManagerPodHealthyCondition)
 	conditions.MarkTrue(m, controlplanev1.MachineSchedulerPodHealthyCondition)

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -493,11 +493,27 @@ func TestPreflightChecks(t *testing.T) {
 			expectResult: ctrl.Result{RequeueAfter: deleteRequeueAfter},
 		},
 		{
+			name: "control plane without a nodeRef should requeue",
+			kcp:  &controlplanev1.KubeadmControlPlane{},
+			machines: []*clusterv1.Machine{
+				{
+					Status: clusterv1.MachineStatus{
+						NodeRef: nil,
+					},
+				},
+			},
+			expectResult: ctrl.Result{RequeueAfter: preflightFailedRequeueAfter},
+		},
+		{
 			name: "control plane with an unhealthy machine condition should requeue",
 			kcp:  &controlplanev1.KubeadmControlPlane{},
 			machines: []*clusterv1.Machine{
 				{
 					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Kind: "Node",
+							Name: "node-1",
+						},
 						Conditions: clusterv1.Conditions{
 							*conditions.FalseCondition(controlplanev1.MachineAPIServerPodHealthyCondition, "fooReason", clusterv1.ConditionSeverityError, ""),
 							*conditions.TrueCondition(controlplanev1.MachineControllerManagerPodHealthyCondition),
@@ -523,6 +539,10 @@ func TestPreflightChecks(t *testing.T) {
 			machines: []*clusterv1.Machine{
 				{
 					Status: clusterv1.MachineStatus{
+						NodeRef: &corev1.ObjectReference{
+							Kind: "Node",
+							Name: "node-1",
+						},
 						Conditions: clusterv1.Conditions{
 							*conditions.TrueCondition(controlplanev1.MachineAPIServerPodHealthyCondition),
 							*conditions.TrueCondition(controlplanev1.MachineControllerManagerPodHealthyCondition),


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Today KCP produces confusing error messages if it can't scale up the control plane because one of the already existing Machines doesn't have a nodeRef (e.g. because it doesn't have a providerID). This PR improves the error log

Before:
> "events: Waiting for control plane to pass preflight checks to continue reconciliation: [machine capi-quickstart-control-plane-5tgwz does not have APIServerPodHealthy condition, machine capi-quickstart-control-plane-5tgwz does not have ControllerManagerPodHealthy condition, machine capi-quickstart-control-plane-5tgwz does not have SchedulerPodHealthy condition, machine capi-quickstart-control-plane-5tgwz does not have EtcdPodHealthy condition, machine capi-quickstart-control-plane-5tgwz does not have EtcdMemberHealthy condition]",

After:
>  "events: Waiting for control plane to pass preflight checks to continue reconciliation: Machine capi-quickstart-control-plane-5tgwz does not have a corresponding Node yet (Machine.status.nodeRef not set)"

xref: https://kubernetes.slack.com/archives/CKFGK3SSD/p1677254478586479


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
