### PR TITLE
:book: Changed inconsistency with kubernetes version in doc

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1229,7 +1229,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.27.0
+export KUBERNETES_VERSION=1.27.1
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the Kubernetes version listed in the documentation for the quick-start tutorial as Kubernetes 1.27.0 had a bug which lead to a faster release of 1.27.1 and the rest of the documentation is already updated with this change 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
