### PR TITLE
📖 Wrapped the values with quotes to make them string

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -323,10 +323,11 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 
 ```yaml
 kustomize_substitutions:
-  NAMESPACE: default
-  KUBERNETES_VERSION: v1.27.1
-  CONTROL_PLANE_MACHINE_COUNT: 1
-  WORKER_MACHINE_COUNT: 3
+  NAMESPACE: "default"
+  KUBERNETES_VERSION: "v1.27.1"
+  CONTROL_PLANE_MACHINE_COUNT: "1"
+  WORKER_MACHINE_COUNT: "3"
+# Note: kustomize substitutions expects the values to be strings. This can be achieved by wrapping the values in quotation marks.
 ```
 
 ### Cleaning up your kind cluster and development environment


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: In Tiltfile function prepare_all() expects the values to be substituted as strings but in the book the example contains machine_counts as integer so we need to wrap the numbers in quotes to make them string to prevent error
