### PR TITLE
:bug: Remove non-functioning ginkgo.no-color flag 

### DIFF
--- a/test/e2e/data/kubetest/conformance-fast.yaml
+++ b/test/e2e/data/kubetest/conformance-fast.yaml
@@ -1,9 +1,0 @@
-ginkgo.focus: \[Conformance\]
-ginkgo.skip: \[sig-scheduling\].*\[Serial\]
-disable-log-dump: true
-ginkgo.progress: true
-ginkgo.slowSpecThreshold: 120.0
-ginkgo.flakeAttempts: 3
-ginkgo.trace: true
-ginkgo.v: true
-ginkgo.no-color: true

--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -6,7 +6,8 @@ ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
 ginkgo.v: true
-ginkgo.no-color: true
 # Use 5m instead of the default 10m to fail faster
 # if kube-system Pods are not coming up.
 system-pods-startup-timeout: 5m
+# TODO: (killianmuldoon) This flag is not currently working with the conformance set-up.
+# ginkgo.noColor: true


### PR DESCRIPTION
Remove `ginkgo.no-color` flag which is not supported in earlier versions of the conformance tests. This flag was not functioning correctly even when enabled.

Currently causing failures in:

- https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-22-1-23
- https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-23-1-24