### PR TITLE
:book: Fix documentation

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -83,7 +83,7 @@ metadata:
   name: my-docker-cluster
 spec:
   topology:
-    class: docker-clusterclass
+    class: docker-clusterclass-v0.1.0
     version: v1.22.4
     controlPlane:
       replicas: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a reference between two examples in the cluster api book