### PR TITLE
🌱 Kcp use one workload cluster for reconcile

### DIFF
--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -34,6 +34,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
@@ -77,7 +78,12 @@ func TestReconcileKubeconfigEmptyAPIEndpoints(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	result, err := r.reconcileKubeconfig(ctx, cluster, kcp)
+	controlPlane := &internal.ControlPlane{
+		KCP:     kcp,
+		Cluster: cluster,
+	}
+
+	result, err := r.reconcileKubeconfig(ctx, controlPlane)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).To(BeZero())
 
@@ -126,7 +132,12 @@ func TestReconcileKubeconfigMissingCACertificate(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	result, err := r.reconcileKubeconfig(ctx, cluster, kcp)
+	controlPlane := &internal.ControlPlane{
+		KCP:     kcp,
+		Cluster: cluster,
+	}
+
+	result, err := r.reconcileKubeconfig(ctx, controlPlane)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: dependentCertRequeueAfter}))
 
@@ -192,7 +203,12 @@ func TestReconcileKubeconfigSecretDoesNotAdoptsUserSecrets(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	result, err := r.reconcileKubeconfig(ctx, cluster, kcp)
+	controlPlane := &internal.ControlPlane{
+		KCP:     kcp,
+		Cluster: cluster,
+	}
+
+	result, err := r.reconcileKubeconfig(ctx, controlPlane)
 	g.Expect(err).To(Succeed())
 	g.Expect(result).To(BeZero())
 
@@ -251,7 +267,13 @@ func TestKubeadmControlPlaneReconciler_reconcileKubeconfig(t *testing.T) {
 		Client:   fakeClient,
 		recorder: record.NewFakeRecorder(32),
 	}
-	result, err := r.reconcileKubeconfig(ctx, cluster, kcp)
+
+	controlPlane := &internal.ControlPlane{
+		KCP:     kcp,
+		Cluster: cluster,
+	}
+
+	result, err := r.reconcileKubeconfig(ctx, controlPlane)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).To(Equal(ctrl.Result{}))
 

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -461,6 +461,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -504,6 +505,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -686,6 +688,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -737,6 +740,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -789,6 +793,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -841,6 +846,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
+
 		_, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -1097,6 +1104,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -1132,6 +1140,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 				EtcdMembersResult: nodes(controlPlane.Machines),
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -1207,6 +1216,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
@@ -1278,6 +1288,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeFalse())
@@ -1309,6 +1320,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1346,6 +1358,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1376,6 +1389,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeFalse())
@@ -1407,6 +1421,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1445,6 +1460,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1476,6 +1492,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeFalse())
@@ -1509,6 +1526,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1542,6 +1560,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeFalse())
@@ -1577,6 +1596,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeTrue())
@@ -1612,6 +1632,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 				},
 			},
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 		ret, err := r.canSafelyRemoveEtcdMember(ctx, controlPlane, m1)
 		g.Expect(ret).To(BeFalse())

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -78,7 +78,7 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 		KCP:     kcp,
 	}
 
-	result, err := r.initializeControlPlane(ctx, cluster, kcp, controlPlane)
+	result, err := r.initializeControlPlane(ctx, controlPlane)
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -155,7 +155,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 			Machines: fmc.Machines,
 		}
 
-		result, err := r.scaleUpControlPlane(ctx, cluster, kcp, controlPlane)
+		result, err := r.scaleUpControlPlane(ctx, controlPlane)
 		g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -216,7 +216,11 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 			disableInPlacePropagation: true,
 		}
 
-		result, err := r.reconcile(context.Background(), cluster, kcp)
+		controlPlane, adoptableMachineFound, err := r.initControlPlaneScope(ctx, cluster, kcp)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(adoptableMachineFound).To(BeFalse())
+
+		result, err := r.reconcile(context.Background(), controlPlane)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}))
 
@@ -267,8 +271,9 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 			Cluster:  cluster,
 			Machines: machines,
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
-		result, err := r.scaleDownControlPlane(context.Background(), cluster, kcp, controlPlane, controlPlane.Machines)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
@@ -307,8 +312,9 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 			Cluster:  cluster,
 			Machines: machines,
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
-		result, err := r.scaleDownControlPlane(context.Background(), cluster, kcp, controlPlane, controlPlane.Machines)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 
@@ -343,8 +349,9 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 			Cluster:  cluster,
 			Machines: machines,
 		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
