### PR TITLE
:bug: Change tilt debug base image to golang

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -195,7 +195,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM gcr.io/distroless/base:debug as tilt
+FROM golang:1.20.6 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .


### PR DESCRIPTION
Change the base image used in the Tiltfile for debug images to golang. This change fixes an error with the output:

```
/dlv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /dlv)
/dlv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /dlv)
```
Still not sure of the root cause of the new error - but given that this is only used in our dev setup we can safely make this change.