### PR TITLE
🌱 Automatically set kubelet args for capd

### DIFF
--- a/bootstrap/kubeadm/types/utils.go
+++ b/bootstrap/kubeadm/types/utils.go
@@ -181,6 +181,26 @@ func UnmarshalClusterStatus(yaml string) (*bootstrapv1.ClusterStatus, error) {
 	return obj, nil
 }
 
+// UnmarshalInitConfiguration tries to translate a Kubeadm API yaml back to the InitConfiguration type.
+// NOTE: The yaml could be any of the known formats for the kubeadm InitConfiguration type.
+func UnmarshalInitConfiguration(yaml string) (*bootstrapv1.InitConfiguration, error) {
+	obj := &bootstrapv1.InitConfiguration{}
+	if err := unmarshalFromVersions(yaml, initConfigurationVersionTypeMap, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// UnmarshalJoinConfiguration tries to translate a Kubeadm API yaml back to the JoinConfiguration type.
+// NOTE: The yaml could be any of the known formats for the kubeadm JoinConfiguration type.
+func UnmarshalJoinConfiguration(yaml string) (*bootstrapv1.JoinConfiguration, error) {
+	obj := &bootstrapv1.JoinConfiguration{}
+	if err := unmarshalFromVersions(yaml, joinConfigurationVersionTypeMap, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
 func unmarshalFromVersions(yaml string, kubeadmAPIVersions map[schema.GroupVersion]conversion.Convertible, capiObj conversion.Hub) error {
 	// For each know kubeadm API version
 	for gv, obj := range kubeadmAPIVersions {
@@ -192,7 +212,8 @@ func unmarshalFromVersions(yaml string, kubeadmAPIVersions map[schema.GroupVersi
 			return errors.Wrapf(err, "failed to build scheme for kubeadm types conversions")
 		}
 
-		if _, _, err := codecs.UniversalDeserializer().Decode([]byte(yaml), &gvk, kubeadmObj); err == nil {
+		_, _, err = codecs.UniversalDeserializer().Decode([]byte(yaml), &gvk, kubeadmObj)
+		if err == nil {
 			// If conversion worked, then converts the kubeadmObj (spoke) back to the Cluster API ClusterConfiguration type (hub).
 			if err := kubeadmObj.(conversion.Convertible).ConvertTo(capiObj); err != nil {
 				return errors.Wrapf(err, "failed to convert kubeadm types to Cluster API types")

--- a/bootstrap/kubeadm/types/utils_test.go
+++ b/bootstrap/kubeadm/types/utils_test.go
@@ -555,3 +555,121 @@ func TestUnmarshalClusterStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalInitConfiguration(t *testing.T) {
+	type args struct {
+		yaml string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *bootstrapv1.InitConfiguration
+		wantErr bool
+	}{
+		{
+			name: "Parses a v1beta1 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta1\n" + "" +
+					"kind: InitConfiguration\n" +
+					"localAPIEndpoint: {}\n" +
+					"nodeRegistration: {}\n",
+			},
+			want:    &bootstrapv1.InitConfiguration{},
+			wantErr: false,
+		},
+		{
+			name: "Parses a v1beta2 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta2\n" + "" +
+					"kind: InitConfiguration\n" +
+					"localAPIEndpoint: {}\n" +
+					"nodeRegistration: {}\n",
+			},
+			want:    &bootstrapv1.InitConfiguration{},
+			wantErr: false,
+		},
+		{
+			name: "Parses a v1beta3 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta3\n" + "" +
+					"kind: InitConfiguration\n" +
+					"localAPIEndpoint: {}\n" +
+					"nodeRegistration: {}\n",
+			},
+			want:    &bootstrapv1.InitConfiguration{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := UnmarshalInitConfiguration(tt.args.yaml)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want), cmp.Diff(tt.want, got))
+		})
+	}
+}
+
+func TestUnmarshalJoinConfiguration(t *testing.T) {
+	type args struct {
+		yaml string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *bootstrapv1.JoinConfiguration
+		wantErr bool
+	}{
+		{
+			name: "Parses a v1beta1 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta1\n" + "" +
+					"caCertPath: \"\"\n" +
+					"discovery: {}\n" +
+					"kind: JoinConfiguration\n",
+			},
+			want:    &bootstrapv1.JoinConfiguration{},
+			wantErr: false,
+		},
+		{
+			name: "Parses a v1beta2 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta2\n" + "" +
+					"caCertPath: \"\"\n" +
+					"discovery: {}\n" +
+					"kind: JoinConfiguration\n",
+			},
+			want:    &bootstrapv1.JoinConfiguration{},
+			wantErr: false,
+		},
+		{
+			name: "Parses a v1beta3 kubeadm configuration",
+			args: args{
+				yaml: "apiVersion: kubeadm.k8s.io/v1beta3\n" + "" +
+					"caCertPath: \"\"\n" +
+					"discovery: {}\n" +
+					"kind: JoinConfiguration\n",
+			},
+			want:    &bootstrapv1.JoinConfiguration{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := UnmarshalJoinConfiguration(tt.args.yaml)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want), cmp.Diff(tt.want, got))
+		})
+	}
+}

--- a/docs/book/src/clusterctl/commands/alpha-topology-plan.md
+++ b/docs/book/src/clusterctl/commands/alpha-topology-plan.md
@@ -132,17 +132,9 @@ spec:
           apiServer:
             certSANs: [ localhost, 127.0.0.1 ]
         initConfiguration:
-          nodeRegistration:
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cgroup-driver: cgroupfs
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
         joinConfiguration:
-          nodeRegistration:
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cgroup-driver: cgroupfs
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -174,10 +166,7 @@ spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            cgroup-driver: cgroupfs
-            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ```
 
 </details>
@@ -485,4 +474,3 @@ If only one cluster is affected or if a Cluster is in the input it defaults as t
 Namespace used for objects with missing namespaces in the input.
 
 If not provided, the namespace defined in kubeconfig is used. If a kubeconfig is not available the value `default` is used.
-

--- a/docs/book/src/tasks/bootstrap/kubeadm-bootstrap.md
+++ b/docs/book/src/tasks/bootstrap/kubeadm-bootstrap.md
@@ -42,9 +42,7 @@ metadata:
   name: my-control-plane1-config
 spec:
   initConfiguration:
-    nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
   clusterConfiguration:
     controllerManager:
       extraArgs:
@@ -119,8 +117,7 @@ metadata:
 spec:
   initConfiguration:
     nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
   clusterConfiguration:
     controllerManager:
       extraArgs:
@@ -136,8 +133,7 @@ metadata:
 spec:
   joinConfiguration:
     nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     controlPlane: {}
 ```
 
@@ -150,8 +146,7 @@ metadata:
 spec:
   joinConfiguration:
     nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ```
 
 ### Bootstrap Orchestration

--- a/docs/book/src/tasks/experimental-features/ignition.md
+++ b/docs/book/src/tasks/experimental-features/ignition.md
@@ -10,6 +10,18 @@ This initial implementation uses Ignition **v2** and was tested with **Flatcar C
 
 </aside>
 
+<aside class="note warning">
+
+<h1>Note</h1>
+
+If using ignition with CAPD you should take care of setting `kubeletExtraArgs` for the `kindest/node` image in use,
+because default CAPD templates do not include anymore those settings since when the cloud-init shim for CAPD is automatically taking care of this.
+An example of how to set `kubeletExtraArgs` for the `kindest/node` can be found under `cluster-api/test/e2e/data/infrastructure-docker/main/cluster-template-ignition`.
+
+Hopefully, this will be automated for Ignition too in a future release.
+
+</aside>
+
 This guide explains how to deploy an AWS workload cluster using Ignition.
 
 ## Prerequisites

--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
@@ -85,15 +85,7 @@ spec:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
     initConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-          fail-swap-on: "false"
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     joinConfiguration:
-      nodeRegistration:
-        criSocket: unix:///var/run/containerd/containerd.sock
-        kubeletExtraArgs:
-          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-          fail-swap-on: "false"
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/main/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/md.yaml
@@ -23,11 +23,7 @@ spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration:
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-            fail-swap-on: "false"
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
@@ -44,7 +44,4 @@ metadata:
   name: "${CLUSTER_NAME}-mp-0-config"
 spec:
   joinConfiguration:
-    nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        fail-swap-on: "false"
+    nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/ignition.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/ignition.yaml
@@ -5,6 +5,20 @@ metadata:
 spec:
   kubeadmConfigSpec:
     format: ignition
+    initConfiguration:
+      nodeRegistration:
+        # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
+        criSocket: unix:///var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
+    joinConfiguration:
+      nodeRegistration:
+        # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
+        criSocket: unix:///var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -24,3 +38,10 @@ spec:
                   contents:
                     inline: Howdy!
                   mode: 0644
+      joinConfiguration:
+        nodeRegistration:
+          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
+          criSocket: unix:///var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
@@ -45,17 +45,9 @@ spec:
     apiServer:
       certSANs: [localhost, 127.0.0.1]
   initConfiguration:
-    nodeRegistration:
-      criSocket: unix:///var/run/containerd/containerd.sock
-      kubeletExtraArgs:
-        eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-        fail-swap-on: "false"
+    nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
   joinConfiguration:
-    nodeRegistration:
-      criSocket: unix:///var/run/containerd/containerd.sock
-      kubeletExtraArgs:
-        eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-        fail-swap-on: "false"
+    nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
 # cp0 Machine
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -59,15 +59,9 @@ spec:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
     initConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-          fail-swap-on: "false"
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     joinConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-          fail-swap-on: "false"
+      nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     files:
     - path: /wait-signal.sh
       content: |

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-cgroupfs/mp-cgroupfs.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-cgroupfs/mp-cgroupfs.yaml
@@ -5,10 +5,9 @@ metadata:
   name: "${CLUSTER_NAME}-mp-0-config-cgroupfs"
 spec:
   joinConfiguration:
+    # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
     nodeRegistration:
       kubeletExtraArgs:
         # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
         # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
         cgroup-driver: cgroupfs
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        fail-swap-on: "false"

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -92,19 +92,9 @@ spec:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
         initConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
         joinConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -136,10 +126,4 @@ spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration:
-          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-            fail-swap-on: "false"
-
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -430,19 +430,13 @@ spec:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, host.docker.internal, "::", "::1", "127.0.0.1", "0.0.0.0"]
         initConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
+          nodeRegistration: # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
+            kubeletExtraArgs: # required for the cgroup-driver patch to work
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
         joinConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
+          nodeRegistration: # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
+            kubeletExtraArgs: # required for the cgroup-driver patch to work
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -501,9 +495,6 @@ spec:
         BootstrapConfigTemplate.machineDeployment.template.annotation: "BootstrapConfigTemplate.machineDeployment.template.annotationValue"
     spec:
       joinConfiguration:
-        nodeRegistration:
-          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
+        nodeRegistration: # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
+          kubeletExtraArgs: # required for the cgroup-driver patch to work
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-            fail-swap-on: "false"

--- a/test/go.mod
+++ b/test/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.2.4
+	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.11.0
 	github.com/onsi/gomega v1.27.8
 	github.com/pkg/errors v0.9.1
@@ -70,7 +71,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.12.6 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-github/v48 v48.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/test/infrastructure/docker/exp/internal/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/internal/docker/nodepool.go
@@ -301,7 +301,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 			}
 
 			// Run the bootstrap script. Simulates cloud-init/Ignition.
-			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format); err != nil {
+			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format, np.machinePool.Spec.Template.Spec.Version, np.dockerMachinePool.Spec.Template.CustomImage); err != nil {
 				return ctrl.Result{}, errors.Wrapf(err, "failed to exec DockerMachinePool instance bootstrap for instance named %s", machine.Name())
 			}
 			// Check for bootstrap success

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -334,7 +334,7 @@ func (r *DockerMachineReconciler) reconcileNormal(ctx context.Context, cluster *
 			}()
 
 			// Run the bootstrap script. Simulates cloud-init/Ignition.
-			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format); err != nil {
+			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format, machine.Spec.Version, dockerMachine.Spec.CustomImage); err != nil {
 				conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededCondition, infrav1.BootstrapFailedReason, clusterv1.ConditionSeverityWarning, "Repeating bootstrap")
 				return ctrl.Result{}, errors.Wrap(err, "failed to exec DockerMachine bootstrap")
 			}

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -329,13 +329,28 @@ func (m *Machine) PreloadLoadImages(ctx context.Context, images []string) error 
 }
 
 // ExecBootstrap runs bootstrap on a node, this is generally `kubeadm <init|join>`.
-func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstrapv1.Format) error {
+func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstrapv1.Format, version *string, image string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if m.container == nil {
 		return errors.New("unable to set ExecBootstrap. the container hosting this machine does not exists")
 	}
 
+	// Get the kindMapping for the target K8s version.
+	// NOTE: The kindMapping allows to select the most recent kindest/node image available, if any, as well as
+	// provide info about the mode to be used when starting the kindest/node image itself.
+	if version == nil {
+		return errors.New("cannot create a DockerMachine for a nil version")
+	}
+
+	semVer, err := semver.Parse(strings.TrimPrefix(*version, "v"))
+	if err != nil {
+		return errors.Wrap(err, "failed to parse DockerMachine version")
+	}
+
+	kindMapping := kind.GetMapping(semVer, image)
+
+	// Decode the cloud config
 	cloudConfig, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		return errors.Wrap(err, "failed to decode machine's bootstrap data")
@@ -345,7 +360,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstr
 
 	switch format {
 	case bootstrapv1.CloudConfig:
-		commands, err = cloudinit.RawCloudInitToProvisioningCommands(cloudConfig)
+		commands, err = cloudinit.RawCloudInitToProvisioningCommands(cloudConfig, kindMapping)
 	case bootstrapv1.Ignition:
 		commands, err = ignition.RawIgnitionToProvisioningCommands(cloudConfig)
 	default:

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/adapter_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/adapter_test.go
@@ -19,9 +19,11 @@ package cloudinit
 import (
 	"testing"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/provisioning"
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 func TestRealUseCase(t *testing.T) {
@@ -141,7 +143,7 @@ write_files:
 		{Cmd: "chmod", Args: []string{"0640", "/run/kubeadm/kubeadm.yaml"}},
 	}
 
-	commands, err := RawCloudInitToProvisioningCommands(cloudData)
+	commands, err := RawCloudInitToProvisioningCommands(cloudData, kind.Mapping{KubernetesVersion: semver.MustParse("1.13.6")})
 
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(commands).To(HaveLen(len(expectedCmds)))

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/provisioning"
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 // runCmd defines parameters of a shell command that is equivalent to an action found in the cloud init rundcmd module.
@@ -36,7 +37,7 @@ func newRunCmdAction() action {
 }
 
 // Unmarshal the runCmd.
-func (a *runCmd) Unmarshal(userData []byte) error {
+func (a *runCmd) Unmarshal(userData []byte, _ kind.Mapping) error {
 	if err := yaml.Unmarshal(userData, a); err != nil {
 		return errors.Wrapf(err, "error parsing run_cmd action: %s", userData)
 	}

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/provisioning"
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 func TestRunCmdUnmarshal(t *testing.T) {
@@ -32,7 +33,7 @@ runcmd:
 - [ ls, -l, / ]
 - "ls -l /"`
 	r := runCmd{}
-	err := r.Unmarshal([]byte(cloudData))
+	err := r.Unmarshal([]byte(cloudData), kind.Mapping{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(r.Cmds).To(HaveLen(2))
 
@@ -94,7 +95,7 @@ runcmd:
 - kubeadm init --config=/run/kubeadm/kubeadm.yaml
 - [ kubeadm, join, --config=/run/kubeadm/kubeadm-controlplane-join-config.yaml ]`
 	r := runCmd{}
-	err := r.Unmarshal([]byte(cloudData))
+	err := r.Unmarshal([]byte(cloudData), kind.Mapping{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(r.Cmds).To(HaveLen(2))
 

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/unknown.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/unknown.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/provisioning"
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 type unknown struct {
@@ -34,7 +35,7 @@ func newUnknown(module string) action {
 }
 
 // Unmarshal will unmarshal unknown actions and slurp the value.
-func (u *unknown) Unmarshal(data []byte) error {
+func (u *unknown) Unmarshal(data []byte, _ kind.Mapping) error {
 	// try unmarshalling to a slice of strings
 	var s1 []string
 	if err := json.Unmarshal(data, &s1); err != nil {

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/unknown_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/unknown_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 func TestUnknown_Run(t *testing.T) {
@@ -40,6 +42,6 @@ func TestUnknown_Unmarshal(t *testing.T) {
 	expected := []string{"test 1", "test 2", "test 3"}
 	input := `["test 1", "test 2", "test 3"]`
 
-	g.Expect(u.Unmarshal([]byte(input))).To(Succeed())
+	g.Expect(u.Unmarshal([]byte(input), kind.Mapping{})).To(Succeed())
 	g.Expect(u.lines).To(Equal(expected))
 }

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/writefiles_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/writefiles_test.go
@@ -21,9 +21,12 @@ import (
 	"compress/gzip"
 	"testing"
 
+	"github.com/blang/semver"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/provisioning"
+	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
 )
 
 func TestWriteFiles(t *testing.T) {
@@ -94,6 +97,150 @@ func TestWriteFiles(t *testing.T) {
 			cmds, err := rt.w.Commands()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(rt.expectedCmds).To(Equal(cmds))
+		})
+	}
+}
+
+func TestFixKubeletArgs(t *testing.T) {
+	var useCases = []struct {
+		name            string
+		files           []byte
+		mapping         kind.Mapping
+		expectedContent []string
+	}{
+		{
+			name: "Fix kubelet args for kind 1.19 mode",
+			files: []byte(`
+write_files:
+- content: |
+    ---
+    ClusterConfiguration...
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: InitConfiguration
+    nodeRegistration:
+      criSocket: unix:///var/run/containerd/containerd.sock
+      kubeletExtraArgs:
+        cloud-provider: aws
+  owner: root:root
+  path: /run/kubeadm/kubeadm.yaml
+  permissions: '0640'
+- content: |
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: JoinConfiguration
+    nodeRegistration:
+      criSocket: unix:///var/run/containerd/containerd.sock
+      kubeletExtraArgs:
+        cloud-provider: aws
+  path: /run/kubeadm/kubeadm-join-config.yaml
+  owner: root:root
+  permissions: '0640'
+`),
+			mapping: kind.Mapping{KubernetesVersion: semver.MustParse("1.28.3"), Mode: kind.Mode0_19},
+			expectedContent: []string{
+				`---
+ClusterConfiguration...
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+localAPIEndpoint: {}
+nodeRegistration:
+  criSocket: unix:///var/run/containerd/containerd.sock
+  kubeletExtraArgs:
+    cloud-provider: aws
+    eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    fail-swap-on: "false"
+  taints: null
+`,
+				`apiVersion: kubeadm.k8s.io/v1beta3
+discovery: {}
+kind: JoinConfiguration
+nodeRegistration:
+  criSocket: unix:///var/run/containerd/containerd.sock
+  kubeletExtraArgs:
+    cloud-provider: aws
+    eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    fail-swap-on: "false"
+  taints: null
+`,
+			},
+		},
+		{
+			name: "Fix kubelet args for kind 1.20 mode",
+			files: []byte(`
+write_files:
+- content: |
+    ---
+    ClusterConfiguration...
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: InitConfiguration
+    nodeRegistration:
+      criSocket: unix:///var/run/containerd/containerd.sock
+      kubeletExtraArgs:
+        cloud-provider: aws
+  owner: root:root
+  path: "/run/kubeadm/kubeadm.yaml"
+  permissions: '0640'
+- content: |
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta1
+    kind: JoinConfiguration
+    nodeRegistration:
+      criSocket: unix:///var/run/containerd/containerd.sock
+      kubeletExtraArgs:
+        cloud-provider: aws
+  path: "/run/kubeadm/kubeadm-join-config.yaml"
+  owner: root:root
+  permissions: '0640'
+`),
+			mapping: kind.Mapping{KubernetesVersion: semver.MustParse("1.28.3"), Mode: kind.Mode0_20},
+			expectedContent: []string{
+				`---
+ClusterConfiguration...
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+localAPIEndpoint: {}
+nodeRegistration:
+  criSocket: unix:///var/run/containerd/containerd.sock
+  kubeletExtraArgs:
+    cgroup-root: /kubelet
+    cloud-provider: aws
+    eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    fail-swap-on: "false"
+    runtime-cgroups: /system.slice/containerd.service
+  taints: null
+`,
+				`apiVersion: kubeadm.k8s.io/v1beta3
+discovery: {}
+kind: JoinConfiguration
+nodeRegistration:
+  criSocket: unix:///var/run/containerd/containerd.sock
+  kubeletExtraArgs:
+    cgroup-root: /kubelet
+    cloud-provider: aws
+    eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    fail-swap-on: "false"
+    runtime-cgroups: /system.slice/containerd.service
+  taints: null
+`,
+			},
+		},
+	}
+
+	for _, rt := range useCases {
+		t.Run(rt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			w := writeFilesAction{}
+			err := w.Unmarshal(rt.files, rt.mapping)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			for i, x := range rt.expectedContent {
+				g.Expect(w.Files[i].Content).To(Equal(x), cmp.Diff(w.Files[i].Content, x))
+			}
 		})
 	}
 }

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -258,19 +258,9 @@ spec:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
         initConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
         joinConfiguration:
-          nodeRegistration:
-            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-              fail-swap-on: "false"
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -302,10 +292,4 @@ spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration:
-          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
-            fail-swap-on: "false"
-
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses the kind mapper introduced by https://github.com/kubernetes-sigs/cluster-api/pull/8880, and use it to automatically set some parameters in the node registration, so the kindest/node image are started as expected.

**Which issue(s) this PR fixes**:
Fixes #
