### PR TITLE
:sparkles: Use caching read for bootstrap config owner

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -158,7 +158,7 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Look up the owner of this kubeadm config if there is one
-	configOwner, err := bsutil.GetConfigOwner(ctx, r.Client, config)
+	configOwner, err := bsutil.GetConfigOwnerFromCache(ctx, r.Client, config)
 	if apierrors.IsNotFound(err) {
 		// Could not find the owner yet, this is not an error and will rereconcile when the owner gets set.
 		return ctrl.Result{}, nil

--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -24,7 +24,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -123,8 +125,20 @@ func (co ConfigOwner) KubernetesVersion() string {
 	return version
 }
 
-// GetConfigOwner returns the Unstructured object owning the current resource.
+// GetConfigOwner returns the Unstructured object owning the current resource
+// using the uncached unstructured client. For performance-sensitive uses,
+// consider GetConfigOwnerCached.
 func GetConfigOwner(ctx context.Context, c client.Client, obj metav1.Object) (*ConfigOwner, error) {
+	return getConfigOwner(ctx, c, obj, GetOwnerByRef)
+}
+
+// GetConfigOwnerFromCache returns the Unstructured object owning the current
+// resource. The implementation ensures a typed client is used, so the objects are read from the cache.
+func GetConfigOwnerFromCache(ctx context.Context, c client.Client, obj metav1.Object) (*ConfigOwner, error) {
+	return getConfigOwner(ctx, c, obj, GetOwnerByRefFromCache)
+}
+
+func getConfigOwner(ctx context.Context, c client.Client, obj metav1.Object, getFn func(context.Context, client.Client, *corev1.ObjectReference) (*ConfigOwner, error)) (*ConfigOwner, error) {
 	allowedGKs := []schema.GroupKind{
 		{
 			Group: clusterv1.GroupVersion.Group,
@@ -148,7 +162,7 @@ func GetConfigOwner(ctx context.Context, c client.Client, obj metav1.Object) (*C
 
 		for _, gk := range allowedGKs {
 			if refGVK.Group == gk.Group && refGVK.Kind == gk.Kind {
-				return GetOwnerByRef(ctx, c, &corev1.ObjectReference{
+				return getFn(ctx, c, &corev1.ObjectReference{
 					APIVersion: ref.APIVersion,
 					Kind:       ref.Kind,
 					Name:       ref.Name,
@@ -167,4 +181,34 @@ func GetOwnerByRef(ctx context.Context, c client.Client, ref *corev1.ObjectRefer
 		return nil, err
 	}
 	return &ConfigOwner{obj}, nil
+}
+
+// GetOwnerByRefFromCache finds and returns the owner by looking at the object
+// reference. The implementation ensures a typed client is used, so the objects are read from the cache.
+func GetOwnerByRefFromCache(ctx context.Context, c client.Client, ref *corev1.ObjectReference) (*ConfigOwner, error) {
+	obj, err := c.Scheme().New(ref.GroupVersionKind())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to construct object of type %s", ref.GroupVersionKind())
+	}
+	metaObj, ok := obj.(client.Object)
+	if !ok {
+		return nil, errors.Errorf("expected owner reference to refer to a client.Object, is actually %T", obj)
+	}
+	key := types.NamespacedName{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+	err = c.Get(ctx, key, metaObj)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(metaObj)
+	if err != nil {
+		return nil, err
+	}
+	u := unstructured.Unstructured{}
+	u.SetUnstructuredContent(content)
+
+	return &ConfigOwner{&u}, nil
 }

--- a/bootstrap/util/configowner_test.go
+++ b/bootstrap/util/configowner_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -34,136 +36,146 @@ import (
 )
 
 func TestGetConfigOwner(t *testing.T) {
-	t.Run("should get the owner when present (Machine)", func(t *testing.T) {
-		g := NewWithT(t)
-		myMachine := &clusterv1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-machine",
-				Namespace: metav1.NamespaceDefault,
-				Labels: map[string]string{
-					clusterv1.MachineControlPlaneLabel: "",
-				},
-			},
-			Spec: clusterv1.MachineSpec{
-				ClusterName: "my-cluster",
-				Bootstrap: clusterv1.Bootstrap{
-					DataSecretName: pointer.String("my-data-secret"),
-				},
-				Version: pointer.String("v1.19.6"),
-			},
-			Status: clusterv1.MachineStatus{
-				InfrastructureReady: true,
-			},
-		}
+	doTests := func(t *testing.T, getFn func(context.Context, client.Client, metav1.Object) (*ConfigOwner, error)) {
+		t.Helper()
 
-		c := fake.NewClientBuilder().WithObjects(myMachine).Build()
-		obj := &bootstrapv1.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind:       "Machine",
-						APIVersion: clusterv1.GroupVersion.String(),
-						Name:       "my-machine",
+		t.Run("should get the owner when present (Machine)", func(t *testing.T) {
+			g := NewWithT(t)
+			myMachine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-machine",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						clusterv1.MachineControlPlaneLabel: "",
 					},
 				},
-				Namespace: metav1.NamespaceDefault,
-				Name:      "my-resource-owned-by-machine",
-			},
-		}
-		configOwner, err := GetConfigOwner(ctx, c, obj)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(configOwner).ToNot(BeNil())
-		g.Expect(configOwner.ClusterName()).To(BeEquivalentTo("my-cluster"))
-		g.Expect(configOwner.IsInfrastructureReady()).To(BeTrue())
-		g.Expect(configOwner.IsControlPlaneMachine()).To(BeTrue())
-		g.Expect(configOwner.IsMachinePool()).To(BeFalse())
-		g.Expect(configOwner.KubernetesVersion()).To(Equal("v1.19.6"))
-		g.Expect(*configOwner.DataSecretName()).To(BeEquivalentTo("my-data-secret"))
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "my-cluster",
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: pointer.String("my-data-secret"),
+					},
+					Version: pointer.String("v1.19.6"),
+				},
+				Status: clusterv1.MachineStatus{
+					InfrastructureReady: true,
+				},
+			}
+
+			c := fake.NewClientBuilder().WithObjects(myMachine).Build()
+			obj := &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Machine",
+							APIVersion: clusterv1.GroupVersion.String(),
+							Name:       "my-machine",
+						},
+					},
+					Namespace: metav1.NamespaceDefault,
+					Name:      "my-resource-owned-by-machine",
+				},
+			}
+			configOwner, err := getFn(ctx, c, obj)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(configOwner).ToNot(BeNil())
+			g.Expect(configOwner.ClusterName()).To(BeEquivalentTo("my-cluster"))
+			g.Expect(configOwner.IsInfrastructureReady()).To(BeTrue())
+			g.Expect(configOwner.IsControlPlaneMachine()).To(BeTrue())
+			g.Expect(configOwner.IsMachinePool()).To(BeFalse())
+			g.Expect(configOwner.KubernetesVersion()).To(Equal("v1.19.6"))
+			g.Expect(*configOwner.DataSecretName()).To(BeEquivalentTo("my-data-secret"))
+		})
+
+		t.Run("should get the owner when present (MachinePool)", func(t *testing.T) {
+			_ = feature.MutableGates.Set("MachinePool=true")
+
+			g := NewWithT(t)
+			myPool := &expv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-machine-pool",
+					Namespace: metav1.NamespaceDefault,
+					Labels: map[string]string{
+						clusterv1.MachineControlPlaneLabel: "",
+					},
+				},
+				Spec: expv1.MachinePoolSpec{
+					ClusterName: "my-cluster",
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: pointer.String("v1.19.6"),
+						},
+					},
+				},
+				Status: expv1.MachinePoolStatus{
+					InfrastructureReady: true,
+				},
+			}
+
+			c := fake.NewClientBuilder().WithObjects(myPool).Build()
+			obj := &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "MachinePool",
+							APIVersion: expv1.GroupVersion.String(),
+							Name:       "my-machine-pool",
+						},
+					},
+					Namespace: metav1.NamespaceDefault,
+					Name:      "my-resource-owned-by-machine-pool",
+				},
+			}
+			configOwner, err := getFn(ctx, c, obj)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(configOwner).ToNot(BeNil())
+			g.Expect(configOwner.ClusterName()).To(BeEquivalentTo("my-cluster"))
+			g.Expect(configOwner.IsInfrastructureReady()).To(BeTrue())
+			g.Expect(configOwner.IsControlPlaneMachine()).To(BeFalse())
+			g.Expect(configOwner.IsMachinePool()).To(BeTrue())
+			g.Expect(configOwner.KubernetesVersion()).To(Equal("v1.19.6"))
+			g.Expect(configOwner.DataSecretName()).To(BeNil())
+		})
+
+		t.Run("return an error when not found", func(t *testing.T) {
+			g := NewWithT(t)
+			c := fake.NewClientBuilder().Build()
+			obj := &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Machine",
+							APIVersion: clusterv1.GroupVersion.String(),
+							Name:       "my-machine",
+						},
+					},
+					Namespace: metav1.NamespaceDefault,
+					Name:      "my-resource-owned-by-machine",
+				},
+			}
+			_, err := getFn(ctx, c, obj)
+			g.Expect(err).To(HaveOccurred())
+		})
+
+		t.Run("return nothing when there is no owner", func(t *testing.T) {
+			g := NewWithT(t)
+			c := fake.NewClientBuilder().Build()
+			obj := &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{},
+					Namespace:       metav1.NamespaceDefault,
+					Name:            "my-resource-owned-by-machine",
+				},
+			}
+			configOwner, err := getFn(ctx, c, obj)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(configOwner).To(BeNil())
+		})
+	}
+	t.Run("uncached", func(t *testing.T) {
+		doTests(t, GetConfigOwner)
 	})
