### PR TITLE
🐛 internal/machine-controller fix flakes in phases test

### DIFF
--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -213,12 +213,12 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
 		// Set the LastUpdated to be able to verify it is updated when the phase changes
 		modifiedMachine := machine.DeepCopy()
-		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
-		machine.Status.LastUpdated = &lastUpdated
 		g.Expect(env.Status().Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		// Set bootstrap ready.
@@ -235,7 +235,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
 			// Verify that the LastUpdated timestamp was updated
 			g.Expect(machine.Status.LastUpdated).NotTo(BeNil())
-			g.Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
+			g.Expect(machine.Status.LastUpdated.After(preUpdate)).To(BeTrue())
 			return true
 		}, 10*time.Second).Should(BeTrue())
 	})
@@ -281,14 +281,13 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: node.Name}
-		// Set the LastUpdated to be able to verify it is updated when the phase changes
-		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
-		machine.Status.LastUpdated = &lastUpdated
 		g.Expect(env.Status().Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		// Set bootstrap ready.
@@ -322,7 +321,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
 			// Verify that the LastUpdated timestamp was updated
 			g.Expect(machine.Status.LastUpdated).NotTo(BeNil())
-			g.Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
+			g.Expect(machine.Status.LastUpdated.After(preUpdate)).To(BeTrue())
 			return true
 		}, 10*time.Second).Should(BeTrue())
 	})
@@ -441,14 +440,13 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: node.Name}
-		// Set the LastUpdated to be able to verify it is updated when the phase changes
-		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
-		machine.Status.LastUpdated = &lastUpdated
 		g.Expect(env.Status().Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		// Set bootstrap ready.
@@ -470,7 +468,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
 			// Verify that the LastUpdated timestamp was updated
 			g.Expect(machine.Status.LastUpdated).NotTo(BeNil())
-			g.Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
+			g.Expect(machine.Status.LastUpdated.After(preUpdate)).To(BeTrue())
 			return true
 		}, 10*time.Second).Should(BeTrue())
 	})
@@ -573,6 +571,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
 		// Set bootstrap ready.
@@ -597,9 +597,6 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: node.Name}
-		// Set the LastUpdated to be able to verify it is updated when the phase changes
-		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
-		machine.Status.LastUpdated = &lastUpdated
 		g.Expect(env.Status().Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		modifiedMachine = machine.DeepCopy()
@@ -621,7 +618,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			g.Expect(nodeHealthyCondition.Reason).To(Equal(clusterv1.DeletingReason))
 			// Verify that the LastUpdated timestamp was updated
 			g.Expect(machine.Status.LastUpdated).NotTo(BeNil())
-			g.Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
+			g.Expect(machine.Status.LastUpdated.After(preUpdate)).To(BeTrue())
 			return true
 		}, 10*time.Second).Should(BeTrue())
 	})


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The test patches the status of the Machine, while the reconciliation may be already happening. This leads to inconsistent state which is not deterministic and into the Machine's status to never reach the targeted state of the test.

With this change, the test just ensures that the LastUpdated timestamp gets set to a later time.

See [this](https://storage.googleapis.com/k8s-triage/index.html?text=Timed%20out%20after%2010&job=.*-cluster-api-.*&test=sigs.k8s.io%2Fcluster-api%2Finternal&xjob=.*-provider-.*) for current flake occurency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8477
