### PR TITLE
✨ Clusterctl alpha rollout status

### DIFF
--- a/cmd/clusterctl/client/alpha/rollout.go
+++ b/cmd/clusterctl/client/alpha/rollout.go
@@ -46,6 +46,7 @@ type Rollout interface {
 	ObjectPauser(context.Context, cluster.Proxy, corev1.ObjectReference) error
 	ObjectResumer(context.Context, cluster.Proxy, corev1.ObjectReference) error
 	ObjectRollbacker(context.Context, cluster.Proxy, corev1.ObjectReference, int64) error
+	ObjectStatusWatcher(cluster.Proxy, corev1.ObjectReference) error
 }
 
 var _ Rollout = &rollout{}

--- a/cmd/clusterctl/client/alpha/rollout.go
+++ b/cmd/clusterctl/client/alpha/rollout.go
@@ -46,7 +46,7 @@ type Rollout interface {
 	ObjectPauser(context.Context, cluster.Proxy, corev1.ObjectReference) error
 	ObjectResumer(context.Context, cluster.Proxy, corev1.ObjectReference) error
 	ObjectRollbacker(context.Context, cluster.Proxy, corev1.ObjectReference, int64) error
-	ObjectStatusWatcher(cluster.Proxy, corev1.ObjectReference) error
+	ObjectStatusWatcher(context.Context, cluster.Proxy, corev1.ObjectReference) error
 }
 
 var _ Rollout = &rollout{}

--- a/cmd/clusterctl/client/alpha/rollout_statuswatcher.go
+++ b/cmd/clusterctl/client/alpha/rollout_statuswatcher.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+)
+
+// StatusWatcher provides an interface for resources that have rollout status.
+type StatusWatcher interface {
+	Status(proxy cluster.Proxy, name, namespace string) (string, bool, error)
+}
+
+// KubeadmControlPlaneStatusWatcher implements the StatusViewer interface.
+type KubeadmControlPlaneStatusWatcher struct{}
+
+// MachineDeploymentStatusWatcher implements the StatusViewer interface.
+type MachineDeploymentStatusWatcher struct{}
+
+// ObjectStatusWatcher will issue a view on the specified cluster-api resource.
+func (r *rollout) ObjectStatusWatcher(proxy cluster.Proxy, ref corev1.ObjectReference) error {
+	log := ctrl.LoggerFrom(ctx)
+	var statusViewer StatusWatcher
+	switch ref.Kind {
+	case KubeadmControlPlane:
+		statusViewer = &KubeadmControlPlaneStatusWatcher{}
+	case MachineDeployment:
+		statusViewer = &MachineDeploymentStatusWatcher{}
+	default:
+		return errors.Errorf("invalid resource type %q, valid values are %v", ref.Kind, validResourceTypes)
+	}
+
+	oldStatus := ""
+	timeout := 600 * time.Second
+	lastChange := time.Now()
+	for {
+		status, done, err := statusViewer.Status(proxy, ref.Name, ref.Namespace)
+		if err != nil {
+			log.Error(err, "failed to get resource status")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		if status != oldStatus {
+			fmt.Fprintf(os.Stdout, "%s", status)
+			oldStatus = status
+			lastChange = time.Now()
+		}
+		if done || time.Since(lastChange) > timeout {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil
+}
+
+// Status returns a status describing kubeadmcontrolplane status, and a bool value indicating if the status is considered done.
+func (s *KubeadmControlPlaneStatusWatcher) Status(proxy cluster.Proxy, name, namespace string) (string, bool, error) {
+	newKcp, err := getKubeadmControlPlane(proxy, name, namespace)
+	if err != nil || newKcp == nil {
+		return "", false, errors.Wrapf(err, "failed to get kubeadmcontrolplane/%v", name)
+	}
+	if newKcp.Spec.Replicas != nil && newKcp.Status.UpdatedReplicas < *newKcp.Spec.Replicas {
+		return fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d out of %d new replicas have been updated...\n", newKcp.Name, newKcp.Status.UpdatedReplicas, *newKcp.Spec.Replicas), false, nil
+	}
+	if newKcp.Status.Replicas > newKcp.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d old replicas are pending termination...\n", newKcp.Name, newKcp.Status.Replicas-newKcp.Status.UpdatedReplicas), false, nil
+	}
+	if newKcp.Status.ReadyReplicas < newKcp.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d of %d updated replicas are ready...\n", newKcp.Name, newKcp.Status.ReadyReplicas, newKcp.Status.UpdatedReplicas), false, nil
+	}
+	return fmt.Sprintf("kubeadmcontrolplane %q successfully rolled out\n", newKcp.Name), true, nil
+}
+
+// Status returns a status describing machinedeployment status, and a bool value indicating if the status is considered done.
+func (s *MachineDeploymentStatusWatcher) Status(proxy cluster.Proxy, name, namespace string) (string, bool, error) {
+	newMD, err := getMachineDeployment(proxy, name, namespace)
+	if err != nil || newMD == nil {
+		return "", false, errors.Wrapf(err, "failed to get machinedeployment/%v", name)
+	}
+	if newMD.Spec.Replicas != nil && newMD.Status.UpdatedReplicas < *newMD.Spec.Replicas {
+		return fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d out of %d new replicas have been updated...\n", newMD.Name, newMD.Status.UpdatedReplicas, *newMD.Spec.Replicas), false, nil
+	}
+	if newMD.Status.Replicas > newMD.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d old replicas are pending termination...\n", newMD.Name, newMD.Status.Replicas-newMD.Status.UpdatedReplicas), false, nil
+	}
+	if newMD.Status.AvailableReplicas < newMD.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d of %d updated replicas are available...\n", newMD.Name, newMD.Status.AvailableReplicas, newMD.Status.UpdatedReplicas), false, nil
+	}
+	return fmt.Sprintf("machinedeployment %q successfully rolled out\n", newMD.Name), true, nil
+}

