### PR TITLE
🌱 Add ClusterClass column to Cluster CRD

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -480,6 +480,7 @@ func (v APIEndpoint) String() string {
 // +kubebuilder:resource:path=clusters,shortName=cl,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ClusterClass",type="string",JSONPath=".spec.topology.class",description="ClusterClass of this Cluster, empty if the Cluster is not using a ClusterClass"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of Cluster"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.topology.version",description="Kubernetes version associated with this Cluster"

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -665,6 +665,11 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: ClusterClass of this Cluster, empty if the Cluster is not using
+        a ClusterClass
+      jsonPath: .spec.topology.class
+      name: ClusterClass
+      type: string
     - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
       jsonPath: .status.phase
       name: Phase


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds a ClusterClass column to the Cluster CRD. Super helpful to determine if a Cluster is a classy cluster, and if yes which ClusterClass it uses

```bash
k get clusterclass,cluster,kcp,md
NAME                                        AGE
clusterclass.cluster.x-k8s.io/quick-start   5m44s

NAME                                       CLUSTERCLASS   PHASE         AGE     VERSION
cluster.cluster.x-k8s.io/capi-quickstart                  Provisioned   5m50s
cluster.cluster.x-k8s.io/my-cluster        quick-start    Provisioned   5m41s   v1.26.0

NAME                                                                              CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/capi-quickstart-control-plane   capi-quickstart   true                                 1                  1         1             5m50s   v1.25.0
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/my-cluster-465k6                my-cluster        true                                 1                  1         1             5m41s   v1.26.0

NAME                                                                        CLUSTER           REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE     VERSION
machinedeployment.cluster.x-k8s.io/capi-quickstart-md-0                     capi-quickstart   1                  1         1             ScalingUp   5m50s   v1.25.0
machinedeployment.cluster.x-k8s.io/my-cluster-default-worker-topo-1-qsrp5   my-cluster        1                  1         1             ScalingUp   5m40s   v1.26.0
machinedeployment.cluster.x-k8s.io/my-cluster-default-worker-topo-2-gx42r   my-cluster        1                  1         1             ScalingUp   5m40s   v1.26.0
machinedeployment.cluster.x-k8s.io/my-cluster-default-worker-topo-3-jmwvt   my-cluster        1                  1         1             ScalingUp   5m40s   v1.26.0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
