### PR TITLE
🌱 test/framework: add functions to collect infrastructure logs in tests

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -31,6 +31,7 @@ maintainers of providers and consumers of our Go API.
 
 - clusterctl move is adding the new annotation `clusterctl.cluster.x-k8s.io/delete-for-move` before object deletion.
 - Providers running CAPI release-0.3 clusterctl upgrade tests should set `WorkloadKubernetesVersion` field to the maximum workload cluster kubernetes version supported by the old providers in `ClusterctlUpgradeSpecInput`. For more information, please see: https://github.com/kubernetes-sigs/cluster-api/pull/8518#issuecomment-1508064859 
+- Introduced function `CollectInfrastructureLogs` at the `ClusterLogCollector` interface in `test/framework/cluster_proxy.go` to allow collecting infrastructure related logs during tests.
 
 ### Suggested changes for providers
 

--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -76,6 +76,25 @@ func (k DockerLogCollector) CollectMachinePoolLog(ctx context.Context, _ client.
 	return kerrors.NewAggregate(errs)
 }
 
+func (k DockerLogCollector) CollectInfrastructureLogs(ctx context.Context, _ client.Client, c *clusterv1.Cluster, outputPath string) error {
+	containerRuntime, err := container.NewDockerClient()
+	if err != nil {
+		return err
+	}
+	ctx = container.RuntimeInto(ctx, containerRuntime)
+
+	lbContainerName := fmt.Sprintf("%s-lb", c.GetName())
+
+	f, err := fileOnHost(filepath.Join(outputPath, fmt.Sprintf("%s.log", lbContainerName)))
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	return containerRuntime.ContainerDebugInfo(ctx, lbContainerName, f)
+}
+
 func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath string, containerName string) error {
 	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -331,8 +332,13 @@ func (d *dockerRuntime) ContainerDebugInfo(ctx context.Context, containerName st
 		return errors.Wrapf(err, "failed to inspect container %q", containerName)
 	}
 
+	rawJSON, err := json.Marshal(containerInfo)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal container info to json")
+	}
+
 	fmt.Fprintln(w, "Inspected the container:")
-	fmt.Fprintf(w, "%+v\n", containerInfo)
+	fmt.Fprintf(w, "%s\n", rawJSON)
 
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,


### PR DESCRIPTION

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This allows collecting logs from CAPD's lb container and hopefully helps to further debug #8641 .


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
