### PR TITLE
🌱 Improve multiple areas PRs with user friendly subs

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -175,6 +175,10 @@ func getAreaLabel(merge string) (string, error) {
 	var areaLabels []string
 	for _, label := range pr.Labels {
 		if area, ok := trimAreaLabel(label.Name); ok {
+			if userFriendlyArea, ok := userFriendlyAreas[area]; ok {
+				area = userFriendlyArea
+			}
+
 			areaLabels = append(areaLabels, area)
 		}
 	}
@@ -183,13 +187,9 @@ func getAreaLabel(merge string) (string, error) {
 	case 0:
 		return missingAreaLabelPrefix, nil
 	case 1:
-		area := areaLabels[0]
-		if userFriendlyArea, ok := userFriendlyAreas[area]; ok {
-			area = userFriendlyArea
-		}
-		return area, nil
+		return areaLabels[0], nil
 	default:
-		return multipleAreaLabelsPrefix + strings.Join(areaLabels, "|") + "]", nil
+		return multipleAreaLabelsPrefix + strings.Join(areaLabels, "/") + "]", nil
 	}
 }
 
@@ -371,6 +371,7 @@ func run() int {
 				str2 := strings.ToLower(mergeslice[j])
 				return str1 < str2
 			})
+
 			for _, merge := range mergeslice {
 				fmt.Println(merge)
 			}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This applies the same user friendly areas substitutions to the multiple areas entries that it was already applied to single area entries.

As a bonus, add a case insensitive string sorting that avoids exponential string allocation. There was no major issue with the previous implementation, I just already had this one lying around and it should be a bit more efficient. This is mostly because strings are immutable in Go, so any `ToLower` call would basically have to allocate memory for a new string.

**Which issue(s) this PR fixes**:
Part of #9008

/area release
