### PR TITLE
:seedling: Use dualstack kind cluster in quick-start and startup script

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -83,6 +83,8 @@ a target [management cluster] on the selected [infrastructure provider].
    cat > kind-cluster-with-extramounts.yaml <<EOF
    kind: Cluster
    apiVersion: kind.x-k8s.io/v1alpha4
+   networking:
+     ipFamily: dual
    nodes:
    - role: control-plane
      extraMounts:

--- a/hack/kind-install-for-capd.sh
+++ b/hack/kind-install-for-capd.sh
@@ -51,6 +51,8 @@ fi
 cat <<EOF | kind create cluster --name="$KIND_CLUSTER_NAME"  --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
 nodes:
 - role: control-plane
   extraMounts:


### PR DESCRIPTION
Update the quickstart guide and kind startup script to create a dualstack kind cluster by default. This keeps parity with a change made in the CAPI e2e tests in #8517.

/area documentation