### PR TITLE
🐛 topology controller should avoid unnecessary rollouts during upgrades

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -282,6 +282,11 @@ const (
 	// not yet completed because Control Plane is not yet updated to match the desired topology spec.
 	TopologyReconciledControlPlaneUpgradePendingReason = "ControlPlaneUpgradePending"
 
+	// TopologyReconciledMachineDeploymentsCreatePendingReason (Severity=Info) documents reconciliation of a Cluster topology
+	// not yet completed because at least one of the MachineDeployments is yet to be created.
+	// This generally happens because new MachineDeployment creations are held off while the ControlPlane is not stable.
+	TopologyReconciledMachineDeploymentsCreatePendingReason = "MachineDeploymentsCreatePending"
+
 	// TopologyReconciledMachineDeploymentsUpgradePendingReason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachineDeployments is not yet updated to match the desired topology spec.
 	TopologyReconciledMachineDeploymentsUpgradePendingReason = "MachineDeploymentsUpgradePending"

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -123,7 +123,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = true
+					ut.ControlPlane.IsPendingUpgrade = true
 					ut.ControlPlane.IsProvisioning = true
 					return ut
 				}(),
@@ -131,7 +131,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledControlPlaneUpgradePendingReason,
-			wantConditionMessage: "Control plane upgrade to v1.22.0 on hold. Control plane is completing initial provisioning",
+			wantConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is completing initial provisioning",
 		},
 		{
 			name:         "should set the condition to false if new version is not picked up because control plane is upgrading",
@@ -154,7 +154,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = true
+					ut.ControlPlane.IsPendingUpgrade = true
 					ut.ControlPlane.IsUpgrading = true
 					return ut
 				}(),
@@ -162,7 +162,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledControlPlaneUpgradePendingReason,
-			wantConditionMessage: "Control plane upgrade to v1.22.0 on hold. Control plane is upgrading to version v1.21.2",
+			wantConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is upgrading to version v1.21.2",
 		},
 		{
 			name:         "should set the condition to false if new version is not picked up because control plane is scaling",
@@ -185,7 +185,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = true
+					ut.ControlPlane.IsPendingUpgrade = true
 					ut.ControlPlane.IsScaling = true
 					return ut
 				}(),
@@ -193,7 +193,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledControlPlaneUpgradePendingReason,
-			wantConditionMessage: "Control plane upgrade to v1.22.0 on hold. Control plane is reconciling desired replicas",
+			wantConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
 		},
 		{
 			name:         "should set the condition to false if new version is not picked up because at least one of the machine deployment is upgrading",
@@ -230,7 +230,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = true
+					ut.ControlPlane.IsPendingUpgrade = true
 					ut.MachineDeployments.MarkUpgrading("md0-abc123")
 					return ut
 				}(),
@@ -238,7 +238,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledControlPlaneUpgradePendingReason,
-			wantConditionMessage: "Control plane upgrade to v1.22.0 on hold. MachineDeployment(s) md0-abc123 are upgrading",
+			wantConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. MachineDeployment(s) md0-abc123 are upgrading",
 		},
 		{
 			name:         "should set the condition to false if control plane picked the new version but machine deployments did not because control plane is upgrading",
@@ -275,7 +275,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.ControlPlane.IsUpgrading = true
 					ut.MachineDeployments.MarkPendingUpgrade("md0-abc123")
 					return ut
@@ -284,7 +284,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledMachineDeploymentsUpgradePendingReason,
-			wantConditionMessage: "MachineDeployment(s) md0-abc123 upgrade to version v1.22.0 on hold. Control plane is upgrading to version v1.22.0",
+			wantConditionMessage: "MachineDeployment(s) md0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is upgrading to version v1.22.0",
 		},
 		{
 			name:         "should set the condition to false if control plane picked the new version but machine deployments did not because control plane is scaling",
@@ -321,7 +321,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.ControlPlane.IsScaling = true
 					ut.MachineDeployments.MarkPendingUpgrade("md0-abc123")
 					return ut
@@ -330,7 +330,39 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledMachineDeploymentsUpgradePendingReason,
-			wantConditionMessage: "MachineDeployment(s) md0-abc123 upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
+			wantConditionMessage: "MachineDeployment(s) md0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
+		},
+		{
+			name:         "should set the condition to false if control plane picked the new version but there are machine deployments pending create because control plane is scaling",
+			reconcileErr: nil,
+			cluster:      &clusterv1.Cluster{},
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						Version: "v1.22.0",
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: builder.ControlPlane("ns1", "controlplane1").
+							WithVersion("v1.22.0").
+							WithReplicas(3).
+							Build(),
+					},
+				},
+				UpgradeTracker: func() *scope.UpgradeTracker {
+					ut := scope.NewUpgradeTracker()
+					ut.ControlPlane.IsPendingUpgrade = false
+					ut.ControlPlane.IsScaling = true
+					ut.MachineDeployments.MarkPendingCreate("md0")
+					return ut
+				}(),
+				HookResponseTracker: scope.NewHookResponseTracker(),
+			},
+			wantConditionStatus:  corev1.ConditionFalse,
+			wantConditionReason:  clusterv1.TopologyReconciledMachineDeploymentsCreatePendingReason,
+			wantConditionMessage: "MachineDeployment(s) for Topologies md0 creation on hold. Control plane is reconciling desired replicas",
 		},
 		{
 			name:         "should set the condition to true if control plane picked the new version and is upgrading but there are no machine deployments",
@@ -353,7 +385,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.ControlPlane.IsUpgrading = true
 					return ut
 				}(),
