### PR TITLE
📖 Fix a typo in `metadata propagation` section

### DIFF
--- a/docs/book/src/developer/architecture/controllers/metadata-propagation.md
+++ b/docs/book/src/developer/architecture/controllers/metadata-propagation.md
@@ -63,7 +63,7 @@ Top-level labels that meet a specific cretria are propagated to the Node labels 
 - `.labels.[label-meets-criteria]` => `Node.labels`
 - `.annotations` => Not propagated.
 
-Label should meet one of the following criterias to propate to Node: 
+Label should meet one of the following criterias to propagate to Node: 
 - Has `node-role.kubernetes.io` as prefix.
 - Belongs to `node-restriction.kubernetes.io` domain.
 - Belongs to `node.cluster.x-k8s.io` domain.  


### PR DESCRIPTION
**What this PR does / why we need it**:

When I was reading `metadata-propagation` docs I've noticed a typo in `propate` word, so I fixed it
