### PR TITLE
:seedling: Add dependency label to github actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
   commit-message:
       prefix: ":seedling:"
   labels:
+    - "area/ci"
     - "ok-to-test"
 # Go
 - package-ecosystem: "gomod"


### PR DESCRIPTION
Add a the `area/ci` label to dependabot updates of github actions.

I think `area/ci` is a better label here than `area/dependency` as these aren't dependencies of CAPI really, and users who care about those dependencies probably don't care about the github actions versions.
