### PR TITLE
🌱 add improvements to scale e2e

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -317,3 +317,7 @@ intervals:
   kcp-remediation/wait-machines: ["5m", "10s"]
   kcp-remediation/check-machines-stable: ["30s", "5s"]
   kcp-remediation/wait-machine-provisioned: ["5m", "10s"]
+  #  Giving a bit more time during scale tests, we analyze independently if everything works quickly enough.
+  scale/wait-cluster: ["10m", "10s"]
+  scale/wait-control-plane: ["20m", "10s"]
+  scale/wait-worker-nodes: ["20m", "10s"]

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -36,7 +36,9 @@ var _ = Describe("When scale testing using in-memory provider [Scale]", func() {
 			Concurrency:              pointer.Int64(5),
 			Flavor:                   pointer.String(""),
 			ControlPlaneMachineCount: pointer.Int64(1),
+			MachineDeploymentCount:   pointer.Int64(1),
 			WorkerMachineCount:       pointer.Int64(3),
+			SkipCleanup:              skipCleanup,
 		}
 	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds the following improvements to the scale E2E test:
- ability to set MachineDeployment count
- ability to skip clean up
- ability to skip waiting for cluster creation
- always use the same namespace for scale testing (this is primarily for the benefit of easy debuggability)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
