### PR TITLE
:seedling: Fix typo: exits -> exists

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -1031,7 +1031,7 @@ func (o *objectMover) restoreTargetObject(nodeToCreate *node, toProxy Proxy) err
 	if err := cTo.Get(ctx, objKey, existingTargetObj); err == nil {
 		log.V(5).Info("Object already exists, skipping moving from directory", nodeToCreate.identity.Kind, nodeToCreate.identity.Name, "Namespace", nodeToCreate.identity.Namespace)
 
-		// Update the nodes UID since it already exits. Any nodes owned by this existing node will be updated when the owner chain is rebuilt
+		// Update the nodes UID since it already exists. Any nodes owned by this existing node will be updated when the owner chain is rebuilt
 		nodeToCreate.newUID = existingTargetObj.GetUID()
 
 		// Return early since the object already exists

--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -114,7 +114,7 @@ func fetchMissingClusterClassTemplates(clusterClassClient repository.ClusterClas
 	}
 
 	// Get the templates for all ClusterClasses and associated objects if the target
-	// ClusterClass does not exits in the cluster.
+	// ClusterClass does not exist in the cluster.
 	templates := []repository.Template{}
 	for _, class := range classes {
 		if clusterInitialized {

--- a/internal/controllers/topology/cluster/patches/variables/merge.go
+++ b/internal/controllers/topology/cluster/patches/variables/merge.go
@@ -32,7 +32,7 @@ func MergeVariableMaps(variableMaps ...map[string]apiextensionsv1.JSON) (map[str
 
 	for _, variableMap := range variableMaps {
 		for variableName, variableValue := range variableMap {
-			// If the variable already exits and is the builtin variable, merge it.
+			// If the variable already exists and is the builtin variable, merge it.
 			if _, ok := res[variableName]; ok && variableName == BuiltinsName {
 				mergedV, err := mergeBuiltinVariables(res[variableName], variableValue)
 				if err != nil {


### PR DESCRIPTION
Fix typo `exits` to `exists` across codebase.

Fixes
