### PR TITLE
📖 Control Plane resources required label from v1.5.0

### DIFF
--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -258,7 +258,9 @@ spec:
 ## Kubeconfig management
 
 Control Plane providers are expected to create and maintain a Kubeconfig
-secret for operators to gain initial access to the cluster. If a provider uses
+secret for operators to gain initial access to the cluster.
+The given secret must be labelled with the key-pair `cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}`
+to make it stored and retrievable in the cache used by CAPI managers. If a provider uses
 client certificates for authentication in these Kubeconfigs, the client
 certificate should be kept with a reasonably short expiration period and
 periodically regenerated to keep a valid set of credentials available. As an

--- a/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
+++ b/docs/book/src/developer/providers/migrations/v1.4-to-v1.5.md
@@ -38,6 +38,8 @@ maintainers of providers and consumers of our Go API.
 - Introduced function `CollectInfrastructureLogs` at the `ClusterLogCollector` interface in `test/framework/cluster_proxy.go` to allow collecting infrastructure related logs during tests.
 - A `GetTypedConfigOwner` function has been added to the `sigs.k8s.io./cluster-api/bootstrap/util` package. It is equivalent to `GetConfigOwner` except that it uses the cached typed client instead of the uncached unstructured client, so `GetTypedConfigOwner` is expected to be more performant.
 - `ClusterToObjectsMapper` in `sigs.k8s.io./cluster-api/util` has been deprecated, please use `ClusterToTypedObjectsMapper` instead.
+- The generated `kubeconfig` by the Control Plane providers must be labelled with the key-value pair `cluster.x-k8s.io/cluster-name=${CLUSTER_NAME}`.
+  This is required for the CAPI managers caches to store and retrieve them for the required operations.     
 
 ### Suggested changes for providers
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Sharing the new required labels for Secret objects generated by a Control Plane provider.

**Which issue(s) this PR fixes**:
Fixes #9079
