### PR TITLE
:book: Update tested upgrade paths in docs

### DIFF
--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -85,12 +85,13 @@ intending to use an upgrade path not tested by us should do their own validation
 
 The following is an example of the tested upgrade paths while v1.5 is being developed:
 
-| From | To     | Note                                                                                                                                                                                    |
-|------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| v0.4 | latest | v0.4 is the latest supported minor release with the v1alpha4 contract (v0.4 is EOL since 2022-04-06). This test will be removed once the v1alpha4 apiVersion has been entirely removed. |
-| v1.0 | latest | v1.0 is the first release with the v1beta1 contract.                                                                                                                                    |
-| v1.2 | latest | v1.2 is a currently supported release. This test will be removed when v1.4 is released and a new test for v1.4 is added.                                                                |
-| v1.3 | latest | v1.3 is a currently supported release. This test will be removed when v1.5 is released and a new test for v1.5 is added.                                                                |
+| From | To     | Note                                                                                                                                                                     |
+|------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| v0.4 | latest | v0.4 is the latest supported minor release with the v1alpha4 contract (v0.4 is EOL since 2022-04-06). This test will be removed once the v1alpha4 apiVersion is removed. |
+| v1.0 | latest | v1.0 is the first release with the v1beta1 contract.                                                                                                                     |
+| v1.3 | latest | v1.3 is a currently supported release. This test will be removed when v1.5 is released and a new test for v1.5 is added.                                                 |
+| v1.4 | latest | v1.4 is a currently supported release. This test will be removed when v1.6 is released and a new test for v1.6 is added.                                                 |
+
 
 </aside>
 


### PR DESCRIPTION
Update tested upgrade paths in the CAPI book.

