### PR TITLE
✨ add cluster.x-k8s.io/skip-defaulting-webhook

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -142,6 +142,10 @@ const (
 	// will receive the resulting object.
 	TopologyDryRunAnnotation = "topology.cluster.x-k8s.io/dry-run"
 
+	// SkipDefaultingWebhook is an annotation that indicates we don't want to mutate objects during admission
+	// Ref: https://cluster-api.sigs.k8s.io/developer/providers/webhooks.html#defaulting-webhooks
+	SkipDefaultingWebhook = "cluster.x-k8s.io/skip-defaulting-webhook"
+
 	// ReplicasManagedByAnnotation is an annotation that indicates external (non-Cluster API) management of infra scaling.
 	// The practical effect of this is that the capi "replica" count should be passively derived from the number of observed infra machines,
 	// instead of being a source of truth for eventual consistency.

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -104,3 +104,16 @@ func hasTruthyAnnotationValue(o metav1.Object, annotation string) bool {
 	}
 	return false
 }
+
+// ShouldSkipDefaultingWebhook returns true if the object has the TopologySkipDefaultingWebhook annotation set, else false
+func ShouldSkipDefaultingWebhook(o metav1.Object) bool {
+	// Check for the TopologySkipDefaultingWebhook
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	if _, ok := annotations[clusterv1.SkipDefaultingWebhook]; ok {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a Cluster API standard annotation to enable optional defaulting webhooks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
