### PR TITLE
🐛 Return error on infra cluster and control plane discovery

### DIFF
--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -19,6 +19,7 @@ package tree
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -83,9 +84,11 @@ func Discovery(ctx context.Context, c client.Client, namespace, name string, opt
 	tree := NewObjectTree(cluster, options.toObjectTreeOptions())
 
 	// Adds cluster infra
-	if clusterInfra, err := external.Get(ctx, c, cluster.Spec.InfrastructureRef, cluster.Namespace); err == nil {
-		tree.Add(cluster, clusterInfra, ObjectMetaName("ClusterInfrastructure"))
+	clusterInfra, err := external.Get(ctx, c, cluster.Spec.InfrastructureRef, cluster.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "get InfraCluster reference from Cluster")
 	}
+	tree.Add(cluster, clusterInfra, ObjectMetaName("ClusterInfrastructure"))
 
 	if options.ShowClusterResourceSets {
 		addClusterResourceSetsToObjectTree(ctx, c, cluster, tree)
@@ -119,9 +122,11 @@ func Discovery(ctx context.Context, c client.Client, namespace, name string, opt
 	}
 
 	controlPlaneMachines := selectControlPlaneMachines(machinesList)
-	for i := range controlPlaneMachines {
-		cp := controlPlaneMachines[i]
-		addMachineFunc(controlPlane, cp)
+	if controlPlane != nil {
+		for i := range controlPlaneMachines {
+			cp := controlPlaneMachines[i]
+			addMachineFunc(controlPlane, cp)
+		}
 	}
 
 	machinePoolList, err := getMachinePoolsInCluster(ctx, c, cluster.Namespace, cluster.Name)


### PR DESCRIPTION
If no control plane reference is set in the Cluster object the describe cluster command will fail. We should validate the error in any case.

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8603

<sub>Tobias Giese <tobias.giese@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [legal info/Impressum](https://github.com/mercedes-benz/foss/blob/master/LEGAL_IMPRINT.md)</sub>