### PR TITLE
🐛Certificate paths in cloud-init scripts should not use a platform-dependent path separator

### DIFF
--- a/util/secret/certificates.go
+++ b/util/secret/certificates.go
@@ -25,7 +25,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"math/big"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -73,25 +73,25 @@ func NewCertificatesForInitialControlPlane(config *bootstrapv1.ClusterConfigurat
 	certificates := Certificates{
 		&Certificate{
 			Purpose:  ClusterCA,
-			CertFile: filepath.Join(certificatesDir, "ca.crt"),
-			KeyFile:  filepath.Join(certificatesDir, "ca.key"),
+			CertFile: path.Join(certificatesDir, "ca.crt"),
+			KeyFile:  path.Join(certificatesDir, "ca.key"),
 		},
 		&Certificate{
 			Purpose:  ServiceAccount,
-			CertFile: filepath.Join(certificatesDir, "sa.pub"),
-			KeyFile:  filepath.Join(certificatesDir, "sa.key"),
+			CertFile: path.Join(certificatesDir, "sa.pub"),
+			KeyFile:  path.Join(certificatesDir, "sa.key"),
 		},
 		&Certificate{
 			Purpose:  FrontProxyCA,
-			CertFile: filepath.Join(certificatesDir, "front-proxy-ca.crt"),
-			KeyFile:  filepath.Join(certificatesDir, "front-proxy-ca.key"),
+			CertFile: path.Join(certificatesDir, "front-proxy-ca.crt"),
+			KeyFile:  path.Join(certificatesDir, "front-proxy-ca.key"),
 		},
 	}
 
 	etcdCert := &Certificate{
 		Purpose:  EtcdCA,
-		CertFile: filepath.Join(certificatesDir, "etcd", "ca.crt"),
-		KeyFile:  filepath.Join(certificatesDir, "etcd", "ca.key"),
+		CertFile: path.Join(certificatesDir, "etcd", "ca.crt"),
+		KeyFile:  path.Join(certificatesDir, "etcd", "ca.key"),
 	}
 
 	// TODO make sure all the fields are actually defined and return an error if not
@@ -124,24 +124,24 @@ func NewControlPlaneJoinCerts(config *bootstrapv1.ClusterConfiguration) Certific
 	certificates := Certificates{
 		&Certificate{
 			Purpose:  ClusterCA,
-			CertFile: filepath.Join(certificatesDir, "ca.crt"),
-			KeyFile:  filepath.Join(certificatesDir, "ca.key"),
+			CertFile: path.Join(certificatesDir, "ca.crt"),
+			KeyFile:  path.Join(certificatesDir, "ca.key"),
 		},
 		&Certificate{
 			Purpose:  ServiceAccount,
-			CertFile: filepath.Join(certificatesDir, "sa.pub"),
-			KeyFile:  filepath.Join(certificatesDir, "sa.key"),
+			CertFile: path.Join(certificatesDir, "sa.pub"),
+			KeyFile:  path.Join(certificatesDir, "sa.key"),
 		},
 		&Certificate{
 			Purpose:  FrontProxyCA,
-			CertFile: filepath.Join(certificatesDir, "front-proxy-ca.crt"),
-			KeyFile:  filepath.Join(certificatesDir, "front-proxy-ca.key"),
+			CertFile: path.Join(certificatesDir, "front-proxy-ca.crt"),
+			KeyFile:  path.Join(certificatesDir, "front-proxy-ca.key"),
 		},
 	}
 	etcdCert := &Certificate{
 		Purpose:  EtcdCA,
-		CertFile: filepath.Join(certificatesDir, "etcd", "ca.crt"),
-		KeyFile:  filepath.Join(certificatesDir, "etcd", "ca.key"),
+		CertFile: path.Join(certificatesDir, "etcd", "ca.crt"),
+		KeyFile:  path.Join(certificatesDir, "etcd", "ca.key"),
 	}
 
 	// TODO make sure all the fields are actually defined and return an error if not
@@ -167,7 +167,7 @@ func NewControlPlaneJoinCerts(config *bootstrapv1.ClusterConfiguration) Certific
 // NewCertificatesForWorker return an initialized but empty set of CA certificates needed to bootstrap a cluster.
 func NewCertificatesForWorker(caCertPath string) Certificates {
 	if caCertPath == "" {
-		caCertPath = filepath.Join(DefaultCertificatesDir, "ca.crt")
+		caCertPath = path.Join(DefaultCertificatesDir, "ca.crt")
 	}
 
 	return Certificates{


### PR DESCRIPTION
**What this PR does / why we need it**:
The path separator in cloud-init scripts should always be "/" and independent of the platform, so path.Join instead of filepath.Join should be used when generating the paths. If Kubeadm bootstrap provider runs in a Windows pod, the certificate paths in cloud-init scripts will be incorrect, and created clusters will not be started due to incorrect certificate paths.

/area bootstrap