### PR TITLE
📖 Add instruction to add /var/run/docker.sock to file sharing for Docker Desktop

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -93,6 +93,8 @@ a target [management cluster] on the selected [infrastructure provider].
    Then follow the instruction for your kind version using  `kind create cluster --config kind-cluster-with-extramounts.yaml`
    to create the management cluster using the above file.
 
+   Note for Docker Desktop users: you may also need to [add `/var/run/docker.sock` to File sharing](https://docs.docker.com/desktop/settings/mac/#file-sharing) in Docker Desktop.
+
    {{#/tab }}
    {{#tab KubeVirt}}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds instructions for Docker Desktop to work with CAPD on the kind. 

[File sharing configuration](https://docs.docker.com/desktop/settings/mac/#file-sharing) would be required for Docker Desktop users (like macOS) to mount `/var/run/docker.sock` in the kind cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a
