### PR TITLE
:bug: Fix ClusterClass enqueue for ExtensionConfig

### DIFF
--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -409,7 +409,7 @@ func (r *Reconciler) extensionConfigToClusterClass(ctx context.Context, o client
 		}
 		for _, patch := range clusterClass.Spec.Patches {
 			if patch.External != nil && patch.External.DiscoverVariablesExtension != nil {
-				res = append(res, ctrl.Request{NamespacedName: client.ObjectKey{Name: ext.Name}})
+				res = append(res, ctrl.Request{NamespacedName: client.ObjectKey{Namespace: clusterClass.Namespace, Name: clusterClass.Name}})
 				break
 			}
 		}


### PR DESCRIPTION
Fix the ClusterClass enqueuing behaviour for ExtensionConfigs. Currently this function can never work as it returns the name of the ExtensionConfig rather than the ClusterClass. This triggers a reconcile which always returns an "object not found error"

c/f https://github.com/kubernetes-sigs/cluster-api/issues/8495#issuecomment-1665879466