### PR TITLE
:bug: Ensure ALWAYS_BUILD_KIND_IMAGES is defaulted correctly in ci script

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -101,6 +101,9 @@ k8s::resolveVersion() {
 kind::prepareKindestImage() {
   local version=$1
 
+  # ALWAYS_BUILD_KIND_IMAGES will default to false if unset.
+  ALWAYS_BUILD_KIND_IMAGES="${ALWAYS_BUILD_KIND_IMAGES:-"false"}"
+
   # Try to pre-pull the image
   kind::prepullImage "kindest/node:$version"
 


### PR DESCRIPTION
Issue introduced in #8859 due to the use of a potentially unbound variable in the bash script. This variable should default to false if unset in the variables passed in to the script.
