### PR TITLE
🌱 test/e2e: Fixup dump kube-system pods

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -79,10 +79,12 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 		LogPath:   filepath.Join(artifactFolder, "clusters", clusterProxy.GetName(), "resources"),
 	})
 
-	// If the cluster still exists, dump kube-system pods in the workload cluster before deleting the cluster.
+	// If the cluster still exists, dump kube-system pods of the workload cluster before deleting the cluster.
 	if err := clusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(cluster), &clusterv1.Cluster{}); err == nil {
-		framework.DumpKubeSystemPods(ctx, framework.DumpKubeSystemPodsInput{
+		Byf("Dumping kube-system Pods of Cluster %s", klog.KObj(cluster))
+		framework.DumpKubeSystemPodsForCluster(ctx, framework.DumpKubeSystemPodsForClusterInput{
 			Lister:  clusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name).GetClient(),
+			Cluster: cluster,
 			LogPath: filepath.Join(artifactFolder, "clusters", cluster.Name, "resources"),
 		})
 	}

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -315,7 +315,7 @@ func (p *clusterProxy) CollectWorkloadClusterLogs(ctx context.Context, namespace
 		mp := &machinePools.Items[i]
 		err := p.logCollector.CollectMachinePoolLog(ctx, p.GetClient(), mp, path.Join(outputPath, "machine-pools", mp.GetName()))
 		if err != nil {
-			// NB. we are treating failures in collecting logs as a non blocking operation (best effort)
+			// NB. we are treating failures in collecting logs as a non-blocking operation (best effort)
 			fmt.Printf("Failed to get logs for MachinePool %s, Cluster %s: %v\n", mp.GetName(), klog.KRef(namespace, name), err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
#8800 introduced some new flakes as apparently the workload clusters are not always still functional at the end of a test.

E.g.: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-dualstack-and-ipv6-main/1666176833378324480

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
