### PR TITLE
:seedling: Pin delve to version supporting go 1.19

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -169,7 +169,7 @@ tilt_helper_dockerfile_header = """
 # Tilt image
 FROM golang:1.19.6 as tilt-helper
 # Support live reloading with Tilt
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/start.sh && \
     chmod +x /start.sh && chmod +x /restart.sh && chmod +x /go/bin/dlv && \


### PR DESCRIPTION
Pin delve to a release that supports Go 1.19.

Note: After the 1.9.1 release delve changed to a release scheme matching the Go version.

/area devtools
