### PR TITLE
🌱 Drop duplicate pprof and unused linter excludes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,10 +88,6 @@ linters-settings:
       - wrapperFunc
       - rangeValCopy
       - hugeParam
-  gosec:
-    excludes:
-    - G307 # Deferring unsafe method "Close" on type "\*os.File"
-    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
   importas:
     no-unaliased: true
     alias:
@@ -264,14 +260,21 @@ issues:
     text: always receives
   # Dot imports for gomega and ginkgo are allowed
   # within test files and test utils.
-  - path: _test\.go
+  - linters:
+    - revive
+    - stylecheck
+    path: _test\.go
     text: should not use dot imports
-  - path: (framework|e2e)/.*.go
+  - linters:
+    - revive
+    - stylecheck
+    path: (framework|e2e)/.*.go
     text: should not use dot imports
-  - path: util/defaulting/defaulting.go
+  - linters:
+    - revive
+    - stylecheck
+    path: util/defaulting/defaulting.go
     text: should not use dot imports
-  - path: _test\.go
-    text: cyclomatic complexity
   # Append should be able to assign to a different var/slice.
   - linters:
     - gocritic
@@ -313,11 +316,6 @@ issues:
     - stylecheck
     text: "ST1016: methods on the same type should have the same receiver name"
     path: .*(api|types)\/.*\/conversion.*\.go$
-  # hack/tools
-  - linters:
-    - typecheck
-    text: import (".+") is a program, not an importable package
-    path: ^tools\.go$
   # We don't care about defer in for loops in test files.
   - linters:
     - gocritic

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	_ "net/http/pprof"
 	"os"
 	goruntime "runtime"
 	"time"

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	_ "net/http/pprof"
 	"os"
 	goruntime "runtime"
 	"time"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Found this while syncing golangci-lint config with CAPV.

The pprof imports for the boostrap and control plane controller are a duplicate to the ones provided via controller-runtime.

The linter exclusions are not necessary anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->