### PR TITLE
🐛 Fix AddAnnotations for unstructured.Unstructured

### DIFF
--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -71,7 +71,6 @@ func AddAnnotations(o metav1.Object, desired map[string]string) bool {
 	annotations := o.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
-		o.SetAnnotations(annotations)
 	}
 	hasChanged := false
 	for k, v := range desired {
@@ -80,6 +79,7 @@ func AddAnnotations(o metav1.Object, desired map[string]string) bool {
 			hasChanged = true
 		}
 	}
+	o.SetAnnotations(annotations)
 	return hasChanged
 }
 

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -22,12 +22,13 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestAddAnnotations(t *testing.T) {
 	g := NewWithT(t)
 
-	var testcases = []struct {
+	testcases := []struct {
 		name     string
 		obj      metav1.Object
 		input    map[string]string
@@ -138,6 +139,39 @@ func TestAddAnnotations(t *testing.T) {
 			},
 			expected: map[string]string{
 				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should add annotations to an empty unstructured",
+			obj:  &unstructured.Unstructured{},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should add annotations to a non empty unstructured",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			input: map[string]string{
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			expected: map[string]string{
+				"foo":    "bar",
+				"thing1": "thing2",
+				"buzz":   "blah",
 			},
 			changed: true,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The previous implementation worked well for most Object implementations (definitely all embedding metav1.ObjectMeta) because it relies on:
* The fact that GetAnnotations doesn't return a copy of the annotations but the underlying map storing them.
* When calling set annotations, the input map is used for storage in the Object implementation, hence when adding entries to that map from the outside, it changes the content of the Object's annotations.

This is not necessarily part of the contract specified by metav1.Object so we can't really guarantee all implementations will satisfy these 2 conditions. It turns out, unstructured.Unstructured doesn't.

This issue is probably and edge and hence why no one has run into it yet. But it bite me when writing some tests the other day, so probably worth fixing jic.


/area util