### PR TITLE
🌱 KCP: fix noisy error log triggered by missing patch helper

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -261,5 +261,10 @@ func (c *ControlPlane) PatchMachines(ctx context.Context) error {
 
 // SetPatchHelpers updates the patch helpers.
 func (c *ControlPlane) SetPatchHelpers(patchHelpers map[string]*patch.Helper) {
-	c.machinesPatchHelpers = patchHelpers
+	if c.machinesPatchHelpers == nil {
+		c.machinesPatchHelpers = map[string]*patch.Helper{}
+	}
+	for machineName, patchHelper := range patchHelpers {
+		c.machinesPatchHelpers[machineName] = patchHelper
+	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The patchHelpers map gets initially build in NewControlPlane based on the passed in ownedMachines.
During the reconcile we update the map via SetPatchHelpers. Unfortunately the new map is missing patchHelpers for Machines with a deletionTimestamp. Later on when we want to patch all machines we cannot patch the Machines with deletionTimestamp because we dropped the patchHelpers for them.

This PR changes SetPatchHelper so it only updates the necessary patchHelpers and doesn't drop any.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
