### PR TITLE
:seedling: Update kpromo to v3.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ HADOLINT_FAILURE_THRESHOLD = warning
 
 SHELLCHECK_VER := v0.9.0
 
-KPROMO_VER := v3.5.2
+KPROMO_VER := v3.6.0
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
 KPROMO_PKG := sigs.k8s.io/promo-tools/v3/cmd/kpromo


### PR DESCRIPTION
Update kpromo to release v3.6.0

Release notes: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.6.0

/area dependency