-		result, err := r.scaleDownControlPlane(context.Background(), cluster, kcp, controlPlane, controlPlane.Machines)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}))
 

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -20,82 +20,68 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 // updateStatus is called after every reconcilitation loop in a defer statement to always make sure we have the
 // resource status subresourcs up-to-date.
-func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, cluster *clusterv1.Cluster) error {
-	log := ctrl.LoggerFrom(ctx)
-
-	selector := collections.ControlPlaneSelectorForCluster(cluster.Name)
+func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, controlPlane *internal.ControlPlane) error {
+	selector := collections.ControlPlaneSelectorForCluster(controlPlane.Cluster.Name)
 	// Copy label selector to its status counterpart in string format.
 	// This is necessary for CRDs including scale subresources.
-	kcp.Status.Selector = selector.String()
+	controlPlane.KCP.Status.Selector = selector.String()
 
-	ownedMachines, err := r.managementCluster.GetMachinesForCluster(ctx, cluster, collections.OwnedMachines(kcp))
-	if err != nil {
-		return errors.Wrap(err, "failed to get list of owned machines")
-	}
+	controlPlane.KCP.Status.UpdatedReplicas = int32(len(controlPlane.UpToDateMachines()))
 
-	controlPlane, err := internal.NewControlPlane(ctx, r.Client, cluster, kcp, ownedMachines)
-	if err != nil {
-		log.Error(err, "failed to initialize control plane")
-		return err
-	}
-	kcp.Status.UpdatedReplicas = int32(len(controlPlane.UpToDateMachines()))
-
-	replicas := int32(len(ownedMachines))
-	desiredReplicas := *kcp.Spec.Replicas
+	replicas := int32(len(controlPlane.Machines))
+	desiredReplicas := *controlPlane.KCP.Spec.Replicas
 
 	// set basic data that does not require interacting with the workload cluster
-	kcp.Status.Replicas = replicas
-	kcp.Status.ReadyReplicas = 0
-	kcp.Status.UnavailableReplicas = replicas
+	controlPlane.KCP.Status.Replicas = replicas
+	controlPlane.KCP.Status.ReadyReplicas = 0
+	controlPlane.KCP.Status.UnavailableReplicas = replicas
 
 	// Return early if the deletion timestamp is set, because we don't want to try to connect to the workload cluster
 	// and we don't want to report resize condition (because it is set to deleting into reconcile delete).
-	if !kcp.DeletionTimestamp.IsZero() {
+	if !controlPlane.KCP.DeletionTimestamp.IsZero() {
 		return nil
 	}
 
-	machinesWithHealthyAPIServer := ownedMachines.Filter(collections.HealthyAPIServer())
+	machinesWithHealthyAPIServer := controlPlane.Machines.Filter(collections.HealthyAPIServer())
 	lowestVersion := machinesWithHealthyAPIServer.LowestVersion()
 	if lowestVersion != nil {
-		kcp.Status.Version = lowestVersion
+		controlPlane.KCP.Status.Version = lowestVersion
 	}
 
 	switch {
 	// We are scaling up
 	case replicas < desiredReplicas:
-		conditions.MarkFalse(kcp, controlplanev1.ResizedCondition, controlplanev1.ScalingUpReason, clusterv1.ConditionSeverityWarning, "Scaling up control plane to %d replicas (actual %d)", desiredReplicas, replicas)
+		conditions.MarkFalse(controlPlane.KCP, controlplanev1.ResizedCondition, controlplanev1.ScalingUpReason, clusterv1.ConditionSeverityWarning, "Scaling up control plane to %d replicas (actual %d)", desiredReplicas, replicas)
 	// We are scaling down
 	case replicas > desiredReplicas:
-		conditions.MarkFalse(kcp, controlplanev1.ResizedCondition, controlplanev1.ScalingDownReason, clusterv1.ConditionSeverityWarning, "Scaling down control plane to %d replicas (actual %d)", desiredReplicas, replicas)
+		conditions.MarkFalse(controlPlane.KCP, controlplanev1.ResizedCondition, controlplanev1.ScalingDownReason, clusterv1.ConditionSeverityWarning, "Scaling down control plane to %d replicas (actual %d)", desiredReplicas, replicas)
 
 		// This means that there was no error in generating the desired number of machine objects
-		conditions.MarkTrue(kcp, controlplanev1.MachinesCreatedCondition)
+		conditions.MarkTrue(controlPlane.KCP, controlplanev1.MachinesCreatedCondition)
 	default:
 		// make sure last resize operation is marked as completed.
 		// NOTE: we are checking the number of machines ready so we report resize completed only when the machines
 		// are actually provisioned (vs reporting completed immediately after the last machine object is created).
-		readyMachines := ownedMachines.Filter(collections.IsReady())
+		readyMachines := controlPlane.Machines.Filter(collections.IsReady())
 		if int32(len(readyMachines)) == replicas {
-			conditions.MarkTrue(kcp, controlplanev1.ResizedCondition)
+			conditions.MarkTrue(controlPlane.KCP, controlplanev1.ResizedCondition)
 		}
 
 		// This means that there was no error in generating the desired number of machine objects
-		conditions.MarkTrue(kcp, controlplanev1.MachinesCreatedCondition)
+		conditions.MarkTrue(controlPlane.KCP, controlplanev1.MachinesCreatedCondition)
 	}
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster))
+	workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to create remote cluster client")
 	}
