### PR TITLE
🌱 test/e2e/in-memory: improve locking, return errors instead of panic

### DIFF
--- a/test/infrastructure/inmemory/internal/server/api/handler.go
+++ b/test/infrastructure/inmemory/internal/server/api/handler.go
@@ -542,7 +542,7 @@ func requestToGVK(req *restful.Request) (*schema.GroupVersionKind, error) {
 	}
 	gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
 	if err != nil {
-		panic(fmt.Sprintf("invalid group version in APIResourceList: %s", resourceList.GroupVersion))
+		return nil, errors.Errorf("invalid group version in APIResourceList: %s", resourceList.GroupVersion)
 	}
 
 	resource := req.PathParameter("resource")

--- a/test/infrastructure/inmemory/internal/server/etcd/handler.go
+++ b/test/infrastructure/inmemory/internal/server/etcd/handler.go
@@ -98,27 +98,27 @@ func (m *maintenanceServer) Status(ctx context.Context, _ *pb.StatusRequest) (*p
 }
 
 func (m *maintenanceServer) Defragment(_ context.Context, _ *pb.DefragmentRequest) (*pb.DefragmentResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: Defragment")
 }
 
 func (m *maintenanceServer) Hash(_ context.Context, _ *pb.HashRequest) (*pb.HashResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: Hash")
 }
 
 func (m *maintenanceServer) HashKV(_ context.Context, _ *pb.HashKVRequest) (*pb.HashKVResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: HashKV")
 }
 
 func (m *maintenanceServer) Snapshot(_ *pb.SnapshotRequest, _ pb.Maintenance_SnapshotServer) error {
-	panic("implement me")
+	return fmt.Errorf("not implemented: Snapshot")
 }
 
 func (m *maintenanceServer) MoveLeader(_ context.Context, _ *pb.MoveLeaderRequest) (*pb.MoveLeaderResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: MoveLeader")
 }
 
 func (m *maintenanceServer) Downgrade(_ context.Context, _ *pb.DowngradeRequest) (*pb.DowngradeResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: Downgrade")
 }
 
 // clusterServerServer implements the ClusterServer grpc server.
@@ -127,15 +127,15 @@ type clusterServerServer struct {
 }
 
 func (c *clusterServerServer) MemberAdd(_ context.Context, _ *pb.MemberAddRequest) (*pb.MemberAddResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: MemberAdd")
 }
 
 func (c *clusterServerServer) MemberRemove(_ context.Context, _ *pb.MemberRemoveRequest) (*pb.MemberRemoveResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: MemberRemove")
 }
 
 func (c *clusterServerServer) MemberUpdate(_ context.Context, _ *pb.MemberUpdateRequest) (*pb.MemberUpdateResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: MemberUpdate")
 }
 
 func (c *clusterServerServer) MemberList(ctx context.Context, _ *pb.MemberListRequest) (*pb.MemberListResponse, error) {
@@ -155,7 +155,7 @@ func (c *clusterServerServer) MemberList(ctx context.Context, _ *pb.MemberListRe
 }
 
 func (c *clusterServerServer) MemberPromote(_ context.Context, _ *pb.MemberPromoteRequest) (*pb.MemberPromoteResponse, error) {
-	panic("implement me")
+	return nil, fmt.Errorf("not implemented: MemberPromote")
 }
 
 type baseServer struct {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I consistently hit deadlocks when running a scale test with 40 clusters and 50 Machines per cluster.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
