### PR TITLE
:book: Release CI tasks: Remove IPv6, add deep dive sessions

### DIFF
--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -468,7 +468,7 @@ The goal of this task is to keep our tests running in CI stable.
     3. Mark the issue as `release-blocking` if applicable.
 5. Triage periodic GitHub actions failures, with special attention to image scan results;
    Eventually open issues as described above.
-6. Monitor IPv6 testing PR informing jobs (look for `capi-pr-e2e-informing-ipv6-<branch_name>` tab on main and supported releases testgrid dashboards), since they are not part of any periodic jobs.
+6. Run periodic deep-dive sessions with the CI team to investigate failing and flaking tests. Example session recording: https://www.youtube.com/watch?v=YApWftmiDTg
 
 #### [Continuously] Reduce the amount of flaky tests
 


### PR DESCRIPTION
Update the CI tasks in the release tasks doc. There is now a periodic job for ipv6 so there's no need to check it independently. Also added a task for running periodic deep dive sessions to debug failing and flaking tests in the CAPI CI.