@@ -382,7 +414,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.ControlPlane.IsScaling = true
 					return ut
 				}(),
@@ -450,7 +482,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.MachineDeployments.MarkUpgrading("md0-abc123")
 					ut.MachineDeployments.MarkPendingUpgrade("md1-abc123")
 					return ut
@@ -469,7 +501,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledMachineDeploymentsUpgradePendingReason,
-			wantConditionMessage: "MachineDeployment(s) md1-abc123 upgrade to version v1.22.0 on hold. MachineDeployment(s) md0-abc123 are upgrading",
+			wantConditionMessage: "MachineDeployment(s) md1-abc123 rollout and upgrade to version v1.22.0 on hold. MachineDeployment(s) md0-abc123 are upgrading",
 		},
 		{
 			name:         "should set the condition to false if some machine deployments have not picked the new version because their upgrade has been deferred",
@@ -520,7 +552,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					ut.MachineDeployments.MarkDeferredUpgrade("md1-abc123")
 					return ut
 				}(),
@@ -528,7 +560,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			},
 			wantConditionStatus:  corev1.ConditionFalse,
 			wantConditionReason:  clusterv1.TopologyReconciledMachineDeploymentsUpgradeDeferredReason,
-			wantConditionMessage: "MachineDeployment(s) md1-abc123 upgrade to version v1.22.0 deferred.",
+			wantConditionMessage: "MachineDeployment(s) md1-abc123 rollout and upgrade to version v1.22.0 deferred.",
 		},
 		{
 			name:         "should set the condition to true if there are no reconcile errors and control plane and all machine deployments picked up the new version",
@@ -579,7 +611,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				},
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.PendingUpgrade = false
+					ut.ControlPlane.IsPendingUpgrade = false
 					return ut
 				}(),
 				HookResponseTracker: scope.NewHookResponseTracker(),
@@ -656,7 +688,7 @@ func TestComputeMachineDeploymentNameList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			g.Expect(computeMachineDeploymentNameList(tt.mdList)).To(Equal(tt.expected))
+			g.Expect(computeNameList(tt.mdList)).To(Equal(tt.expected))
 		})
 	}
 }

