### PR TITLE
🐛 CAPD: change the haproxy entrypoint to prevent getting stopped immediately after start

### DIFF
--- a/test/infrastructure/docker/internal/docker/kind_manager.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager.go
@@ -38,6 +38,9 @@ const ControlPlanePort = 6443
 // DefaultNetwork is the default network name to use in kind.
 const DefaultNetwork = "kind"
 
+// haproxyEntrypoint is the entrypoint used to start the haproxy load balancer container.
+var haproxyEntrypoint = []string{"haproxy", "-W", "-db", "-f", "/usr/local/etc/haproxy/haproxy.cfg"}
+
 // Manager is the kind manager type.
 type Manager struct{}
 
@@ -46,6 +49,7 @@ type nodeCreateOpts struct {
 	Image        string
 	ClusterName  string
 	Role         string
+	EntryPoint   []string
 	Mounts       []v1alpha4.Mount
 	PortMappings []v1alpha4.PortMapping
 	Labels       map[string]string
@@ -113,6 +117,7 @@ func (m *Manager) CreateExternalLoadBalancerNode(ctx context.Context, name, imag
 		ClusterName:  clusterName,
 		Role:         constants.ExternalLoadBalancerNodeRoleValue,
 		PortMappings: portMappings,
+		EntryPoint:   haproxyEntrypoint,
 	}
 	node, err := createNode(ctx, createOpts)
 	if err != nil {
@@ -143,6 +148,7 @@ func createNode(ctx context.Context, opts *nodeCreateOpts) (*types.Node, error) 
 		// filesystem, which is not only better for performance, but allows
 		// running kind in kind for "party tricks"
 		// (please don't depend on doing this though!)
+		Entrypoint:   opts.EntryPoint,
 		Volumes:      map[string]string{"/var": ""},
 		Mounts:       generateMountInfo(opts.Mounts),
 		PortMappings: generatePortMappings(opts.PortMappings),


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

For more context see #8641.

We came to the conclusion that we can drop the `-sf 7` arguments when starting haproxy.
This seem to be able to exit the haproxy process immediately after start, resulting in not-running lb container and by that in flaky tests.

Kudos to @killianmuldoon for testing the updated arguments to see if config updating still works.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Tries to fix #8641