--- a/cmd/clusterctl/client/alpha/rollout_statuswatcher_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_statuswatcher_test.go
@@ -1,0 +1,418 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alpha
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+)
+
+func captureStdout(fnc func()) (string, error) {
+	r, w, _ := os.Pipe()
+
+	stdout := os.Stdout
+	defer func() {
+		os.Stdout = stdout
+	}()
+	os.Stdout = w
+
+	fnc()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func Test_ObjectStatusWatcher(t *testing.T) {
+	namespace := metav1.NamespaceDefault
+	clusterName := "test"
+	mdName := "test-md-0"
+	kcpName := "test-cp"
+
+	type fields struct {
+		objs []client.Object
+		ref  corev1.ObjectReference
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		expectedOutput string
+		wantErr        bool
+	}{
+		{
+			name: "watch machindeployment is successfully rolled out",
+			fields: fields{
+				objs: []client.Object{
+					&clusterv1.MachineDeployment{
+						TypeMeta: metav1.TypeMeta{
+							Kind: "MachineDeployment",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      mdName,
+						},
+						Spec: clusterv1.MachineDeploymentSpec{
+							ClusterName: clusterName,
+							Replicas:    pointer.Int32(2),
+						},
+						Status: clusterv1.MachineDeploymentStatus{
+							Replicas:          2,
+							UpdatedReplicas:   2,
+							AvailableReplicas: 2,
+						},
+					},
+				},
+				ref: corev1.ObjectReference{
+					Kind:      MachineDeployment,
+					Name:      mdName,
+					Namespace: namespace,
+				},
+			},
+			expectedOutput: fmt.Sprintf(
+				"machinedeployment %q successfully rolled out\n", mdName,
+			),
+		},
+		{
+			name: "watch kubeadmcontrolplane is successfully rolled out",
+			fields: fields{
+				objs: []client.Object{
+					&controlplanev1.KubeadmControlPlane{
+						TypeMeta: metav1.TypeMeta{
+							Kind: "KubeadmControlPlane",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      kcpName,
+						},
+						Spec: controlplanev1.KubeadmControlPlaneSpec{
+							Replicas: pointer.Int32(2),
+						},
+						Status: controlplanev1.KubeadmControlPlaneStatus{
+							Replicas:        2,
+							UpdatedReplicas: 2,
+							ReadyReplicas:   2,
+						},
+					},
+				},
+				ref: corev1.ObjectReference{
+					Kind:      KubeadmControlPlane,
+					Name:      kcpName,
+					Namespace: namespace,
+				},
+			},
+			expectedOutput: fmt.Sprintf(
+				"kubeadmcontrolplane %q successfully rolled out\n", kcpName,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := newRolloutClient()
+			proxy := test.NewFakeProxy().WithObjs(tt.fields.objs...)
+			output, err := captureStdout(func() {
+				err := r.ObjectStatusWatcher(proxy, tt.fields.ref)
+				if tt.wantErr {
+					g.Expect(err).To(HaveOccurred())
+				} else {
+					g.Expect(err).ToNot(HaveOccurred())
+				}
+			})
+			if err != nil {
+				t.Fatalf("unable to captureStdout")
+			}
+			g.Expect(output).To(Equal(tt.expectedOutput))
+		})
+	}
+}
+
+func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
+	namespace := metav1.NamespaceDefault
+	clusterName := "test"
+	mdName := "test-md-0"
+	statusViewer := &MachineDeploymentStatusWatcher{}
+
+	tests := []struct {
+		name           string
+		md             *clusterv1.MachineDeployment
+		expectedDone   bool
+		expectedStatus string
+		wantErr        bool
+	}{
+		{
+			name: "new replicas are fewer than desired replicas",
+			md: &clusterv1.MachineDeployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      mdName,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: clusterName,
+					Replicas:    pointer.Int32(2),
+				},
+				Status: clusterv1.MachineDeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   1,
+					AvailableReplicas: 0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d out of %d new replicas have been updated...\n", mdName, 1, 2),
+		},
+		{
+			name: "replicas are greater than desired replicas due to surge",
+			md: &clusterv1.MachineDeployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      mdName,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: clusterName,
+					Replicas:    pointer.Int32(2),
+				},
+				Status: clusterv1.MachineDeploymentStatus{
+					Replicas:          3,
+					UpdatedReplicas:   2,
+					AvailableReplicas: 0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d old replicas are pending termination...\n", mdName, 1),
+		},
+		{
+			name: "available replicas are fewer than updated replicas",
+			md: &clusterv1.MachineDeployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      mdName,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: clusterName,
+					Replicas:    pointer.Int32(2),
+				},
+				Status: clusterv1.MachineDeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   2,
+					AvailableReplicas: 0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for machinedeployment %q rollout to finish: %d of %d updated replicas are available...\n", mdName, 0, 2),
+		},
+		{
+			name: "all replicas are available",
+			md: &clusterv1.MachineDeployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      mdName,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: clusterName,
+					Replicas:    pointer.Int32(2),
+				},
+				Status: clusterv1.MachineDeploymentStatus{
+					Replicas:          2,
+					UpdatedReplicas:   2,
+					AvailableReplicas: 2,
+				},
+			},
+			expectedDone:   true,
+			expectedStatus: fmt.Sprintf("machinedeployment %q successfully rolled out\n", mdName),
+		},
+		{
+			name:           "failed to get machinedeployment",
+			expectedDone:   false,
+			expectedStatus: "",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			proxy := test.NewFakeProxy()
+			if tt.md != nil {
+				proxy = proxy.WithObjs(tt.md)
+			}
+			status, done, err := statusViewer.Status(proxy, mdName, namespace)
+			g.Expect(done).Should(Equal(tt.expectedDone))
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(status).To(Equal(tt.expectedStatus))
+		})
+	}
+}
+
+func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
+	namespace := metav1.NamespaceDefault
+	kcpName := "test-cp"
+	statusViewer := &KubeadmControlPlaneStatusWatcher{}
+
+	tests := []struct {
+		name           string
+		md             *controlplanev1.KubeadmControlPlane
+		expectedDone   bool
+		expectedStatus string
+		wantErr        bool
+	}{
+		{
+			name: "new replicas are fewer than desired replicas",
+			md: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      kcpName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: pointer.Int32(2),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        2,
+					UpdatedReplicas: 1,
+					ReadyReplicas:   0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d out of %d new replicas have been updated...\n", kcpName, 1, 2),
+		},
+		{
+			name: "replicas are greater than desired replicas due to surge",
+			md: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      kcpName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: pointer.Int32(2),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        3,
+					UpdatedReplicas: 2,
+					ReadyReplicas:   0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d old replicas are pending termination...\n", kcpName, 1),
+		},
+		{
+			name: "ready replicas are fewer than updated replicas",
+			md: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      kcpName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: pointer.Int32(2),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        2,
+					UpdatedReplicas: 2,
+					ReadyReplicas:   0,
+				},
+			},
+			expectedDone:   false,
+			expectedStatus: fmt.Sprintf("Waiting for kubeadmcontrolplane %q rollout to finish: %d of %d updated replicas are ready...\n", kcpName, 0, 2),
+		},
+		{
+			name: "all replicas are available",
+			md: &controlplanev1.KubeadmControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "KubeadmControlPlane",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      kcpName,
+				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: pointer.Int32(2),
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Replicas:        2,
+					UpdatedReplicas: 2,
+					ReadyReplicas:   2,
+				},
+			},
+			expectedDone:   true,
+			expectedStatus: fmt.Sprintf("kubeadmcontrolplane %q successfully rolled out\n", kcpName),
+		},
+		{
+			name:           "failed to get kubeadmcontrolplane",
+			expectedDone:   false,
+			expectedStatus: "",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			proxy := test.NewFakeProxy()
+			if tt.md != nil {
+				proxy = proxy.WithObjs(tt.md)
+			}
+			status, done, err := statusViewer.Status(proxy, kcpName, namespace)
+			g.Expect(done).Should(Equal(tt.expectedDone))
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(status).To(Equal(tt.expectedStatus))
+		})
+	}
+}

