### PR TITLE
🌱 test/e2e/in-memory: enable unit tests

### DIFF
--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -31,6 +31,10 @@ echo -e "\n*** Testing Cluster API Provider Docker ***\n"
 # Docker provider
 make test-docker-infrastructure-junit
 
+echo -e "\n*** Testing Cluster API Provider In-Memory ***\n"
+# Docker provider
+make test-in-memory-infrastructure-junit
+
 echo -e "\n*** Testing Cluster API Runtime SDK test extension ***\n"
 # Test Extension
 make test-test-extension-junit

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller_test.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller_test.go
@@ -314,8 +314,14 @@ func TestReconcileNormalEtcd(t *testing.T) {
 		manager := cmanager.New(scheme)
 
 		host := "127.0.0.1"
-		wcmux := server.NewWorkloadClustersMux(manager, host)
-		_, err := wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
+		wcmux, err := server.NewWorkloadClustersMux(manager, host, server.CustomPorts{
+			// NOTE: make sure to use ports different than other tests, so we can run tests in parallel
+			MinPort:   server.DefaultMinPort + 1000,
+			MaxPort:   server.DefaultMinPort + 1099,
+			DebugPort: server.DefaultDebugPort,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
 		g.Expect(err).ToNot(HaveOccurred())
 
 		r := InMemoryMachineReconciler{
@@ -436,8 +442,14 @@ func TestReconcileNormalApiServer(t *testing.T) {
 		manager := cmanager.New(scheme)
 
 		host := "127.0.0.1"
-		wcmux := server.NewWorkloadClustersMux(manager, host)
-		_, err := wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
+		wcmux, err := server.NewWorkloadClustersMux(manager, host, server.CustomPorts{
+			// NOTE: make sure to use ports different than other tests, so we can run tests in parallel
+			MinPort:   server.DefaultMinPort + 1100,
+			MaxPort:   server.DefaultMinPort + 1299,
+			DebugPort: server.DefaultDebugPort,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
 		g.Expect(err).ToNot(HaveOccurred())
 
 		r := InMemoryMachineReconciler{

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -257,7 +257,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	// Start an http server
 	podIP := os.Getenv("POD_IP")
-	apiServerMux := server.NewWorkloadClustersMux(cloudMgr, podIP)
+	apiServerMux, err := server.NewWorkloadClustersMux(cloudMgr, podIP)
+	if err != nil {
+		setupLog.Error(err, "unable to create workload clusters mux")
+		os.Exit(1)
+	}
 
 	// Setup reconcilers
 	if err := (&controllers.InMemoryClusterReconciler{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR contains https://github.com/kubernetes-sigs/cluster-api/pull/8879 + enable tests

Kudos to @fabriziopandini for the second half of the implementation :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
