### PR TITLE
:sparkles: Conditional reconciliation based on CEL expression

### DIFF
--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -45,6 +45,7 @@ func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		Named("remote/clustercache").
 		For(&clusterv1.Cluster{}).
 		WithOptions(options).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -106,6 +106,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 					predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx)),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Build(r)

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -56,6 +56,7 @@ func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Conte
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -83,6 +83,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		For(&expv1.MachinePool{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachinePools),
@@ -91,6 +92,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -68,6 +68,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/cel-go v0.12.6 // indirect
+	github.com/google/cel-go v0.12.6
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -85,6 +85,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -58,6 +58,7 @@ import (
 
 // Reconciler reconciles the ClusterClass object.
 type Reconciler struct {
+	*predicates.ExpressionMatcher
 	Client    client.Client
 	APIReader client.Reader
 
@@ -82,6 +83,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.extensionConfigToClusterClass),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 
 	if err != nil {

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -109,6 +109,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		For(&clusterv1.Machine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachines),
@@ -120,6 +121,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 						predicates.ClusterControlPlaneInitialized(ctrl.LoggerFrom(ctx)),
 					),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			)).
 		Build(r)

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -89,6 +89,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
@@ -97,6 +98,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -93,6 +93,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
@@ -101,6 +102,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Build(r)

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -106,6 +106,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
@@ -114,6 +115,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -105,6 +105,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -63,6 +63,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -65,6 +65,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -153,6 +153,7 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr 
 		For(&infraexpv1.DockerMachinePool{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&expv1.MachinePool{},
 			handler.EnqueueRequestsFromMapFunc(utilexp.MachinePoolToInfrastructureMapFunc(

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -201,6 +201,7 @@ func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		For(&infrav1.DockerCluster{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("DockerCluster"), mgr.GetClient(), &infrav1.DockerCluster{})),

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -432,6 +432,7 @@ func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		For(&infrav1.DockerMachine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Machine{},
 			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("DockerMachine"))),

--- a/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
@@ -210,6 +210,7 @@ func (r *InMemoryClusterReconciler) SetupWithManager(ctx context.Context, mgr ct
 		For(&infrav1.InMemoryCluster{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("InMemoryCluster"), mgr.GetClient(), &infrav1.InMemoryCluster{})),

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
@@ -1160,6 +1160,7 @@ func (r *InMemoryMachineReconciler) SetupWithManager(ctx context.Context, mgr ct
 		For(&infrav1.InMemoryMachine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Machine{},
 			handler.EnqueueRequestsFromMapFunc(util.MachineToInfrastructureMapFunc(infrav1.GroupVersion.WithKind("InMemoryMachine"))),

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -52,6 +52,7 @@ import (
 	cloudv1 "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/cloud/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/server"
 	"sigs.k8s.io/cluster-api/util/flags"
+	"sigs.k8s.io/cluster-api/util/predicates"
 	"sigs.k8s.io/cluster-api/version"
 )
 
@@ -68,6 +69,7 @@ var (
 	leaderElectionRetryPeriod   time.Duration
 	watchNamespace              string
 	watchFilterValue            string
+	watchExpressionValue        string
 	profilerAddress             string
 	enableContentionProfiling   bool
 	clusterConcurrency          int
@@ -119,6 +121,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
+
+	fs.StringVar(&watchExpressionValue, "watch-expression", "",
+		"More generic version of watch-filter which allows to pass a CEL expression evaluating to boolean result to filter reconcled objects. If unspecified, then the behavior defaults to watch-filter argument")
 
 	fs.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
@@ -271,6 +276,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	apiServerMux, err := server.NewWorkloadClustersMux(cloudMgr, podIP)
 	if err != nil {
 		setupLog.Error(err, "unable to create workload clusters mux")
+		os.Exit(1)
+	}
+
+	if err := predicates.InitExpressionMatcher(setupLog, watchExpressionValue); err != nil {
+		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)
 	}
 

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var expressionMatcher *ExpressionMatcher
+
+// ExpressionMatcher holds initialized CEL program for evaluation of incoming objects on events
+// and filtering which objects to reconcile.
+type ExpressionMatcher struct {
+	program cel.Program
+}
+
+// InitExpressionMatcher initializes expression which will apply on all processed objects in events in every controller.
+func InitExpressionMatcher(log logr.Logger, expression string) error {
+	if expression == "" {
+		return nil
+	}
+	program, err := getProgram(log, expression)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Unable to compile CEL program for %s", expression))
+		return err
+	}
+	log.Info("Initialized expression predicate for the given rule: ", expression)
+
+	expressionMatcher = &ExpressionMatcher{program}
+	return nil
+}
+
+// GetExpressionMatcher returns existing ExpressionMatcher.
+func GetExpressionMatcher() *ExpressionMatcher {
+	return expressionMatcher
+}
+
+func (m *ExpressionMatcher) matches(log logr.Logger, o client.Object) bool {
+	matches, err := m.matchesExpression(log, o)
+	if err != nil {
+		return false
+	}
+
+	return matches
+}
+
+func getProgram(log logr.Logger, expression string) (cel.Program, error) {
+	declarations := cel.Declarations(
+		decls.NewVar("self", decls.NewMapType(decls.String, decls.Dyn)),
+	)
+
+	env, err := cel.NewEnv(declarations)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create CEL environment")
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		log.Error(issues.Err(), "Unable to compile provided expression %s", expression)
+		return nil, issues.Err()
+	}
+	if ast.OutputType() != cel.BoolType {
+		return nil, errors.New("Expression should evaluate to boolean value")
+	}
+
+	prg, err := env.Program(ast)
+	if err != nil {
+		log.Error(err, "Unable to create CEL instance")
+		return nil, err
+	}
+
+	return prg, nil
+}
+
+func (m *ExpressionMatcher) matchesExpression(log logr.Logger, o client.Object) (bool, error) {
+	if o == nil {
+		return false, nil
+	}
+
+	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+	if err != nil {
+		log.Error(err, "Unable to convert object to unstructured")
+		return false, err
+	}
+
+	result, details, err := m.program.Eval(map[string]interface{}{
+		"self": unstructured,
+	})
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Can't eval object with provided expression: %v", details))
+		return false, err
+	}
+
+	return result == types.True, nil
+}
+
+// PassThrough returns a predicate accepting anything.
+func PassThrough() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return true },
+	}
+}
+
+// Matches returns a predicate that returns true only if the provided
+// CEL expression matches on filtered resource.
+func (m *ExpressionMatcher) Matches(log logr.Logger) predicate.Funcs {
+	if m == nil {
+		log.Info("Skipping filter apply, no expression was set")
+		return PassThrough()
+	}
+
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "update"), e.ObjectNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "create"), e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "delete"), e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "generic"), e.Object)
+		},
+	}
+}

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -62,7 +62,11 @@ func GetExpressionMatcher() *ExpressionMatcher {
 func (m *ExpressionMatcher) matches(log logr.Logger, o client.Object) bool {
 	matches, err := m.matchesExpression(log, o)
 	if err != nil {
+		log.V(6).Info(fmt.Sprintf("Rejecting object %+v due to errror: %s", o, err))
 		return false
+	}
+	if !matches {
+		log.V(6).Info(fmt.Sprintf("Rejecting object - does not match expression %+v", o))
 	}
 
 	return matches

--- a/util/predicates/expression_predicates_test.go
+++ b/util/predicates/expression_predicates_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	logger = logr.New(klogr.New().GetSink())
+)
+
+func TestMatchExpression(t *testing.T) {
+	g := NewWithT(t)
+
+	var testcases = []struct {
+		name       string
+		obj        client.Object
+		expression string
+		err        string
+		matcherErr string
+		matched    bool
+	}{
+		{
+			name:       "Object with stub expression should be accepted",
+			expression: "true",
+			obj:        &corev1.Node{},
+			matched:    true,
+		},
+		{
+			name:       "Empty object is rejected",
+			expression: "true",
+			matched:    false,
+		},
+		{
+			name:       "Object with expression evaluated to false should be rejected",
+			expression: "false",
+			obj:        &corev1.Node{},
+			matched:    false,
+		},
+		{
+			name:       "Object with self expression should be matched",
+			expression: "self.metadata.name == 'test'",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			matched: true,
+		},
+		{
+			name:       "Object with matching expression on labels should be matched",
+			expression: "'label' in self.metadata.labels",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"label": "something",
+					},
+				},
+			},
+			matched: true,
+		},
+		{
+			name:       "Logical expression with correctly handled absent key should be matched",
+			expression: "!has(self.metadata.labels) || !('label' in self.metadata.labels)",
+			obj:        &corev1.Node{},
+			matched:    true,
+		},
+		{
+			name:       "Expression error should prevent object from matching",
+			expression: "'label' in self.metadata.labels",
+			obj:        &corev1.Node{},
+			err:        "no such key: labels",
+			matched:    false,
+		},
+		{
+			name:       "Object with non boolean expression should not be matched",
+			expression: "self",
+			obj:        &corev1.Node{},
+			matcherErr: "Expression should evaluate to boolean value",
+			matched:    false,
+		},
+		{
+			name:       "Object with expression on unknown variable should not be matched",
+			expression: "other",
+			obj:        &corev1.Node{},
+			matcherErr: "undeclared reference to 'other'",
+			matched:    false,
+		},
+	}
+
+	for _, tt := range testcases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := InitExpressionMatcher(logger, tt.expression)
+			if tt.matcherErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.matcherErr)))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			result, err := GetExpressionMatcher().matchesExpression(logger, tt.obj)
+			if tt.err != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.err)))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(tt.matched).To(Equal(result))
+			g.Expect(tt.matched).To(Equal(GetExpressionMatcher().matches(logger, tt.obj)))
+		})
+	}
+}
+
+func TestEmptyMatcher(t *testing.T) {
+	expressionMatcher = nil
+	g := NewWithT(t)
+	g.Expect(InitExpressionMatcher(logger, "")).ToNot(HaveOccurred())
+	g.Expect(GetExpressionMatcher()).To(BeNil())
+}
+
+func TestMachineReconciliationWithComplexExpression(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := env.CreateNamespace(ctx, "watch-expression-namespace")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		g.Expect(env.Delete(ctx, ns)).To(Succeed())
+	}()
+
+	original := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "cluster",
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.String("my-data-secret"),
+			},
+		},
+	}
+
+	t.Run("Machine with annotations present should not be reconciled according to expression", func(t *testing.T) {
+		g := NewWithT(t)
+		annotatedObj := original.DeepCopy()
+		annotatedObj.Name = "annotated"
+
+		annotatedObj.SetAnnotations(map[string]string{
+			"some": "annotation",
+		})
+
+		g.Expect(env.Create(ctx, annotatedObj)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(annotatedObj), annotatedObj)
+		}, timeout).Should(Succeed())
+
+		g.Consistently(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(annotatedObj), annotatedObj)).To(Succeed())
+			return annotatedObj.Status.BootstrapReady
+		}, timeout).Should(BeFalse())
+	})
+
+	t.Run("Machine with one label but not another will be reconciled", func(t *testing.T) {
+		g := NewWithT(t)
+		oneLabel := original.DeepCopy()
+		oneLabel.Name = "one-label"
+		oneLabel.SetLabels(map[string]string{
+			"one": "",
+		})
+
+		g.Expect(env.Create(ctx, oneLabel)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(oneLabel), oneLabel)
+		}, timeout).Should(Succeed())
+
+		g.Eventually(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(oneLabel), oneLabel)).To(Succeed())
+			return oneLabel.Status.BootstrapReady
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Machine with another label will not be reconciled", func(t *testing.T) {
+		g := NewWithT(t)
+		anotherLabel := original.DeepCopy()
+		anotherLabel.Name = "another-label"
+		anotherLabel.SetLabels(map[string]string{
+			"one":     "",
+			"another": "",
+		})
+
+		g.Expect(env.Create(ctx, anotherLabel)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(anotherLabel), anotherLabel)
+		}, timeout).Should(Succeed())
+
+		g.Consistently(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(anotherLabel), anotherLabel)).To(Succeed())
+			return anotherLabel.Status.BootstrapReady
+		}, timeout).Should(BeFalse())
+	})
+}

