### PR TITLE
🌱 KCP: avoid panic if etcd server misbehaves

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -121,6 +121,10 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 		// Retrieve the member and check for alarms.
 		// NB. The member for this node always exists given forFirstAvailableNode(node) used above
 		member := etcdutil.MemberForName(currentMembers, node.Name)
+		if member == nil {
+			conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "etcd member reports the cluster is composed by members %s, but the member itself (%s) is not included", etcdutil.MemberNames(currentMembers), node.Name)
+			continue
+		}
 		if len(member.Alarms) > 0 {
 			alarmList := []string{}
 			for _, alarm := range member.Alarms {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Looks like this issue doesn't occur with the real etcd server, but with the in-memory provider. I would adjust this in KCP regardless as I think KCP should not panic if the etcd server provides wrong data.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
