### PR TITLE
📖 Update Runtime Extension CAPI Book

### DIFF
--- a/docs/book/src/tasks/experimental-features/runtime-sdk/deploy-runtime-extension.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/deploy-runtime-extension.md
@@ -15,6 +15,7 @@ controllers. The recommended deployment model is to deploy a Runtime Extension i
 - Using a Kubernetes Deployment to run the above container inside the Management Cluster.
 - Using a Cluster IP Service to make the Runtime Extension instances accessible via a stable DNS name.
 - Using a cert-manager generated Certificate to protect the endpoint.
+- Register the Runtime Extension using ExtensionConfig.
 
 For an example, please see our [test extension](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/extension)
 which follows, as closely as possible, the kubebuilder setup used for controllers in Cluster API.

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
@@ -291,6 +291,34 @@ controllers processing those resource that might impact system stability.
 
 </aside>
 
+### ExtensionConfig
+
+To register your runtime extension apply the ExtensionConfig resource in the management cluster, including your CA 
+certs, ClusterIP service associated with the app and namespace, and the target namespace for the given extension. Once 
+created, the extension will detect the associated service and discover the associated Hooks. For clarification, you can 
+check the status of the ExtensionConfig. Below is an example of `ExtensionConfig` -
+
+```yaml
+apiVersion: runtime.cluster.x-k8s.io/v1alpha1
+kind: ExtensionConfig
+metadata:
+  annotations:
+    runtime.cluster.x-k8s.io/inject-ca-from-secret: default/test-runtime-sdk-svc-cert
+  name: test-runtime-sdk-extensionconfig
+spec:
+  clientConfig:
+    service:
+      name: test-runtime-sdk-svc
+      namespace: default # Note: this assumes the test extension get deployed in the default namespace
+      port: 443
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+          - default # Note: this assumes the test extension is used by Cluster in the default namespace only
+```
+
 ### Settings
 
 Settings can be added to the ExtensionConfig object in the form of a map with string keys and values. These settings are


### PR DESCRIPTION
- Add Point for registering the app
- Add an ExtensionConfig Example

**What this PR does / why we need it**:
This PR enhances the CAPI Book in the Runtime Extension Section. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8679 

/cc @killianmuldoon 