### PR TITLE
:sparkles: Enable configuring the kube config timeout

### DIFF
--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -61,7 +61,9 @@ func RESTConfig(ctx context.Context, sourceName string, c client.Reader, cluster
 	}
 
 	restConfig.UserAgent = DefaultClusterAPIUserAgent(sourceName)
-	restConfig.Timeout = defaultClientTimeout
+	restConfig.Timeout = restConfigTimeout
+	restConfig.QPS = restConfigQPS
+	restConfig.Burst = restConfigBurst
 
 	return restConfig, nil
 }

--- a/controllers/remote/flags.go
+++ b/controllers/remote/flags.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	restConfigTimeout         = defaultClientTimeout
+	restConfigQPS     float32 = 20
+	restConfigBurst           = 30
+)
+
+// AddRestConfigFlags adds the kube-api rest configuration flags to the flag set.
+func AddRestConfigFlags(fs *pflag.FlagSet) {
+	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
+		"Maximum queries per second from the controller client to the Kubernetes API server.")
+
+	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
+		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server.")
+
+	fs.DurationVar(&restConfigTimeout, "kube-api-timeout", defaultClientTimeout,
+		"The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.")
+}
+
+// DefaultRestConfig returns the runtime rest configuration with values set from the flags.
+func DefaultRestConfig() *rest.Config {
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = restConfigQPS
+	restConfig.Burst = restConfigBurst
+	return restConfig
+}

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -88,8 +88,6 @@ var (
 	profilerAddress                string
 	kubeadmControlPlaneConcurrency int
 	syncPeriod                     time.Duration
-	restConfigQPS                  float32
-	restConfigBurst                int
 	webhookPort                    int
 	webhookCertDir                 string
 	healthAddr                     string
@@ -130,11 +128,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
-		"Maximum queries per second from the controller client to the Kubernetes API server. Defaults to 20")
-
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
-		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
+	remote.AddRestConfigFlags(fs)
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
@@ -172,9 +166,7 @@ func main() {
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.QPS = restConfigQPS
-	restConfig.Burst = restConfigBurst
+	restConfig := remote.DefaultRestConfig()
 	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent(controllerName)
 
 	tlsOptionOverrides, err := flags.GetTLSOptionOverrideFuncs(tlsOptions)

--- a/main.go
+++ b/main.go
@@ -97,8 +97,6 @@ var (
 	clusterResourceSetConcurrency int
 	machineHealthCheckConcurrency int
 	syncPeriod                    time.Duration
-	restConfigQPS                 float32
-	restConfigBurst               int
 	webhookPort                   int
 	webhookCertDir                string
 	healthAddr                    string
@@ -192,11 +190,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
-		"Maximum queries per second from the controller client to the Kubernetes API server. Defaults to 20")
-
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
-		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
+	remote.AddRestConfigFlags(fs)
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
@@ -226,9 +220,7 @@ func main() {
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.QPS = restConfigQPS
-	restConfig.Burst = restConfigBurst
+	restConfig := remote.DefaultRestConfig()
 	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent(controllerName)
 
 	minVer := version.MinimumKubernetesVersion

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -75,8 +75,6 @@ var (
 	profilerAddress             string
 	concurrency                 int
 	syncPeriod                  time.Duration
-	restConfigQPS               float32
-	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
 	healthAddr                  string
@@ -131,11 +129,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
-		"Maximum queries per second from the controller client to the Kubernetes API server. Defaults to 20")
-
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
-		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
+	remote.AddRestConfigFlags(fs)
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
@@ -170,9 +164,7 @@ func main() {
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.QPS = restConfigQPS
-	restConfig.Burst = restConfigBurst
+	restConfig := remote.DefaultRestConfig()
 	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent(controllerName)
 
 	tlsOptionOverrides, err := flags.GetTLSOptionOverrideFuncs(tlsOptions)

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -70,8 +70,6 @@ var (
 	clusterConcurrency          int
 	machineConcurrency          int
 	syncPeriod                  time.Duration
-	restConfigQPS               float32
-	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
 	healthAddr                  string
@@ -128,11 +126,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
-	fs.Float32Var(&restConfigQPS, "kube-api-qps", 20,
-		"Maximum queries per second from the controller client to the Kubernetes API server. Defaults to 20")
-
-	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
-		"Maximum number of queries that should be allowed in one burst from the controller client to the Kubernetes API server. Default 30")
+	remote.AddRestConfigFlags(fs)
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
@@ -162,9 +156,7 @@ func main() {
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
 
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.QPS = restConfigQPS
-	restConfig.Burst = restConfigBurst
+	restConfig := remote.DefaultRestConfig()
 	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent("cluster-api-inmemory-controller-manager")
 
 	tlsOptionOverrides, err := flags.GetTLSOptionOverrideFuncs(tlsOptions)


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows configuring the kubernetes client configuration timeout. Also moves the other related configuration into a standard place and reduces duplicated logic in various main functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8864
