### PR TITLE
:seedling: Extend docs for patch.NewHelper

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -48,7 +48,8 @@ type Helper struct {
 	isConditionsSetter bool
 }
 
-// NewHelper returns an initialized Helper.
+// NewHelper returns an initialized Helper. Use NewHelper before changing
+// obj. After changing obj use Helper.Patch to persist your changes.
 func NewHelper(obj client.Object, crClient client.Client) (*Helper, error) {
 	// Return early if the object is nil.
 	if util.IsNil(obj) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend docs for patch.NewHelper

It took me some time to understand why my first usage if the handy patch helper did not work.

You need to give NewHelper the original (unchanged) object.

I hope this PR makes it more obvious for the newcomer.