### PR TITLE
:sparkles: Add topology-owned label to MachineHealthChecks.

### DIFF
--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -1001,6 +1001,9 @@ func computeMachineHealthCheck(healthCheckTarget client.Object, selector *metav1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      healthCheckTarget.GetName(),
 			Namespace: healthCheckTarget.GetNamespace(),
+			Labels: map[string]string{
+				clusterv1.ClusterTopologyOwnedLabel: "",
+			},
 		},
 		Spec: clusterv1.MachineHealthCheckSpec{
 			ClusterName:         clusterName,

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -2246,7 +2246,10 @@ func Test_computeMachineHealthCheck(t *testing.T) {
 			Name:      "md1",
 			Namespace: "ns1",
 			// Label is added by defaulting values using MachineHealthCheck.Default()
-			Labels: map[string]string{"cluster.x-k8s.io/cluster-name": "cluster1"},
+			Labels: map[string]string{
+				"cluster.x-k8s.io/cluster-name":     "cluster1",
+				clusterv1.ClusterTopologyOwnedLabel: "",
+			},
 		},
 		Spec: clusterv1.MachineHealthCheckSpec{
 			ClusterName: "cluster1",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add topology-owned label to MachineHealthChecks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9134

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area machinehealthcheck