### PR TITLE
🌱 Remove unnecessary requeues

### DIFF
--- a/controllers/external/tracker.go
+++ b/controllers/external/tracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package external
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -56,7 +57,7 @@ func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handl
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(gvk)
 
-	log.Info("Adding watcher on external object", "groupVersionKind", gvk.String())
+	log.Info(fmt.Sprintf("Adding watch on external object %q", gvk.String()))
 	err := o.Controller.Watch(
 		source.Kind(o.Cache, u),
 		handler,
@@ -64,7 +65,7 @@ func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handl
 	)
 	if err != nil {
 		o.m.Delete(key)
-		return errors.Wrapf(err, "failed to add watcher on external object %q", gvk.String())
+		return errors.Wrapf(err, "failed to add watch on external object %q", gvk.String())
 	}
 	return nil
 }

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -43,10 +43,6 @@ const (
 	wrongNamespace = "wrong-namespace"
 )
 
-func init() {
-	externalReadyWait = 1 * time.Second
-}
-
 func TestReconcileMachinePoolPhases(t *testing.T) {
 	deletionTimestamp := metav1.Now()
 
@@ -569,7 +565,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 				"status": map[string]interface{}{},
 			},
 			expectError:  false,
-			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
+			expectResult: ctrl.Result{},
 			expected: func(g *WithT, m *expv1.MachinePool) {
 				g.Expect(m.Status.BootstrapReady).To(BeFalse())
 			},
@@ -727,7 +723,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 				},
 			},
 			expectError:  false,
-			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
+			expectResult: ctrl.Result{},
 			expected: func(g *WithT, m *expv1.MachinePool) {
 				g.Expect(m.Status.BootstrapReady).To(BeFalse())
 			},

--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -92,6 +92,11 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.C
 		return external.ReconcileOutput{}, err
 	}
 
+	// Ensure we add a watcher to the external object.
+	if err := r.externalTracker.Watch(log, obj, handler.EnqueueRequestForOwner(r.Client.Scheme(), r.Client.RESTMapper(), &clusterv1.Cluster{})); err != nil {
+		return external.ReconcileOutput{}, err
+	}
+
 	// if external ref is paused, return error.
 	if annotations.IsPaused(cluster, obj) {
 		log.V(3).Info("External object referenced is paused")
@@ -119,11 +124,6 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.C
 
 	// Always attempt to Patch the external object.
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return external.ReconcileOutput{}, err
-	}
-
-	// Ensure we add a watcher to the external object.
-	if err := r.externalTracker.Watch(log, obj, handler.EnqueueRequestForOwner(r.Client.Scheme(), r.Client.RESTMapper(), &clusterv1.Cluster{})); err != nil {
 		return external.ReconcileOutput{}, err
 	}
 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -128,7 +128,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	}
 
 	r.controller = c
-
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
 	r.externalTracker = external.ObjectTracker{
 		Controller: c,

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -715,7 +715,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"spec":   map[string]interface{}{},
 				"status": map[string]interface{}{},
 			},
-			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
+			expectResult: ctrl.Result{},
 			expectError:  false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
 				g.Expect(m.Status.BootstrapReady).To(BeFalse())
@@ -836,7 +836,7 @@ func TestReconcileBootstrap(t *testing.T) {
 					BootstrapReady: true,
 				},
 			},
-			expectResult: ctrl.Result{RequeueAfter: externalReadyWait},
+			expectResult: ctrl.Result{},
 			expectError:  false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
 				g.Expect(m.GetOwnerReferences()).NotTo(ContainRefOfGroupKind("cluster.x-k8s.io", "MachineSet"))


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR removes requeues in places where we already watch objects.

E.g. we don't have to requeue if the BootstrapConfig is not ready, because an update on a BootstrapConfig automatically triggers a reconcile (because we have a watch on BootstrapConfigs).

There should be no problems with stale caches after updates because we don't cache unstructured.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8735
