### PR TITLE
:seedling: Pin delve to match go minor version

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -166,8 +166,9 @@ def load_provider_tiltfiles():
 tilt_helper_dockerfile_header = """
 # Tilt image
 FROM golang:1.20.3 as tilt-helper
+# Install delve. Note this should be kept in step with the Go release minor version.
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.20
 # Support live reloading with Tilt
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/start.sh && \
     chmod +x /start.sh && chmod +x /restart.sh && chmod +x /go/bin/dlv && \


### PR DESCRIPTION
Pin delve to use Golang v1.20. 

Note: This version should be kept in line with the Go minor version used. 


Fixes #8723 
/area devtools