### PR TITLE
:seedling: CAPIM: Enable update for coreDNS and kube-proxy

### DIFF
--- a/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
+++ b/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
@@ -6,11 +6,6 @@ spec:
   controlPlane:
     metadata:
       annotations:
-        # The in-memory provider currently does not support looking up coredns
-        # and kube-proxy information and leads to reconcile errors in KCP.
-        # With these annotations KCP will skip processing those steps.
-        controlplane.cluster.x-k8s.io/skip-coredns: ""
-        controlplane.cluster.x-k8s.io/skip-kube-proxy: ""
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/test/infrastructure/inmemory/internal/server/api/const.go
+++ b/test/infrastructure/inmemory/internal/server/api/const.go
@@ -122,6 +122,19 @@ var (
 					Version:      "v1",
 				},
 			},
+			{
+				Name: "apps",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "apps/v1",
+						Version:      "v1",
+					},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "apps/v1",
+					Version:      "v1",
+				},
+			},
 		},
 	}
 
@@ -195,6 +208,51 @@ var (
 					"patch",
 					"update",
 					"watch",
+				},
+				StorageVersionHash: "",
+			},
+		},
+	}
+	appsV1ResourceList = &metav1.APIResourceList{
+		GroupVersion: "apps/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:         "daemonsets",
+				SingularName: "daemonset",
+				Namespaced:   true,
+				Kind:         "DaemonSet",
+				Verbs: []string{
+					"create",
+					"delete",
+					"deletecollection",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+				ShortNames: []string{
+					"ds",
+				},
+				StorageVersionHash: "",
+			},
+			{
+				Name:         "deployments",
+				SingularName: "deployment",
+				Namespaced:   true,
+				Kind:         "Deployment",
+				Verbs: []string{
+					"create",
+					"delete",
+					"deletecollection",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+				ShortNames: []string{
+					"deploy",
 				},
 				StorageVersionHash: "",
 			},

--- a/test/infrastructure/inmemory/internal/server/api/handler.go
+++ b/test/infrastructure/inmemory/internal/server/api/handler.go
@@ -153,6 +153,14 @@ func (h *apiServerHandler) apisDiscovery(req *restful.Request, resp *restful.Res
 			}
 			return
 		}
+		if req.PathParameter("group") == "apps" && req.PathParameter("version") == "v1" {
+			if err := resp.WriteEntity(appsV1ResourceList); err != nil {
+				_ = resp.WriteErrorString(http.StatusInternalServerError, err.Error())
+				return
+			}
+			return
+		}
+
 		_ = resp.WriteErrorString(http.StatusInternalServerError, fmt.Sprintf("discovery info not defined for %s/%s", req.PathParameter("group"), req.PathParameter("version")))
 		return
 	}
@@ -551,6 +559,9 @@ func getAPIResourceList(req *restful.Request) *metav1.APIResourceList {
 	if req.PathParameter("group") != "" {
 		if req.PathParameter("group") == "rbac.authorization.k8s.io" && req.PathParameter("version") == "v1" {
 			return rbacv1APIResourceList
+		}
+		if req.PathParameter("group") == "apps" && req.PathParameter("version") == "v1" {
+			return appsV1ResourceList
 		}
 		return nil
 	}

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +89,7 @@ func init() {
 	// scheme used for operating on the cloud resource.
 	_ = cloudv1.AddToScheme(cloudScheme)
 	_ = corev1.AddToScheme(cloudScheme)
+	_ = appsv1.AddToScheme(cloudScheme)
 	_ = rbacv1.AddToScheme(cloudScheme)
 }
 

--- a/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
+++ b/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
@@ -6,11 +6,6 @@ spec:
   controlPlane:
     metadata:
       annotations:
-        # The in-memory provider currently does not support looking up coredns
-        # and kube-proxy information and leads to reconcile errors in KCP.
-        # With these annotations KCP will skip processing those steps.
-        controlplane.cluster.x-k8s.io/skip-coredns: ""
-        controlplane.cluster.x-k8s.io/skip-kube-proxy: ""
     machineInfrastructure:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1


### PR DESCRIPTION
Enable the CAPIM to respond to calls to update coreDNS and kube-proxy.

Part of #8814 
