### PR TITLE
:seedling: Fix typos in phrase "to exist"

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -376,7 +376,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			input.PreWaitForCluster(managementClusterProxy, testNamespace.Name, workLoadClusterName)
 		}
 
-		By("Waiting for the machines to exists")
+		By("Waiting for the machines to exist")
 		Eventually(func() (int64, error) {
 			var n int64
 			machineList := &clusterv1alpha3.MachineList{}

--- a/test/e2e/kcp_remediations.go
+++ b/test/e2e/kcp_remediations.go
@@ -537,7 +537,7 @@ type waitForMachinesInput struct {
 	CheckMachineListStableIntervals []interface{}
 }
 
-// waitForMachines waits for machines to reach a well known state defined by number of replicas, a list of machines to exists,
+// waitForMachines waits for machines to reach a well known state defined by number of replicas, a list of machines to exist,
 // a list of machines to not exist anymore. The func also check that the state is stable for some time before
 // returning the list of new machines.
 func waitForMachines(ctx context.Context, input waitForMachinesInput) (allMachineNames, newMachineNames []string) {

--- a/test/framework/machinehealthcheck_helpers.go
+++ b/test/framework/machinehealthcheck_helpers.go
@@ -143,7 +143,7 @@ func WaitForMachineHealthCheckToRemediateUnhealthyNodeCondition(ctx context.Cont
 			ClusterName:        input.Cluster.Name,
 			MachineHealthCheck: input.MachineHealthCheck,
 		})
-		// Wait for all the machines to exists.
+		// Wait for all the machines to exist.
 		// NOTE: this is required given that this helper is called after a remediation
 		// and we want to make sure all the machine are back in place before testing for unhealthyCondition being fixed.
 		if len(machines) < input.MachinesCount {


### PR DESCRIPTION
Fix a minor typo in the the phrase "to exist" in different instances across the codebase.

/area testing