--- a/internal/controllers/topology/cluster/scope/hookresponsetracker_test.go
+++ b/internal/controllers/topology/cluster/scope/hookresponsetracker_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -143,5 +144,61 @@ func TestHookResponseTracker_AggregateMessage(t *testing.T) {
 		hrt.Add(runtimehooksv1.BeforeClusterUpgrade, nonBlockingBeforeClusterUpgradeResponse)
 
 		g.Expect(hrt.AggregateMessage()).To(Equal(""))
+	})
+}
+
+func TestHookResponseTracker_IsBlocking(t *testing.T) {
+	nonBlockingBeforeClusterCreateResponse := &runtimehooksv1.BeforeClusterCreateResponse{
+		CommonRetryResponse: runtimehooksv1.CommonRetryResponse{
+			RetryAfterSeconds: int32(0),
+			CommonResponse: runtimehooksv1.CommonResponse{
+				Status: runtimehooksv1.ResponseStatusSuccess,
+			},
+		},
+	}
+	blockingBeforeClusterCreateResponse := &runtimehooksv1.BeforeClusterCreateResponse{
+		CommonRetryResponse: runtimehooksv1.CommonRetryResponse{
+			RetryAfterSeconds: int32(10),
+			CommonResponse: runtimehooksv1.CommonResponse{
+				Status: runtimehooksv1.ResponseStatusSuccess,
+			},
+		},
+	}
+
+	afterClusterUpgradeResponse := &runtimehooksv1.AfterClusterUpgradeResponse{
+		TypeMeta:       metav1.TypeMeta{},
+		CommonResponse: runtimehooksv1.CommonResponse{},
+	}
+
+	t.Run("should return true if the tracker received a blocking response for the hook", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hrt := NewHookResponseTracker()
+		hrt.Add(runtimehooksv1.BeforeClusterCreate, blockingBeforeClusterCreateResponse)
+
+		g.Expect(hrt.IsBlocking(runtimehooksv1.BeforeClusterCreate)).To(BeTrue())
+	})
+
+	t.Run("should return false if the tracker received a non blocking response for the hook", func(t *testing.T) {
+		g := NewWithT(t)
+
+		hrt := NewHookResponseTracker()
+		hrt.Add(runtimehooksv1.BeforeClusterCreate, nonBlockingBeforeClusterCreateResponse)
+
+		g.Expect(hrt.IsBlocking(runtimehooksv1.BeforeClusterCreate)).To(BeFalse())
+	})
+
+	t.Run("should return false if the tracker did not receive a response for the hook", func(t *testing.T) {
+		g := NewWithT(t)
+		hrt := NewHookResponseTracker()
+		g.Expect(hrt.IsBlocking(runtimehooksv1.BeforeClusterCreate)).To(BeFalse())
+	})
+
+	t.Run("should return false if the hook is non-blocking", func(t *testing.T) {
+		g := NewWithT(t)
+		hrt := NewHookResponseTracker()
+		// AfterClusterUpgradeHook is non-blocking.
+		hrt.Add(runtimehooksv1.AfterClusterUpgrade, afterClusterUpgradeResponse)
+		g.Expect(hrt.IsBlocking(runtimehooksv1.AfterClusterUpgrade)).To(BeFalse())
 	})
 }

