### PR TITLE
:bug: Fix Documentation for Ignition Bootstrap Feature Gate Environment Variable

### DIFF
--- a/docs/book/src/tasks/experimental-features/ignition.md
+++ b/docs/book/src/tasks/experimental-features/ignition.md
@@ -48,7 +48,7 @@ export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm bootstrap credentials encode-a
 
 # Enable the feature gates controlling Ignition bootstrap.
 export EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION=true # Used by the kubeadm bootstrap provider
-export BOOTSTRAP_FORMAT_IGNITION=true # Used by the AWS provider
+export EXP_BOOTSTRAP_FORMAT_IGNITION=true # Used by the AWS provider
 
 # Initialize the management cluster.
 clusterctl init --infrastructure aws


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses an inconsistency found between our documentation and the actual code for setting the Ignition bootstrap feature gate environment variable. The aim is to ensure users are provided with accurate instructions, thus eliminating possible confusion or issues.

In the current [documentation](https://cluster-api.sigs.k8s.io/tasks/experimental-features/ignition.html#initialize-the-management-cluster), users are instructed to use
`export BOOTSTRAP_FORMAT_IGNITION=true` for the AWS provider.
However, in the [actual code](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/d307586108c09543e3cdf4c5462228065081d20b/config/manager/manager.yaml#L22), the environment variable is `BootstrapFormatIgnition=${EXP_BOOTSTRAP_FORMAT_IGNITION:=false}`.

This PR updates the documentation to reflect the correct usage.