### PR TITLE
[WIP] :bug: Set defaultClientTimeout to 0 for external clients

### DIFF
--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultClientTimeout = 10 * time.Second
+	defaultClientTimeout = 0 * time.Second
 )
 
 // ClusterClientGetter returns a new remote client.

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -103,7 +103,7 @@ func TestNewClusterClient(t *testing.T) {
 		gs.Expect(err).NotTo(HaveOccurred())
 		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api.nodomain.example.com:6443"))
 		gs.Expect(restConfig.UserAgent).To(MatchRegexp("remote.test/unknown test-source (.*) cluster.x-k8s.io/unknown"))
-		gs.Expect(restConfig.Timeout).To(Equal(10 * time.Second))
+		gs.Expect(restConfig.Timeout).To(Equal(0 * time.Second))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {


### PR DESCRIPTION
Sets the default timeout on the external client to 0. This makes this timeout non-active by default, which is in line with the way the base client in controller runtime is configured. 

This should fix an issue where Watches were closing too regularly on external clusters.


Related to #8865  which makes this value configurable.