-
-	t.Run("should get the owner when present (MachinePool)", func(t *testing.T) {
-		_ = feature.MutableGates.Set("MachinePool=true")
-
-		g := NewWithT(t)
-		myPool := &expv1.MachinePool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-machine-pool",
-				Namespace: metav1.NamespaceDefault,
-				Labels: map[string]string{
-					clusterv1.MachineControlPlaneLabel: "",
-				},
-			},
-			Spec: expv1.MachinePoolSpec{
-				ClusterName: "my-cluster",
-				Template: clusterv1.MachineTemplateSpec{
-					Spec: clusterv1.MachineSpec{
-						Version: pointer.String("v1.19.6"),
-					},
-				},
-			},
-			Status: expv1.MachinePoolStatus{
-				InfrastructureReady: true,
-			},
-		}
-
-		c := fake.NewClientBuilder().WithObjects(myPool).Build()
-		obj := &bootstrapv1.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind:       "MachinePool",
-						APIVersion: expv1.GroupVersion.String(),
-						Name:       "my-machine-pool",
-					},
-				},
-				Namespace: metav1.NamespaceDefault,
-				Name:      "my-resource-owned-by-machine-pool",
-			},
-		}
-		configOwner, err := GetConfigOwner(ctx, c, obj)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(configOwner).ToNot(BeNil())
-		g.Expect(configOwner.ClusterName()).To(BeEquivalentTo("my-cluster"))
-		g.Expect(configOwner.IsInfrastructureReady()).To(BeTrue())
-		g.Expect(configOwner.IsControlPlaneMachine()).To(BeFalse())
-		g.Expect(configOwner.IsMachinePool()).To(BeTrue())
-		g.Expect(configOwner.KubernetesVersion()).To(Equal("v1.19.6"))
-		g.Expect(configOwner.DataSecretName()).To(BeNil())
-	})
-
-	t.Run("return an error when not found", func(t *testing.T) {
-		g := NewWithT(t)
-		c := fake.NewClientBuilder().Build()
-		obj := &bootstrapv1.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind:       "Machine",
-						APIVersion: clusterv1.GroupVersion.String(),
-						Name:       "my-machine",
-					},
-				},
-				Namespace: metav1.NamespaceDefault,
-				Name:      "my-resource-owned-by-machine",
-			},
-		}
-		_, err := GetConfigOwner(ctx, c, obj)
-		g.Expect(err).To(HaveOccurred())
-	})
-
-	t.Run("return nothing when there is no owner", func(t *testing.T) {
-		g := NewWithT(t)
-		c := fake.NewClientBuilder().Build()
-		obj := &bootstrapv1.KubeadmConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				OwnerReferences: []metav1.OwnerReference{},
-				Namespace:       metav1.NamespaceDefault,
-				Name:            "my-resource-owned-by-machine",
-			},
-		}
-		configOwner, err := GetConfigOwner(ctx, c, obj)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(configOwner).To(BeNil())
+	t.Run("cached", func(t *testing.T) {
+		doTests(t, GetConfigOwnerFromCache)
 	})
 }
 

