### PR TITLE
[release-1.3] :seedling: Update kpromo to v3.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ HADOLINT_FAILURE_THRESHOLD = warning
 
 SHELLCHECK_VER := v0.9.0
 
-KPROMO_VER := v3.5.1
+KPROMO_VER := v3.6.0
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
 KPROMO_PKG := sigs.k8s.io/promo-tools/v3/cmd/kpromo


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/8680

Update kpromo to release v3.6.0

Release notes: https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.6.0

/area dependency
