### PR TITLE
✨ Label selector conditional reconciler

### DIFF
--- a/bootstrap/kubeadm/controllers/alias.go
+++ b/bootstrap/kubeadm/controllers/alias.go
@@ -44,8 +44,8 @@ type KubeadmConfigReconciler struct {
 
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// TokenTTL is the amount of time a bootstrap token (and therefore a KubeadmConfig) will be valid.
 	TokenTTL time.Duration
@@ -54,10 +54,10 @@ type KubeadmConfigReconciler struct {
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmbootstrapcontrollers.KubeadmConfigReconciler{
-		Client:               r.Client,
-		SecretCachingClient:  r.SecretCachingClient,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
-		TokenTTL:             r.TokenTTL,
+		Client:              r.Client,
+		SecretCachingClient: r.SecretCachingClient,
+		Tracker:             r.Tracker,
+		WatchFilterValue:    r.WatchFilterValue,
+		TokenTTL:            r.TokenTTL,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/bootstrap/kubeadm/controllers/alias.go
+++ b/bootstrap/kubeadm/controllers/alias.go
@@ -26,6 +26,7 @@ import (
 
 	kubeadmbootstrapcontrollers "sigs.k8s.io/cluster-api/bootstrap/kubeadm/internal/controllers"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // Following types provides access to reconcilers implemented in internal/controllers, thus
@@ -43,8 +44,8 @@ type KubeadmConfigReconciler struct {
 
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	// TokenTTL is the amount of time a bootstrap token (and therefore a KubeadmConfig) will be valid.
 	TokenTTL time.Duration
@@ -53,10 +54,10 @@ type KubeadmConfigReconciler struct {
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmbootstrapcontrollers.KubeadmConfigReconciler{
-		Client:              r.Client,
-		SecretCachingClient: r.SecretCachingClient,
-		Tracker:             r.Tracker,
-		WatchFilterValue:    r.WatchFilterValue,
-		TokenTTL:            r.TokenTTL,
+		Client:               r.Client,
+		SecretCachingClient:  r.SecretCachingClient,
+		Tracker:              r.Tracker,
+		WatchFilterPredicate: r.WatchFilterPredicate,
+		TokenTTL:             r.TokenTTL,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -81,8 +81,8 @@ type KubeadmConfigReconciler struct {
 	Tracker             *remote.ClusterCacheTracker
 	KubeadmInitLock     InitLocker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// TokenTTL is the amount of time a bootstrap token (and therefore a KubeadmConfig) will be valid.
 	TokenTTL time.Duration
@@ -111,7 +111,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		Watches(
 			&clusterv1.Machine{},
 			handler.EnqueueRequestsFromMapFunc(r.MachineToBootstrapMapFunc),
-		).WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate))
+		).WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue))
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		b = b.Watches(
@@ -126,7 +126,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		builder.WithPredicates(
 			predicates.All(ctrl.LoggerFrom(ctx),
 				predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx)),
-				predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+				predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			),
 		),
 	)

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -81,8 +81,8 @@ type KubeadmConfigReconciler struct {
 	Tracker             *remote.ClusterCacheTracker
 	KubeadmInitLock     InitLocker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	// TokenTTL is the amount of time a bootstrap token (and therefore a KubeadmConfig) will be valid.
 	TokenTTL time.Duration
@@ -111,7 +111,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		Watches(
 			&clusterv1.Machine{},
 			handler.EnqueueRequestsFromMapFunc(r.MachineToBootstrapMapFunc),
-		).WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue))
+		).WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate))
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		b = b.Watches(
@@ -126,7 +126,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		builder.WithPredicates(
 			predicates.All(ctrl.LoggerFrom(ctx),
 				predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx)),
-				predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+				predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
 			),
 		),
 	)

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -318,20 +318,20 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&remote.ClusterCacheReconciler{
-		Client:               mgr.GetClient(),
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCacheReconciler")
 		os.Exit(1)
 	}
 
 	if err := (&kubeadmbootstrapcontrollers.KubeadmConfigReconciler{
-		Client:               mgr.GetClient(),
-		SecretCachingClient:  secretCachingClient,
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
-		TokenTTL:             tokenTTL,
+		Client:              mgr.GetClient(),
+		SecretCachingClient: secretCachingClient,
+		Tracker:             tracker,
+		WatchFilterValue:    labelSelector,
+		TokenTTL:            tokenTTL,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmConfigConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmConfig")
 		os.Exit(1)

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -203,7 +203,7 @@ func main() {
 	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 
-	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, watchExpressionValue)
 	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -150,7 +150,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
 
 	fs.StringVar(&watchExpressionValue, "watch-expression", "",
-		"More generic version of watch-filter which allows to pass a CEL expression evaluating to boolean result to filter reconcled objects. If unspecified, then the behavior defaults to watch-filter argument")
+		"More generic version of watch-filter which allows to pass a label selector to filter reconcled objects. If unspecified, then the behavior defaults to the watch-filter argument")
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
@@ -203,6 +203,12 @@ func main() {
 	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	if err != nil {
+		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
+		os.Exit(1)
+	}
+
 	ctrlOptions := ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         metricsBindAddr,
@@ -215,8 +221,9 @@ func main() {
 		HealthProbeBindAddress:     healthAddr,
 		PprofBindAddress:           profilerAddress,
 		Cache: cache.Options{
-			Namespaces: watchNamespaces,
-			SyncPeriod: &syncPeriod,
+			Namespaces:           watchNamespaces,
+			SyncPeriod:           &syncPeriod,
+			DefaultLabelSelector: labelSelector.Selector(),
 			ByObject: map[client.Object]cache.ByObject{
 				// Note: Only Secrets with the cluster name label are cached.
 				// The default client of the manager won't use the cache for secrets at all (see Client.Cache.DisableFor).
@@ -304,26 +311,27 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := predicates.InitExpressionMatcher(setupLog, watchExpressionValue); err != nil {
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)
 	}
 
 	if err := (&remote.ClusterCacheReconciler{
-		Client:           mgr.GetClient(),
-		Tracker:          tracker,
-		WatchFilterValue: watchFilterValue,
+		Client:               mgr.GetClient(),
+		Tracker:              tracker,
+		WatchFilterPredicate: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCacheReconciler")
 		os.Exit(1)
 	}
 
 	if err := (&kubeadmbootstrapcontrollers.KubeadmConfigReconciler{
-		Client:              mgr.GetClient(),
-		SecretCachingClient: secretCachingClient,
-		Tracker:             tracker,
-		WatchFilterValue:    watchFilterValue,
-		TokenTTL:            tokenTTL,
+		Client:               mgr.GetClient(),
+		SecretCachingClient:  secretCachingClient,
+		Tracker:              tracker,
+		WatchFilterPredicate: labelSelector,
+		TokenTTL:             tokenTTL,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmConfigConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmConfig")
 		os.Exit(1)

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -47,8 +47,8 @@ type ClusterReconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -56,7 +56,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Client:                    r.Client,
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
 		APIReader:                 r.APIReader,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -67,8 +67,8 @@ type MachineReconciler struct {
 	APIReader                 client.Reader
 	Tracker                   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// NodeDrainClientTimeout timeout of the client used for draining nodes.
 	NodeDrainClientTimeout time.Duration
@@ -80,7 +80,7 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
 		APIReader:                 r.APIReader,
 		Tracker:                   r.Tracker,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 		NodeDrainClientTimeout:    r.NodeDrainClientTimeout,
 	}).SetupWithManager(ctx, mgr, options)
 }
@@ -92,8 +92,8 @@ type MachineSetReconciler struct {
 	APIReader                 client.Reader
 	Tracker                   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachineSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -102,7 +102,7 @@ func (r *MachineSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
 		APIReader:                 r.APIReader,
 		Tracker:                   r.Tracker,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -112,8 +112,8 @@ type MachineDeploymentReconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachineDeploymentReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -121,7 +121,7 @@ func (r *MachineDeploymentReconciler) SetupWithManager(ctx context.Context, mgr 
 		Client:                    r.Client,
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
 		APIReader:                 r.APIReader,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -130,15 +130,15 @@ type MachineHealthCheckReconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachineHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinehealthcheckcontroller.Reconciler{
-		Client:               r.Client,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -151,8 +151,8 @@ type ClusterTopologyReconciler struct {
 
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
 	// thus allowing to optimize reads for templates or provider specific objects in a managed topology.
@@ -165,7 +165,7 @@ func (r *ClusterTopologyReconciler) SetupWithManager(ctx context.Context, mgr ct
 		APIReader:                 r.APIReader,
 		RuntimeClient:             r.RuntimeClient,
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -177,15 +177,15 @@ type MachineDeploymentTopologyReconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader            client.Reader
-	WatchFilterPredicate predicates.LabelMatcher
+	APIReader        client.Reader
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachineDeploymentTopologyReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinedeploymenttopologycontroller.Reconciler{
-		Client:               r.Client,
-		APIReader:            r.APIReader,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -197,15 +197,15 @@ type MachineSetTopologyReconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader            client.Reader
-	WatchFilterPredicate predicates.LabelMatcher
+	APIReader        client.Reader
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachineSetTopologyReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinesettopologycontroller.Reconciler{
-		Client:               r.Client,
-		APIReader:            r.APIReader,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -217,8 +217,8 @@ type ClusterClassReconciler struct {
 	// RuntimeClient is a client for calling runtime extensions.
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
 	// thus allowing to optimize reads for templates or provider specific objects.
@@ -231,6 +231,6 @@ func (r *ClusterClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		APIReader:                 r.APIReader,
 		RuntimeClient:             r.RuntimeClient,
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
-		WatchFilterPredicate:      r.WatchFilterPredicate,
+		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -36,8 +36,8 @@ type ClusterCacheReconciler struct {
 	Client  client.Client
 	Tracker *ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -45,8 +45,7 @@ func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		Named("remote/clustercache").
 		For(&clusterv1.Cluster{}).
 		WithOptions(options).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
-		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Complete(r)
 
 	if err != nil {

--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -45,6 +45,7 @@ func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		Named("remote/clustercache").
 		For(&clusterv1.Cluster{}).
 		WithOptions(options).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 

--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -36,8 +36,8 @@ type ClusterCacheReconciler struct {
 	Client  client.Client
 	Tracker *ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -45,7 +45,7 @@ func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		Named("remote/clustercache").
 		For(&clusterv1.Cluster{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 
 	if err != nil {

--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // KubeadmControlPlaneReconciler reconciles a KubeadmControlPlane object.
@@ -37,18 +38,18 @@ type KubeadmControlPlaneReconciler struct {
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:              r.Client,
-		SecretCachingClient: r.SecretCachingClient,
-		Tracker:             r.Tracker,
-		EtcdDialTimeout:     r.EtcdDialTimeout,
-		EtcdCallTimeout:     r.EtcdCallTimeout,
-		WatchFilterValue:    r.WatchFilterValue,
+		Client:               r.Client,
+		SecretCachingClient:  r.SecretCachingClient,
+		Tracker:              r.Tracker,
+		EtcdDialTimeout:      r.EtcdDialTimeout,
+		EtcdCallTimeout:      r.EtcdCallTimeout,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -38,18 +38,18 @@ type KubeadmControlPlaneReconciler struct {
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:               r.Client,
-		SecretCachingClient:  r.SecretCachingClient,
-		Tracker:              r.Tracker,
-		EtcdDialTimeout:      r.EtcdDialTimeout,
-		EtcdCallTimeout:      r.EtcdCallTimeout,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:              r.Client,
+		SecretCachingClient: r.SecretCachingClient,
+		Tracker:             r.Tracker,
+		EtcdDialTimeout:     r.EtcdDialTimeout,
+		EtcdCallTimeout:     r.EtcdCallTimeout,
+		WatchFilterValue:    r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -80,8 +80,8 @@ type KubeadmControlPlaneReconciler struct {
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	managementCluster         internal.ManagementCluster
 	managementClusterUncached internal.ManagementCluster
@@ -99,13 +99,13 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 		For(&controlplanev1.KubeadmControlPlane{}).
 		Owns(&clusterv1.Machine{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.ClusterToKubeadmControlPlane),
 			builder.WithPredicates(
 				predicates.All(ctrl.LoggerFrom(ctx),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 					predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx)),
 				),
 			),

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -107,6 +107,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 					predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(ctx)),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Build(r)

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -207,7 +207,7 @@ func main() {
 	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 
-	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, watchExpressionValue)
 	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -331,21 +331,21 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&remote.ClusterCacheReconciler{
-		Client:               mgr.GetClient(),
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCacheReconciler")
 		os.Exit(1)
 	}
 
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:               mgr.GetClient(),
-		SecretCachingClient:  secretCachingClient,
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
-		EtcdDialTimeout:      etcdDialTimeout,
-		EtcdCallTimeout:      etcdCallTimeout,
+		Client:              mgr.GetClient(),
+		SecretCachingClient: secretCachingClient,
+		Tracker:             tracker,
+		WatchFilterValue:    labelSelector,
+		EtcdDialTimeout:     etcdDialTimeout,
+		EtcdCallTimeout:     etcdCallTimeout,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")
 		os.Exit(1)

--- a/exp/addons/controllers/alias.go
+++ b/exp/addons/controllers/alias.go
@@ -33,15 +33,15 @@ type ClusterResourceSetReconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&clusterresourcesets.ClusterResourceSetReconciler{
-		Client:               r.Client,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -49,13 +49,13 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 type ClusterResourceSetBindingReconciler struct {
 	Client client.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&clusterresourcesets.ClusterResourceSetBindingReconciler{
-		Client:               r.Client,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/addons/controllers/alias.go
+++ b/exp/addons/controllers/alias.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	clusterresourcesets "sigs.k8s.io/cluster-api/exp/addons/internal/controllers"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // ClusterResourceSetReconciler reconciles a ClusterResourceSet object.
@@ -32,15 +33,15 @@ type ClusterResourceSetReconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&clusterresourcesets.ClusterResourceSetReconciler{
-		Client:           r.Client,
-		Tracker:          r.Tracker,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		Tracker:              r.Tracker,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -48,13 +49,13 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 type ClusterResourceSetBindingReconciler struct {
 	Client client.Client
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&clusterresourcesets.ClusterResourceSetBindingReconciler{
-		Client:           r.Client,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -61,8 +61,8 @@ type ClusterResourceSetReconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -87,7 +87,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 			),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -61,8 +61,8 @@ type ClusterResourceSetReconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -87,7 +87,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 			),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -56,6 +56,7 @@ func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Conte
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -43,8 +43,8 @@ import (
 type ClusterResourceSetBindingReconciler struct {
 	Client client.Client
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -55,8 +55,7 @@ func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Conte
 			handler.EnqueueRequestsFromMapFunc(r.clusterToClusterResourceSetBinding),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -43,8 +43,8 @@ import (
 type ClusterResourceSetBindingReconciler struct {
 	Client client.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -55,7 +55,7 @@ func (r *ClusterResourceSetBindingReconciler) SetupWithManager(ctx context.Conte
 			handler.EnqueueRequestsFromMapFunc(r.clusterToClusterResourceSetBinding),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -34,15 +34,15 @@ type MachinePoolReconciler struct {
 	APIReader client.Reader
 	Tracker   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinepool.MachinePoolReconciler{
-		Client:               r.Client,
-		APIReader:            r.APIReader,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	machinepool "sigs.k8s.io/cluster-api/exp/internal/controllers"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // MachinePoolReconciler reconciles a MachinePool object.
@@ -33,15 +34,15 @@ type MachinePoolReconciler struct {
 	APIReader client.Reader
 	Tracker   *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinepool.MachinePoolReconciler{
-		Client:           r.Client,
-		APIReader:        r.APIReader,
-		Tracker:          r.Tracker,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		APIReader:            r.APIReader,
+		Tracker:              r.Tracker,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -83,6 +83,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		For(&expv1.MachinePool{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachinePools),
@@ -91,6 +92,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -65,8 +65,8 @@ type MachinePoolReconciler struct {
 	APIReader client.Reader
 	Tracker   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	controller      controller.Controller
 	recorder        record.EventRecorder
@@ -82,7 +82,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&expv1.MachinePool{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachinePools),
@@ -90,7 +90,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			builder.WithPredicates(
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			),
 		).

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -34,15 +34,15 @@ type ExtensionConfigReconciler struct {
 	APIReader     client.Reader
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&runtimecontrollers.Reconciler{
-		Client:               r.Client,
-		APIReader:            r.APIReader,
-		RuntimeClient:        r.RuntimeClient,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		RuntimeClient:    r.RuntimeClient,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -25,6 +25,7 @@ import (
 
 	runtimecontrollers "sigs.k8s.io/cluster-api/exp/runtime/internal/controllers"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // ExtensionConfigReconciler reconciles an ExtensionConfig object.
@@ -33,15 +34,15 @@ type ExtensionConfigReconciler struct {
 	APIReader     client.Reader
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&runtimecontrollers.Reconciler{
-		Client:           r.Client,
-		APIReader:        r.APIReader,
-		RuntimeClient:    r.RuntimeClient,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		APIReader:            r.APIReader,
+		RuntimeClient:        r.RuntimeClient,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -68,6 +68,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -55,8 +55,8 @@ type Reconciler struct {
 	Client        client.Client
 	APIReader     client.Reader
 	RuntimeClient runtimeclient.Client
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -67,8 +67,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.secretToExtensionConfig),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -55,8 +55,8 @@ type Reconciler struct {
 	Client        client.Client
 	APIReader     client.Reader
 	RuntimeClient runtimeclient.Client
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -67,7 +67,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.secretToExtensionConfig),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -85,6 +85,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -69,8 +69,8 @@ type Reconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	recorder        record.EventRecorder
 	externalTracker external.ObjectTracker
@@ -84,7 +84,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.controlPlaneMachineToCluster),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -69,8 +69,8 @@ type Reconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	recorder        record.EventRecorder
 	externalTracker external.ObjectTracker
@@ -84,8 +84,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.controlPlaneMachineToCluster),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -62,8 +62,8 @@ type Reconciler struct {
 	Client    client.Client
 	APIReader client.Reader
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// RuntimeClient is a client for calling runtime extensions.
 	RuntimeClient runtimeclient.Client
@@ -82,7 +82,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			&runtimev1.ExtensionConfig{},
 			handler.EnqueueRequestsFromMapFunc(r.extensionConfigToClusterClass),
 		).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 
 	if err != nil {

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -58,6 +58,7 @@ import (
 
 // Reconciler reconciles the ClusterClass object.
 type Reconciler struct {
+	*predicates.ExpressionMatcher
 	Client    client.Client
 	APIReader client.Reader
 
@@ -82,6 +83,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.extensionConfigToClusterClass),
 		).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 
 	if err != nil {

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -58,12 +58,12 @@ import (
 
 // Reconciler reconciles the ClusterClass object.
 type Reconciler struct {
-	*predicates.ExpressionMatcher
+	*predicates.LabelMatcher
 	Client    client.Client
 	APIReader client.Reader
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	// RuntimeClient is a client for calling runtime extensions.
 	RuntimeClient runtimeclient.Client
@@ -82,8 +82,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			&runtimev1.ExtensionConfig{},
 			handler.EnqueueRequestsFromMapFunc(r.extensionConfigToClusterClass),
 		).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Complete(r)
 
 	if err != nil {

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -109,6 +109,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		For(&clusterv1.Machine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachines),
@@ -120,6 +121,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 						predicates.ClusterControlPlaneInitialized(ctrl.LoggerFrom(ctx)),
 					),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			)).
 		Build(r)

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -79,8 +79,8 @@ type Reconciler struct {
 	APIReader                 client.Reader
 	Tracker                   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// NodeDrainClientTimeout timeout of the client used for draining nodes.
 	NodeDrainClientTimeout time.Duration
@@ -108,7 +108,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Machine{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachines),
@@ -119,7 +119,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 						predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 						predicates.ClusterControlPlaneInitialized(ctrl.LoggerFrom(ctx)),
 					),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			)).
 		Build(r)

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -67,8 +67,8 @@ type Reconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	recorder record.EventRecorder
 	ssaCache ssa.Cache
@@ -88,7 +88,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.MachineSetToDeployments),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
@@ -96,7 +96,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -67,8 +67,8 @@ type Reconciler struct {
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	recorder record.EventRecorder
 	ssaCache ssa.Cache
@@ -88,8 +88,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.MachineSetToDeployments),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
@@ -97,8 +96,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
-					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -89,6 +89,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
@@ -97,6 +98,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -77,8 +77,8 @@ type Reconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	controller controller.Controller
 	recorder   record.EventRecorder
@@ -92,7 +92,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.machineToMachineHealthCheck),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
@@ -100,7 +100,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			),
 		).Build(r)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -93,6 +93,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
@@ -101,6 +102,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Build(r)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -77,8 +77,8 @@ type Reconciler struct {
 	Client  client.Client
 	Tracker *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	controller controller.Controller
 	recorder   record.EventRecorder
@@ -92,8 +92,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.machineToMachineHealthCheck),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
@@ -101,8 +100,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
-					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
 				),
 			),
 		).Build(r)

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -106,6 +106,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
@@ -114,6 +115,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+					predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -84,8 +84,8 @@ type Reconciler struct {
 	APIReader                 client.Reader
 	Tracker                   *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	ssaCache ssa.Cache
 	recorder record.EventRecorder
@@ -105,7 +105,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.MachineToMachineSets),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
@@ -113,7 +113,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
-					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -70,8 +70,8 @@ type Reconciler struct {
 
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
 	// thus allowing to optimize reads for templates or provider specific objects in a managed topology.
@@ -104,7 +104,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			builder.WithPredicates(predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx))),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -105,6 +105,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -70,8 +70,8 @@ type Reconciler struct {
 
 	RuntimeClient runtimeclient.Client
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
 	// thus allowing to optimize reads for templates or provider specific objects in a managed topology.
@@ -104,8 +104,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			builder.WithPredicates(predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx))),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate)).
 		Build(r)
 
 	if err != nil {

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -50,8 +50,8 @@ type Reconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader        client.Reader
-	WatchFilterValue string
+	APIReader            client.Reader
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -60,10 +60,9 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Named("topology/machinedeployment").
 		WithOptions(options).
 		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
-			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -50,8 +50,8 @@ type Reconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader            client.Reader
-	WatchFilterPredicate predicates.LabelMatcher
+	APIReader        client.Reader
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -60,7 +60,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Named("topology/machinedeployment").
 		WithOptions(options).
 		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
-			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
 		Complete(r)

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -63,6 +63,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -65,6 +65,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
+		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -52,8 +52,8 @@ type Reconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader        client.Reader
-	WatchFilterValue string
+	APIReader            client.Reader
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -62,10 +62,9 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Named("topology/machineset").
 		WithOptions(options).
 		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
-			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
-		WithEventFilter(predicates.GetExpressionMatcher().Matches(ctrl.LoggerFrom(ctx))).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -52,8 +52,8 @@ type Reconciler struct {
 	Client client.Client
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
-	APIReader            client.Reader
-	WatchFilterPredicate predicates.LabelMatcher
+	APIReader        client.Reader
+	WatchFilterValue predicates.LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -62,7 +62,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Named("topology/machineset").
 		WithOptions(options).
 		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
-			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterPredicate),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
 		)).
 		Complete(r)

--- a/main.go
+++ b/main.go
@@ -405,9 +405,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&remote.ClusterCacheReconciler{
-		Client:               mgr.GetClient(),
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCacheReconciler")
 		os.Exit(1)
@@ -441,7 +441,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			APIReader:                 mgr.GetAPIReader(),
 			RuntimeClient:             runtimeClient,
 			UnstructuredCachingClient: unstructuredCachingClient,
-			WatchFilterPredicate:      labelSelector,
+			WatchFilterValue:          labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterClassConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterClass")
 			os.Exit(1)
@@ -452,25 +452,25 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			APIReader:                 mgr.GetAPIReader(),
 			RuntimeClient:             runtimeClient,
 			UnstructuredCachingClient: unstructuredCachingClient,
-			WatchFilterPredicate:      labelSelector,
+			WatchFilterValue:          labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterTopologyConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterTopology")
 			os.Exit(1)
 		}
 
 		if err := (&controllers.MachineDeploymentTopologyReconciler{
-			Client:               mgr.GetClient(),
-			APIReader:            mgr.GetAPIReader(),
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachineDeploymentTopology")
 			os.Exit(1)
 		}
 
 		if err := (&controllers.MachineSetTopologyReconciler{
-			Client:               mgr.GetClient(),
-			APIReader:            mgr.GetAPIReader(),
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachineSetTopology")
 			os.Exit(1)
@@ -479,10 +479,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		if err = (&runtimecontrollers.ExtensionConfigReconciler{
-			Client:               mgr.GetClient(),
-			APIReader:            mgr.GetAPIReader(),
-			RuntimeClient:        runtimeClient,
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			RuntimeClient:    runtimeClient,
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(extensionConfigConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ExtensionConfig")
 			os.Exit(1)
@@ -493,7 +493,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:                    mgr.GetClient(),
 		UnstructuredCachingClient: unstructuredCachingClient,
 		APIReader:                 mgr.GetAPIReader(),
-		WatchFilterPredicate:      labelSelector,
+		WatchFilterValue:          labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		os.Exit(1)
@@ -503,7 +503,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		UnstructuredCachingClient: unstructuredCachingClient,
 		APIReader:                 mgr.GetAPIReader(),
 		Tracker:                   tracker,
-		WatchFilterPredicate:      labelSelector,
+		WatchFilterValue:          labelSelector,
 		NodeDrainClientTimeout:    nodeDrainClientTimeout,
 	}).SetupWithManager(ctx, mgr, concurrency(machineConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Machine")
@@ -514,7 +514,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		UnstructuredCachingClient: unstructuredCachingClient,
 		APIReader:                 mgr.GetAPIReader(),
 		Tracker:                   tracker,
-		WatchFilterPredicate:      labelSelector,
+		WatchFilterValue:          labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(machineSetConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
 		os.Exit(1)
@@ -523,7 +523,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		Client:                    mgr.GetClient(),
 		UnstructuredCachingClient: unstructuredCachingClient,
 		APIReader:                 mgr.GetAPIReader(),
-		WatchFilterPredicate:      labelSelector,
+		WatchFilterValue:          labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(machineDeploymentConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineDeployment")
 		os.Exit(1)
@@ -531,10 +531,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.MachinePoolReconciler{
-			Client:               mgr.GetClient(),
-			APIReader:            mgr.GetAPIReader(),
-			Tracker:              tracker,
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			Tracker:          tracker,
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(machinePoolConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachinePool")
 			os.Exit(1)
@@ -543,16 +543,16 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.ClusterResourceSet) {
 		if err := (&addonscontrollers.ClusterResourceSetReconciler{
-			Client:               mgr.GetClient(),
-			Tracker:              tracker,
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			Tracker:          tracker,
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSet")
 			os.Exit(1)
 		}
 		if err := (&addonscontrollers.ClusterResourceSetBindingReconciler{
-			Client:               mgr.GetClient(),
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSetBinding")
 			os.Exit(1)
@@ -560,9 +560,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.MachineHealthCheckReconciler{
-		Client:               mgr.GetClient(),
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(machineHealthCheckConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineHealthCheck")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -281,7 +281,7 @@ func main() {
 	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 
-	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, watchExpressionValue)
 	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)

--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockercontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/controllers"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // Following types provides access to reconcilers implemented in internal/controllers, thus
@@ -38,17 +39,17 @@ type DockerMachineReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerMachineReconciler{
-		Client:           r.Client,
-		ContainerRuntime: r.ContainerRuntime,
-		Tracker:          r.Tracker,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		ContainerRuntime:     r.ContainerRuntime,
+		Tracker:              r.Tracker,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -57,15 +58,15 @@ type DockerClusterReconciler struct {
 	Client           client.Client
 	ContainerRuntime container.Runtime
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerClusterReconciler{
-		Client:           r.Client,
-		ContainerRuntime: r.ContainerRuntime,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		ContainerRuntime:     r.ContainerRuntime,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -39,17 +39,17 @@ type DockerMachineReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerMachineReconciler{
-		Client:               r.Client,
-		ContainerRuntime:     r.ContainerRuntime,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		ContainerRuntime: r.ContainerRuntime,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -58,15 +58,15 @@ type DockerClusterReconciler struct {
 	Client           client.Client
 	ContainerRuntime container.Runtime
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerClusterReconciler{
-		Client:               r.Client,
-		ContainerRuntime:     r.ContainerRuntime,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		ContainerRuntime: r.ContainerRuntime,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // DockerMachinePoolReconciler reconciles a DockerMachinePool object.
@@ -37,17 +38,17 @@ type DockerMachinePoolReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager will add watches for this controller.
 func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockermachinepoolcontrollers.DockerMachinePoolReconciler{
-		Client:           r.Client,
-		Scheme:           r.Scheme,
-		ContainerRuntime: r.ContainerRuntime,
-		Tracker:          r.Tracker,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		Scheme:               r.Scheme,
+		ContainerRuntime:     r.ContainerRuntime,
+		Tracker:              r.Tracker,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -38,17 +38,17 @@ type DockerMachinePoolReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager will add watches for this controller.
 func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockermachinepoolcontrollers.DockerMachinePoolReconciler{
-		Client:               r.Client,
-		Scheme:               r.Scheme,
-		ContainerRuntime:     r.ContainerRuntime,
-		Tracker:              r.Tracker,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		Scheme:           r.Scheme,
+		ContainerRuntime: r.ContainerRuntime,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -53,8 +53,8 @@ type DockerMachinePoolReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachinepools,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -53,8 +53,8 @@ type DockerMachinePoolReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachinepools,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -45,8 +45,8 @@ type DockerClusterReconciler struct {
 	client.Client
 	ContainerRuntime container.Runtime
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockerclusters,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -45,8 +45,8 @@ type DockerClusterReconciler struct {
 	client.Client
 	ContainerRuntime container.Runtime
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockerclusters,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -54,8 +54,8 @@ type DockerMachineReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachines,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -54,8 +54,8 @@ type DockerMachineReconciler struct {
 	ContainerRuntime container.Runtime
 	Tracker          *remote.ClusterCacheTracker
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockermachines,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -325,9 +325,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&remote.ClusterCacheReconciler{
-		Client:               mgr.GetClient(),
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, controller.Options{
 		MaxConcurrentReconciles: concurrency,
 	}); err != nil {
@@ -336,10 +336,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.DockerMachineReconciler{
-		Client:               mgr.GetClient(),
-		ContainerRuntime:     runtimeClient,
-		Tracker:              tracker,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		ContainerRuntime: runtimeClient,
+		Tracker:          tracker,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, controller.Options{
 		MaxConcurrentReconciles: concurrency,
 	}); err != nil {
@@ -348,9 +348,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.DockerClusterReconciler{
-		Client:               mgr.GetClient(),
-		ContainerRuntime:     runtimeClient,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		ContainerRuntime: runtimeClient,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DockerCluster")
 		os.Exit(1)
@@ -358,10 +358,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.DockerMachinePoolReconciler{
-			Client:               mgr.GetClient(),
-			ContainerRuntime:     runtimeClient,
-			Tracker:              tracker,
-			WatchFilterPredicate: labelSelector,
+			Client:           mgr.GetClient(),
+			ContainerRuntime: runtimeClient,
+			Tracker:          tracker,
+			WatchFilterValue: labelSelector,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: concurrency}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DockerMachinePool")
 			os.Exit(1)

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -205,7 +205,7 @@ func main() {
 	req, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.Exists, nil)
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 
-	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, watchExpressionValue)
 	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)

--- a/test/infrastructure/inmemory/controllers/alias.go
+++ b/test/infrastructure/inmemory/controllers/alias.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/cloud"
 	inmemorycontrollers "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/controllers"
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/server"
+	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
 // Following types provides access to reconcilers implemented in internal/controllers, thus
@@ -38,17 +39,17 @@ type InMemoryClusterReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux // TODO: find a way to use an interface here
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *InMemoryClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&inmemorycontrollers.InMemoryClusterReconciler{
-		Client:           r.Client,
-		CloudManager:     r.CloudManager,
-		APIServerMux:     r.APIServerMux,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		CloudManager:         r.CloudManager,
+		APIServerMux:         r.APIServerMux,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -58,16 +59,16 @@ type InMemoryMachineReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux // TODO: find a way to use an interface here
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *InMemoryMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&inmemorycontrollers.InMemoryMachineReconciler{
-		Client:           r.Client,
-		CloudManager:     r.CloudManager,
-		APIServerMux:     r.APIServerMux,
-		WatchFilterValue: r.WatchFilterValue,
+		Client:               r.Client,
+		CloudManager:         r.CloudManager,
+		APIServerMux:         r.APIServerMux,
+		WatchFilterPredicate: r.WatchFilterPredicate,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/inmemory/controllers/alias.go
+++ b/test/infrastructure/inmemory/controllers/alias.go
@@ -39,17 +39,17 @@ type InMemoryClusterReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux // TODO: find a way to use an interface here
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *InMemoryClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&inmemorycontrollers.InMemoryClusterReconciler{
-		Client:               r.Client,
-		CloudManager:         r.CloudManager,
-		APIServerMux:         r.APIServerMux,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		CloudManager:     r.CloudManager,
+		APIServerMux:     r.APIServerMux,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
@@ -59,16 +59,16 @@ type InMemoryMachineReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux // TODO: find a way to use an interface here
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *InMemoryMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&inmemorycontrollers.InMemoryMachineReconciler{
-		Client:               r.Client,
-		CloudManager:         r.CloudManager,
-		APIServerMux:         r.APIServerMux,
-		WatchFilterPredicate: r.WatchFilterPredicate,
+		Client:           r.Client,
+		CloudManager:     r.CloudManager,
+		APIServerMux:     r.APIServerMux,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
@@ -46,8 +46,8 @@ type InMemoryClusterReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 
 	hotRestartDone bool
 	hotRestartLock sync.RWMutex

--- a/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
@@ -46,8 +46,8 @@ type InMemoryClusterReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 
 	hotRestartDone bool
 	hotRestartLock sync.RWMutex

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
@@ -64,8 +64,8 @@ type InMemoryMachineReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux
 
-	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
-	WatchFilterPredicate predicates.LabelMatcher
+	// WatchFilterValue is the label selector value used to filter events prior to reconciliation.
+	WatchFilterValue predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachines,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
@@ -64,8 +64,8 @@ type InMemoryMachineReconciler struct {
 	CloudManager cloud.Manager
 	APIServerMux *server.WorkloadClustersMux
 
-	// WatchFilterValue is the label value used to filter events prior to reconciliation.
-	WatchFilterValue string
+	// WatchFilterPredicate is the label selector value used to filter events prior to reconciliation.
+	WatchFilterPredicate predicates.LabelMatcher
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachines,verbs=get;list;watch;create;update;patch;delete

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -194,6 +194,12 @@ func main() {
 		goruntime.SetBlockProfileRate(1)
 	}
 
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	if err != nil {
+		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
+		os.Exit(1)
+	}
+
 	ctrlOptions := ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         metricsBindAddr,
@@ -206,8 +212,9 @@ func main() {
 		HealthProbeBindAddress:     healthAddr,
 		PprofBindAddress:           profilerAddress,
 		Cache: cache.Options{
-			Namespaces: watchNamespaces,
-			SyncPeriod: &syncPeriod,
+			DefaultLabelSelector: labelSelector.Selector(),
+			Namespaces:           watchNamespaces,
+			SyncPeriod:           &syncPeriod,
 		},
 		Client: client.Options{
 			Cache: &client.CacheOptions{

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -294,20 +294,20 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	// Setup reconcilers
 	if err := (&controllers.InMemoryClusterReconciler{
-		Client:               mgr.GetClient(),
-		CloudManager:         cloudMgr,
-		APIServerMux:         apiServerMux,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		CloudManager:     cloudMgr,
+		APIServerMux:     apiServerMux,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InMemoryCluster")
 		os.Exit(1)
 	}
 
 	if err := (&controllers.InMemoryMachineReconciler{
-		Client:               mgr.GetClient(),
-		CloudManager:         cloudMgr,
-		APIServerMux:         apiServerMux,
-		WatchFilterPredicate: labelSelector,
+		Client:           mgr.GetClient(),
+		CloudManager:     cloudMgr,
+		APIServerMux:     apiServerMux,
+		WatchFilterValue: labelSelector,
 	}).SetupWithManager(ctx, mgr, concurrency(machineConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InMemoryMachine")
 		os.Exit(1)

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -194,7 +194,7 @@ func main() {
 		goruntime.SetBlockProfileRate(1)
 	}
 
-	labelSelector, err := predicates.InitLabelMatcher(setupLog, predicates.ComposeFilterExpression(watchExpressionValue, watchFilterValue))
+	labelSelector, err := predicates.InitLabelMatcher(setupLog, watchExpressionValue)
 	if err != nil {
 		setupLog.Error(err, "unable to create expression matcher from provided expression %s", watchExpressionValue)
 		os.Exit(1)

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -161,7 +161,7 @@ func ClusterUpdateUnpaused(logger logr.Logger) predicate.Funcs {
 //	    handler.EnqueueRequestsFromMapFunc(clusterToMachines)
 //	    predicates.ClusterUnpaused(r.Log),
 //	)
-func ClusterUnpaused(logger logr.Logger) predicate.Funcs {
+func ClusterUnpaused(logger logr.Logger) predicate.Predicate {
 	log := logger.WithValues("predicate", "ClusterUnpaused")
 
 	// Use any to ensure we process either create or update events we care about
@@ -218,7 +218,7 @@ func ClusterControlPlaneInitialized(logger logr.Logger) predicate.Funcs {
 //	    handler.EnqueueRequestsFromMapFunc(clusterToMachines)
 //	    predicates.ClusterUnpausedAndInfrastructureReady(r.Log),
 //	)
-func ClusterUnpausedAndInfrastructureReady(logger logr.Logger) predicate.Funcs {
+func ClusterUnpausedAndInfrastructureReady(logger logr.Logger) predicate.Predicate {
 	log := logger.WithValues("predicate", "ClusterUnpausedAndInfrastructureReady")
 
 	// Only continue processing create events if both not paused and infrastructure is ready

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var expressionMatcher *ExpressionMatcher
+
+// ExpressionMatcher holds initialized CEL program for evaluation of incoming objects on events
+// and filtering which objects to reconcile.
+type ExpressionMatcher struct {
+	program cel.Program
+}
+
+// InitExpressionMatcher initializes expression which will apply on all processed objects in events in every controller.
+func InitExpressionMatcher(log logr.Logger, expression string) error {
+	if expression == "" {
+		return nil
+	}
+	program, err := getProgram(log, expression)
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Unable to compile CEL program for %s", expression))
+		return err
+	}
+	log.Info("Initialized expression predicate for the given rule: ", expression)
+
+	expressionMatcher = &ExpressionMatcher{program}
+	return nil
+}
+
+// GetExpressionMatcher returns existing ExpressionMatcher.
+func GetExpressionMatcher() *ExpressionMatcher {
+	return expressionMatcher
+}
+
+func (m *ExpressionMatcher) matches(log logr.Logger, o client.Object) bool {
+	matches, err := m.matchesExpression(log, o)
+	if err != nil {
+		return false
+	}
+
+	return matches
+}
+
+func getProgram(log logr.Logger, expression string) (cel.Program, error) {
+	declarations := cel.Declarations(
+		decls.NewVar("self", decls.NewMapType(decls.String, decls.Dyn)),
+	)
+
+	env, err := cel.NewEnv(declarations)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create CEL environment")
+	}
+
+	ast, issues := env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		log.Error(issues.Err(), "Unable to compile provided expression %s", expression)
+		return nil, issues.Err()
+	}
+	if ast.OutputType() != cel.BoolType {
+		return nil, errors.New("Expression should evaluate to boolean value")
+	}
+
+	prg, err := env.Program(ast)
+	if err != nil {
+		log.Error(err, "Unable to create CEL instance")
+		return nil, err
+	}
+
+	return prg, nil
+}
+
+func (m *ExpressionMatcher) matchesExpression(log logr.Logger, o client.Object) (bool, error) {
+	if o == nil {
+		return false, nil
+	}
+
+	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
+	if err != nil {
+		log.Error(err, "Unable to convert object to unstructured")
+		return false, err
+	}
+
+	result, details, err := m.program.Eval(map[string]interface{}{
+		"self": unstructured,
+	})
+	if err != nil {
+		log.Error(err, fmt.Sprintf("Can't eval object with provided expression: %v", details))
+		return false, err
+	}
+
+	return result == types.True, nil
+}
+
+// PassThrough returns a predicate accepting anything.
+func PassThrough() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return true },
+	}
+}
+
+// Matches returns a predicate that returns true only if the provided
+// CEL expression matches on filtered resource.
+func (m *ExpressionMatcher) Matches(log logr.Logger) predicate.Funcs {
+	if m == nil {
+		log.Info("Skipping filter apply, no expression was set")
+		return PassThrough()
+	}
+
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "update"), e.ObjectNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "create"), e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "delete"), e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "generic"), e.Object)
+		},
+	}
+}

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -62,7 +62,11 @@ func GetExpressionMatcher() *ExpressionMatcher {
 func (m *ExpressionMatcher) matches(log logr.Logger, o client.Object) bool {
 	matches, err := m.matchesExpression(log, o)
 	if err != nil {
+		log.V(6).Info(fmt.Sprintf("Rejecting object %+v due to errror: %s", o, err))
 		return false
+	}
+	if !matches {
+		log.V(6).Info(fmt.Sprintf("Rejecting object - does not match expression %+v", o))
 	}
 
 	return matches

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -75,7 +74,7 @@ func InitLabelMatcher(log logr.Logger, labelExpression string) (LabelMatcher, er
 	return matcher, nil
 }
 
-// Selector returns compiled label selector if it was initialized from expression
+// Selector returns compiled label selector if it was initialized from expression.
 func (m *LabelMatcher) Selector() labels.Selector {
 	return m.selector
 }

--- a/util/predicates/expression_predicates.go
+++ b/util/predicates/expression_predicates.go
@@ -20,138 +20,73 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-var expressionMatcher *ExpressionMatcher
-
-// ExpressionMatcher holds initialized CEL program for evaluation of incoming objects on events
-// and filtering which objects to reconcile.
-type ExpressionMatcher struct {
-	program cel.Program
+// LabelMatcher holds initialized Label Selector predicate for evaluation of incoming
+// objects on events and filtering which objects to reconcile.
+type LabelMatcher struct {
+	selector  labels.Selector
+	predicate predicate.Predicate
 }
 
-// InitExpressionMatcher initializes expression which will apply on all processed objects in events in every controller.
-func InitExpressionMatcher(log logr.Logger, expression string) error {
-	if expression == "" {
-		return nil
+// ComposeFilterExpression will return a valid label selector string representation
+// by converting watchFilter to a default for watchExpression.
+func ComposeFilterExpression(watchExpression, watchFilter string) string {
+	if watchExpression == "" && watchFilter != "" {
+		return fmt.Sprintf("%s = %s", clusterv1.WatchLabel, watchFilter)
 	}
-	program, err := getProgram(log, expression)
+	return watchExpression
+}
+
+// InitLabelMatcher initializes expression which will apply on all processed objects in events in every controller.
+func InitLabelMatcher(log logr.Logger, labelExpression string) (LabelMatcher, error) {
+	matcher := LabelMatcher{}
+	if labelExpression == "" {
+		return matcher, nil
+	}
+
+	expr, err := metav1.ParseToLabelSelector(labelExpression)
 	if err != nil {
-		log.Error(err, fmt.Sprintf("Unable to compile CEL program for %s", expression))
-		return err
+		log.Error(err, fmt.Sprintf("Unable to compile LabelSelector from %s", labelExpression))
+		return matcher, err
 	}
-	log.Info("Initialized expression predicate for the given rule: ", expression)
+	log.Info("Initialized label selector predicate for the given rule: ", labelExpression)
 
-	expressionMatcher = &ExpressionMatcher{program}
-	return nil
-}
-
-// GetExpressionMatcher returns existing ExpressionMatcher.
-func GetExpressionMatcher() *ExpressionMatcher {
-	return expressionMatcher
-}
-
-func (m *ExpressionMatcher) matches(log logr.Logger, o client.Object) bool {
-	matches, err := m.matchesExpression(log, o)
+	labelPredicate, err := predicate.LabelSelectorPredicate(*expr)
 	if err != nil {
-		log.V(6).Info(fmt.Sprintf("Rejecting object %+v due to errror: %s", o, err))
-		return false
-	}
-	if !matches {
-		log.V(6).Info(fmt.Sprintf("Rejecting object - does not match expression %+v", o))
+		log.Error(err, fmt.Sprintf("Unable to compile label selector for %s", labelExpression))
+		return matcher, err
 	}
 
-	return matches
+	selector, err := metav1.LabelSelectorAsSelector(expr)
+	if err != nil {
+		log.Error(err, "Unable to parse label selector for cache filtering for %s", labelExpression)
+		return matcher, err
+	}
+
+	matcher.selector = selector
+	matcher.predicate = labelPredicate
+	return matcher, nil
 }
 
-func getProgram(log logr.Logger, expression string) (cel.Program, error) {
-	declarations := cel.Declarations(
-		decls.NewVar("self", decls.NewMapType(decls.String, decls.Dyn)),
-	)
-
-	env, err := cel.NewEnv(declarations)
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to create CEL environment")
-	}
-
-	ast, issues := env.Compile(expression)
-	if issues != nil && issues.Err() != nil {
-		log.Error(issues.Err(), "Unable to compile provided expression %s", expression)
-		return nil, issues.Err()
-	}
-	if ast.OutputType() != cel.BoolType {
-		return nil, errors.New("Expression should evaluate to boolean value")
-	}
-
-	prg, err := env.Program(ast)
-	if err != nil {
-		log.Error(err, "Unable to create CEL instance")
-		return nil, err
-	}
-
-	return prg, nil
+// Selector returns compiled label selector if it was initialized from expression
+func (m *LabelMatcher) Selector() labels.Selector {
+	return m.selector
 }
 
-func (m *ExpressionMatcher) matchesExpression(log logr.Logger, o client.Object) (bool, error) {
-	if o == nil {
-		return false, nil
+// Matches returns a predicate that accepts objects only matching
+// watch-filter or watch-expression value.
+func (m *LabelMatcher) Matches(log logr.Logger) predicate.Predicate {
+	if m.predicate == nil {
+		log.Info("Skipping filter apply, no label expression was set")
+		return predicate.Funcs{}
 	}
 
-	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(o)
-	if err != nil {
-		log.Error(err, "Unable to convert object to unstructured")
-		return false, err
-	}
-
-	result, details, err := m.program.Eval(map[string]interface{}{
-		"self": unstructured,
-	})
-	if err != nil {
-		log.Error(err, fmt.Sprintf("Can't eval object with provided expression: %v", details))
-		return false, err
-	}
-
-	return result == types.True, nil
-}
-
-// PassThrough returns a predicate accepting anything.
-func PassThrough() predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return true },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
-		GenericFunc: func(e event.GenericEvent) bool { return true },
-	}
-}
-
-// Matches returns a predicate that returns true only if the provided
-// CEL expression matches on filtered resource.
-func (m *ExpressionMatcher) Matches(log logr.Logger) predicate.Funcs {
-	if m == nil {
-		log.Info("Skipping filter apply, no expression was set")
-		return PassThrough()
-	}
-
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "update"), e.ObjectNew)
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "create"), e.Object)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "delete"), e.Object)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return m.matches(log.WithValues("predicate", "ResourceMatchesExpression", "eventType", "generic"), e.Object)
-		},
-	}
+	return m.predicate
 }

--- a/util/predicates/expression_predicates_test.go
+++ b/util/predicates/expression_predicates_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	logger = logr.New(klogr.New().GetSink())
+)
+
+func TestMatchExpression(t *testing.T) {
+	g := NewWithT(t)
+
+	var testcases = []struct {
+		name       string
+		obj        client.Object
+		expression string
+		err        string
+		matcherErr string
+		matched    bool
+	}{
+		{
+			name:       "Object with stub expression should be accepted",
+			expression: "true",
+			obj:        &corev1.Node{},
+			matched:    true,
+		},
+		{
+			name:       "Empty object is rejected",
+			expression: "true",
+			matched:    false,
+		},
+		{
+			name:       "Object with expression evaluated to false should be rejected",
+			expression: "false",
+			obj:        &corev1.Node{},
+			matched:    false,
+		},
+		{
+			name:       "Object with self expression should be matched",
+			expression: "self.metadata.name == 'test'",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+			matched: true,
+		},
+		{
+			name:       "Object with matching expression on labels should be matched",
+			expression: "'label' in self.metadata.labels",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"label": "something",
+					},
+				},
+			},
+			matched: true,
+		},
+		{
+			name:       "Logical expression with correctly handled absent key should be matched",
+			expression: "!has(self.metadata.labels) || !('label' in self.metadata.labels)",
+			obj:        &corev1.Node{},
+			matched:    true,
+		},
+		{
+			name:       "Expression error should prevent object from matching",
+			expression: "'label' in self.metadata.labels",
+			obj:        &corev1.Node{},
+			err:        "no such key: labels",
+			matched:    false,
+		},
+		{
+			name:       "Object with non boolean expression should not be matched",
+			expression: "self",
+			obj:        &corev1.Node{},
+			matcherErr: "Expression should evaluate to boolean value",
+			matched:    false,
+		},
+		{
+			name:       "Object with expression on unknown variable should not be matched",
+			expression: "other",
+			obj:        &corev1.Node{},
+			matcherErr: "undeclared reference to 'other'",
+			matched:    false,
+		},
+	}
+
+	for _, tt := range testcases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := InitExpressionMatcher(logger, tt.expression)
+			if tt.matcherErr != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.matcherErr)))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			result, err := GetExpressionMatcher().matchesExpression(logger, tt.obj)
+			if tt.err != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring(tt.err)))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(tt.matched).To(Equal(result))
+			g.Expect(tt.matched).To(Equal(GetExpressionMatcher().matches(logger, tt.obj)))
+		})
+	}
+}
+
+func TestEmptyMatcher(t *testing.T) {
+	expressionMatcher = nil
+	g := NewWithT(t)
+	g.Expect(InitExpressionMatcher(logger, "")).ToNot(HaveOccurred())
+	g.Expect(GetExpressionMatcher()).To(BeNil())
+}
+
+func TestMachineReconciliationWithComplexExpression(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := env.CreateNamespace(ctx, "watch-expression-namespace")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		g.Expect(env.Delete(ctx, ns)).To(Succeed())
+	}()
+
+	original := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "cluster",
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.String("my-data-secret"),
+			},
+		},
+	}
+
+	t.Run("Machine with annotations present should not be reconciled according to expression", func(t *testing.T) {
+		g := NewWithT(t)
+		annotatedObj := original.DeepCopy()
+		annotatedObj.Name = "annotated"
+
+		annotatedObj.SetAnnotations(map[string]string{
+			"some": "annotation",
+		})
+
+		g.Expect(env.Create(ctx, annotatedObj)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(annotatedObj), annotatedObj)
+		}, timeout).Should(Succeed())
+
+		g.Consistently(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(annotatedObj), annotatedObj)).To(Succeed())
+			return annotatedObj.Status.BootstrapReady
+		}, timeout).Should(BeFalse())
+	})
+
+	t.Run("Machine with one label but not another will be reconciled", func(t *testing.T) {
+		g := NewWithT(t)
+		oneLabel := original.DeepCopy()
+		oneLabel.Name = "one-label"
+		oneLabel.SetLabels(map[string]string{
+			"one": "",
+		})
+
+		g.Expect(env.Create(ctx, oneLabel)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(oneLabel), oneLabel)
+		}, timeout).Should(Succeed())
+
+		g.Eventually(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(oneLabel), oneLabel)).To(Succeed())
+			return oneLabel.Status.BootstrapReady
+		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Machine with another label will not be reconciled", func(t *testing.T) {
+		g := NewWithT(t)
+		anotherLabel := original.DeepCopy()
+		anotherLabel.Name = "another-label"
+		anotherLabel.SetLabels(map[string]string{
+			"one":     "",
+			"another": "",
+		})
+
+		g.Expect(env.Create(ctx, anotherLabel)).To(Succeed())
+		g.Eventually(func() error {
+			return env.Get(ctx, client.ObjectKeyFromObject(anotherLabel), anotherLabel)
+		}, timeout).Should(Succeed())
+
+		g.Consistently(func() bool {
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(anotherLabel), anotherLabel)).To(Succeed())
+			return anotherLabel.Status.BootstrapReady
+		}, timeout).Should(BeFalse())
+	})
+}

--- a/util/predicates/suite_test.go
+++ b/util/predicates/suite_test.go
@@ -40,14 +40,14 @@ var (
 
 // Reconciler reconciles a Machine object.
 type Reconciler struct {
-	Client               client.Client
-	WatchFilterPredicate LabelMatcher
+	Client           client.Client
+	WatchFilterValue LabelMatcher
 }
 
 func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager, opts controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Machine{}).
-		WithEventFilter(r.WatchFilterPredicate.Matches(logger)).
+		WithEventFilter(r.WatchFilterValue.Matches(logger)).
 		WithOptions(opts).
 		Complete(r)
 }
@@ -71,8 +71,8 @@ func TestMain(m *testing.M) {
 	}
 	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
 		if err := (&Reconciler{
-			Client:               mgr.GetClient(),
-			WatchFilterPredicate: matcher,
+			Client:           mgr.GetClient(),
+			WatchFilterValue: matcher,
 		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
 			panic(fmt.Sprintf("unable to create machine reconciler: %v", err))
 		}

--- a/util/predicates/suite_test.go
+++ b/util/predicates/suite_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+var (
+	ctx     = ctrl.SetupSignalHandler()
+	timeout = 10 * time.Second
+	env     *envtest.Environment
+)
+
+// Reconciler reconciles a Machine object.
+type Reconciler struct {
+	Client client.Client
+}
+
+func (r *Reconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Machine{}).
+		WithEventFilter(GetExpressionMatcher().Matches(logger)).
+		Complete(r)
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	m := &clusterv1.Machine{}
+	if err := r.Client.Get(ctx, req.NamespacedName, m); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	patch := client.MergeFrom(m.DeepCopy())
+	m.Status.BootstrapReady = true
+
+	return ctrl.Result{}, r.Client.Status().Patch(ctx, m, patch)
+}
+
+func TestMain(m *testing.M) {
+	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
+		if err := InitExpressionMatcher(logger, "!has(self.metadata.annotations) && ('one' in self.metadata.labels && !('another' in self.metadata.labels))"); err != nil {
+			panic(fmt.Sprintf("unable to setup matcher expression: %v", err))
+		}
+
+		if err := (&Reconciler{
+			Client: mgr.GetClient(),
+		}).SetupWithManager(ctx, mgr); err != nil {
+			panic(fmt.Sprintf("unable to create machine reconciler: %v", err))
+		}
+	}
+
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:                m,
+		SetupEnv:         func(e *envtest.Environment) { env = e },
+		SetupReconcilers: setupReconcilers,
+	}))
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This implementation may allow users to optionally reconcile resources based on `watch-expression` flag. With the flag in place, provided label selector expression will evaluate each resource preventing reconciliation. Based on https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement

Examples may include ignoring resources marked by a label:
```
label-name notin (value)
```

**Which issue(s) this PR fixes**
This implementation covers the basic scenario of `==` and `!=`, `in` and `notin` on resource labels.
 
Fixes #7775
