### PR TITLE
✨ v1.28: Prepare quickstart, capd and tests for the new release including kind bump

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,7 @@
 envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
-kubernetes_version = "v1.27.3"
+kubernetes_version = "v1.28.0"
 
 load("ext://uibutton", "cmd_button", "location", "text_input")
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -330,7 +330,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: "default"
-  KUBERNETES_VERSION: "v1.27.3"
+  KUBERNETES_VERSION: "v1.28.0"
   CONTROL_PLANE_MACHINE_COUNT: "1"
   WORKER_MACHINE_COUNT: "3"
 # Note: kustomize substitutions expects the values to be strings. This can be achieved by wrapping the values in quotation marks.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1217,7 +1217,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.27.3 \
+  --kubernetes-version v1.28.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1229,7 +1229,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.27.1
+export KUBERNETES_VERSION=1.28.0
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -1260,7 +1260,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.27.3 \
+  --kubernetes-version v1.28.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1314,7 +1314,7 @@ and see an output similar to this:
 
 ```bash
 NAME              PHASE         AGE   VERSION
-capi-quickstart   Provisioned   8s    v1.27.3
+capi-quickstart   Provisioned   8s    v1.28.0
 ```
 
 To verify the first control plane is up:
@@ -1327,7 +1327,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.27.3
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.28.0
 ```
 
 <aside class="note warning">
@@ -1536,7 +1536,7 @@ kube-scheduler-capi-quickstart-control-plane-kjjbb            1/1     Running   
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml
+  apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,
@@ -1547,12 +1547,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE    VERSION
-capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.27.3
-capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.27.3
-capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.27.3
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.27.3
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.27.3
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.27.3
+capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.28.0
+capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.28.0
+capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.28.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.28.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.28.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.28.0
 ```
 
 {{#/tab }}

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -152,8 +152,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.5=>current)", func() {
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			// NOTE: If this version is changed here the image and SHA must also be updated in all DockerMachineTemplates in `test/e2e/data/infrastructure-docker/v1.5/bases.
-			InitWithKubernetesVersion: "v1.27.3",
-			WorkloadKubernetesVersion: "v1.27.3",
+			InitWithKubernetesVersion: "v1.28.0",
+			WorkloadKubernetesVersion: "v1.28.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
@@ -183,8 +183,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.5=>cur
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
 			// NOTE: If this version is changed here the image and SHA must also be updated in all DockerMachineTemplates in `test/e2e/data/infrastructure-docker/v1.5/bases.
-			InitWithKubernetesVersion: "v1.27.3",
-			WorkloadKubernetesVersion: "v1.27.3",
+			InitWithKubernetesVersion: "v1.28.0",
+			WorkloadKubernetesVersion: "v1.28.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -237,11 +237,11 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.27.3"
-  KUBERNETES_VERSION: "v1.27.3"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.26.6"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.27.3"
-  ETCD_VERSION_UPGRADE_TO: "3.5.7-0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.28.0"
+  KUBERNETES_VERSION: "v1.28.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.3"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.28.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.9-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "dual"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+	DefaultNodeImageVersion = "v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.3
+  version: v1.28.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.27.3
+      version: v1.28.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.3
+  version: v1.28.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.3
+      version: v1.28.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.27.3
+  version: v1.28.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.3
+      version: v1.28.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.27.3
+  version: v1.28.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.27.3
+      version: v1.28.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -82,6 +82,11 @@ var preBuiltMappings = []Mapping{
 
 	// Pre-built images for Kind v1.20.
 	{
+		KubernetesVersion: semver.MustParse("1.28.0"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31",
+	},
+	{
 		KubernetesVersion: semver.MustParse("1.27.3"),
 		Mode:              Mode0_20,
 		Image:             "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

According to #8708 : Modify quickstart and CAPD to use the new Kubernetes release:
  
  * Bump the Kubernetes version in:
    
    * `test/*`: search for occurrences of the previous Kubernetes version
    * `Tiltfile`
  * Ensure the latest available kind version is used (including the latest images for this kind release)
  * Verify the quickstart manually
  * Prior art: [⚠️ Use Kubernetes 1.25 in Quick Start docs and CAPD. #7156](https://github.com/kubernetes-sigs/cluster-api/pull/7156)
  * bump `InitWithKubernetesVersion` and `WorkloadKubernetesVersion` in `clusterctl_upgrade_test.go`

Open TODOs:
- [x] Wait for v1.28 release (+ kind release / released images)
- [x] rebase after #9097 merges
- [ ] ~finish kind image bump after release (also bump kind itself it was an entire release)~
- [x] fix kindest/node sha's
- [ ] ~verify we did everything defined in #8977~
- [x] Verify quickstart

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to #8708

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->