### PR TITLE
[release-1.4] :bug: Bump kindest/node image used in e2e tests

### DIFF
--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.27.0"
+	DefaultNodeImageVersion = "v1.27.3"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.


### PR DESCRIPTION
This image bump was missed in the process of bumping the KIND version to `v0.20.0` in https://github.com/kubernetes-sigs/cluster-api/pull/8908


Related slack thread: https://kubernetes.slack.com/archives/C8TSNPY4T/p1688679227454029
