### PR TITLE
:bug: Generate warning when release notes can not be generated 

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -63,7 +63,7 @@ var (
 		unknown,
 	}
 
-	repo = flag.String("repository", "kubernetes-sigs/cluster-api", "The tag or commit to start from.")
+	repo = flag.String("repository", "kubernetes-sigs/cluster-api", "The repo to run the tool from.")
 
 	fromTag = flag.String("from", "", "The tag or commit to start from.")
 
@@ -447,6 +447,9 @@ func modifyEntryTitle(title string, prefixes []string) string {
 // generateReleaseNoteEntry processes a commit into a PR line item for the release notes.
 func generateReleaseNoteEntry(c *commit) (*releaseNoteEntry, error) {
 	entry := &releaseNoteEntry{}
+	if c.body == "" {
+		c.body = "ERROR: BODY MISSING. FIX MANUALLY"
+	}
 	entry.title = trimTitle(c.body)
 	var fork string
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a warning to the release notes tool when a release note can not be generated at all - i.e. when the body is empty. We noticed this error when using the release tool to generate notes for the Cluster API provider for CAPV.

This error hasn't occured in releases of CAPI AFAICT. Running   `go run ./hack/tools/release/notes.go --from=v1.4.0` doesn't produce any errors. 