### PR TITLE
Revert "Pin cgroup driver used in v0.3, v0.4 and templates"

### DIFF
--- a/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
@@ -67,16 +67,10 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-          # This cluster is used in tests where the Kubernetes version is < 1.24
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-          # This cluster is used in tests where the Kubernetes version is < 1.24
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
@@ -24,9 +24,6 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-            # This cluster is used in tests where the Kubernetes version is < 1.24
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object with

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -68,16 +68,10 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-          # This cluster is used in tests where the Kubernetes version is < 1.24
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-          # This cluster is used in tests where the Kubernetes version is < 1.24
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
@@ -24,9 +24,6 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-            # This cluster is used in tests where the Kubernetes version is < 1.24
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
@@ -36,7 +36,4 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-        # This cluster is used in tests where the Kubernetes version is < 1.24
-        cgroup-driver: cgroupfs
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%


### PR DESCRIPTION
This reverts commit 5ed1846faa7fe3f51f82b3c7b597fdf828100ded.

Release 1.3 tests are failing since merging this. Let's revert and I'll follow up taking a deeper look at why.

Added in https://github.com/kubernetes-sigs/cluster-api/pull/8692