### PR TITLE
🌱 KCP: cache unstructured

### DIFF
--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -30,9 +30,8 @@ import (
 
 // KubeadmControlPlaneReconciler reconciles a KubeadmControlPlane object.
 type KubeadmControlPlaneReconciler struct {
-	Client    client.Client
-	APIReader client.Reader
-	Tracker   *remote.ClusterCacheTracker
+	Client  client.Client
+	Tracker *remote.ClusterCacheTracker
 
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
@@ -45,7 +44,6 @@ type KubeadmControlPlaneReconciler struct {
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
 		Client:           r.Client,
-		APIReader:        r.APIReader,
 		Tracker:          r.Tracker,
 		EtcdDialTimeout:  r.EtcdDialTimeout,
 		EtcdCallTimeout:  r.EtcdCallTimeout,

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -70,11 +70,11 @@ const (
 
 // KubeadmControlPlaneReconciler reconciles a KubeadmControlPlane object.
 type KubeadmControlPlaneReconciler struct {
-	Client          client.Client
-	APIReader       client.Reader
-	controller      controller.Controller
-	recorder        record.EventRecorder
-	Tracker         *remote.ClusterCacheTracker
+	Client     client.Client
+	controller controller.Controller
+	recorder   record.EventRecorder
+	Tracker    *remote.ClusterCacheTracker
+
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
 

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -515,7 +515,6 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		fmc.Reader = fakeClient
 		r := &KubeadmControlPlaneReconciler{
 			Client:                    fakeClient,
-			APIReader:                 fakeClient,
 			managementCluster:         fmc,
 			managementClusterUncached: fmc,
 		}
@@ -611,7 +610,6 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		fmc.Reader = fakeClient
 		r := &KubeadmControlPlaneReconciler{
 			Client:                    fakeClient,
-			APIReader:                 fakeClient,
 			managementCluster:         fmc,
 			managementClusterUncached: fmc,
 		}
@@ -697,7 +695,6 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		fmc.Reader = fakeClient
 		r := &KubeadmControlPlaneReconciler{
 			Client:                    fakeClient,
-			APIReader:                 fakeClient,
 			managementCluster:         fmc,
 			managementClusterUncached: fmc,
 		}
@@ -750,7 +747,6 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		recorder := record.NewFakeRecorder(32)
 		r := &KubeadmControlPlaneReconciler{
 			Client:                    fakeClient,
-			APIReader:                 fakeClient,
 			recorder:                  recorder,
 			managementCluster:         fmc,
 			managementClusterUncached: fmc,
@@ -1281,9 +1277,8 @@ kubernetesVersion: metav1.16.1`,
 
 	expectedLabels := map[string]string{clusterv1.ClusterNameLabel: "foo"}
 	r := &KubeadmControlPlaneReconciler{
-		Client:    env,
-		APIReader: env.GetAPIReader(),
-		recorder:  record.NewFakeRecorder(32),
+		Client:   env,
+		recorder: record.NewFakeRecorder(32),
 		managementCluster: &fakeManagementCluster{
 			Management: &internal.Management{Client: env},
 			Workload: fakeWorkloadCluster{
@@ -1309,13 +1304,13 @@ kubernetesVersion: metav1.16.1`,
 	g.Expect(err).NotTo(HaveOccurred())
 	// this first requeue is to add finalizer
 	g.Expect(result).To(Equal(ctrl.Result{}))
-	g.Expect(r.APIReader.Get(ctx, util.ObjectKey(kcp), kcp)).To(Succeed())
+	g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(kcp), kcp)).To(Succeed())
 	g.Expect(kcp.Finalizers).To(ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
 
 	g.Eventually(func(g Gomega) {
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(r.APIReader.Get(ctx, client.ObjectKey{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKey{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 		// Expect the referenced infrastructure template to have a Cluster Owner Reference.
 		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(genericInfrastructureMachineTemplate), genericInfrastructureMachineTemplate)).To(Succeed())
 		g.Expect(genericInfrastructureMachineTemplate.GetOwnerReferences()).To(ContainElement(metav1.OwnerReference{

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -784,8 +784,7 @@ func TestKubeadmControlPlaneReconciler_adoptKubeconfigSecret(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := newFakeClient(kcp, tt.configSecret)
 			r := &KubeadmControlPlaneReconciler{
-				APIReader: fakeClient,
-				Client:    fakeClient,
+				Client: fakeClient,
 			}
 			g.Expect(r.adoptKubeconfigSecret(ctx, tt.configSecret, kcp)).To(Succeed())
 			actualSecret := &corev1.Secret{}

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -209,7 +209,6 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 
 		r := &KubeadmControlPlaneReconciler{
 			Client:                    env,
-			APIReader:                 env.GetAPIReader(),
 			managementCluster:         fmc,
 			managementClusterUncached: fmc,
 			recorder:                  record.NewFakeRecorder(32),

--- a/controlplane/kubeadm/internal/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade_test.go
@@ -78,9 +78,8 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	setKCPHealthy(kcp)
 
 	r := &KubeadmControlPlaneReconciler{
-		Client:    env,
-		APIReader: env.GetAPIReader(),
-		recorder:  record.NewFakeRecorder(32),
+		Client:   env,
+		recorder: record.NewFakeRecorder(32),
 		managementCluster: &fakeManagementCluster{
 			Management: &internal.Management{Client: env},
 			Workload: fakeWorkloadCluster{
@@ -227,7 +226,6 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleDown(t *testing.T) {
 	fakeClient := newFakeClient(objs...)
 	fmc.Reader = fakeClient
 	r := &KubeadmControlPlaneReconciler{
-		APIReader:                 fakeClient,
 		Client:                    fakeClient,
 		managementCluster:         fmc,
 		managementClusterUncached: fmc,

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -209,6 +209,11 @@ func main() {
 					&corev1.ConfigMap{},
 					&corev1.Secret{},
 				},
+				// This config ensures that the default client caches Unstructured objects.
+				// KCP is only using Unstructured to retrieve InfraMachines and InfraMachineTemplates.
+				// As the cache should be used in those cases, caching is configured globally instead of
+				// creating a separate client that caches Unstructured.
+				Unstructured: true,
 			},
 		},
 		WebhookServer: webhook.NewServer(
@@ -283,7 +288,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
 		Client:           mgr.GetClient(),
-		APIReader:        mgr.GetAPIReader(),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 		EtcdDialTimeout:  etcdDialTimeout,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In KCP we only ever use unstructured to get InfraMachine and InfraMachineTemplate. In both cases it absolutely does not matter if the object is stale:
* We only use InfraMachine to:
  * check via the template annotations if we have to rollout. The annotations never change.
  * as original object before we apply labels/annotations. Doesn't matter if it is slightly stale there (we also use SSA)
* We only use InfraMachineTemplate to set an ownerRef

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
