### PR TITLE
🐛 test/e2e fix fail-swap-on=false flag not being part of kind images anymore

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
@@ -89,9 +89,11 @@ spec:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/main/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/md.yaml
@@ -27,6 +27,7 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
@@ -47,3 +47,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
@@ -49,11 +49,13 @@ spec:
       criSocket: unix:///var/run/containerd/containerd.sock
       kubeletExtraArgs:
         eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        fail-swap-on: "false"
   joinConfiguration:
     nodeRegistration:
       criSocket: unix:///var/run/containerd/containerd.sock
       kubeletExtraArgs:
         eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        fail-swap-on: "false"
 ---
 # cp0 Machine
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -62,10 +62,12 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     files:
     - path: /wait-signal.sh
       content: |

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-cgroupfs/mp-cgroupfs.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-cgroupfs/mp-cgroupfs.yaml
@@ -11,3 +11,4 @@ spec:
         # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
         cgroup-driver: cgroupfs
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -97,12 +97,14 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -139,4 +141,5 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -435,12 +435,14 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -504,4 +506,5 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -72,6 +72,7 @@ spec:
           # This cluster is used in tests where the Kubernetes version is < 1.24
           cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
@@ -80,4 +81,5 @@ spec:
           # This cluster is used in tests where the Kubernetes version is < 1.24
           cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
@@ -28,6 +28,7 @@ spec:
             # This cluster is used in tests where the Kubernetes version is < 1.24
             cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1alpha4

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/mp.yaml
@@ -40,3 +40,4 @@ spec:
         # This cluster is used in tests where the Kubernetes version is < 1.24
         cgroup-driver: cgroupfs
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
@@ -90,6 +90,7 @@ spec:
           # This cluster is used in tests where the Kubernetes version is < 1.24
           cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
@@ -98,4 +99,5 @@ spec:
           # This cluster is used in tests where the Kubernetes version is < 1.24
           cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v1.0/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.0/bases/md.yaml
@@ -28,6 +28,7 @@ spec:
             # This cluster is used in tests where the Kubernetes version is < 1.24
             cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1.3/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/bases/cluster-with-kcp.yaml
@@ -89,9 +89,11 @@ spec:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v1.3/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/bases/md.yaml
@@ -27,6 +27,7 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1.3/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/bases/mp.yaml
@@ -47,3 +47,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/v1.3/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/clusterclass-quick-start.yaml
@@ -352,12 +352,14 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -394,4 +396,5 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 

--- a/test/e2e/data/infrastructure-docker/v1.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.4/bases/cluster-with-kcp.yaml
@@ -89,9 +89,11 @@ spec:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v1.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.4/bases/md.yaml
@@ -27,6 +27,7 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1.4/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.4/bases/mp.yaml
@@ -47,3 +47,4 @@ spec:
     nodeRegistration:
       kubeletExtraArgs:
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/v1.4/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.4/clusterclass-quick-start.yaml
@@ -375,12 +375,14 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -444,4 +446,5 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -263,12 +263,14 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -305,4 +307,5 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a json patch for KubeadmControlPlanes and MachineDeployments, to set the `fail-swap-on` flag for the kubelet to `false` in our ClusterClasses for the release, main and v1.4 tests.

This prevents that the kubelet refuses to start for newer kind images which don't specify the flag anymore (because kind sets the configuration parameter in KubeletConfiguration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8766
