### PR TITLE
:book: Add link to "clusterctl move" docs.

### DIFF
--- a/docs/book/src/clusterctl/commands/move.md
+++ b/docs/book/src/clusterctl/commands/move.md
@@ -24,6 +24,8 @@ clusterctl move --to-kubeconfig="path-to-target-kubeconfig.yaml"
 To move the Cluster API objects existing in the current namespace of the source management cluster; in case if you want
 to move the Cluster API objects defined in another namespace, you can use the `--namespace` flag.
 
+The discovery mechanism for determining the objects to be moved is in the [provider contract](../provider-contract.md#move)
+
 <aside class="note">
 
 <h1> Pause Reconciliation </h1>


### PR DESCRIPTION
**What this PR does / why we need it**:

The details of "clusterctl move" are in the provider contract. A link to that helps new users.

