### PR TITLE
🌱 e2e: log leftover processes to eventually detect zombies

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -88,6 +88,8 @@ cleanup() {
   ctr -n moby images list > "${ARTIFACTS_LOCAL}/containerd-images.txt" || true
   ctr -n moby version > "${ARTIFACTS_LOCAL}/containerd-version.txt" || true
 
+  ps -ef > "${ARTIFACTS_LOCAL}/processes-ps-ef.txt" || true
+
   # Verify that no containers are running at this time
   # Note: This verifies that all our tests clean up clusters correctly.
   if [[ ! "$(docker ps -q | wc -l)" -eq "0" ]]


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Provides the output of `ps -ef` at the end of a test, to eventually detect existing zombie processes.

Tries to gather this data for inspecting #8560 some more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
