### PR TITLE
🐛 handle nil pointer in clusterctl describe

### DIFF
--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -249,6 +249,54 @@ var moveTests = []struct {
 		wantErr: false,
 	},
 	{
+		name: "Cluster with MachineDeployment with a static bootstrap config",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithMachineDeployments(
+					test.NewFakeMachineDeployment("md1").
+						WithStaticBootstrapConfig().
+						WithMachineSets(
+							test.NewFakeMachineSet("ms1").
+								WithStaticBootstrapConfig().
+								WithMachines(
+									test.NewFakeMachine("m1").
+										WithStaticBootstrapConfig(),
+									test.NewFakeMachine("m2").
+										WithStaticBootstrapConfig(),
+								),
+						),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ // group 1
+				"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+			},
+			{ // group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"cluster.x-k8s.io/v1beta1, Kind=MachineDeployment, ns1/md1",
+				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns1/cluster1",
+				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachineTemplate, ns1/md1",
+			},
+			{ // group 3 (objects with ownerReferences in group 1,2)
+				// owned by MachineDeployments
+				"cluster.x-k8s.io/v1beta1, Kind=MachineSet, ns1/ms1",
+			},
+			{ // group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by MachineSets
+				"cluster.x-k8s.io/v1beta1, Kind=Machine, ns1/m1",
+				"cluster.x-k8s.io/v1beta1, Kind=Machine, ns1/m2",
+			},
+			{ // group 5 (objects with ownerReferences in group 1,2,3,4)
+				// owned by Machines
+				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachine, ns1/m1",
+				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachine, ns1/m2",
+			},
+		},
+		wantErr: false,
+	},
+	{
 		name: "Cluster with Control Plane",
 		fields: moveTestsFields{
 			objs: test.NewFakeCluster("ns1", "cluster1").
@@ -825,7 +873,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 				oTo.SetKind(node.identity.Kind)
 
 				if err := csTo.Get(ctx, key, oTo); err != nil {
-					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v created in target cluster", err, oTo.GetKind(), key)
 					continue
 				}
 
@@ -853,7 +901,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 				oAfter.SetKind(node.identity.Kind)
 
 				if err := csAfter.Get(ctx, keyAfter, oAfter); err != nil {
-					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v created in target cluster", err, oAfter.GetKind(), key)
 					continue
 				}
 
@@ -1076,7 +1124,7 @@ func Test_objectMover_fromDirectory(t *testing.T) {
 				oTo.SetKind(node.identity.Kind)
 
 				if err := csTo.Get(ctx, key, oTo); err != nil {
-					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v created in target cluster", err, oTo.GetKind(), key)
 					continue
 				}
 			}
@@ -1164,7 +1212,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 				oFrom.SetKind(node.identity.Kind)
 
 				if err := csFrom.Get(ctx, key, oFrom); err != nil {
-					t.Errorf("error = %v when checking for %v kept in source cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v kept in source cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 
@@ -1176,11 +1224,11 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 				err := csTo.Get(ctx, key, oTo)
 				if err == nil {
 					if oFrom.GetNamespace() != "" {
-						t.Errorf("%v created in target cluster which should not", key)
+						t.Errorf("%s %v created in target cluster which should not", oFrom.GetKind(), key)
 						continue
 					}
 				} else if !apierrors.IsNotFound(err) {
-					t.Errorf("error = %v when checking for %v should not created ojects in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v should not created ojects in target cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 			}
@@ -1240,11 +1288,11 @@ func Test_objectMover_move(t *testing.T) {
 				err := csFrom.Get(ctx, key, oFrom)
 				if err == nil {
 					if !node.isGlobal && !node.isGlobalHierarchy {
-						t.Errorf("%v not deleted in source cluster", key)
+						t.Errorf("%s %v not deleted in source cluster", oFrom.GetKind(), key)
 						continue
 					}
 				} else if !apierrors.IsNotFound(err) {
-					t.Errorf("error = %v when checking for %v deleted in source cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v deleted in source cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 
@@ -1254,7 +1302,7 @@ func Test_objectMover_move(t *testing.T) {
 				oTo.SetKind(node.identity.Kind)
 
 				if err := csTo.Get(ctx, key, oTo); err != nil {
-					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v created in target cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 			}
@@ -1349,11 +1397,11 @@ func Test_objectMover_move_with_Mutator(t *testing.T) {
 				err := csFrom.Get(ctx, key, oFrom)
 				if err == nil {
 					if !node.isGlobal && !node.isGlobalHierarchy {
-						t.Errorf("%v not deleted in source cluster", key)
+						t.Errorf("%s %v not deleted in source cluster", oFrom.GetKind(), key)
 						continue
 					}
 				} else if !apierrors.IsNotFound(err) {
-					t.Errorf("error = %v when checking for %v deleted in source cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v deleted in source cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 
@@ -1366,7 +1414,7 @@ func Test_objectMover_move_with_Mutator(t *testing.T) {
 				}
 
 				if err := csTo.Get(ctx, key, oTo); err != nil {
-					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					t.Errorf("error = %v when checking for %s %v created in target cluster", err, oFrom.GetKind(), key)
 					continue
 				}
 				if fields, knownKind := updateKnownKinds[oTo.GetKind()]; knownKind {

--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -241,8 +241,11 @@ func addMachineDeploymentToObjectTree(ctx context.Context, c client.Client, clus
 				templateParent = md
 			}
 
-			bootstrapTemplateRefObject := ObjectReferenceObject(md.Spec.Template.Spec.Bootstrap.ConfigRef)
-			tree.Add(templateParent, bootstrapTemplateRefObject, ObjectMetaName("BootstrapConfigTemplate"))
+			// md.Spec.Template.Spec.Bootstrap.ConfigRef is optional
+			if md.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
+				bootstrapTemplateRefObject := ObjectReferenceObject(md.Spec.Template.Spec.Bootstrap.ConfigRef)
+				tree.Add(templateParent, bootstrapTemplateRefObject, ObjectMetaName("BootstrapConfigTemplate"))
+			}
 
 			machineTemplateRefObject := ObjectReferenceObject(&md.Spec.Template.Spec.InfrastructureRef)
 			tree.Add(templateParent, machineTemplateRefObject, ObjectMetaName("MachineInfrastructureTemplate"))

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -397,6 +397,17 @@ func Test_Discovery(t *testing.T) {
 								test.NewFakeInfrastructureTemplate("md1"),
 							),
 					).
+					WithMachineDeployments(
+						test.NewFakeMachineDeployment("md2").
+							WithStaticBootstrapConfig().
+							WithMachineSets(
+								test.NewFakeMachineSet("ms2").
+									WithMachines(
+										test.NewFakeMachine("m3"),
+										test.NewFakeMachine("m4"),
+									),
+							),
+					).
 					Objs(),
 			},
 			wantTree: map[string][]string{
@@ -418,6 +429,7 @@ func Test_Discovery(t *testing.T) {
 				// Workers should have a machine deployment
 				"virtual.cluster.x-k8s.io/v1beta1, Kind=WorkerGroup, ns1/Workers": {
 					"cluster.x-k8s.io/v1beta1, Kind=MachineDeployment, ns1/md1",
+					"cluster.x-k8s.io/v1beta1, Kind=MachineDeployment, ns1/md2",
 				},
 				// Machine deployment should have a group of machines (grouping) and templates group
 				"cluster.x-k8s.io/v1beta1, Kind=MachineDeployment, ns1/md1": {
@@ -433,6 +445,17 @@ func Test_Discovery(t *testing.T) {
 				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachineTemplate, ns1/md1": {},
 				// MachineDeployment BootstrapConfigRef should be a leaf
 				"bootstrap.cluster.x-k8s.io/v1beta1, Kind=GenericBootstrapConfigTemplate, ns1/md1": {},
+				// Machine deployment should have a group of machines (grouping) and templates group
+				"cluster.x-k8s.io/v1beta1, Kind=MachineDeployment, ns1/md2": {
+					"virtual.cluster.x-k8s.io/v1beta1, Kind=MachineGroup, ns1/zzz_",
+					"virtual.cluster.x-k8s.io/v1beta1, Kind=TemplateGroup, ns1/md2",
+				},
+				// MachineDeployment TemplateGroup using static bootstrap will only have InfrastructureRef
+				"virtual.cluster.x-k8s.io/v1beta1, Kind=TemplateGroup, ns1/md2": {
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachineTemplate, ns1/md2",
+				},
+				// MachineDeployment InfrastructureRef should be a leaf
+				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachineTemplate, ns1/md2": {},
 				// ControlPlane TemplateGroup should have a InfrastructureRef
 				"virtual.cluster.x-k8s.io/v1beta1, Kind=TemplateGroup, ns1/cp": {
 					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureMachineTemplate, ns1/cp",


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

if a cluster as an empy bootstrap.configref in the machinedeployment (which is allowed), a nil pointer will raise if clusterctl describe cluster is called with --show-templates.

Also add a second type of a fake machinedeployment which has a secret reference in the boostrap object instead of a config ref

```
/*
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x19478c0]

goroutine 1 [running]:
sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree.ObjectReferenceObject(0x0)
        sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree/util.go:116 +0x40
sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree.addMachineDeploymentToObjectTree({0x2153e90, 0xc000120008}, {0x215ebf8, 0xc0002ca770}, 0xc000c336c0, 0xc000c336c0?, 0x2171100?, 0xc0009e2200, {{0x7fffd7f57514, 0x3}, ...}, ...)
        sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree/discovery.go:244 +0x35b
sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree.Discovery({0x2153e90, 0xc000120008}, {0x215ebf8?, 0xc0002ca770?}, {0x7fffd7f574f3, 0xe}, {0x7fffd7f574eb, 0x4}, {{0x7fffd7f57514, 0x3}, ...})
        sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree/discovery.go:145 +0x94c
sigs.k8s.io/cluster-api/cmd/clusterctl/client.(*clusterctlClient).DescribeCluster(0x0?, {{{0x0, 0x0}, {0x0, 0x0}}, {0x7fffd7f574f3, 0xe}, {0x7fffd7f574eb, 0x4}, {0x7fffd7f57514, ...}, ...})
        sigs.k8s.io/cluster-api/cmd/clusterctl/client/describe.go:91 +0x218
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.runDescribeCluster(0x0?, {0x7fffd7f574eb, 0x4})
        sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/describe_cluster.go:154 +0x1d8
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.glob..func6(0x31aae60?, {0xc00018af80?, 0x8?, 0x8?})
        sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/describe_cluster.go:105 +0x2d
github.com/spf13/cobra.(*Command).execute(0x31aae60, {0xc00018af00, 0x8, 0x8})
        github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x31ad980)
        github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.7.0/command.go:992
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.Execute()
        sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/root.go:105 +0x25
main.main()
        sigs.k8s.io/cluster-api/cmd/clusterctl/main.go:27 +0x17
*/
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
