### PR TITLE
🌱 test/e2e: increase apply timeout to 1m

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -502,7 +502,7 @@ func getClusterCreateFn(clusterProxy framework.ClusterProxy, namespace string) c
 		log.Logf("Applying the cluster template yaml of cluster %s", klog.KRef(namespace, clusterName))
 		Eventually(func() error {
 			return clusterProxy.Apply(ctx, clusterTemplateYAML)
-		}, 10*time.Second).Should(Succeed(), "Failed to apply the cluster template of cluster %s", klog.KRef(namespace, clusterName))
+		}, 1*time.Minute).Should(Succeed(), "Failed to apply the cluster template of cluster %s", klog.KRef(namespace, clusterName))
 	}
 }
 

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -373,7 +373,7 @@ func ApplyCustomClusterTemplateAndWait(ctx context.Context, input ApplyCustomClu
 	log.Logf("Applying the cluster template yaml of cluster %s", klog.KRef(input.Namespace, input.ClusterName))
 	Eventually(func() error {
 		return input.ClusterProxy.Apply(ctx, input.CustomTemplateYAML, input.Args...)
-	}, 10*time.Second).Should(Succeed(), "Failed to apply the cluster template")
+	}, 1*time.Minute).Should(Succeed(), "Failed to apply the cluster template")
 
 	// Once we applied the cluster template we can run PreWaitForCluster.
 	// Note: This can e.g. be used to verify the BeforeClusterCreate lifecycle hook is executed


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We ran into some issues during scale tests where 10 seconds wasn't enough. let's increase this slightly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
