### PR TITLE
:bug: Increase timeout for clusterclass rollout test

### DIFF
--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -279,7 +279,7 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 		assertMachineSetsMachines(g, clusterObjects, cluster)
 
 		By("All cluster objects have the right labels, annotations and selectors")
-	}, 10*time.Second, 1*time.Second).Should(Succeed())
+	}, 30*time.Second, 1*time.Second).Should(Succeed())
 }
 
 func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects clusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {


### PR DESCRIPTION
Increase the timeout for the comparisons in this test to see if they have an impact on the flake in https://github.com/kubernetes-sigs/cluster-api/issues/8747

I'm not certain what's causing the drop in speed here, but looking at the artifacts of the failing tests the cert annotation is correctly reconciled on the control plane machine, but this happens after the timeout completes.

