### PR TITLE
:seedling: Update cert-manager to v1.12.2

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -29,7 +29,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.12.1"
+	CertManagerDefaultVersion = "v1.12.2"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -190,7 +190,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.12.1). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.12.2). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -81,7 +81,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.2/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -204,9 +204,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.12.1"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.12.1"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.12.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.12.2"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.12.2"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.12.2"
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -23,11 +23,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/test-extension-{ARCH}:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.12.1
+- name: quay.io/jetstack/cert-manager-cainjector:v1.12.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.12.1
+- name: quay.io/jetstack/cert-manager-webhook:v1.12.2
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.12.1
+- name: quay.io/jetstack/cert-manager-controller:v1.12.2
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
Update cert manager to v1.12.2.

Release notes: https://github.com/cert-manager/cert-manager/releases/tag/v1.12.2
