### PR TITLE
:book: Fix role names in release docs

### DIFF
--- a/docs/release/release-team.md
+++ b/docs/release/release-team.md
@@ -82,7 +82,7 @@ When assembling a release team, the release team lead should look for volunteers
 - Can commit to the amount of time required across the release cycle
 - Are enthusiastic about being on the release team
 - Are members of the Cluster Lifecycle SIG
-- Have some prior experience with contributing to CAPI releases (such as shadowing a role for a prior release)
+- Have some prior experience with contributing to CAPI releases (such having been in the release team for a prior release)
 - Have diverse company affiliations (i.e. not all from the same company)
 
 ## Time Commitment

--- a/docs/release/releases/release-1.6.md
+++ b/docs/release/releases/release-1.6.md
@@ -28,9 +28,9 @@ After the `.0` release monthly patch release will be created.
 
 ## Release team
 
-| **Role**                                  | **Lead Name** (**GitHub / Slack ID**)                                                      | **Shadow Name(s) (GitHub / Slack ID)**                                                                                                                                                                                                                                          |
-|-------------------------------------------|--------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Release Lead                              | TBD | TBD   |
-| Communications/Docs/Release Notes Manager | TBD | TBD   |
-| CI Signal/Bug Triage/Automation Manager   | TBD | TBD   |
-| Release Writer                            | TBD | TBD   |
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
+| Release Lead                              | TBD | TBD                                    |
+| Communications/Docs/Release Notes Manager | TBD | TBD                                    |
+| CI Signal/Bug Triage/Automation Manager   | TBD | TBD                                    |
+| Maintainer                                | TBD | TBD                                    |


### PR DESCRIPTION
Fix role names in the release docs to align with current naming.

`Shadows` -> `Team members`
`Release writer` -> `Maintainer`


Ref: https://github.com/kubernetes-sigs/cluster-api/pull/8988#discussion_r1267345341
