### PR TITLE
:seedling: Add colored-line-number output for golangci-lint action

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -31,4 +31,5 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # tag=v3.6.0
         with:
           version: v1.54.1
+          args: --out-format=colored-line-number
           working-directory: ${{matrix.working-directory}}


### PR DESCRIPTION
Adds the colored-line-number output format for the golangci-lint action run in CI.

Idea taken from https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2180.
