### PR TITLE
:book: Small doc fixes for XDG_CONFIG_HOME

### DIFF
--- a/cmd/clusterctl/hack/create-local-repository.py
+++ b/cmd/clusterctl/hack/create-local-repository.py
@@ -289,7 +289,7 @@ def print_instructions(repos):
     cmd = "clusterctl init \\\n"
     for name, type, next_version, components_path in repos:
         cmd += "   {} {}:{} \\\n".format(type_to_flag(type), name, next_version)
-    cmd += "   --config ~/.cluster-api/dev-repository/config.yaml"
+    cmd += "   --config $XDG_CONFIG_HOME/cluster-api/dev-repository/config.yaml"
     print(cmd)
     print
     if 'infrastructure-docker' in providerList:

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -80,7 +80,7 @@ clusterctl init \
    --control-plane kubeadm:v0.3.8 \
    --infrastructure aws:v0.5.0 \
    --infrastructure docker:v0.3.8 \
-   --config ~/.cluster-api/dev-repository/config.yaml
+   --config $XDG_CONFIG_HOME/cluster-api/dev-repository/config.yaml
 ```
 
 As you might notice, the command is using the `$XDG_CONFIG_HOME/cluster-api/dev-repository/config.yaml` config file,
@@ -90,7 +90,7 @@ containing all the required setting to make clusterctl use the local repository.
 
 <h1>Warnings</h1>
 
-You must pass `--config ~/.cluster-api/dev-repository/config.yaml` to all the clusterctl commands you are running
+You must pass `--config $XDG_CONFIG_HOME/cluster-api/dev-repository/config.yaml` to all the clusterctl commands you are running
 during your dev session.
 
 The above config file changes the location of the [overrides layer] folder thus ensuring

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -719,7 +719,7 @@ clusterctl init --infrastructure virtink
 # The username used to access the remote vSphere endpoint
 export VSPHERE_USERNAME="vi-admin@vsphere.local"
 # The password used to access the remote vSphere endpoint
-# You may want to set this in ~/.cluster-api/clusterctl.yaml so your password is not in
+# You may want to set this in `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml` so your password is not in
 # bash history
 export VSPHERE_PASSWORD="admin!23"
 
@@ -756,7 +756,7 @@ You can now create your first workload cluster by running the following:
 <h1>Alternatives to environment variables</h1>
 
 Throughout this quickstart guide we've given instructions on setting parameters using environment variables. For most
-environment variables in the rest of the guide, you can also set them in ~/.cluster-api/clusterctl.yaml
+environment variables in the rest of the guide, you can also set them in `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`
 
 See [`clusterctl init`](../clusterctl/commands/init.md) for more details.
 

--- a/docs/book/src/user/troubleshooting.md
+++ b/docs/book/src/user/troubleshooting.md
@@ -165,7 +165,7 @@ Installing cert-manager Version="v1.11.0"
 Error: action failed after 10 attempts: failed to get cert-manager object /, Kind=, /: Object 'Kind' is missing in 'unstructured object has no kind'
 ```
 
-This error was fixed in more recent Cluster API releases on the 0.4 and 1.0 release branches. The simplest way to resolve the issue is to upgrade to a newer version of Cluster API for a given release. For who need to continue using an older release it is possible to override the repository used by `clusterctl init` in the clusterctl config file. The default location of this file is in `~/.cluster-api/clusterctl.yaml`.
+This error was fixed in more recent Cluster API releases on the 0.4 and 1.0 release branches. The simplest way to resolve the issue is to upgrade to a newer version of Cluster API for a given release. For who need to continue using an older release it is possible to override the repository used by `clusterctl init` in the clusterctl config file. The default location of this file is in `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`.
 
 To do so add the following to the file:
 ```yaml


### PR DESCRIPTION
Some additional doc fixes pointing toward the new XDG_CONFIG_HOME default location for clusterctl configuration.

Related to #6913 