### PR TITLE
:bug: Increased assertClusterObjects timeout

### DIFF
--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -268,7 +268,7 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 		assertMachineSetsMachines(g, clusterObjects, cluster)
 
 		By("All cluster objects have the right labels, annotations and selectors")
-	}, 10*time.Second, 1*time.Second).Should(Succeed())
+	}, 30*time.Second, 1*time.Second).Should(Succeed())
 }
 
 func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects clusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {


### PR DESCRIPTION
Increase the timeout on asserClusterObjects for the ClusterClass rollout test. Since https://github.com/kubernetes-sigs/cluster-api/pull/8711 this test has been flaky, due to the certificate reconciliation happening much later in the reconcile loop. Lengthening this timeout should fix the issue.

Fixes #8747
