### PR TITLE
🐛 test/capd: fix kind mapper entry for v1.25.11

### DIFF
--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -94,7 +94,7 @@ var preBuiltMappings = []Mapping{
 	{
 		KubernetesVersion: semver.MustParse("1.25.11"),
 		Mode:              Mode0_20,
-		Image:             " kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8",
+		Image:             "kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8",
 	},
 	{
 		KubernetesVersion: semver.MustParse("1.24.15"),


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Fixes a wrong entry in kind mapper and by that it fixes the broken tests for `capi-e2e-main-1-24-1-25`  and `capi-e2e-main-1-25-1-26`.

Follow-up for #8880

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

