### PR TITLE
🌱 Move `internal.labels` to `format` package for use by providers

### DIFF
--- a/api/v1beta1/machineset_webhook.go
+++ b/api/v1beta1/machineset_webhook.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/cluster-api/feature"
-	capilabels "sigs.k8s.io/cluster-api/internal/labels"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
@@ -70,8 +70,8 @@ func (m *MachineSet) Default() {
 
 	if len(m.Spec.Selector.MatchLabels) == 0 && len(m.Spec.Selector.MatchExpressions) == 0 {
 		// Note: MustFormatValue is used here as the value of this label will be a hash if the MachineSet name is longer than 63 characters.
-		m.Spec.Selector.MatchLabels[MachineSetNameLabel] = capilabels.MustFormatValue(m.Name)
-		m.Spec.Template.Labels[MachineSetNameLabel] = capilabels.MustFormatValue(m.Name)
+		m.Spec.Selector.MatchLabels[MachineSetNameLabel] = format.MustFormatValue(m.Name)
+		m.Spec.Template.Labels[MachineSetNameLabel] = format.MustFormatValue(m.Name)
 	}
 
 	if m.Spec.Template.Spec.Version != nil && !strings.HasPrefix(*m.Spec.Template.Spec.Version, "v") {

--- a/controlplane/kubeadm/internal/cluster_labels.go
+++ b/controlplane/kubeadm/internal/cluster_labels.go
@@ -19,7 +19,7 @@ package internal
 import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
-	capilabels "sigs.k8s.io/cluster-api/internal/labels"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 )
 
 // ControlPlaneMachineLabelsForCluster returns a set of labels to add to a control plane machine for this specific cluster.
@@ -36,6 +36,6 @@ func ControlPlaneMachineLabelsForCluster(kcp *controlplanev1.KubeadmControlPlane
 	labels[clusterv1.ClusterNameLabel] = clusterName
 	labels[clusterv1.MachineControlPlaneLabel] = ""
 	// Note: MustFormatValue is used here as the label value can be a hash if the control plane name is longer than 63 characters.
-	labels[clusterv1.MachineControlPlaneNameLabel] = capilabels.MustFormatValue(kcp.Name)
+	labels[clusterv1.MachineControlPlaneNameLabel] = format.MustFormatValue(kcp.Name)
 	return labels
 }

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -42,11 +42,11 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
-	capilabels "sigs.k8s.io/cluster-api/internal/labels"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -342,7 +342,7 @@ func (r *MachinePoolReconciler) reconcileMachines(ctx context.Context, mp *expv1
 
 	infraMachineSelector := metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			clusterv1.MachinePoolNameLabel: capilabels.MustFormatValue(mp.Name),
+			clusterv1.MachinePoolNameLabel: format.MustFormatValue(mp.Name),
 			clusterv1.ClusterNameLabel:     mp.Spec.ClusterName,
 		},
 	}
@@ -503,7 +503,7 @@ func getNewMachine(mp *expv1.MachinePool, infraMachine *unstructured.Unstructure
 	}
 
 	// Enforce that the MachinePoolNameLabel and ClusterNameLabel are present on the Machine.
-	machine.Labels[clusterv1.MachinePoolNameLabel] = capilabels.MustFormatValue(mp.Name)
+	machine.Labels[clusterv1.MachinePoolNameLabel] = format.MustFormatValue(mp.Name)
 	machine.Labels[clusterv1.ClusterNameLabel] = mp.Spec.ClusterName
 
 	return machine
@@ -528,7 +528,7 @@ func (r *MachinePoolReconciler) infraMachineToMachinePoolMapper(ctx context.Cont
 		}
 
 		for _, mp := range machinePoolList.Items {
-			if capilabels.MustFormatValue(mp.Name) == poolNameHash {
+			if format.MustFormatValue(mp.Name) == poolNameHash {
 				return []ctrl.Request{
 					{
 						NamespacedName: client.ObjectKey{

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -38,10 +38,10 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
-	capilabels "sigs.k8s.io/cluster-api/internal/labels"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 )
 
 const (
@@ -1398,7 +1398,7 @@ func TestInfraMachineToMachinePoolMapper(t *testing.T) {
 				"namespace": metav1.NamespaceDefault,
 				"labels": map[string]interface{}{
 					clusterv1.ClusterNameLabel:     clusterName,
-					clusterv1.MachinePoolNameLabel: capilabels.MustFormatValue(machinePool1.Name),
+					clusterv1.MachinePoolNameLabel: format.MustFormatValue(machinePool1.Name),
 				},
 			},
 		},
@@ -1413,7 +1413,7 @@ func TestInfraMachineToMachinePoolMapper(t *testing.T) {
 				"namespace": metav1.NamespaceDefault,
 				"labels": map[string]interface{}{
 					clusterv1.ClusterNameLabel:     "other-cluster",
-					clusterv1.MachinePoolNameLabel: capilabels.MustFormatValue(machinePoolLongName.Name),
+					clusterv1.MachinePoolNameLabel: format.MustFormatValue(machinePoolLongName.Name),
 				},
 			},
 		},
@@ -1428,7 +1428,7 @@ func TestInfraMachineToMachinePoolMapper(t *testing.T) {
 				"namespace": metav1.NamespaceDefault,
 				"labels": map[string]interface{}{
 					clusterv1.ClusterNameLabel:     "other-cluster",
-					clusterv1.MachinePoolNameLabel: capilabels.MustFormatValue("missing-machinepool"),
+					clusterv1.MachinePoolNameLabel: format.MustFormatValue("missing-machinepool"),
 				},
 			},
 		},

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -45,13 +45,13 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/controllers/machine"
-	capilabels "sigs.k8s.io/cluster-api/internal/labels"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	"sigs.k8s.io/cluster-api/util/labels/format"
 	clog "sigs.k8s.io/cluster-api/util/log"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -684,7 +684,7 @@ func machineLabelsFromMachineSet(machineSet *clusterv1.MachineSet) map[string]st
 	// Note: If a client tries to create a MachineSet without a selector, the MachineSet webhook
 	// will add this label automatically. But we want this label to always be present even if the MachineSet
 	// has a selector which doesn't include it. Therefore, we have to set it here explicitly.
-	machineLabels[clusterv1.MachineSetNameLabel] = capilabels.MustFormatValue(machineSet.Name)
+	machineLabels[clusterv1.MachineSetNameLabel] = format.MustFormatValue(machineSet.Name)
 	// Propagate the MachineDeploymentNameLabel from MachineSet to Machine if it exists.
 	if mdName, ok := machineSet.Labels[clusterv1.MachineDeploymentNameLabel]; ok {
 		machineLabels[clusterv1.MachineDeploymentNameLabel] = mdName

--- a/util/labels/format/helpers.go
+++ b/util/labels/format/helpers.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package labels contains functions to validate and compare values used in Kubernetes labels.
-package labels
+// Package format contains functions to format and compare formatted values used in Kubernetes labels.
+package format
 
 import (
 	"encoding/base64"

--- a/util/labels/format/helpers_test.go
+++ b/util/labels/format/helpers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package labels
+package format
 
 import (
 	"testing"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: We need `capilabels.MustFormatValue()` to be available for providers implementing MachinePool Machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
