### PR TITLE
🐛 ignition: start kubeadm after network.target

### DIFF
--- a/bootstrap/kubeadm/internal/ignition/clc/clc.go
+++ b/bootstrap/kubeadm/internal/ignition/clc/clc.go
@@ -96,6 +96,7 @@ systemd:
         Description=kubeadm
         # Run only once. After successful run, this file is moved to /tmp/.
         ConditionPathExists=/etc/kubeadm.yml
+        After=network.target
         [Service]
         # To not restart the unit when it exits, as it is expected.
         Type=oneshot

--- a/bootstrap/kubeadm/internal/ignition/clc/clc_test.go
+++ b/bootstrap/kubeadm/internal/ignition/clc/clc_test.go
@@ -249,7 +249,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  pointer.Bool(true),
 							Name:     "kubeadm.service",
 						},
@@ -340,7 +340,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  pointer.Bool(true),
 							Name:     "kubeadm.service",
 						},
@@ -423,7 +423,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  pointer.Bool(true),
 							Name:     "kubeadm.service",
 						},
@@ -550,7 +550,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  pointer.Bool(true),
 							Name:     "kubeadm.service",
 						},


### PR DESCRIPTION
In certain baremetal environment, where there are multiple connected and/or disconnected network ports, the network target is reached more slowly, and the kubeadm.service might fail because it does not have the proper pre-kubeadm commands correctly done (like a ctr image pull) or it cannot connect to other k8s nodes.

Also, kubeadm.service and kubeadm.sh relies to on containerd to be working at that moment too. Please let me know if I need to remove the After=containerd.service part and maybe add this check in another place?
