### PR TITLE
:seedling: Pin cgroup driver used in v0.3 and v0.4 templates

### DIFF
--- a/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
@@ -67,10 +67,16 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
@@ -24,6 +24,9 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+            # This cluster is used in tests where the Kubernetes version is < 1.24
+            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object with

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -68,10 +68,16 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
@@ -24,6 +24,9 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+            # This cluster is used in tests where the Kubernetes version is < 1.24
+            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
@@ -36,4 +36,7 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
+        # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+        # This cluster is used in tests where the Kubernetes version is < 1.24
+        cgroup-driver: cgroupfs
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
@@ -86,10 +86,16 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v1.0/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.0/bases/md.yaml
@@ -24,6 +24,9 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+            # This cluster is used in tests where the Kubernetes version is < 1.24
+            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object


### PR DESCRIPTION
Pin the cgroup driver used in templates for v0.3 and v0.4. This is required when running the tests locally - otherwise the created clusters end up with crashing control plane pods. 

Should hopefully also work in CI, but these tests have been generally stable in CI without pinning the versions.

/area e2e-testing