### PR TITLE
📖 book: Update versions doc adding Kubernetes 1.28 + prowjob documentation

### DIFF
--- a/docs/book/src/developer/providers/version-migration.md
+++ b/docs/book/src/developer/providers/version-migration.md
@@ -10,3 +10,4 @@ maintainers of other providers and consumers of the Go API in upgrading from one
 - [v1.2 to v1.3](migrations/v1.2-to-v1.3.md)
 - [v1.3 to v1.4](migrations/v1.3-to-v1.4.md)
 - [v1.4 to v1.5](migrations/v1.4-to-v1.5.md)
+- [v1.5 to v1.6](migrations/v1.5-to-v1.6.md)

--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -32,7 +32,7 @@ Prow Presubmits:
     * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]`
   * [pull-cluster-api-e2e-full-main] `./scripts/ci-e2e.sh`
     * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]|[IPv6]`
-  * [pull-cluster-api-e2e-workload-upgrade-1-27-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.27` TO: `ci/latest-1.28`
+  * [pull-cluster-api-e2e-workload-upgrade-1-28-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.28` TO: `ci/latest-1.29`
     * GINKGO_FOCUS: `[K8s-Upgrade]`
   * [pull-cluster-api-e2e-scale-main-experimental] `./scripts/ci-e2e-scale.sh`
 
@@ -78,8 +78,6 @@ Prow Periodics:
 * [periodic-cluster-api-e2e-dualstack-and-ipv6-main] `./scripts/ci-e2e.sh`
   * DOCKER_IN_DOCKER_IPV6_ENABLED: `true`
   * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main] `./scripts/ci-e2e.sh` FROM: `stable-1.22` TO: `stable-1.23`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main] `./scripts/ci-e2e.sh` FROM: `stable-1.23` TO: `stable-1.24`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main] `./scripts/ci-e2e.sh` FROM: `stable-1.24` TO: `stable-1.25`
@@ -88,7 +86,9 @@ Prow Periodics:
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-main] `./scripts/ci-e2e.sh` FROM: `stable-1.26` TO: `stable-1.27`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-27-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.27` TO: `ci/latest-1.28`
+* [periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main] `./scripts/ci-e2e.sh` FROM: `stable-1.27` TO: `stable-1.28`
+  * GINKGO_FOCUS: `[K8s-Upgrade]`
+* [periodic-cluster-api-e2e-workload-upgrade-1-28-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.28` TO: `ci/latest-1.29`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [cluster-api-push-images-nightly] Google Cloud Build: `make release-staging-nightly`
 
@@ -125,18 +125,18 @@ Prow Periodics:
 [pull-cluster-api-e2e-informing-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-informing-main
 [pull-cluster-api-e2e-full-dualstack-and-ipv6-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-full-dualstack-and-ipv6-main
 [pull-cluster-api-e2e-full-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-full-main
-[pull-cluster-api-e2e-workload-upgrade-1-27-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-1-27-latest
+[pull-cluster-api-e2e-workload-upgrade-1-28-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-1-28-latest
 [pull-cluster-api-e2e-scale-main-experimental]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-scale-main-experimental
 [periodic-cluster-api-test-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-main
 [periodic-cluster-api-test-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-mink8s-main
 [periodic-cluster-api-e2e-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main
 [periodic-cluster-api-e2e-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-mink8s-main
 [periodic-cluster-api-e2e-dualstack-and-ipv6-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-dualstack-and-ipv6-main
-[periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-22-1-23
 [periodic-cluster-api-e2e-workload-upgrade-1-23-1-24-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-23-1-24
 [periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-24-1-25
 [periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-25-1-26
 [periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-26-1-27
-[periodic-cluster-api-e2e-workload-upgrade-1-27-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-27-latest
+[periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-27-1-28
+[periodic-cluster-api-e2e-workload-upgrade-1-28-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-28-latest
 [cluster-api-push-images-nightly]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#cluster-api-push-images-nightly
 [post-cluster-api-push-images]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-cluster-api-push-images

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -78,12 +78,13 @@ These diagrams show the relationships between components in a Cluster API releas
 | Kubernetes v1.19  | ✓ (only workload)    |                   |                   |                   |
 | Kubernetes v1.20  | ✓                    |                   |                   |                   |
 | Kubernetes v1.21  | ✓                    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.22  | ✓                    | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.22  | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
 | Kubernetes v1.23* | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.24  | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
 | Kubernetes v1.25  | ✓                    | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.26  | ✓                    | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.27  |                      | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.28  |                      |                   | ✓                 | ✓                 |
 
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
@@ -101,12 +102,13 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 | Kubernetes v1.19 + kubeadm/v1beta2 | ✓ (only workload)    |                    |                    |                    |
 | Kubernetes v1.20 + kubeadm/v1beta2 | ✓                    |                    |                    |                    |
 | Kubernetes v1.21 + kubeadm/v1beta2 | ✓                    | ✓  (only workload) |                    |                    |
-| Kubernetes v1.22 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) | ✓  (only workload) |
+| Kubernetes v1.22 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) |                    |
 | Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓  (only workload) | ✓  (only workload) |
-| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
+| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓  (only workload) |
 | Kubernetes v1.25 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
 | Kubernetes v1.26 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
 | Kubernetes v1.27 + kubeadm/v1beta3 |                      | ✓                  | ✓                  | ✓                  |
+| Kubernetes v1.28 + kubeadm/v1beta3 |                      |                    | ✓                  | ✓                  |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
@@ -118,12 +120,13 @@ The Kubeadm Bootstrap Provider generates kubeadm configuration using the API ver
 | Kubernetes v1.19 + etcd/v3 | ✓ (only workload)    |                   |                   |                   |
 | Kubernetes v1.20 + etcd/v3 | ✓                    |                   |                   |                   |
 | Kubernetes v1.21 + etcd/v3 | ✓                    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.22 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.22 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
 | Kubernetes v1.23 + etcd/v3 | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
 | Kubernetes v1.25 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.26 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.27 + etcd/v3 |                      | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.28 + etcd/v3 |                      |                   | ✓                 | ✓                 |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
@@ -143,6 +146,9 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 | v1.5 (v1beta1)       | v1.10.1                         |
 
 #### Kubernetes version specific notes
+
+**1.28**:
+* No specific notes
 
 **1.27**:
 * No specific notes


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Update book:
  
  * Update supported versions in `versions.md`
  * Update job documentation in `jobs.md`
  * Prior art: [🌱 Update versions doc adding Kubernetes 1.25 #7194](https://github.com/kubernetes-sigs/cluster-api/pull/7194) [📖 docs update jobs.md #7196](https://github.com/kubernetes-sigs/cluster-api/pull/7196)

TODO

- [ ] Wait for merge of https://github.com/kubernetes/test-infra/pull/30347

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8708

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->