### PR TITLE
:bug: [WIP] Make CAPD compatible with new kindest/node images 

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -38,7 +38,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.20.4
+  minimum_go_version=go1.20.0
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -104,6 +104,8 @@ kind::prepareKindestImage() {
   # Try to pre-pull the image
   kind::prepullImage "kindest/node:$version"
 
+  ALWAYS_BUILD_NODE=true
+
   # if pre-pull failed, falling back to local build
   if [[ "$retVal" != 0 ]]; then
     echo "+ image for Kuberentes $version is not available in docker hub, trying local build"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -17,6 +17,8 @@
 set -o errexit
 set -o pipefail
 
+export KUBERNETES_VERSION_UPGRADE_FROM="v1.26.4"
+
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}" || exit 1
@@ -59,7 +61,7 @@ export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=false
 export USE_EXISTING_CLUSTER=false
-
+export ALWAYS_BUILD_NODE=true
 # Setup local output directory
 ARTIFACTS_LOCAL="${ARTIFACTS}/localhost"
 mkdir -p "${ARTIFACTS_LOCAL}"
@@ -67,7 +69,6 @@ echo "This folder contains logs from the local host where the tests ran." > "${A
 
 # Configure the containerd socket, otherwise 'ctr' would not work
 export CONTAINERD_ADDRESS=/var/run/docker/containerd/containerd.sock
-
 # ensure we retrieve additional info for debugging when we leave the script
 cleanup() {
   # shellcheck disable=SC2046

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -259,7 +259,7 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.27.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.27.2"
   KUBERNETES_VERSION: "v1.27.1"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.4"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.27.1"

--- a/test/e2e/data/infrastructure-docker/main/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/md.yaml
@@ -28,6 +28,8 @@ spec:
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
             fail-swap-on: "false"
+            cgroup-root: /kubelet
+            runtime-cgroups: /system.slice/containerd.service
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -436,6 +436,8 @@ spec:
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
               fail-swap-on: "false"
+              cgroup-root: /kubelet
+              runtime-cgroups: /system.slice/containerd.service
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
@@ -443,6 +445,8 @@ spec:
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
               fail-swap-on: "false"
+              cgroup-root: /kubelet
+              runtime-cgroups: /system.slice/containerd.service
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -507,4 +511,6 @@ spec:
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
             fail-swap-on: "false"
+            cgroup-root: /kubelet
+            runtime-cgroups: /system.slice/containerd.service
 

--- a/test/e2e/data/test-extension/deployment.yaml
+++ b/test/e2e/data/test-extension/deployment.yaml
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager
+  namespace: test-extension-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-extension-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-extension-manager
+  namespace: test-extension-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-webhook-service
+  namespace: test-extension-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    app: test-extension-manager
+    cluster.x-k8s.io/provider: runtime-extension-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager
+  namespace: test-extension-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-extension-manager
+      cluster.x-k8s.io/provider: runtime-extension-test
+  template:
+    metadata:
+      labels:
+        app: test-extension-manager
+        cluster.x-k8s.io/provider: runtime-extension-test
+    spec:
+      containers:
+      - command:
+        - /manager
+        image: gcr.io/k8s-staging-cluster-api/test-extension-amd64:dev
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: test-extension-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: test-extension-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-serving-cert
+  namespace: test-extension-system
+spec:
+  dnsNames:
+  - test-extension-webhook-service.test-extension-system.svc
+  - test-extension-webhook-service.test-extension-system.svc.cluster.local
+  - localhost
+  issuerRef:
+    kind: Issuer
+    name: test-extension-selfsigned-issuer
+  secretName: test-extension-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-selfsigned-issuer
+  namespace: test-extension-system
+spec:
+  selfSigned: {}

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.27.1"
+	DefaultNodeImageVersion = "v1.27.2"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -101,6 +101,16 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 		return errors.Wrap(err, "Failed to collect logs from node")
 	}
 
+	// Get docker logs for node container.
+	f, err := fileOnHost(filepath.Join(outputPath, fmt.Sprintf("%s.log", containerName)))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err = containerRuntime.ContainerDebugInfo(ctx, containerName, f); err != nil {
+		return err
+	}
+
 	execToPathFn := func(outputFileName, command string, args ...string) func() error {
 		return func() error {
 			f, err := fileOnHost(filepath.Join(outputPath, outputFileName))

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -406,6 +406,10 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 	}
 	networkConfig := network.NetworkingConfig{}
 
+	if strings.Contains(runConfig.Image, "v1.27.2") {
+		hostConfig.CgroupnsMode = "private"
+
+	}
 	if runConfig.IPFamily == clusterv1.IPv6IPFamily || runConfig.IPFamily == clusterv1.DualStackIPFamily {
 		hostConfig.Sysctls = map[string]string{
 			"net.ipv6.conf.all.disable_ipv6": "0",

--- a/test/infrastructure/docker/internal/docker/kind_manager.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager.go
@@ -81,7 +81,6 @@ func (m *Manager) CreateControlPlaneNode(ctx context.Context, name, image, clust
 	if err != nil {
 		return nil, err
 	}
-
 	return node, nil
 }
 


### PR DESCRIPTION
Update CAPD to be compatible with the new `kindest/node` images. The change involves setting `cgroupns: "private"` on each of the containers started by CAPD.

There's also a couple of additional changes to the Kubelet config passed in in response to changes made to KIND's config of kubelet.