@@ -103,17 +89,17 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	if err != nil {
 		return err
 	}
-	kcp.Status.ReadyReplicas = status.ReadyNodes
-	kcp.Status.UnavailableReplicas = replicas - status.ReadyNodes
+	controlPlane.KCP.Status.ReadyReplicas = status.ReadyNodes
+	controlPlane.KCP.Status.UnavailableReplicas = replicas - status.ReadyNodes
 
 	// This only gets initialized once and does not change if the kubeadm config map goes away.
 	if status.HasKubeadmConfig {
-		kcp.Status.Initialized = true
-		conditions.MarkTrue(kcp, controlplanev1.AvailableCondition)
+		controlPlane.KCP.Status.Initialized = true
+		conditions.MarkTrue(controlPlane.KCP, controlplanev1.AvailableCondition)
 	}
 
-	if kcp.Status.ReadyReplicas > 0 {
-		kcp.Status.Ready = true
+	if controlPlane.KCP.Status.ReadyReplicas > 0 {
+		controlPlane.KCP.Status.Ready = true
 	}
 
 	// Surface lastRemediation data in status.
@@ -121,14 +107,14 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	// most recent of the remediation we are keeping track on machines.
 	var lastRemediation *RemediationData
 
-	if v, ok := kcp.Annotations[controlplanev1.RemediationInProgressAnnotation]; ok {
+	if v, ok := controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation]; ok {
 		remediationData, err := RemediationDataFromAnnotation(v)
 		if err != nil {
 			return err
 		}
 		lastRemediation = remediationData
 	} else {
-		for _, m := range ownedMachines.UnsortedList() {
+		for _, m := range controlPlane.Machines.UnsortedList() {
 			if v, ok := m.Annotations[controlplanev1.RemediationForAnnotation]; ok {
 				remediationData, err := RemediationDataFromAnnotation(v)
 				if err != nil {
@@ -142,7 +128,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	}
 
 	if lastRemediation != nil {
-		kcp.Status.LastRemediation = lastRemediation.ToStatus()
+		controlPlane.KCP.Status.LastRemediation = lastRemediation.ToStatus()
 	}
 	return nil
 }

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -81,7 +81,13 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.updateStatus(ctx, kcp, cluster)).To(Succeed())
+	controlPlane := &internal.ControlPlane{
+		KCP:     kcp,
+		Cluster: cluster,
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	g.Expect(r.updateStatus(ctx, controlPlane)).To(Succeed())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(0))
 	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
 	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
@@ -147,7 +153,14 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.updateStatus(ctx, kcp, cluster)).To(Succeed())
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: machines,
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	g.Expect(r.updateStatus(ctx, controlPlane)).To(Succeed())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
 	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(3))
@@ -219,7 +232,14 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.updateStatus(ctx, kcp, cluster)).To(Succeed())
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: machines,
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	g.Expect(r.updateStatus(ctx, controlPlane)).To(Succeed())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(3))
 	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
@@ -294,7 +314,14 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.updateStatus(ctx, kcp, cluster)).To(Succeed())
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: machines,
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	g.Expect(r.updateStatus(ctx, controlPlane)).To(Succeed())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(5))
 	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(1))
 	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(4))
@@ -368,7 +395,14 @@ func TestKubeadmControlPlaneReconciler_machinesCreatedIsIsTrueEvenWhenTheNodesAr
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.updateStatus(ctx, kcp, cluster)).To(Succeed())
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: machines,
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	g.Expect(r.updateStatus(ctx, controlPlane)).To(Succeed())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
 	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(3))

--- a/controlplane/kubeadm/internal/controllers/suite_test.go
+++ b/controlplane/kubeadm/internal/controllers/suite_test.go
@@ -20,7 +20,9 @@ import (
 	"os"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/internal/test/envtest"
 )
