### PR TITLE
📖 Document new scheme-builder patterns in provider migration doc

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
+++ b/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
@@ -31,3 +31,4 @@ maintainers of providers and consumers of our Go API.
 
 ### Suggested changes for providers
 
+- In order to reduce dependencies for API package consumers, CAPI has diverged from the default kubebuilder scheme builder. This new pattern may also be useful for reducing dependencies in provider API packages. For more information [see the implementers guide.](../implementers-guide/create_api.md#registering-apis-in-the-scheme)


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents changes from https://github.com/kubernetes-sigs/cluster-api/pull/9045 in v1.5-v1.6 migration document 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref comment: https://github.com/kubernetes-sigs/cluster-api/pull/9045#discussion_r1286114504 
