### PR TITLE
:seedling: Bump kind to v0.19.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -4,7 +4,7 @@ envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
 default_build_engine = "docker"
-kubernetes_version = "v1.27.0"
+kubernetes_version = "v1.27.1"
 
 if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
     fail("Required command '" + kubectl_cmd + "' not found in PATH")

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -325,7 +325,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: default
-  KUBERNETES_VERSION: v1.27.0
+  KUBERNETES_VERSION: v1.27.1
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 3
 ```

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1217,7 +1217,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.27.0 \
+  --kubernetes-version v1.27.1 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1260,7 +1260,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.27.0 \
+  --kubernetes-version v1.27.1 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1314,7 +1314,7 @@ and see an output similar to this:
 
 ```bash
 NAME              PHASE         AGE   VERSION
-capi-quickstart   Provisioned   8s    v1.27.0
+capi-quickstart   Provisioned   8s    v1.27.1
 ```
 
 To verify the first control plane is up:
@@ -1327,7 +1327,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.27.0
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.27.1
 ```
 
 <aside class="note warning">
@@ -1547,12 +1547,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE    VERSION
-capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.27.0
-capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.27.0
-capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.27.0
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.27.0
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.27.0
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.27.0
+capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.27.1
+capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.27.1
+capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.27.1
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.27.1
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.27.1
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.27.1
 ```
 
 {{#/tab }}

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -26,7 +26,7 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 GOPATH_BIN="$(go env GOPATH)/bin"
-MINIMUM_KIND_VERSION=v0.18.0
+MINIMUM_KIND_VERSION=v0.19.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -146,8 +146,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithProvidersContract:         "v1beta1",
-			InitWithKubernetesVersion:         "v1.26.3",
-			WorkloadKubernetesVersion:         "v1.26.3",
+			InitWithKubernetesVersion:         "v1.26.4",
+			WorkloadKubernetesVersion:         "v1.26.4",
 			MgmtFlavor:                        "topology",
 			WorkloadFlavor:                    "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -185,8 +185,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			// try to deploy the latest version of our test-extension from docker.yaml.
 			InitWithRuntimeExtensionProviders: []string{},
 			InitWithProvidersContract:         "v1beta1",
-			InitWithKubernetesVersion:         "v1.26.3",
-			WorkloadKubernetesVersion:         "v1.26.3",
+			InitWithKubernetesVersion:         "v1.26.4",
+			WorkloadKubernetesVersion:         "v1.26.4",
 			MgmtFlavor:                        "topology",
 			WorkloadFlavor:                    "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -214,8 +214,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.4=>current)", func() {
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.27.0",
-			WorkloadKubernetesVersion: "v1.27.0",
+			InitWithKubernetesVersion: "v1.27.1",
+			WorkloadKubernetesVersion: "v1.27.1",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -243,8 +243,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.4=>cur
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.27.0",
-			WorkloadKubernetesVersion: "v1.27.0",
+			InitWithKubernetesVersion: "v1.27.1",
+			WorkloadKubernetesVersion: "v1.27.1",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -296,10 +296,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.27.0"
-  KUBERNETES_VERSION: "v1.27.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.27.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.27.1"
+  KUBERNETES_VERSION: "v1.27.1"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.27.1"
   ETCD_VERSION_UPGRADE_TO: "3.5.7-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
   DOCKER_SERVICE_DOMAIN: "cluster.local"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.27.0"
+	DefaultNodeImageVersion = "v1.27.1"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/go.mod
+++ b/test/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.14.6
-	sigs.k8s.io/kind v0.18.0
+	sigs.k8s.io/kind v0.19.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -926,8 +926,8 @@ sigs.k8s.io/controller-runtime v0.14.6 h1:oxstGVvXGNnMvY7TAESYk+lzr6S3V5VFxQ6d92
 sigs.k8s.io/controller-runtime v0.14.6/go.mod h1:WqIdsAY6JBsjfc/CqO0CORmNtoCtE4S6qbPc9s68h+0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kind v0.18.0 h1:ahgZdVV1pdhXlYe1f+ztISakT23KdrBl/NFY9JMygzs=
-sigs.k8s.io/kind v0.18.0/go.mod h1:Qqp8AiwOlMZmJWs37Hgs31xcbiYXjtXlRBSftcnZXQk=
+sigs.k8s.io/kind v0.19.0 h1:ZSUh6/kpab6fiowT6EqL4k8xSbedI2NWxyuUOtoPFe4=
+sigs.k8s.io/kind v0.19.0/go.mod h1:aBlbxg08cauDgZ612shr017/rZwqd7AS563FvpWKPVs=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.0
+  version: v1.27.1
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.27.0
+      version: v1.27.1
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.0
+  version: v1.27.1
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.0
+      version: v1.27.1
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.27.0
+  version: v1.27.1
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.0
+      version: v1.27.1
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.0
+  version: v1.27.1
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.0
+      version: v1.27.1
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -51,7 +51,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.27.0"
+	defaultImageTag  = "v1.27.1"
 )
 
 var (


### PR DESCRIPTION
Bump kind to v0.19.0.
Release notes: https://github.com/kubernetes-sigs/kind/releases/tag/v0.19.0

/area dependency
