### PR TITLE
:bug: Deduplicating area in pr title in release notes

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -435,6 +435,7 @@ type releaseNoteEntry struct {
 	prNumber string
 }
 
+// modifyEntryTitle removes the specified prefixes from the title.
 func modifyEntryTitle(title string, prefixes []string) string {
 	entryWithoutTag := title
 	for _, prefix := range prefixes {
@@ -442,6 +443,16 @@ func modifyEntryTitle(title string, prefixes []string) string {
 	}
 
 	return strings.ToUpper(string(entryWithoutTag[0])) + entryWithoutTag[1:]
+}
+
+// trimAreaFromTitle removes the prefixed area from title to avoid duplication.
+func trimAreaFromTitle(title, area string) string {
+	titleWithoutArea := title
+	pattern := `(?i)^` + regexp.QuoteMeta(area+":")
+	re := regexp.MustCompile(pattern)
+	titleWithoutArea = re.ReplaceAllString(titleWithoutArea, "")
+	titleWithoutArea = strings.TrimSpace(titleWithoutArea)
+	return titleWithoutArea
 }
 
 // generateReleaseNoteEntry processes a commit into a PR line item for the release notes.
@@ -501,6 +512,7 @@ func generateReleaseNoteEntry(c *commit) (*releaseNoteEntry, error) {
 	}
 
 	if *prefixAreaLabel {
+		entry.title = trimAreaFromTitle(entry.title, area)
 		entry.title = fmt.Sprintf("- %s: %s", area, entry.title)
 	} else {
 		entry.title = fmt.Sprintf("- %s", entry.title)

--- a/hack/tools/release/notes_test.go
+++ b/hack/tools/release/notes_test.go
@@ -61,3 +61,45 @@ func Test_trimTitle(t *testing.T) {
 		})
 	}
 }
+
+func Test_trimAreaFromTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		area  string
+		want  string
+	}{
+		{
+			name:  "PR title with area",
+			title: "e2e: improve logging for a detected rollout",
+			area:  "e2e",
+			want:  "improve logging for a detected rollout",
+		},
+		{
+			name:  "PR title without area",
+			title: "improve logging for a detected rollout",
+			area:  "e2e",
+			want:  "improve logging for a detected rollout",
+		},
+		{
+			name:  "PR title without area being prefixed",
+			title: "test/e2e: improve logging for a detected rollout",
+			area:  "e2e",
+			want:  "test/e2e: improve logging for a detected rollout",
+		},
+		{
+			name:  "PR title without space between area and title",
+			title: "e2e:improve logging for a detected rollout",
+			area:  "e2e",
+			want:  "improve logging for a detected rollout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimAreaFromTitle(tt.title, tt.area); got != tt.want {
+				t.Errorf("trimAreaFromTitle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:Deduplicating prefix in release notes as stated in #9104 Release Notes section 3rd task

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: #9190 
Part of: #9104

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->