### PR TITLE
:book: Bump kind version to v1.19.0 in docs

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -11,7 +11,7 @@ maintainers of providers and consumers of our Go API.
 
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
-- sigs.k8s.io/kind: v0.17.x => v0.18.x
+- sigs.k8s.io/kind: v0.17.x => v0.19.x
 
 ## Changes by Kind
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -8,7 +8,7 @@ workflow that offers easy deployments and rapid iterative builds.
 ## Prerequisites
 
 1. [Docker](https://docs.docker.com/install/): v19.03 or newer
-1. [kind](https://kind.sigs.k8s.io): v0.17 or newer
+1. [kind](https://kind.sigs.k8s.io): v0.19 or newer
 1. [Tilt](https://docs.tilt.dev/install.html): v0.30.8 or newer
 1. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
 1. [envsubst](https://github.com/drone/envsubst): provided via `make envsubst`

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -46,7 +46,7 @@ a target [management cluster] on the selected [infrastructure provider].
 
    [kind] is not designed for production use.
 
-   **Minimum [kind] supported version**: v0.18.0
+   **Minimum [kind] supported version**: v0.19.0
 
    **Help with common issues can be found in the [Troubleshooting Guide](./troubleshooting.md).**
 


### PR DESCRIPTION
Follow on from #8681.

Bumping the minimum supported kind version in places where it was missed in the docs.

