### PR TITLE
🌱 deprecate MachineDeployment.Spec.Paused

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -231,7 +231,7 @@ issues:
   # should be removed as the referenced deprecated item is removed from the project.
   - linters:
       - staticcheck
-    text: "SA1019: (bootstrapv1.ClusterStatus|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped) is deprecated"
+    text: "SA1019: (bootstrapv1.ClusterStatus|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped|deployment.Spec.Paused|md.Spec.Paused) is deprecated"
   # Specific exclude rules for deprecated packages that are still part of the codebase. These
   # should be removed as the referenced deprecated packages are removed from the project.
   - linters:

--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -136,6 +136,8 @@ type MachineDeploymentSpec struct {
 
 	// Indicates that the deployment is paused.
 	// +optional
+	//
+	// Deprecated: This field will be dropped in the next API version.
 	Paused bool `json:"paused,omitempty"`
 
 	// The maximum time in seconds for a deployment to make progress before it

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1745,7 +1745,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentSpec(ref common.R
 					},
 					"paused": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Indicates that the deployment is paused.",
+							Description: "Indicates that the deployment is paused.\n\nDeprecated: This field will be dropped in the next API version.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/cmd/clusterctl/client/alpha/rollout_restarter.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter.go
@@ -34,7 +34,7 @@ func (r *rollout) ObjectRestarter(proxy cluster.Proxy, ref corev1.ObjectReferenc
 		if err != nil || deployment == nil {
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
-		if deployment.Spec.Paused {
+		if deployment.Spec.Paused || annotations.HasPaused(deployment) {
 			return errors.Errorf("can't restart paused MachineDeployment (run rollout resume first): %v/%v", ref.Kind, ref.Name)
 		}
 		if deployment.Spec.RolloutAfter != nil && deployment.Spec.RolloutAfter.After(time.Now()) {

--- a/cmd/clusterctl/client/alpha/rollout_restarter_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter_test.go
@@ -67,7 +67,7 @@ func Test_ObjectRestarter(t *testing.T) {
 			wantRollout: true,
 		},
 		{
-			name: "paused machinedeployment should not have rolloutAfter",
+			name: "paused (.spec.paused) machinedeployment should not have rolloutAfter",
 			fields: fields{
 				objs: []client.Object{
 					&clusterv1.MachineDeployment{
@@ -81,6 +81,33 @@ func Test_ObjectRestarter(t *testing.T) {
 						},
 						Spec: clusterv1.MachineDeploymentSpec{
 							Paused: true,
+						},
+					},
+				},
+				ref: corev1.ObjectReference{
+					Kind:      MachineDeployment,
+					Name:      "md-1",
+					Namespace: "default",
+				},
+			},
+			wantErr:     true,
+			wantRollout: false,
+		},
+		{
+			name: "paused (paused annotation) machinedeployment should not have rolloutAfter",
+			fields: fields{
+				objs: []client.Object{
+					&clusterv1.MachineDeployment{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "MachineDeployment",
+							APIVersion: "cluster.x-k8s.io/v1beta1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "md-1",
+							Annotations: map[string]string{
+								clusterv1.PausedAnnotation: "true",
+							},
 						},
 					},
 				},

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1045,7 +1045,8 @@ spec:
                 format: int32
                 type: integer
               paused:
-                description: Indicates that the deployment is paused.
+                description: "Indicates that the deployment is paused. \n Deprecated:
+                  This field will be dropped in the next API version."
                 type: boolean
               progressDeadlineSeconds:
                 description: The maximum time in seconds for a deployment to make


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR deprecated the `MachineDeployment.Spec.Paused` field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8629
