### PR TITLE
:seedling: Remove auto-labelling for clusterctl

### DIFF
--- a/cmd/clusterctl/OWNERS
+++ b/cmd/clusterctl/OWNERS
@@ -6,6 +6,3 @@ approvers:
 reviewers:
   - cluster-api-reviewers
   - cluster-api-clusterctl-reviewers
-
-labels:
-  - area/clusterctl


### PR DESCRIPTION
This behaviour of automatically adding a code area based on the OWNERs file is not a great solution as it exists for release notes.

We should revisit automating these labels in a more holistic way, but for now this should be removed.