### PR TITLE
🌱 Change endpoints to endpoint in the etcd client

### DIFF
--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -131,7 +131,7 @@ func pbMemberToMember(m *etcdserverpb.Member) *Member {
 
 // ClientConfiguration describes the configuration for an etcd client.
 type ClientConfiguration struct {
-	Endpoints   []string
+	Endpoint    string
 	Proxy       proxy.Proxy
 	TLSConfig   *tls.Config
 	DialTimeout time.Duration
@@ -146,7 +146,7 @@ func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error)
 	}
 
 	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:   config.Endpoints,
+		Endpoints:   []string{config.Endpoint}, // NOTE: endpoint is used only as a host for certificate validation, the network connection is defined by DialOptions.
 		DialTimeout: config.DialTimeout,
 		DialOptions: []grpc.DialOption{
 			grpc.WithBlock(), // block until the underlying connection is up

--- a/controlplane/kubeadm/internal/etcd_client_generator_test.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator_test.go
@@ -54,8 +54,8 @@ func TestFirstAvailableNode(t *testing.T) {
 		{
 			name:  "Returns client successfully",
 			nodes: []string{"node-1"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
-				return &etcd.Client{Endpoint: endpoints[0]}, nil
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
+				return &etcd.Client{Endpoint: endpoint}, nil
 			},
 			expectedClient: etcd.Client{Endpoint: "etcd-node-1"},
 		},
@@ -68,7 +68,7 @@ func TestFirstAvailableNode(t *testing.T) {
 		{
 			name:  "Returns error from client",
 			nodes: []string{"node-1", "node-2"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
 				return nil, errors.New("something went wrong")
 			},
 			expectedErr: "could not establish a connection to any etcd node: something went wrong",
@@ -76,12 +76,12 @@ func TestFirstAvailableNode(t *testing.T) {
 		{
 			name:  "Returns client when some of the nodes are down but at least one node is up",
 			nodes: []string{"node-down-1", "node-down-2", "node-up"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
-				if strings.Contains(endpoints[0], "node-down") {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
+				if strings.Contains(endpoint, "node-down") {
 					return nil, errors.New("node down")
 				}
 
-				return &etcd.Client{Endpoint: endpoints[0]}, nil
+				return &etcd.Client{Endpoint: endpoint}, nil
 			},
 			expectedClient: etcd.Client{Endpoint: "etcd-node-up"},
 		},
@@ -117,9 +117,9 @@ func TestForLeader(t *testing.T) {
 		{
 			name:  "Returns client for leader successfully",
 			nodes: []string{"node-1", "node-leader"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
 				return &etcd.Client{
-					Endpoint: endpoints[0],
+					Endpoint: endpoint,
 					LeaderID: 1729,
 					EtcdClient: &etcdfake.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -146,12 +146,12 @@ func TestForLeader(t *testing.T) {
 		{
 			name:  "Returns client for leader even when one or more nodes are down",
 			nodes: []string{"node-down-1", "node-down-2", "node-leader"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
-				if strings.Contains(endpoints[0], "node-down") {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
+				if strings.Contains(endpoint, "node-down") {
 					return nil, errors.New("node down")
 				}
 				return &etcd.Client{
-					Endpoint: endpoints[0],
+					Endpoint: endpoint,
 					LeaderID: 1729,
 					EtcdClient: &etcdfake.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -182,9 +182,9 @@ func TestForLeader(t *testing.T) {
 		{
 			name:  "Returns error when the leader does not have a corresponding node",
 			nodes: []string{"node-1"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
 				return &etcd.Client{
-					Endpoint: endpoints[0],
+					Endpoint: endpoint,
 					LeaderID: 1729,
 					EtcdClient: &etcdfake.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -201,7 +201,7 @@ func TestForLeader(t *testing.T) {
 		{
 			name:  "Returns error when all nodes are down",
 			nodes: []string{"node-down-1", "node-down-2", "node-down-3"},
-			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+			cc: func(ctx context.Context, endpoint string) (*etcd.Client, error) {
 				return nil, errors.New("node down")
 			},
 			expectedErr: "could not establish a connection to the etcd leader: [could not establish a connection to any etcd node: node down, failed to connect to etcd node]",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes endpoints to endpoint in the etcd client, and also adds a comment making it clear how this parameter is used internally by the dialer

cc @sbueringer 