### PR TITLE
:seedling: Bump golangci-lint to v1.54.1

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -30,5 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # tag=v3.6.0
         with:
-          version: v1.53.3
+          version: v1.54.1
           working-directory: ${{matrix.working-directory}}


### PR DESCRIPTION
Bump golangci-lint to v1.54.1.

The main feature here is go v1.21 support. Notes:

v1.54.0: https://github.com/golangci/golangci-lint/releases/tag/v1.54.0
v1.54.1: https://github.com/golangci/golangci-lint/releases/tag/v1.54.1 