### PR TITLE
:book: Add comment about MachinePool MinReadySeconds behaviour

### DIFF
--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1034,9 +1034,10 @@ spec:
                   type: string
                 type: array
               minReadySeconds:
-                description: Minimum number of seconds for which a newly created machine
-                  instances should be ready. Defaults to 0 (machine instance will
-                  be considered available as soon as it is ready)
+                description: 'Minimum number of seconds for which a newly created
+                  machine instances should be ready. Defaults to 0 (machine instance
+                  will be considered available as soon as it is ready) NOTE: No logic
+                  is implemented for this field and it currently has no behaviour.'
                 format: int32
                 type: integer
               providerIDList:

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -49,6 +49,7 @@ type MachinePoolSpec struct {
 	// be ready.
 	// Defaults to 0 (machine instance will be considered available as soon as it
 	// is ready)
+	// NOTE: No logic is implemented for this field and it currently has no behaviour.
 	// +optional
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 


### PR DESCRIPTION
Add a comment about the current status of the implementation of MinReadySeconds on the MachinePool. This field currently has no behaviour and should be documented as such.

/area machinepool
