### PR TITLE
🐛 Fix deleting workload cluster in e2e clusterctl upgrade test

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -525,13 +525,12 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 					}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
 				default:
 					log.Logf("Management Cluster does not appear to support CAPI resources.")
+					Byf("Deleting cluster %s", klog.KRef(testNamespace.Name, managementClusterName))
+					framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
+						Client:    managementClusterProxy.GetClient(),
+						Namespace: testNamespace.Name,
+					}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
 				}
-
-				Byf("Deleting cluster %s", klog.KRef(testNamespace.Name, managementClusterName))
-				framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
-					Client:    managementClusterProxy.GetClient(),
-					Namespace: testNamespace.Name,
-				}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
 
 				Byf("Deleting namespace %s used for hosting the %q test", testNamespace.Name, specName)
 				framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{


### PR DESCRIPTION
The cleaning part of clusterctl test was running deleting the workload test cluster twice this PR fix the issue 