--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -36,6 +36,7 @@ maintainers of providers and consumers of our Go API.
 - clusterctl move is adding the new annotation `clusterctl.cluster.x-k8s.io/delete-for-move` before object deletion.
 - Providers running CAPI release-0.3 clusterctl upgrade tests should set `WorkloadKubernetesVersion` field to the maximum workload cluster kubernetes version supported by the old providers in `ClusterctlUpgradeSpecInput`. For more information, please see: https://github.com/kubernetes-sigs/cluster-api/pull/8518#issuecomment-1508064859 
 - Introduced function `CollectInfrastructureLogs` at the `ClusterLogCollector` interface in `test/framework/cluster_proxy.go` to allow collecting infrastructure related logs during tests.
+- A `GetConfigOwnerFromCache` function has been added to the `sigs.k8s.io./cluster-api/bootstrap/util` package. It is equivalent to `GetConfigOwner` except that it uses the cached typed client instead of the uncached unstructured client, so `GetConfigOwnerFromCache` is expected to be more performant.
 
 ### Suggested changes for providers
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR makes the lookup of the KubeadmConfig's owner use a cached client instead of the uncached unstructured client. To make the rest of the adjacent plumbing reusable, the new typed read by `GetOwnerByRefCached` converts the object into `Unstructured` to construct a `ConfigOwner`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8849

/cc @fabriziopandini 