@@ -32,7 +34,11 @@ var (
 
 func TestMain(m *testing.M) {
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:        m,
+		M: m,
+		ManagerUncachedObjs: []client.Object{
+			&corev1.ConfigMap{},
+			&corev1.Secret{},
+		},
 		SetupEnv: func(e *envtest.Environment) { env = e },
 	}))
 }

--- a/controlplane/kubeadm/internal/controllers/upgrade.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/util"
@@ -33,28 +32,26 @@ import (
 
 func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 	ctx context.Context,
-	cluster *clusterv1.Cluster,
-	kcp *controlplanev1.KubeadmControlPlane,
 	controlPlane *internal.ControlPlane,
 	machinesRequireUpgrade collections.Machines,
 ) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	if kcp.Spec.RolloutStrategy == nil || kcp.Spec.RolloutStrategy.RollingUpdate == nil {
+	if controlPlane.KCP.Spec.RolloutStrategy == nil || controlPlane.KCP.Spec.RolloutStrategy.RollingUpdate == nil {
 		return ctrl.Result{}, errors.New("rolloutStrategy is not set")
 	}
 
 	// TODO: handle reconciliation of etcd members and kubeadm config in case they get out of sync with cluster
 
-	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster))
+	workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
 	if err != nil {
-		logger.Error(err, "failed to get remote client for workload cluster", "cluster key", util.ObjectKey(cluster))
+		logger.Error(err, "failed to get remote client for workload cluster", "cluster key", util.ObjectKey(controlPlane.Cluster))
 		return ctrl.Result{}, err
 	}
 
-	parsedVersion, err := semver.ParseTolerant(kcp.Spec.Version)
+	parsedVersion, err := semver.ParseTolerant(controlPlane.KCP.Spec.Version)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", kcp.Spec.Version)
+		return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", controlPlane.KCP.Spec.Version)
 	}
 
 	if err := workloadCluster.ReconcileKubeletRBACRole(ctx, parsedVersion); err != nil {
@@ -75,43 +72,43 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
 	}
 
-	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+	if controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
 		// We intentionally only parse major/minor/patch so that the subsequent code
 		// also already applies to beta versions of new releases.
-		parsedVersionTolerant, err := version.ParseMajorMinorPatchTolerant(kcp.Spec.Version)
+		parsedVersionTolerant, err := version.ParseMajorMinorPatchTolerant(controlPlane.KCP.Spec.Version)
 		if err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", kcp.Spec.Version)
+			return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", controlPlane.KCP.Spec.Version)
 		}
 		// Get the imageRepository or the correct value if nothing is set and a migration is necessary.
-		imageRepository := internal.ImageRepositoryFromClusterConfig(kcp.Spec.KubeadmConfigSpec.ClusterConfiguration, parsedVersionTolerant)
+		imageRepository := internal.ImageRepositoryFromClusterConfig(controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration, parsedVersionTolerant)
 
 		if err := workloadCluster.UpdateImageRepositoryInKubeadmConfigMap(ctx, imageRepository, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update the image repository in the kubeadm config map")
 		}
 	}
 
-	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil && kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {
-		meta := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageMeta
+	if controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration != nil && controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {
+		meta := controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageMeta
 		if err := workloadCluster.UpdateEtcdVersionInKubeadmConfigMap(ctx, meta.ImageRepository, meta.ImageTag, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update the etcd version in the kubeadm config map")
 		}
 
-		extraArgs := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs
+		extraArgs := controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs
 		if err := workloadCluster.UpdateEtcdExtraArgsInKubeadmConfigMap(ctx, extraArgs, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update the etcd extra args in the kubeadm config map")
 		}
 	}
 
-	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
-		if err := workloadCluster.UpdateAPIServerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer, parsedVersion); err != nil {
+	if controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+		if err := workloadCluster.UpdateAPIServerInKubeadmConfigMap(ctx, controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update api server in the kubeadm config map")
 		}
 
-		if err := workloadCluster.UpdateControllerManagerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager, parsedVersion); err != nil {
+		if err := workloadCluster.UpdateControllerManagerInKubeadmConfigMap(ctx, controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update controller manager in the kubeadm config map")
 		}
 
-		if err := workloadCluster.UpdateSchedulerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler, parsedVersion); err != nil {
+		if err := workloadCluster.UpdateSchedulerInKubeadmConfigMap(ctx, controlPlane.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler, parsedVersion); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update scheduler in the kubeadm config map")
 		}
 	}
