### PR TITLE
🌱 test/e2e/in-memory: sync in-memory provider ClusterClass with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ hack/tools/bin
 # E2E test templates
 test/e2e/data/infrastructure-docker/**/cluster-template*.yaml
 test/e2e/data/infrastructure-inmemory/**/cluster-template*.yaml
+
 # Output of Makefile targets using sed on MacOS systems
 *.yaml-e
 

--- a/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
+++ b/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
@@ -4,6 +4,13 @@ metadata:
   name: in-memory-quick-start
 spec:
   controlPlane:
+    metadata:
+      annotations:
+        # The in-memory provider currently does not support looking up coredns
+        # and kube-proxy information and leads to reconcile errors in KCP.
+        # With these annotations KCP will skip processing those steps.
+        controlplane.cluster.x-k8s.io/skip-coredns: ""
+        controlplane.cluster.x-k8s.io/skip-kube-proxy: ""
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1


### PR DESCRIPTION
ClusterClass

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
