### PR TITLE
🐛 test/e2e check for machines being ready after provisioning on Runtime SDK test

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -169,6 +169,30 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 					clusterRef,
 					input.E2EConfig.GetIntervals(specName, "wait-cluster"))
 			},
+			PostMachinesProvisioned: func() {
+				Eventually(func() error {
+					// Before running the BeforeClusterUpgrade hook, the topology controller
+					// checks if the ControlPlane `IsScaling()` and for MachineDeployments if
+					// `IsAnyRollingOut()`.
+					// This PostMachineProvisioned function ensures that the clusters machines
+					// are healthy by checking the MachineNodeHealthyCondition, so the upgrade
+					// below does not get delayed or runs into timeouts before even reaching
+					// the BeforeClusterUpgrade hook.
+					machineList := &clusterv1.MachineList{}
+					if err := input.BootstrapClusterProxy.GetClient().List(ctx, machineList, client.InNamespace(namespace.Name)); err != nil {
+						return errors.Wrap(err, "list machines")
+					}
+
+					for i := range machineList.Items {
+						machine := &machineList.Items[i]
+						if !conditions.IsTrue(machine, clusterv1.MachineNodeHealthyCondition) {
+							return errors.Errorf("machine %q does not have %q condition set to true", machine.GetName(), clusterv1.MachineNodeHealthyCondition)
+						}
+					}
+
+					return nil
+				}, 5*time.Minute, 15*time.Second).Should(Succeed(), "Waiting for rollouts to finish")
+			},
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes when reaching the parts where we wait for the hooks, not all machines are ready. This results in the hook not even getting executed during the 30s period.

Failed test logs did show that it may only be a minute which is missing until everything would succeed.

This PR adds a check to ensure all machines are healthy before continuing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Workaround for #8486

We want to still try to track it down to see if we have an underlying issue.

cc @killianmuldoon 

Note:
* for control plane nodes we already check if this condition is true (edit: when upgrading a cluster): https://github.com/kubernetes-sigs/cluster-api/blob/e4144f88f1538c0c574435c5b69d031adc9d592d/test/framework/machine_helpers.go#L167
* but we don't do the same for e.g. machinedeployments (edit: when upgrading a cluster): https://github.com/kubernetes-sigs/cluster-api/blob/e4144f88f1538c0c574435c5b69d031adc9d592d/test/framework/machine_helpers.go#L207