--- a/internal/controllers/topology/cluster/scope/upgradetracker.go
+++ b/internal/controllers/topology/cluster/scope/upgradetracker.go
@@ -26,28 +26,76 @@ type UpgradeTracker struct {
 
 // ControlPlaneUpgradeTracker holds the current upgrade status of the Control Plane.
 type ControlPlaneUpgradeTracker struct {
-	// PendingUpgrade is true if the control plane version needs to be updated. False otherwise.
-	PendingUpgrade bool
+	// IsPendingUpgrade is true if the Control Plane version needs to be updated. False otherwise.
+	// If IsPendingUpgrade is true it also means the Control Plane is not going to pick up the new version
+	// in the current reconcile loop.
+	// Example cases when IsPendingUpgrade is set to true:
+	// - Upgrade is blocked by BeforeClusterUpgrade hook
+	// - Upgrade is blocked because the current ControlPlane is not stable (provisioning OR scaling OR upgrading)
+	// - Upgrade is blocked because any of the current MachineDeployments are upgrading.
+	IsPendingUpgrade bool
 
-	// IsProvisioning is true if the control plane is being provisioned for the first time. False otherwise.
+	// IsProvisioning is true if the current Control Plane is being provisioned for the first time. False otherwise.
 	IsProvisioning bool
 
-	// IsUpgrading is true if the control plane is in the middle of an upgrade.
-	// Note: Refer to control plane contract for definition of upgrading.
+	// IsUpgrading is true if the Control Plane is in the middle of an upgrade.
+	// Note: Refer to Control Plane contract for definition of upgrading.
+	// IsUpgrading is set to true if the current ControlPlane (ControlPlane at the beginning of the reconcile)
+	// is upgrading.
+	// Note: IsUpgrading only represents the current ControlPlane state. If the Control Plane is about to pick up the
+	// version in the reconcile loop IsUpgrading will not be true, because the current ControlPlane is not upgrading,
+	// the desired ControlPlane is.
+	// Also look at: IsStartingUpgrade.
 	IsUpgrading bool
 
-	// IsScaling is true if the control plane is in the middle of a scale operation.
+	// IsStartingUpgrade is true if the Control Plane is picking up the new version in the current reconcile loop.
+	// If IsStartingUpgrade is true it implies that the desired Control Plane version and the current Control Plane
+	// versions are different.
+	IsStartingUpgrade bool
+
+	// IsScaling is true if the current Control Plane is scaling. False otherwise.
+	// IsScaling only represents the state of the current Control Plane. IsScaling does not represent the state
+	// of the desired Control Plane.
+	// Example:
+	// - IsScaling will be true if the current ControlPlane is scaling.
+	// - IsScaling will not be true if the current Control Plane is stable and the reconcile loop is going to scale the Control Plane.
 	// Note: Refer to control plane contract for definition of scaling.
+	// Note: IsScaling will be false if the Control Plane does not support replicas.
 	IsScaling bool
 }
 
-// MachineDeploymentUpgradeTracker holds the current upgrade status and makes upgrade
-// decisions for MachineDeployments.
+// MachineDeploymentUpgradeTracker holds the current upgrade status of MachineDeployments.
 type MachineDeploymentUpgradeTracker struct {
-	pendingNames                           sets.Set[string]
-	deferredNames                          sets.Set[string]
-	upgradingNames                         sets.Set[string]
-	holdUpgrades                           bool
+	// pendingCreateTopologyNames is the set of MachineDeployment topology names that are newly added to the
+	// Cluster Topology but will not be created in the current reconcile loop.
+	// By marking a MachineDeployment topology as pendingCreate we skip creating the MachineDeployment.
+	// Nb. We use MachineDeployment topology names instead of MachineDeployment names because the new MachineDeployment
+	// names can keep changing for each reconcile loop leading to continuous updates to the TopologyReconciled condition.
+	pendingCreateTopologyNames sets.Set[string]
+
+	// pendingUpgradeNames is the set of MachineDeployment names that are not going to pick up the new version
+	// in the current reconcile loop.
+	// By marking a MachineDeployment as pendingUpgrade we skip reconciling the MachineDeployment.
+	pendingUpgradeNames sets.Set[string]
+
+	// deferredNames is the set of MachineDeployment names that are not going to pick up the new version
+	// in the current reconcile loop because they are deferred by the user.
+	// Note: If a MachineDeployment is marked as deferred it should also be marked as pendingUpgrade.
+	deferredNames sets.Set[string]
+
+	// upgradingNames is the set of MachineDeployment names that are upgrading. This set contains the names of
+	// MachineDeployments that are currently upgrading and the names of MachineDeployments that will pick up the upgrade
+	// in the current reconcile loop.
+	// Note: This information is used to:
+	// - decide if ControlPlane can be upgraded.
+	// - calculate MachineDeployment upgrade concurrency.
+	// - update TopologyReconciled Condition.
+	// - decide if the AfterClusterUpgrade hook can be called.
+	upgradingNames sets.Set[string]
+
+	// maxMachineDeploymentUpgradeConcurrency defines the maximum number of MachineDeployments that should be in an
+	// upgrading state. This includes the MachineDeployments that are currently upgrading and the MachineDeployments that
+	// will start the upgrade after the current reconcile loop.
 	maxMachineDeploymentUpgradeConcurrency int
 }
 
@@ -82,7 +130,8 @@ func NewUpgradeTracker(opts ...UpgradeTrackerOption) *UpgradeTracker {
 	}
 	return &UpgradeTracker{
 		MachineDeployments: MachineDeploymentUpgradeTracker{
-			pendingNames:                           sets.Set[string]{},
+			pendingCreateTopologyNames:             sets.Set[string]{},
+			pendingUpgradeNames:                    sets.Set[string]{},
 			deferredNames:                          sets.Set[string]{},
 			upgradingNames:                         sets.Set[string]{},
 			maxMachineDeploymentUpgradeConcurrency: options.maxMDUpgradeConcurrency,
@@ -103,42 +152,57 @@ func (m *MachineDeploymentUpgradeTracker) UpgradingNames() []string {
 	return sets.List(m.upgradingNames)
 }
 
-// HoldUpgrades is used to set if any subsequent upgrade operations should be paused,
-// e.g. because a AfterControlPlaneUpgrade hook response asked to do so.
-// If HoldUpgrades is called with `true` then AllowUpgrade would return false.
-func (m *MachineDeploymentUpgradeTracker) HoldUpgrades(val bool) {
-	m.holdUpgrades = val
+// UpgradeConcurrencyReached returns true if the number of MachineDeployments upgrading is at the concurrency limit.
+func (m *MachineDeploymentUpgradeTracker) UpgradeConcurrencyReached() bool {
+	return m.upgradingNames.Len() >= m.maxMachineDeploymentUpgradeConcurrency
 }
 
-// AllowUpgrade returns true if a MachineDeployment is allowed to upgrade,
-// returns false otherwise.
-// Note: If AllowUpgrade returns true the machine deployment will pick up
-// the topology version. This will eventually trigger a machine deployment
-// rollout.
-func (m *MachineDeploymentUpgradeTracker) AllowUpgrade() bool {
-	if m.holdUpgrades {
-		return false
-	}
-	return m.upgradingNames.Len() < m.maxMachineDeploymentUpgradeConcurrency
+// MarkPendingCreate marks a machine deployment topology that is pending to be created.
+// This is generally used to capture machine deployments that are yet to be created
+// because the control plane is not yet stable.
+func (m *MachineDeploymentUpgradeTracker) MarkPendingCreate(mdTopologyName string) {
+	m.pendingCreateTopologyNames.Insert(mdTopologyName)
+}
+
+// IsPendingCreate returns true is the MachineDeployment topology is marked as pending create.
+func (m *MachineDeploymentUpgradeTracker) IsPendingCreate(mdTopologyName string) bool {
+	return m.pendingCreateTopologyNames.Has(mdTopologyName)
+}
+
+// IsAnyPendingCreate returns true if any of the machine deployments are pending
+// to be created. Returns false, otherwise.
+func (m *MachineDeploymentUpgradeTracker) IsAnyPendingCreate() bool {
+	return len(m.pendingCreateTopologyNames) != 0
+}
+
+// PendingCreateTopologyNames returns the list of machine deployment topology names that
+// are pending create.
+func (m *MachineDeploymentUpgradeTracker) PendingCreateTopologyNames() []string {
+	return sets.List(m.pendingCreateTopologyNames)
 }
 
 // MarkPendingUpgrade marks a machine deployment as in need of an upgrade.
 // This is generally used to capture machine deployments that have not yet
 // picked up the topology version.
 func (m *MachineDeploymentUpgradeTracker) MarkPendingUpgrade(name string) {
-	m.pendingNames.Insert(name)
+	m.pendingUpgradeNames.Insert(name)
+}
+
+// IsPendingUpgrade returns true is the MachineDeployment marked as pending upgrade.
+func (m *MachineDeploymentUpgradeTracker) IsPendingUpgrade(name string) bool {
+	return m.pendingUpgradeNames.Has(name)
+}
+
+// IsAnyPendingUpgrade returns true if any of the machine deployments are pending
+// an upgrade. Returns false, otherwise.
+func (m *MachineDeploymentUpgradeTracker) IsAnyPendingUpgrade() bool {
+	return len(m.pendingUpgradeNames) != 0
 }
 
 // PendingUpgradeNames returns the list of machine deployment names that
 // are pending an upgrade.
 func (m *MachineDeploymentUpgradeTracker) PendingUpgradeNames() []string {
-	return sets.List(m.pendingNames)
-}
-
-// PendingUpgrade returns true if any of the machine deployments are pending
-// an upgrade. Returns false, otherwise.
-func (m *MachineDeploymentUpgradeTracker) PendingUpgrade() bool {
-	return len(m.pendingNames) != 0
+	return sets.List(m.pendingUpgradeNames)
 }
 
 // MarkDeferredUpgrade marks that the upgrade for a MachineDeployment


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR modified the topology controller so that it modified pushing any changes to ControlPlane/MachineDeployment if it is pending an upgrade.

If a ControlPlane or MD is pending an upgrade it implies that it will be rollouts after it picks up the upgrade. Therefore it is better to hold out other changes, potentially causing rollouts, to these objects as well in the mean time to avoid unnecessary machine churn.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8656
Fixes #8695
