### PR TITLE
🌱 all: Add flags to enable block profiling

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	goruntime "runtime"
 	"time"
 
 	// +kubebuilder:scaffold:imports
@@ -86,6 +87,7 @@ var (
 	watchNamespace                string
 	watchFilterValue              string
 	profilerAddress               string
+	enableContentionProfiling     bool
 	clusterTopologyConcurrency    int
 	clusterClassConcurrency       int
 	clusterConcurrency            int
@@ -158,6 +160,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
+
+	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
+		"Enable block profiling, if profiler-address is set.")
 
 	fs.IntVar(&clusterTopologyConcurrency, "clustertopology-concurrency", 10,
 		"Number of clusters to process simultaneously")
@@ -250,6 +255,10 @@ func main() {
 	var watchNamespaces []string
 	if watchNamespace != "" {
 		watchNamespaces = []string{watchNamespace}
+	}
+
+	if profilerAddress != "" && enableContentionProfiling {
+		goruntime.SetBlockProfileRate(1)
 	}
 
 	ctrlOptions := ctrl.Options{

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	goruntime "runtime"
 	"time"
 
 	// +kubebuilder:scaffold:imports
@@ -73,6 +74,7 @@ var (
 	watchNamespace              string
 	watchFilterValue            string
 	profilerAddress             string
+	enableContentionProfiling   bool
 	concurrency                 int
 	syncPeriod                  time.Duration
 	restConfigQPS               float32
@@ -124,6 +126,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
+
+	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
+		"Enable block profiling, if profiler-address is set.")
 
 	fs.IntVar(&concurrency, "concurrency", 10,
 		"The number of docker machines to process simultaneously")
@@ -184,6 +189,10 @@ func main() {
 	var watchNamespaces []string
 	if watchNamespace != "" {
 		watchNamespaces = []string{watchNamespace}
+	}
+
+	if profilerAddress != "" && enableContentionProfiling {
+		goruntime.SetBlockProfileRate(1)
 	}
 
 	ctrlOptions := ctrl.Options{

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	goruntime "runtime"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -68,6 +69,7 @@ var (
 	watchNamespace              string
 	watchFilterValue            string
 	profilerAddress             string
+	enableContentionProfiling   bool
 	clusterConcurrency          int
 	machineConcurrency          int
 	syncPeriod                  time.Duration
@@ -120,6 +122,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
+
+	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
+		"Enable block profiling, if profiler-address is set.")
 
 	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
 		"Number of clusters to process simultaneously")
@@ -178,6 +183,10 @@ func main() {
 	var watchNamespaces []string
 	if watchNamespace != "" {
 		watchNamespaces = []string{watchNamespace}
+	}
+
+	if profilerAddress != "" && enableContentionProfiling {
+		goruntime.SetBlockProfileRate(1)
 	}
 
 	ctrlOptions := ctrl.Options{


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a flag to all providers to enable block profiling. This makes it possible to use block profiling without having to recompile / fork Cluster API.

The flag is modeled after the flags in k/k components, e.g. https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
