### PR TITLE
:seedling: Fixups for watch in in-memory apiServer

### DIFF
--- a/test/infrastructure/inmemory/internal/cloud/runtime/cache/client.go
+++ b/test/infrastructure/inmemory/internal/cloud/runtime/cache/client.go
@@ -422,11 +422,6 @@ func (c *cache) doTryDeleteLocked(resourceGroup string, tracker *resourceGroupTr
 			return false, apierrors.NewBadRequest(err.Error())
 		}
 
-		// TODO: (killianmuldoon) Understand if setting this twice is necessary.
-		// Required to override default beforeUpdate behaviour
-		// that prevent changes to automatically managed fields.
-		obj.SetDeletionTimestamp(&now)
-
 		objects[objKey] = obj
 		c.afterUpdate(resourceGroup, oldObj, obj)
 	}

--- a/test/infrastructure/inmemory/internal/server/api/watch.go
+++ b/test/infrastructure/inmemory/internal/server/api/watch.go
@@ -86,11 +86,6 @@ func (m *WatchEventDispatcher) OnGeneric(resourceGroup string, o client.Object) 
 	}
 }
 
-// isWatch is true if the request contains `watch="true"` as a query parameter.
-func isWatch(req *restful.Request) bool {
-	return req.QueryParameter("watch") == "true"
-}
-
 func (h *apiServerHandler) watchForResource(req *restful.Request, resp *restful.Response, resourceGroup string, gvk schema.GroupVersionKind) (reterr error) {
 	ctx := req.Request.Context()
 	queryTimeout := req.QueryParameter("timeoutSeconds")
@@ -126,10 +121,7 @@ func (h *apiServerHandler) watchForResource(req *restful.Request, resp *restful.
 		}
 	}()
 
-	if err = watcher.Run(ctx, queryTimeout, resp); err != nil {
-		return err
-	}
-	return reterr
+	return watcher.Run(ctx, queryTimeout, resp)
 }
 
 // Run serves a series of encoded events via HTTP with Transfer-Encoding: chunked.


### PR DESCRIPTION
Has a number of small improvements following on from reviews of #8851.

Related to #8814 
