### PR TITLE
🌱 controlplane: add a test case for syncMachines where the InfraMachine does not exist.

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1562,6 +1562,32 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 		return !deletingMachine.DeletionTimestamp.IsZero()
 	}, 30*time.Second).Should(BeTrue())
 
+	// Existing machine that has a InfrastructureRef which does not exist.
+	nilInfraMachineMachine := &clusterv1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Machine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "nil-infra-machine-machine",
+			Namespace:   namespace.Name,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+			Finalizers:  []string{"testing-finalizer"},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: testCluster.Name,
+			InfrastructureRef: corev1.ObjectReference{
+				Namespace: namespace.Name,
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.String("machine-bootstrap-secret"),
+			},
+		},
+	}
+	g.Expect(env.Create(ctx, nilInfraMachineMachine, client.FieldOwner(classicManager))).To(Succeed())
+	// Delete the machine to put it in the deleting state
+
 	kcp := &controlplanev1.KubeadmControlPlane{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeadmControlPlane",
@@ -1607,6 +1633,7 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 		Machines: collections.Machines{
 			inPlaceMutatingMachine.Name: inPlaceMutatingMachine,
 			deletingMachine.Name:        deletingMachine,
+			nilInfraMachineMachine.Name: nilInfraMachineMachine,
 		},
 		KubeadmConfigs: map[string]*bootstrapv1.KubeadmConfig{
 			inPlaceMutatingMachine.Name: existingKubeadmConfig,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

To stay in sync with the changes we do at #8991 and prevent regressions for #8989

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
