### PR TITLE
🌱 use providerID string as-is

### DIFF
--- a/api/v1beta1/index/machine.go
+++ b/api/v1beta1/index/machine.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 const (
@@ -82,14 +81,11 @@ func machineByProviderID(o client.Object) []string {
 		panic(fmt.Sprintf("Expected a Machine but got a %T", o))
 	}
 
-	if pointer.StringDeref(machine.Spec.ProviderID, "") == "" {
+	providerID := pointer.StringDeref(machine.Spec.ProviderID, "")
+
+	if providerID == "" {
 		return nil
 	}
 
-	providerID, err := noderefutil.NewProviderID(*machine.Spec.ProviderID)
-	if err != nil {
-		// Failed to create providerID, skipping.
-		return nil
-	}
-	return []string{providerID.IndexKey()}
+	return []string{providerID}
 }

--- a/api/v1beta1/index/machine_test.go
+++ b/api/v1beta1/index/machine_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 func TestIndexMachineByNodeName(t *testing.T) {
@@ -62,9 +61,7 @@ func TestIndexMachineByNodeName(t *testing.T) {
 }
 
 func TestIndexMachineByProviderID(t *testing.T) {
-	validProviderID, err := noderefutil.NewProviderID("aws://region/zone/id")
-	g := NewWithT(t)
-	g.Expect(err).ToNot(HaveOccurred())
+	validProviderID := "aws://region/zone/id"
 
 	testCases := []struct {
 		name     string
@@ -80,7 +77,7 @@ func TestIndexMachineByProviderID(t *testing.T) {
 			name: "Machine has invalid providerID",
 			object: &clusterv1.Machine{
 				Spec: clusterv1.MachineSpec{
-					ProviderID: pointer.String("invalid"),
+					ProviderID: pointer.String(""),
 				},
 			},
 			expected: nil,
@@ -89,10 +86,10 @@ func TestIndexMachineByProviderID(t *testing.T) {
 			name: "Machine has valid providerID",
 			object: &clusterv1.Machine{
 				Spec: clusterv1.MachineSpec{
-					ProviderID: pointer.String(validProviderID.String()),
+					ProviderID: pointer.String(validProviderID),
 				},
 			},
-			expected: []string{validProviderID.IndexKey()},
+			expected: []string{validProviderID},
 		},
 	}
 

--- a/api/v1beta1/index/machinepool.go
+++ b/api/v1beta1/index/machinepool.go
@@ -24,7 +24,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
@@ -93,12 +92,11 @@ func machinePoolByProviderID(o client.Object) []string {
 
 	providerIDs := make([]string, 0, len(machinepool.Spec.ProviderIDList))
 	for _, id := range machinepool.Spec.ProviderIDList {
-		providerID, err := noderefutil.NewProviderID(id)
-		if err != nil {
-			// Failed to create providerID, skipping.
+		if id == "" {
+			// Valid providerID not found, skipping.
 			continue
 		}
-		providerIDs = append(providerIDs, providerID.IndexKey())
+		providerIDs = append(providerIDs, id)
 	}
 
 	return providerIDs

--- a/api/v1beta1/index/machinepool_test.go
+++ b/api/v1beta1/index/machinepool_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 )
 
@@ -66,11 +65,8 @@ func TestIndexMachinePoolByNodeName(t *testing.T) {
 }
 
 func TestIndexMachinePoolByProviderID(t *testing.T) {
-	g := NewWithT(t)
-	validProviderID, err := noderefutil.NewProviderID("aws://region/zone/1")
-	g.Expect(err).ToNot(HaveOccurred())
-	otherValidProviderID, err := noderefutil.NewProviderID("aws://region/zone/2")
-	g.Expect(err).ToNot(HaveOccurred())
+	validProviderID := "aws://region/zone/1"
+	otherValidProviderID := "aws://region/zone/2"
 
 	testCases := []struct {
 		name     string
@@ -86,7 +82,7 @@ func TestIndexMachinePoolByProviderID(t *testing.T) {
 			name: "MachinePool has invalid providerID",
 			object: &expv1.MachinePool{
 				Spec: expv1.MachinePoolSpec{
-					ProviderIDList: []string{"invalid"},
+					ProviderIDList: []string{""},
 				},
 			},
 			expected: []string{},
@@ -95,10 +91,10 @@ func TestIndexMachinePoolByProviderID(t *testing.T) {
 			name: "MachinePool has valid providerIDs",
 			object: &expv1.MachinePool{
 				Spec: expv1.MachinePoolSpec{
-					ProviderIDList: []string{validProviderID.String(), otherValidProviderID.String()},
+					ProviderIDList: []string{validProviderID, otherValidProviderID},
 				},
 			},
-			expected: []string{validProviderID.IndexKey(), otherValidProviderID.IndexKey()},
+			expected: []string{validProviderID, otherValidProviderID},
 		},
 	}
 

--- a/api/v1beta1/index/node.go
+++ b/api/v1beta1/index/node.go
@@ -21,8 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 const (
@@ -42,10 +40,5 @@ func NodeByProviderID(o client.Object) []string {
 		return nil
 	}
 
-	providerID, err := noderefutil.NewProviderID(node.Spec.ProviderID)
-	if err != nil {
-		// Failed to create providerID, skipping.
-		return nil
-	}
-	return []string{providerID.IndexKey()}
+	return []string{node.Spec.ProviderID}
 }

--- a/api/v1beta1/index/node_test.go
+++ b/api/v1beta1/index/node_test.go
@@ -22,14 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 func TestIndexNodeByProviderID(t *testing.T) {
-	validProviderID, err := noderefutil.NewProviderID("aws://region/zone/id")
-	g := NewWithT(t)
-	g.Expect(err).ToNot(HaveOccurred())
+	validProviderID := "aws://region/zone/id"
 
 	testCases := []struct {
 		name     string
@@ -45,7 +41,7 @@ func TestIndexNodeByProviderID(t *testing.T) {
 			name: "Node has invalid providerID",
 			object: &corev1.Node{
 				Spec: corev1.NodeSpec{
-					ProviderID: "invalid",
+					ProviderID: "",
 				},
 			},
 			expected: nil,
@@ -54,10 +50,10 @@ func TestIndexNodeByProviderID(t *testing.T) {
 			name: "Node has valid providerID",
 			object: &corev1.Node{
 				Spec: corev1.NodeSpec{
-					ProviderID: validProviderID.String(),
+					ProviderID: validProviderID,
 				},
 			},
-			expected: []string{validProviderID.IndexKey()},
+			expected: []string{validProviderID},
 		},
 	}
 

--- a/controllers/noderefutil/providerid.go
+++ b/controllers/noderefutil/providerid.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 // Package noderefutil implements NodeRef utils.
+// The ProviderID type is deprecated and unused by Cluster API internally.
+// It will be removed entirely in a future release.
 package noderefutil
 
 import (
@@ -25,14 +27,20 @@ import (
 
 var (
 	// ErrEmptyProviderID means that the provider id is empty.
+	//
+	// Deprecated: This var is going to be removed in a future release.
 	ErrEmptyProviderID = errors.New("providerID is empty")
 
 	// ErrInvalidProviderID means that the provider id has an invalid form.
+	//
+	// Deprecated: This var is going to be removed in a future release.
 	ErrInvalidProviderID = errors.New("providerID must be of the form <cloudProvider>://<optional>/<segments>/<provider id>")
 )
 
 // ProviderID is a struct representation of a Kubernetes ProviderID.
 // Format: cloudProvider://optional/segments/etc/id
+//
+// Deprecated: This struct is going to be removed in a future release.
 type ProviderID struct {
 	original      string
 	cloudProvider string
@@ -48,6 +56,8 @@ type ProviderID struct {
 var providerIDRegex = regexp.MustCompile("^[^:]+://.*[^/]$")
 
 // NewProviderID parses the input string and returns a new ProviderID.
+//
+// Deprecated: This constructor is going to be removed in a future release.
 func NewProviderID(id string) (*ProviderID, error) {
 	if id == "" {
 		return nil, ErrEmptyProviderID
@@ -77,32 +87,44 @@ func NewProviderID(id string) (*ProviderID, error) {
 }
 
 // CloudProvider returns the cloud provider portion of the ProviderID.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) CloudProvider() string {
 	return p.cloudProvider
 }
 
 // ID returns the identifier portion of the ProviderID.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) ID() string {
 	return p.id
 }
 
 // Equals returns true if this ProviderID string matches another ProviderID string.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) Equals(o *ProviderID) bool {
 	return p.String() == o.String()
 }
 
 // String returns the string representation of this object.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p ProviderID) String() string {
 	return p.original
 }
 
 // Validate returns true if the provider id is valid.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) Validate() bool {
 	return p.CloudProvider() != "" && p.ID() != ""
 }
 
 // IndexKey returns the required level of uniqueness
 // to represent and index machines uniquely from their node providerID.
+//
+// Deprecated: This method is going to be removed in a future release.
 func (p *ProviderID) IndexKey() string {
 	return p.String()
 }

--- a/controllers/noderefutil/providerid_test.go
+++ b/controllers/noderefutil/providerid_test.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// The ProviderID type is deprecated and unused by Cluster API internally.
+// It will be removed entirely in a future release.
 package noderefutil
 
 import (

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -41,7 +41,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -352,15 +351,14 @@ func (r *MachinePoolReconciler) nodeToMachinePool(o client.Object) []reconcile.R
 
 	// Otherwise let's match by providerID. This is useful when e.g the NodeRef has not been set yet.
 	// Match by providerID
-	nodeProviderID, err := noderefutil.NewProviderID(node.Spec.ProviderID)
-	if err != nil {
+	if node.Spec.ProviderID == "" {
 		return nil
 	}
 	machinePoolList = &expv1.MachinePoolList{}
 	if err := r.Client.List(
 		context.TODO(),
 		machinePoolList,
-		append(filters, client.MatchingFields{index.MachinePoolProviderIDField: nodeProviderID.IndexKey()})...); err != nil {
+		append(filters, client.MatchingFields{index.MachinePoolProviderIDField: node.Spec.ProviderID})...); err != nil {
 		return nil
 	}
 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -837,15 +837,14 @@ func (r *Reconciler) nodeToMachine(o client.Object) []reconcile.Request {
 
 	// Otherwise let's match by providerID. This is useful when e.g the NodeRef has not been set yet.
 	// Match by providerID
-	nodeProviderID, err := noderefutil.NewProviderID(node.Spec.ProviderID)
-	if err != nil {
+	if node.Spec.ProviderID == "" {
 		return nil
 	}
 	machineList = &clusterv1.MachineList{}
 	if err := r.Client.List(
 		context.TODO(),
 		machineList,
-		append(filters, client.MatchingFields{index.MachineProviderIDField: nodeProviderID.IndexKey()})...); err != nil {
+		append(filters, client.MatchingFields{index.MachineProviderIDField: node.Spec.ProviderID})...); err != nil {
 		return nil
 	}
 

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
@@ -154,10 +153,7 @@ func TestGetNode(t *testing.T) {
 			remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(testCluster))
 			g.Expect(err).ToNot(HaveOccurred())
 
-			providerID, err := noderefutil.NewProviderID(tc.providerIDInput)
-			g.Expect(err).ToNot(HaveOccurred())
-
-			node, err := r.getNode(ctx, remoteClient, providerID)
+			node, err := r.getNode(ctx, remoteClient, tc.providerIDInput)
 			if tc.error != nil {
 				g.Expect(err).To(Equal(tc.error))
 				return


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR updates code flows that use a strongly typed, constructed `ProviderID` object to represent a CAPI-opinionated version of a cloud provider's node providerID: instead of wrapping the raw providerID in a CAPI object, we now simply evaluate machine-node affinity by simply comparing the providerID strings for equality.

As an exercise in best practices, the existing `ProviderID` type definition is kept in place and marked for deprecation. This is to allow this change to be backported to existing minor releases so that cloud providers who are blocked on the current CAPI-opinionated `ProviderID` validations can make forward progress towards CAPI adoption.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8485
