### PR TITLE
📖 Fix description of example values for MHC unhealthy ranges

### DIFF
--- a/docs/book/src/tasks/automated-machine-management/healthchecking.md
+++ b/docs/book/src/tasks/automated-machine-management/healthchecking.md
@@ -201,7 +201,7 @@ If both `maxUnhealthy` and `unhealthyRange` are specified, `unhealthyRange` take
 
 If `unhealthyRange` is set to `[3-5]` and there are 10 Machines being checked:
 - If 2 or fewer nodes are unhealthy, remediation will not be performed.
-- If 5 or more nodes are unhealthy, remediation will not be performed.
+- If 6 or more nodes are unhealthy, remediation will not be performed.
 - In all other cases, remediation will be performed.
 
 Note, the above example had 10 machines as sample set. But, this would work the same way for any other number.


### PR DESCRIPTION
**What this PR does / why we need it**:

"If unhealthyRange is set to [3-5] and there are 10 Machines being checked".

It should: **6** or more nodes are unhealthy, remediation will not be performed


Reference Code:
```go
// isAllowedRemediation checks the value of the MaxUnhealthy field to determine
// returns whether remediation should be allowed or not, the remediation count, and error if any.
func isAllowedRemediation(mhc *clusterv1.MachineHealthCheck) (bool, int32, error) {
	var remediationAllowed bool
	var remediationCount int32
	if mhc.Spec.UnhealthyRange != nil {
		min, max, err := getUnhealthyRange(mhc)
		if err != nil {
			return false, 0, err
		}
		unhealthyMachineCount := unhealthyMachineCount(mhc)
		remediationAllowed = unhealthyMachineCount >= min && unhealthyMachineCount <= max
		remediationCount = int32(max - unhealthyMachineCount)
		return remediationAllowed, remediationCount, nil
	}

}
```

