### PR TITLE
:seedling: Deprecate DefaultIndex usage and remove where not needed

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -258,7 +258,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		remote.ClusterCacheTrackerOptions{
 			ControllerName: controllerName,
 			Log:            &log,
-			Indexes:        remote.DefaultIndexes,
 		},
 	)
 	if err != nil {

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -76,7 +76,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			log := klogr.New()
 			cct, err = NewClusterCacheTracker(mgr, ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: DefaultIndexes,
+				Indexes: []Index{NodeProviderIDIndex},
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -90,7 +90,7 @@ func TestClusterCacheTracker(t *testing.T) {
 
 			t.Log("Setting up a ClusterCacheTracker")
 			cct, err = NewClusterCacheTracker(mgr, ClusterCacheTrackerOptions{
-				Indexes: DefaultIndexes,
+				Indexes: []Index{NodeProviderIDIndex},
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/remote/index.go
+++ b/controllers/remote/index.go
@@ -30,11 +30,15 @@ type Index struct {
 	ExtractValue client.IndexerFunc
 }
 
-var nodeProviderIDIndex = Index{
+// NodeProviderIDIndex is used to index Nodes by ProviderID.
+var NodeProviderIDIndex = Index{
 	Object:       &corev1.Node{},
 	Field:        index.NodeProviderIDField,
 	ExtractValue: index.NodeByProviderID,
 }
 
 // DefaultIndexes is the default list of indexes on a ClusterCacheTracker.
-var DefaultIndexes = []Index{nodeProviderIDIndex}
+//
+// Deprecated: This variable is deprecated and will be removed in a future release of Cluster API.
+// Instead please use `[]Index{NodeProviderIDIndex}`.
+var DefaultIndexes = []Index{NodeProviderIDIndex}

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -108,8 +108,7 @@ func TestGetWorkloadCluster(t *testing.T) {
 	tracker, err := remote.NewClusterCacheTracker(
 		env.Manager,
 		remote.ClusterCacheTrackerOptions{
-			Log:     &log.Log,
-			Indexes: remote.DefaultIndexes,
+			Log: &log.Log,
 		},
 	)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -260,7 +260,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	tracker, err := remote.NewClusterCacheTracker(mgr, remote.ClusterCacheTrackerOptions{
 		ControllerName: controllerName,
 		Log:            &log,
-		Indexes:        remote.DefaultIndexes,
 		ClientUncachedObjects: []client.Object{
 			&corev1.ConfigMap{},
 			&corev1.Secret{},

--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -20,6 +20,7 @@ maintainers of providers and consumers of our Go API.
 ### Deprecation
 
 - API version`v1alpha4` is deprecated and CAPI will stop serving this version in v1.6.
+- `sigs.k8s.io/cluster-api/controllers/remote.DefaultIndexex` has been deprecated and will be removed in a future release. Please use `sigs.k8s.io/cluster-api/controllers/external.NodeProviderIDIndex` instead. This index should not be used as a default index and should only be used if a controller is using `index.NodeProviderIDField`.
 
 ### Removals
 

--- a/internal/controllers/cluster/suite_test.go
+++ b/internal/controllers/cluster/suite_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 			mgr,
 			remote.ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: remote.DefaultIndexes,
+				Indexes: []remote.Index{remote.NodeProviderIDIndex},
 			},
 		)
 		if err != nil {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -125,7 +125,7 @@ func TestGetNode(t *testing.T) {
 
 	tracker, err := remote.NewClusterCacheTracker(
 		env.Manager, remote.ClusterCacheTrackerOptions{
-			Indexes: remote.DefaultIndexes,
+			Indexes: []remote.Index{remote.NodeProviderIDIndex},
 		},
 	)
 	g.Expect(err).ToNot(HaveOccurred())

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -74,7 +74,7 @@ func TestMain(m *testing.M) {
 			mgr,
 			remote.ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: remote.DefaultIndexes,
+				Indexes: []remote.Index{remote.NodeProviderIDIndex},
 			},
 		)
 		if err != nil {

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 			mgr,
 			remote.ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: remote.DefaultIndexes,
+				Indexes: []remote.Index{remote.NodeProviderIDIndex},
 			},
 		)
 		if err != nil {

--- a/internal/controllers/machinehealthcheck/suite_test.go
+++ b/internal/controllers/machinehealthcheck/suite_test.go
@@ -72,7 +72,7 @@ func TestMain(m *testing.M) {
 			mgr,
 			remote.ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: remote.DefaultIndexes,
+				Indexes: []remote.Index{remote.NodeProviderIDIndex},
 			},
 		)
 		if err != nil {

--- a/internal/controllers/machineset/suite_test.go
+++ b/internal/controllers/machineset/suite_test.go
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 			mgr,
 			remote.ClusterCacheTrackerOptions{
 				Log:     &log,
-				Indexes: remote.DefaultIndexes,
+				Indexes: []remote.Index{remote.NodeProviderIDIndex},
 			},
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -334,7 +334,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		remote.ClusterCacheTrackerOptions{
 			ControllerName: controllerName,
 			Log:            &log,
-			Indexes:        remote.DefaultIndexes,
+			Indexes:        []remote.Index{remote.NodeProviderIDIndex},
 		},
 	)
 	if err != nil {

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -265,7 +265,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		remote.ClusterCacheTrackerOptions{
 			ControllerName: controllerName,
 			Log:            &log,
-			Indexes:        remote.DefaultIndexes,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Deprecate the `remote.DefaultIndex` due to confusing naming and replace its current valid usages with `[]Index{NodeProviderIDIndex}` instead.

Remove the use of the index entirely from places where it is not currently used: 
- CAPD
- CAPBK
- KCP 

