### PR TITLE
:book: Fix formatting error on proposals

### DIFF
--- a/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
+++ b/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
@@ -1,5 +1,4 @@
 ---
-
 title: Label Sync Between Machines and underlying Kubernetes Nodes
 authors:
 - "@arvinderpal" (original proposal author)
@@ -14,7 +13,6 @@ last-updated: 2022-02-26
 status: implementable
 replaces:
 superseded-by:
-
 ---
 
 # Label Sync Between Machines and underlying Kubernetes Nodes

--- a/docs/proposals/20221003-In-place-propagation-of-Kubernetes-objects-only-changes.md
+++ b/docs/proposals/20221003-In-place-propagation-of-Kubernetes-objects-only-changes.md
@@ -1,5 +1,4 @@
 ---
-
 title: In place propagation of changes affecting Kubernetes objects only
 authors:
 - "@fabriziopandini"
@@ -12,7 +11,6 @@ last-updated: 2022-02-26
 status: implementable
 replaces:
 superseded-by:
-
 ---
 
 # In place propagation of changes affecting Kubernetes objects only


### PR DESCRIPTION
Fix formatting errors in yaml block for label sync and metadata propagation proposals.
