### PR TITLE
📖 add a note to check with maintainers for blocked comms emails

### DIFF
--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -89,6 +89,7 @@ As of now we ask for volunteers in Slack and office hours.
 1. Finalize release schedule and team in the [docs/release/releases](../../docs/release/releases), e.g. [release-1.4.md](../../docs/release/releases/release-1.4.md).
 2. Update @cluster-api-release-team Slack user group and GitHub team accordingly.
    <br>Prior art: https://github.com/kubernetes-sigs/cluster-api/issues/7476
+3. Announce the _release team_ and _release schedule_ to the mailing list.
 
 #### Prepare main branch for development of the new release
 
@@ -346,6 +347,7 @@ upcoming code freezes etc based on the [release timeline (1.4 example)](./releas
 
 Information can be distributed via:
 * `sig-cluster-lifecycle` mailing list
+  * Note: The person sending out the email should ensure that they are first part of the mailing list. If the email is sent out is not received by the community, reach out to the maintainers to unblock and approve the email.
 * Slack
 * Office hours
 * Cluster API book


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Adds a note to the `mailing-list` step of `#### Continuously: Communicate key dates to the community` task.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
