### PR TITLE
🌱 Add back flavor to Waiter interface

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -315,6 +315,7 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 		ClusterName:                  input.ConfigCluster.ClusterName,
 		Namespace:                    input.ConfigCluster.Namespace,
 		CNIManifestPath:              input.CNIManifestPath,
+		Flavor:                       input.ConfigCluster.Flavor,
 		WaitForClusterIntervals:      input.WaitForClusterIntervals,
 		WaitForControlPlaneIntervals: input.WaitForControlPlaneIntervals,
 		WaitForMachineDeployments:    input.WaitForMachineDeployments,
@@ -333,6 +334,7 @@ type ApplyCustomClusterTemplateAndWaitInput struct {
 	ClusterName                  string
 	Namespace                    string
 	CNIManifestPath              string
+	Flavor                       string
 	WaitForClusterIntervals      []interface{}
 	WaitForControlPlaneIntervals []interface{}
 	WaitForMachineDeployments    []interface{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: As part of https://github.com/kubernetes-sigs/cluster-api/commit/caaa74482b51fae777334cd7a29595da1c06481e#diff-7084fa27f2b10b8d2472295c14187d21ea186aae39efa12e051f340562a4cca4, the `Waiter` interface input type in the e2e test framework was changed from `ApplyClusterTemplateAndWaitInput ` to `ApplyCustomClusterTemplateAndWaitInput`, however this is breaking for providers that use the `Waiter` interface outside of scale.go. 

When bumping CAPI to v1.5.0 in CAPZ, we ran into an issue where `Flavor` is no longer available from that input type (see [here](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3707/files#r1283473277)).

This PR adds `Flavor` to the new struct which should have no negative impacts for tests that don't use it but allows tests who need it to keep using it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:

-->

/area e2e-testing
