### PR TITLE
🐛 Skipping cleanup unhealthy replicas when oldMSReplicas is lower than oldMSAvailableReplicas

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -210,7 +210,7 @@ func (r *Reconciler) cleanupUnhealthyReplicas(ctx context.Context, oldMSs []*clu
 		oldMSAvailableReplicas := targetMS.Status.AvailableReplicas
 		log.V(4).Info("Found available Machines in old MachineSet",
 			"count", oldMSAvailableReplicas, "target-machineset", client.ObjectKeyFromObject(targetMS).String())
-		if oldMSReplicas == oldMSAvailableReplicas {
+		if oldMSReplicas <= oldMSAvailableReplicas {
 			// no unhealthy replicas found, no scaling required.
 			continue
 		}

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -278,8 +278,8 @@ func (r *Reconciler) scaleDownOldMachineSetsForRollingUpdate(ctx context.Context
 		}
 
 		// Scale down.
-		scaleDownCount := integer.Int32Min(*(targetMS.Spec.Replicas), totalScaleDownCount-totalScaledDown)
-		newReplicasCount := *(targetMS.Spec.Replicas) - scaleDownCount
+		scaleDownCount := integer.Int32Min(targetMS.Status.AvailableReplicas, totalScaleDownCount-totalScaledDown)
+		newReplicasCount := targetMS.Status.AvailableReplicas - scaleDownCount
 		if newReplicasCount > *(targetMS.Spec.Replicas) {
 			return totalScaledDown, errors.Errorf("when scaling down old MachineSet, got invalid request to scale down %v: %d -> %d",
 				client.ObjectKeyFromObject(targetMS), *(targetMS.Spec.Replicas), newReplicasCount)

--- a/internal/controllers/machinedeployment/machinedeployment_rolling_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling_test.go
@@ -550,7 +550,6 @@ func TestCleanupUnhealthyReplicas(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 			machineDeployment := &clusterv1.MachineDeployment{
@@ -590,7 +589,7 @@ func TestCleanupUnhealthyReplicas(t *testing.T) {
 
 			_, cleanupCount, err := r.cleanupUnhealthyReplicas(context.TODO(), []*clusterv1.MachineSet{oldMS}, machineDeployment, tc.maxCleanupCount)
 			if tc.wantErr {
-				g.Expect(err).ShouldNot(BeNil())
+				g.Expect(err).Should(HaveOccurred())
 				return
 			}
 


### PR DESCRIPTION

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The cause of https://github.com/kubernetes-sigs/cluster-api/issues/8987 is that after MachineDeployment first scale down old MachineSets, `oldMSReplicas < oldMSAvailableReplicas`, and when MachineDeployment need to scale down old MachineSets in a further step, cleaning up unhealthy  replicas failed due to `oldMSReplicas < oldMSAvailableReplicas`=> `newReplicasCount > oldMSReplicas`, and the scaleDownOldMachineSetsForRollingUpdate method will not be executed.

https://github.com/kubernetes-sigs/cluster-api/blob/0cbde4a7d4189aaaac32580e335074467b6efc98/internal/controllers/machinedeployment/machinedeployment_rolling.go#L184-L236



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/cluster-api/issues/8987