### PR TITLE
🐛 Update MachinePool bootstrap dataSecretName when bootstrap config changes

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -605,7 +605,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "existing machinepool, bootstrap data should not change",
+			name: "existing machinepool with config ref, update data secret name",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       builder.TestBootstrapConfigKind,
 				"apiVersion": builder.BootstrapGroupVersion.String(),
@@ -645,11 +645,50 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError: false,
 			expected: func(g *WithT, m *expv1.MachinePool) {
 				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
+			},
+		},
+		{
+			name: "existing machinepool without config ref, do not update data secret name",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": metav1.NamespaceDefault,
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready":          true,
+					"dataSecretName": "secret-data",
+				},
+			},
+			machinepool: &expv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bootstrap-test-existing",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: expv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								DataSecretName: pointer.String("data"),
+							},
+						},
+					},
+				},
+				Status: expv1.MachinePoolStatus{
+					BootstrapReady: true,
+				},
+			},
+			expectError: false,
+			expected: func(g *WithT, m *expv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeTrue())
 				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("data"))
 			},
 		},
 		{
-			name: "existing machinepool, bootstrap provider is to not ready",
+			name: "existing machinepool, bootstrap provider is not ready",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       builder.TestBootstrapConfigKind,
 				"apiVersion": builder.BootstrapGroupVersion.String(),
@@ -683,12 +722,13 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 					},
 				},
 				Status: expv1.MachinePoolStatus{
-					BootstrapReady: true,
+					BootstrapReady: false,
 				},
 			},
-			expectError: false,
+			expectError:  false,
+			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
 			expected: func(g *WithT, m *expv1.MachinePool) {
-				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(m.Status.BootstrapReady).To(BeFalse())
 			},
 		},
 	}


### PR DESCRIPTION
…nges

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:  Update MachinePool bootstrap dataSecretName when bootstrap config changes. Before, we would return early whenever the dataSecretName was set which means there's no way to update it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6563
