### PR TITLE
:bug: test/framework fix docker pod log collector

### DIFF
--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -106,8 +107,10 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 
 			defer os.Remove(tempfileName)
 
+			var execErr string
 			execConfig := container.ExecContainerInput{
 				OutputBuffer: f,
+				ErrorBuffer:  bytes.NewBufferString(execErr),
 			}
 			err = containerRuntime.ExecContainer(
 				ctx,
@@ -116,7 +119,7 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 				"tar", "--hard-dereference", "--dereference", "--directory", containerDir, "--create", "--file", "-", ".",
 			)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, execErr)
 			}
 
 			err = os.MkdirAll(outputDir, os.ModePerm)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When using ExecContainerInput to create the tarball, the same buffer got used for stdout and stderr. This broke the tarball which resulted in not extracting the files and having them not available in artifacts.

I noticed this when I wanted to debug a failed e2e test.

All e2e tests currently log the following per machine (no matter of succeeded or failed):

```
  Failed to get logs for Machine mhc-remediation-zy726b-control-plane-gl7bs, Cluster mhc-remediation-fxvkzb/mhc-remediation-zy726b: exit status 2
```

And this should be resolved by this MR.

We maybe should cherry-pick this to v1.4 and v1.3?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
