### PR TITLE
:bug: Fix deprecation marker for RolloutAfter

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -83,8 +83,10 @@ type Topology struct {
 
 	// RolloutAfter performs a rollout of the entire cluster one component at a time,
 	// control plane first and then machine deployments.
-	// +optional
+	//
 	// Deprecated: This field has no function and is going to be removed in the next apiVersion.
+	//
+	// +optional
 	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
 
 	// ControlPlane describes the cluster control plane.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -3147,7 +3147,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_Topology(ref common.ReferenceCallb
 					},
 					"rolloutAfter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments. Deprecated: This field has no function and is going to be removed in the next apiVersion.",
+							Description: "RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.\n\nDeprecated: This field has no function and is going to be removed in the next apiVersion.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1008,10 +1008,10 @@ spec:
                         type: integer
                     type: object
                   rolloutAfter:
-                    description: 'RolloutAfter performs a rollout of the entire cluster
+                    description: "RolloutAfter performs a rollout of the entire cluster
                       one component at a time, control plane first and then machine
-                      deployments. Deprecated: This field has no function and is going
-                      to be removed in the next apiVersion.'
+                      deployments. \n Deprecated: This field has no function and is
+                      going to be removed in the next apiVersion."
                     format: date-time
                     type: string
                   variables:


### PR DESCRIPTION
Fix the deprecation marker for Cluster `.spec.Topology.RolloutAfter` so it is correctly picked up by go tooling. Deprecation markers should always be in a new paragraph block in the godoc comment.

I went through all of our deprecation markers and this was the only one I found that didn't meet the standard.
