### PR TITLE
📖 Add v1.6 Release Team members' GitHub/Slack handles

### DIFF
--- a/docs/release/releases/release-1.6.md
+++ b/docs/release/releases/release-1.6.md
@@ -4,33 +4,33 @@
 
 The following table shows the preliminary dates for the `v1.6` release cycle.
 
-| **What**                                             | **Who**      | **When**                   | **Week** |
-|------------------------------------------------------|--------------|----------------------------|----------|
-| Start of Release Cycle                               | Release Lead | Monday 31st July 2023      | week 1   |
+| **What**                                             | **Who**      | **When**                    | **Week** |
+|------------------------------------------------------|--------------|-----------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 31st July 2023       | week 1   |
 | Schedule finalized                                   | Release Lead | Friday 4th August 2023      | week 1   |
 | Team finalized                                       | Release Lead | Friday 4th August 2023      | week 1   |
-| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 29th August 2023       | week 5   |
-| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 26th September 2023      | week 9   |
-| v1.6.0-beta.0 released                               | Release Lead | Tuesday 24th October 2023     | week 13  |
-| Communicate beta to providers                        | Comms Manager| Tuesday 24th October 2023     | week 13  |
-| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 24th October 2023     | week 13  |
-| v1.6.0-beta.x released                               | Release Lead | Tuesday 31st October 2023      | week 14  |
-| KubeCon idle week | - | 6th - 10th November 2023 | week 15 |
-| release-1.6 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 14th November 2023     | week 16  |
-| v1.6.0-rc.0 released                                 | Release Lead | Tuesday 14th November 2023     | week 16  |
-| release-1.6 jobs created                             | CI Manager   | Tuesday 14th November 2023     | week 16  |
-| v1.6.0-rc.x released                                 | Release Lead | Tuesday 21th November 2023     | week 17  |
-| **v1.6.0 released**                                  | Release Lead | Tuesday 28st November 2023     | week 18  |
-| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 28st November 2023     | week 18  |
-| Organize release retrospective                       | Release Lead | TBC                        | week 18  |
+| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 29th August 2023    | week 5   |
+| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 26th September 2023 | week 9   |
+| v1.6.0-beta.0 released                               | Release Lead | Tuesday 24th October 2023   | week 13  |
+| Communicate beta to providers                        | Comms Manager| Tuesday 24th October 2023   | week 13  |
+| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 24th October 2023   | week 13  |
+| v1.6.0-beta.x released                               | Release Lead | Tuesday 31st October 2023   | week 14  |
+| KubeCon idle week                                    |      -       | 6th - 10th November 2023    | week 15  |
+| release-1.6 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 14th November 2023  | week 16  |
+| v1.6.0-rc.0 released                                 | Release Lead | Tuesday 14th November 2023  | week 16  |
+| release-1.6 jobs created                             | CI Manager   | Tuesday 14th November 2023  | week 16  |
+| v1.6.0-rc.x released                                 | Release Lead | Tuesday 21st November 2023  | week 17  |
+| **v1.6.0 released**                                  | Release Lead | Tuesday 28th November 2023  | week 18  |
+| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 28th November 2023  | week 18  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 18  |
 
 After the `.0` release monthly patch release will be created.
 
 ## Release team
 
-| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                          | **Team member(s) (GitHub / Slack ID)** |
 |-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
-| Release Lead                              | TBD | TBD                                    |
-| Communications/Docs/Release Notes Manager | TBD | TBD                                    |
-| CI Signal/Bug Triage/Automation Manager   | TBD | TBD                                    |
-| Maintainer                                | TBD | TBD                                    |
+| Release Lead                              | Furkat Gofurov ([@furkatgofurov7](https://github.com/furkatgofurov7) ✉️ ️`@Furkat Gofurov`) | Chirayu Kapoor ([@chiukapoor](https://github.com/chiukapoor) ✉️ `@Chirayu Kapoor`) <br> Prajyot Parab ([@Prajyot-Parab](https://github.com/Prajyot-Parab) ✉️ ️`@Prajyot Parab`) <br> Stephen Cahill ([@cahillsf](https://github.com/cahillsf) ✉️ ️`@Stephen Cahill`) |
+| Communications/Docs/Release Notes Manager | Guillermo Gaston ([@g-gaston](https://github.com/g-gaston) ✉️ ️`@ggaston`) | Michael Shen ([@mjlshen](https://github.com/mjlshen) ✉️ ️`@mishen`) <br> Nikola Prokopić ([@nprokopic](https://github.com/nprokopic) ✉️ ️`@Nikola`) <br> Willie Yao ([@willie-yao](https://github.com/willie-yao) ✉️ ️`@willie`) |
+| CI Signal/Bug Triage/Automation Manager   | Nawaz Hussain Khazielakha ([@nawazkh](https://github.com/nawazkh) ✉️ `@nawazkh`) | Abdur Rehman Shahid ([@razashahid107](https://github.com/razashahid107) ✉️ `@Abdur Rehman Shahid`) <br> Amit Kumar ([@hackeramitkumar](https://github.com/hackeramitkumar) ✉️ `@Amit Kumar`) <br> Anurag ([@kranurag7](https://github.com/kranurag7) ✉️ `@Anurag`) <br> Muhammad Adil Ghaffar ([@adilGhaffarDev](https://github.com/adilGhaffarDev) ✉️ `@adil`) <br> Sunnat Samadov ([@Sunnatillo](https://github.com/Sunnatillo) ✉️ `@Sunnat`) |
+| Maintainer                                | Vince Prignano ([@vincepri](https://github.com/vincepri) ✉️ ️`@vincepri`) |


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes formatting issues in the table
- adds v1.6 Release Team members GitHub/Slack handles in an alphabetical order


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