--- a/cmd/clusterctl/client/alpha/rollout_statuswatcher_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_statuswatcher_test.go
@@ -18,6 +18,7 @@ package alpha
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -84,7 +85,7 @@ func Test_ObjectStatusWatcher(t *testing.T) {
 						},
 						Spec: clusterv1.MachineDeploymentSpec{
 							ClusterName: clusterName,
-							Replicas:    pointer.Int32(2),
+							Replicas:    ptr.To[int32](2),
 						},
 						Status: clusterv1.MachineDeploymentStatus{
 							Replicas:          2,
@@ -116,7 +117,7 @@ func Test_ObjectStatusWatcher(t *testing.T) {
 							Name:      kcpName,
 						},
 						Spec: controlplanev1.KubeadmControlPlaneSpec{
-							Replicas: pointer.Int32(2),
+							Replicas: ptr.To[int32](2),
 						},
 						Status: controlplanev1.KubeadmControlPlaneStatus{
 							Replicas:        2,
@@ -143,7 +144,7 @@ func Test_ObjectStatusWatcher(t *testing.T) {
 			r := newRolloutClient()
 			proxy := test.NewFakeProxy().WithObjs(tt.fields.objs...)
 			output, err := captureStdout(func() {
-				err := r.ObjectStatusWatcher(proxy, tt.fields.ref)
+				err := r.ObjectStatusWatcher(context.Background(), proxy, tt.fields.ref)
 				if tt.wantErr {
 					g.Expect(err).To(HaveOccurred())
 				} else {
@@ -183,7 +184,7 @@ func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
 				},
 				Spec: clusterv1.MachineDeploymentSpec{
 					ClusterName: clusterName,
-					Replicas:    pointer.Int32(2),
+					Replicas:    ptr.To[int32](2),
 				},
 				Status: clusterv1.MachineDeploymentStatus{
 					Replicas:          2,
@@ -206,7 +207,7 @@ func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
 				},
 				Spec: clusterv1.MachineDeploymentSpec{
 					ClusterName: clusterName,
-					Replicas:    pointer.Int32(2),
+					Replicas:    ptr.To[int32](2),
 				},
 				Status: clusterv1.MachineDeploymentStatus{
 					Replicas:          3,
@@ -229,7 +230,7 @@ func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
 				},
 				Spec: clusterv1.MachineDeploymentSpec{
 					ClusterName: clusterName,
-					Replicas:    pointer.Int32(2),
+					Replicas:    ptr.To[int32](2),
 				},
 				Status: clusterv1.MachineDeploymentStatus{
 					Replicas:          2,
@@ -252,7 +253,7 @@ func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
 				},
 				Spec: clusterv1.MachineDeploymentSpec{
 					ClusterName: clusterName,
-					Replicas:    pointer.Int32(2),
+					Replicas:    ptr.To[int32](2),
 				},
 				Status: clusterv1.MachineDeploymentStatus{
 					Replicas:          2,
@@ -278,7 +279,7 @@ func Test_MachineDeploymentStatusWatcherStatus(t *testing.T) {
 			if tt.md != nil {
 				proxy = proxy.WithObjs(tt.md)
 			}
-			status, done, err := statusViewer.Status(proxy, mdName, namespace)
+			status, done, err := statusViewer.Status(context.Background(), proxy, mdName, namespace)
 			g.Expect(done).Should(Equal(tt.expectedDone))
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -313,7 +314,7 @@ func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
 					Name:      kcpName,
 				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: pointer.Int32(2),
+					Replicas: ptr.To[int32](2),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
 					Replicas:        2,
@@ -335,7 +336,7 @@ func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
 					Name:      kcpName,
 				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: pointer.Int32(2),
+					Replicas: ptr.To[int32](2),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
 					Replicas:        3,
@@ -357,7 +358,7 @@ func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
 					Name:      kcpName,
 				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: pointer.Int32(2),
+					Replicas: ptr.To[int32](2),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
 					Replicas:        2,
@@ -379,7 +380,7 @@ func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
 					Name:      kcpName,
 				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: pointer.Int32(2),
+					Replicas: ptr.To[int32](2),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
 					Replicas:        2,
@@ -405,7 +406,7 @@ func Test_KubeadmControlPlaneStatusWatcherStatus(t *testing.T) {
 			if tt.md != nil {
 				proxy = proxy.WithObjs(tt.md)
 			}
-			status, done, err := statusViewer.Status(proxy, kcpName, namespace)
+			status, done, err := statusViewer.Status(context.Background(), proxy, kcpName, namespace)
 			g.Expect(done).Should(Equal(tt.expectedDone))
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -86,6 +86,8 @@ type AlphaClient interface {
 	RolloutResume(ctx context.Context, options RolloutResumeOptions) error
 	// RolloutUndo provides rollout rollback of cluster-api resources
 	RolloutUndo(ctx context.Context, options RolloutUndoOptions) error
+	// RolloutStatus provides rollout status of cluster-api resources
+	RolloutStatus(options RolloutStatusOptions) error
 	// TopologyPlan dry runs the topology reconciler
 	TopologyPlan(ctx context.Context, options TopologyPlanOptions) (*TopologyPlanOutput, error)
 }

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -87,7 +87,7 @@ type AlphaClient interface {
 	// RolloutUndo provides rollout rollback of cluster-api resources
 	RolloutUndo(ctx context.Context, options RolloutUndoOptions) error
 	// RolloutStatus provides rollout status of cluster-api resources
-	RolloutStatus(options RolloutStatusOptions) error
+	RolloutStatus(ctx context.Context, options RolloutStatusOptions) error
 	// TopologyPlan dry runs the topology reconciler
 	TopologyPlan(ctx context.Context, options TopologyPlanOptions) (*TopologyPlanOutput, error)
 }

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -147,8 +147,8 @@ func (f fakeClient) RolloutUndo(ctx context.Context, options RolloutUndoOptions)
 	return f.internalClient.RolloutUndo(ctx, options)
 }
 
-func (f fakeClient) RolloutStatus(options RolloutStatusOptions) error {
-	return f.internalClient.RolloutStatus(options)
+func (f fakeClient) RolloutStatus(ctx context.Context, options RolloutStatusOptions) error {
+	return f.internalClient.RolloutStatus(ctx, options)
 }
 
 func (f fakeClient) TopologyPlan(ctx context.Context, options TopologyPlanOptions) (*cluster.TopologyPlanOutput, error) {

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -147,6 +147,10 @@ func (f fakeClient) RolloutUndo(ctx context.Context, options RolloutUndoOptions)
 	return f.internalClient.RolloutUndo(ctx, options)
 }
 
+func (f fakeClient) RolloutStatus(options RolloutStatusOptions) error {
+	return f.internalClient.RolloutStatus(options)
+}
+
 func (f fakeClient) TopologyPlan(ctx context.Context, options TopologyPlanOptions) (*cluster.TopologyPlanOutput, error) {
 	return f.internalClient.TopologyPlan(ctx, options)
 }

--- a/cmd/clusterctl/client/rollout.go
+++ b/cmd/clusterctl/client/rollout.go
@@ -168,7 +168,7 @@ func (c *clusterctlClient) RolloutUndo(ctx context.Context, options RolloutUndoO
 	return nil
 }
 
-func (c *clusterctlClient) RolloutStatus(options RolloutStatusOptions) error {
+func (c *clusterctlClient) RolloutStatus(ctx context.Context, options RolloutStatusOptions) error {
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return err
@@ -178,7 +178,7 @@ func (c *clusterctlClient) RolloutStatus(options RolloutStatusOptions) error {
 		return err
 	}
 	for _, ref := range objRefs {
-		if err := c.alphaClient.Rollout().ObjectStatusWatcher(clusterClient.Proxy(), ref); err != nil {
+		if err := c.alphaClient.Rollout().ObjectStatusWatcher(ctx, clusterClient.Proxy(), ref); err != nil {
 			return err
 		}
 	}

--- a/cmd/clusterctl/client/rollout.go
+++ b/cmd/clusterctl/client/rollout.go
@@ -86,6 +86,20 @@ type RolloutUndoOptions struct {
 	ToRevision int64
 }
 
+// RolloutStatusOptions carries the options supported by RolloutStatus.
+type RolloutStatusOptions struct {
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
+
+	// Resources for the rollout command
+	Resources []string
+
+	// Namespace where the resource(s) live. If unspecified, the namespace name will be inferred
+	// from the current configuration.
+	Namespace string
+}
+
 func (c *clusterctlClient) RolloutRestart(ctx context.Context, options RolloutRestartOptions) error {
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
@@ -148,6 +162,23 @@ func (c *clusterctlClient) RolloutUndo(ctx context.Context, options RolloutUndoO
 	}
 	for _, ref := range objRefs {
 		if err := c.alphaClient.Rollout().ObjectRollbacker(ctx, clusterClient.Proxy(), ref, options.ToRevision); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *clusterctlClient) RolloutStatus(options RolloutStatusOptions) error {
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
+	if err != nil {
+		return err
+	}
+	objRefs, err := getObjectRefs(clusterClient, options.Namespace, options.Resources)
+	if err != nil {
+		return err
+	}
+	for _, ref := range objRefs {
+		if err := c.alphaClient.Rollout().ObjectStatusWatcher(clusterClient.Proxy(), ref); err != nil {
 			return err
 		}
 	}

--- a/cmd/clusterctl/cmd/rollout.go
+++ b/cmd/clusterctl/cmd/rollout.go
@@ -45,7 +45,11 @@ var (
 		clusterctl alpha rollout resume kubeadmcontrolplane/my-kcp
 
 		# Rollback a machinedeployment
-		clusterctl alpha rollout undo machinedeployment/my-md-0 --to-revision=3`)
+		clusterctl alpha rollout undo machinedeployment/my-md-0 --to-revision=3
+
+		# Watch rollout status of a machinedeployment
+		clusterctl alpha rollout status machinedeployment/my-md-0
+		clusterctl alpha rollout status kubeadmcontrolplane/my-kcp`)
 
 	rolloutCmd = &cobra.Command{
 		Use:     "rollout SUBCOMMAND",
@@ -61,4 +65,5 @@ func init() {
 	rolloutCmd.AddCommand(rollout.NewCmdRolloutPause(cfgFile))
 	rolloutCmd.AddCommand(rollout.NewCmdRolloutResume(cfgFile))
 	rolloutCmd.AddCommand(rollout.NewCmdRolloutUndo(cfgFile))
+	rolloutCmd.AddCommand(rollout.NewCmdRolloutStatus(cfgFile))
 }

--- a/cmd/clusterctl/cmd/rollout/status.go
+++ b/cmd/clusterctl/cmd/rollout/status.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollout
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+// statusOptions is the start of the data required to perform the operation.
+type statusOptions struct {
+	kubeconfig        string
+	kubeconfigContext string
+	resources         []string
+	namespace         string
+}
+
+var statusOpt = &statusOptions{}
+
+var (
+	statusLong = templates.LongDesc(`
+		Show the status of the rollout.`)
+
+	statusExample = templates.Examples(`
+		# Watch the rollout status of a deployment
+		clusterctl alpha rollout status machinedeployment/my-md-0`)
+)
+
+// NewCmdRolloutStatus returns a Command instance for 'rollout status' sub command.
+func NewCmdRolloutStatus(cfgFile string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "status RESOURCE",
+		DisableFlagsInUseLine: true,
+		Short:                 "Status a cluster-api resource",
+		Long:                  statusLong,
+		Example:               statusExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(cfgFile, args)
+		},
+	}
+	cmd.Flags().StringVar(&statusOpt.kubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
+	cmd.Flags().StringVar(&statusOpt.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+	cmd.Flags().StringVarP(&statusOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+
+	return cmd
+}
+
+func runStatus(cfgFile string, args []string) error {
+	statusOpt.resources = args
+
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	return c.RolloutStatus(client.RolloutStatusOptions{
+		Kubeconfig: client.Kubeconfig{Path: statusOpt.kubeconfig, Context: statusOpt.kubeconfigContext},
+		Namespace:  statusOpt.namespace,
+		Resources:  statusOpt.resources,
+	})
+}

--- a/cmd/clusterctl/cmd/rollout/status.go
+++ b/cmd/clusterctl/cmd/rollout/status.go
@@ -17,6 +17,8 @@ limitations under the License.
 package rollout
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"k8s.io/kubectl/pkg/util/templates"
 
@@ -66,12 +68,14 @@ func NewCmdRolloutStatus(cfgFile string) *cobra.Command {
 func runStatus(cfgFile string, args []string) error {
 	statusOpt.resources = args
 
-	c, err := client.New(cfgFile)
+	ctx := context.Background()
+
+	c, err := client.New(ctx, cfgFile)
 	if err != nil {
 		return err
 	}
 
-	return c.RolloutStatus(client.RolloutStatusOptions{
+	return c.RolloutStatus(ctx, client.RolloutStatusOptions{
 		Kubeconfig: client.Kubeconfig{Path: statusOpt.kubeconfig, Context: statusOpt.kubeconfigContext},
 		Namespace:  statusOpt.namespace,
 		Resources:  statusOpt.resources,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

In the current implementation, it's hard to track the status of rollout for a specific resource.
The basic behavior of this status command is similar to the `kubectl rollout status` which shows a message ever time rollout progress. A few differences are: i) only the machinedeployment/kubeadmcontrolplane are supported; ii) `--revision=<revision>` option is omitted since when setting this option in kubectl, it just shows an error which is not informative; iii) As a business logic, codes in this PR directly GET resources whereas kubectl uses informer, because using the informer only for this command is too much; iv) timeout is hard coded whereas kubeclt use `.spec.progressDeadlineSeconds`, because `.spec.progressDeadlineSeconds` in MachineDeployment doesn't have any effect.

In other words, this PR is the minimum implementation to satisfy most usecases of `rollout status` command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Tracking Issue:
https://github.com/kubernetes-sigs/cluster-api/issues/3439
