### PR TITLE
🌱 Move ClusterClass quickstart test from e2e-informing to e2e-main

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/kubetest"
 )
 
-var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", func() {
+var _ = Describe("When following the Cluster API quick-start", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
@@ -51,7 +51,7 @@ var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", fun
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Informing] [ClusterClass]", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,


### PR DESCRIPTION
**What this PR does / why we need it**:
and drop the regular quickstart test from e2e-main. It covers additional changes from #8224 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/8224
