### PR TITLE
🌱 hack/observability: use 20 Gi of storage for Prometheus

### DIFF
--- a/hack/observability/prometheus/values.yaml
+++ b/hack/observability/prometheus/values.yaml
@@ -17,6 +17,9 @@ server:
   - "web.enable-lifecycle"
   # Used by tempo to write traces.
   - "web.enable-remote-write-receiver"
+  persistentVolume:
+    # Give Prometheus more space to store metrics.
+    size: 20Gi
 
 # Scrape metrics from deployed providers
 extraScrapeConfigs: |


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Increases the storage for Prometheus. I regularly hit "no space left on device" in scale tests with the current 8 Gi default

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
