### PR TITLE
:seedling: Add dependabot for test and hack/tools module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,13 @@ updates:
   labels:
     - "area/ci"
     - "ok-to-test"
-# Go
+
+# Main Go module
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "weekly"
+    day: "monday"
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -25,6 +27,46 @@ updates:
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
   - dependency-name: "google.golang.org/grpc"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "area/dependency"
+    - "ok-to-test"
+
+  # Test Go module
+- package-ecosystem: "gomod"
+  directory: "/test"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "google.golang.org/grpc"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "area/dependency"
+    - "ok-to-test"
+
+  # Hack/tools Go module
+- package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "wednesday"
+  ignore:
+    # Ignore controller-runtime as its upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "google.golang.org/grpc"
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Enable dependabot for the `hack/tools` and `test` go modules.

Dependabot needs to be pointed to each directory holding a go module seperately. Previously we got updates to some dependencies in these files due to our dependeabot go generation job which runs `go mod tidy` on all modules.
Fixes #
