### PR TITLE
🌱 hack/observability: add capi_machine_status_certificatesexpirydate metric

### DIFF
--- a/hack/observability/kube-state-metrics/crd-config.yaml
+++ b/hack/observability/kube-state-metrics/crd-config.yaml
@@ -569,6 +569,15 @@ spec:
             address:
             - address
         type: Info
+    - name: status_certificatesexpirydate
+      help: Information about certificate expiration date of a control plane node.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+            - status
+            - certificatesExpiryDate
+        type: Gauge
     - name: status_noderef
       help: Information about the node reference of a machine.
       each:

--- a/hack/observability/kube-state-metrics/metrics/machine.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machine.yaml
@@ -87,6 +87,15 @@
             address:
             - address
         type: Info
+    - name: status_certificatesexpirydate
+      help: Information about certificate expiration date of a control plane node.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+            - status
+            - certificatesExpiryDate
+        type: Gauge
     - name: status_noderef
       help: Information about the node reference of a machine.
       each:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Adds a gauge metric to our kube-state-metrics configuration for exposing a machines `.status.certificatesExpiryDate`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9019