--- a/util/predicates/suite_test.go
+++ b/util/predicates/suite_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+var (
+	ctx     = ctrl.SetupSignalHandler()
+	timeout = 10 * time.Second
+	env     *envtest.Environment
+)
+
+// Reconciler reconciles a Machine object.
+type Reconciler struct {
+	Client client.Client
+}
+
+func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Machine{}).
+		WithEventFilter(GetExpressionMatcher().Matches(logger)).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	m := &clusterv1.Machine{}
+	if err := r.Client.Get(ctx, req.NamespacedName, m); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	patch := client.MergeFrom(m.DeepCopy())
+	m.Status.BootstrapReady = true
+
+	return ctrl.Result{}, r.Client.Status().Patch(ctx, m, patch)
+}
+
+func TestMain(m *testing.M) {
+	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
+		if err := InitExpressionMatcher(logger, "!has(self.metadata.annotations) && ('one' in self.metadata.labels && !('another' in self.metadata.labels))"); err != nil {
+			panic(fmt.Sprintf("unable to setup matcher expression: %v", err))
+		}
+
+		if err := (&Reconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr); err != nil {
+			panic(fmt.Sprintf("unable to create machine reconciler: %v", err))
+		}
+	}
+
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:                m,
+		SetupEnv:         func(e *envtest.Environment) { env = e },
+		SetupReconcilers: setupReconcilers,
+	}))
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This implementation may allow users to optionally reconcile resources based on `watch-expression` flag. With the flag in place, each resource will be evaluated by the filter for a boolean match.

CEL library is already vendored with apimachinery, so it brings no cost to add native support.

Examples may include ignoring resources marked by a label:
```
!has(self.metadata.labels) || !('some-label' in self.metadata.labels)
```
or filtering based on some object fields
```
!has(self.spec.controlPlaneRef) || self.spec.controlPlaneRef.name == 'some-ref'
```
or namespaces
```
self.metadata.namespace == "" || self.metadata.namespace == 'specific-namespace'
```

**Which issue(s) this PR fixes**
Fixes #7775
