### PR TITLE
:seedling: Add exclude for Kustomize API to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
   - dependency-name: "google.golang.org/grpc"
+  # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi
+  # as a dependency.
+  - dependency-name: "sigs.k8s.io/kustomize/api"
   commit-message:
     prefix: ":seedling:"
   labels:
@@ -47,6 +50,9 @@ updates:
     - dependency-name: "k8s.io/*"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "google.golang.org/grpc"
+    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi
+    # as a dependency.
+    - dependency-name: "sigs.k8s.io/kustomize/api"
   commit-message:
     prefix: ":seedling:"
   labels:
@@ -67,6 +73,9 @@ updates:
     - dependency-name: "k8s.io/*"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "google.golang.org/grpc"
+    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi
+    # as a dependency.
+    - dependency-name: "sigs.k8s.io/kustomize/api"
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Add an exclude to the dependabot configuration for `sigs.k8s.io/kustomize/api`. Bumping the kustomize API independently can break compatibility with client-go as they share `k8s.io/kube-openapi` as a dependency.

Related to https://github.com/kubernetes-sigs/cluster-api/pull/9049