@@ -120,16 +117,16 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		return ctrl.Result{}, errors.Wrap(err, "failed to upgrade kubelet config map")
 	}
 
-	switch kcp.Spec.RolloutStrategy.Type {
+	switch controlPlane.KCP.Spec.RolloutStrategy.Type {
 	case controlplanev1.RollingUpdateStrategyType:
 		// RolloutStrategy is currently defaulted and validated to be RollingUpdate
 		// We can ignore MaxUnavailable because we are enforcing health checks before we get here.
-		maxNodes := *kcp.Spec.Replicas + int32(kcp.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntValue())
+		maxNodes := *controlPlane.KCP.Spec.Replicas + int32(controlPlane.KCP.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntValue())
 		if int32(controlPlane.Machines.Len()) < maxNodes {
 			// scaleUp ensures that we don't continue scaling up while waiting for Machines to have NodeRefs
-			return r.scaleUpControlPlane(ctx, cluster, kcp, controlPlane)
+			return r.scaleUpControlPlane(ctx, controlPlane)
 		}
-		return r.scaleDownControlPlane(ctx, cluster, kcp, controlPlane, machinesRequireUpgrade)
+		return r.scaleDownControlPlane(ctx, controlPlane, machinesRequireUpgrade)
 	default:
 		logger.Info("RolloutStrategy type is not set to RollingUpdateStrategyType, unable to determine the strategy for rolling out machines")
 		return ctrl.Result{}, nil

--- a/controlplane/kubeadm/internal/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade_test.go
@@ -100,8 +100,9 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 		Cluster:  cluster,
 		Machines: nil,
 	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
 
-	result, err := r.initializeControlPlane(ctx, cluster, kcp, controlPlane)
+	result, err := r.initializeControlPlane(ctx, controlPlane)
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -123,7 +124,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	// run upgrade the first time, expect we scale up
 	needingUpgrade := collections.FromMachineList(initialMachine)
 	controlPlane.Machines = needingUpgrade
-	result, err = r.upgradeControlPlane(ctx, cluster, kcp, controlPlane, needingUpgrade)
+	result, err = r.upgradeControlPlane(ctx, controlPlane, needingUpgrade)
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	g.Expect(err).To(BeNil())
 	bothMachines := &clusterv1.MachineList{}
@@ -135,7 +136,14 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	// run upgrade a second time, simulate that the node has not appeared yet but the machine exists
 
 	// Unhealthy control plane will be detected during reconcile loop and upgrade will never be called.
-	result, err = r.reconcile(context.Background(), cluster, kcp)
+	controlPlane = &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: collections.FromMachineList(bothMachines),
+	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+	result, err = r.reconcile(context.Background(), controlPlane)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}))
 	g.Eventually(func(g Gomega) {
@@ -158,7 +166,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	}
 
 	// run upgrade the second time, expect we scale down
-	result, err = r.upgradeControlPlane(ctx, cluster, kcp, controlPlane, machinesRequireUpgrade)
+	result, err = r.upgradeControlPlane(ctx, controlPlane, machinesRequireUpgrade)
 	g.Expect(err).To(BeNil())
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	finalMachine := &clusterv1.MachineList{}
@@ -230,8 +238,9 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleDown(t *testing.T) {
 		Cluster:  cluster,
 		Machines: nil,
 	}
+	controlPlane.InjectTestManagementCluster(r.managementCluster)
 
-	result, err := r.reconcile(ctx, cluster, kcp)
+	result, err := r.reconcile(ctx, controlPlane)
 	g.Expect(result).To(Equal(ctrl.Result{}))
 	g.Expect(err).NotTo(HaveOccurred())
 
@@ -248,7 +257,8 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleDown(t *testing.T) {
 	// run upgrade, expect we scale down
 	needingUpgrade := collections.FromMachineList(machineList)
 	controlPlane.Machines = needingUpgrade
-	result, err = r.upgradeControlPlane(ctx, cluster, kcp, controlPlane, needingUpgrade)
+
+	result, err = r.upgradeControlPlane(ctx, controlPlane, needingUpgrade)
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	g.Expect(err).To(BeNil())
 	remainingMachines := &clusterv1.MachineList{}


### PR DESCRIPTION
**What this PR does / why we need it**:
As of today, KCP creates the workloadCluster internal struct several times during every reconciliation, and this is one of the factors slowing down reconciliation duration in a way that can impact performance at scale.

This PR refactor KCP so only one workloadCluster internal struct is going to be created and re-used all around during the same reconcile

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/8814
