### PR TITLE
:seedling: Add SHA to default KIND image used in e2e tests

### DIFF
--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.27.3"
+	DefaultNodeImageVersion = "v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.


### PR DESCRIPTION
Add a SHA to the default KIND image used for bootstrapping a cluster for the e2e tests. 

Ref: https://github.com/kubernetes-sigs/cluster-api/pull/8974#discussion_r1255433718
