### PR TITLE
:seedling: Bump kindnet and haproxy images to latest

### DIFF
--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: kindnet
       containers:
         - name: kindnet-cni
-          image: kindest/kindnetd:v20230330-48f316cd
+          image: kindest/kindnetd:v20230511-dc714da8
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/infrastructure/docker/internal/loadbalancer/const.go
+++ b/test/infrastructure/docker/internal/loadbalancer/const.go
@@ -24,7 +24,7 @@ const (
 	DefaultImageRepository = "kindest"
 
 	// DefaultImageTag is the loadbalancer image tag.
-	DefaultImageTag = "v20230330-2f738c2"
+	DefaultImageTag = "v20230510-486859a6"
 
 	// ConfigPath is the path to the config file in the image.
 	ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Bump images used by kind for networking and load balancer to the latest published versions.

/area dependency
