### PR TITLE
🌱 Kustomize: Update deprecated syntax

### DIFF
--- a/bootstrap/kubeadm/config/certmanager/certificate.yaml
+++ b/bootstrap/kubeadm/config/certmanager/certificate.yaml
@@ -15,14 +15,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - k8s-sig-cluster-lifecycle

--- a/bootstrap/kubeadm/config/certmanager/kustomizeconfig.yaml
+++ b/bootstrap/kubeadm/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/bootstrap/kubeadm/config/crd/kustomization.yaml
+++ b/bootstrap/kubeadm/config/crd/kustomization.yaml
@@ -11,17 +11,17 @@ resources:
   - bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_kubeadmconfigs.yaml
-- patches/webhook_in_kubeadmconfigtemplates.yaml
+- path: patches/webhook_in_kubeadmconfigs.yaml
+- path: patches/webhook_in_kubeadmconfigtemplates.yaml
   # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
   # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
   # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_kubeadmconfigs.yaml
-- patches/cainjection_in_kubeadmconfigtemplates.yaml
+- path: patches/cainjection_in_kubeadmconfigs.yaml
+- path: patches/cainjection_in_kubeadmconfigtemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/bootstrap/kubeadm/config/crd/kustomizeconfig.yaml
+++ b/bootstrap/kubeadm/config/crd/kustomizeconfig.yaml
@@ -12,6 +12,3 @@ namespace:
     group: apiextensions.k8s.io
     path: spec/conversion/webhook/clientConfig/service/namespace
     create: false
-
-varReference:
-  - path: metadata/annotations

--- a/bootstrap/kubeadm/config/crd/patches/cainjection_in_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/patches/cainjection_in_kubeadmconfigs.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: kubeadmconfigs.bootstrap.cluster.x-k8s.io

--- a/bootstrap/kubeadm/config/crd/patches/cainjection_in_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/patches/cainjection_in_kubeadmconfigtemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io

--- a/bootstrap/kubeadm/config/default/kustomization.yaml
+++ b/bootstrap/kubeadm/config/default/kustomization.yaml
@@ -7,51 +7,116 @@ commonLabels:
   cluster.x-k8s.io/provider: "bootstrap-kubeadm"
 
 resources:
-- namespace.yaml
-
-bases:
 - ../crd
 - ../rbac
 - ../manager
 - ../webhook
 - ../certmanager
+- namespace.yaml
 
-patchesStrategicMerge:
+patches:
   # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
+  - path: manager_image_patch.yaml
+  - path: manager_pull_policy.yaml
   # Enable webhook.
-  - manager_webhook_patch.yaml
+  - path: manager_webhook_patch.yaml
   # Inject certificate in the webhook definition.
-  - webhookcainjection_patch.yaml
+  - path: webhookcainjection_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/bootstrap/kubeadm/config/default/kustomizeconfig.yaml
+++ b/bootstrap/kubeadm/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: webhook-service-cert

--- a/bootstrap/kubeadm/config/default/webhookcainjection_patch.yaml
+++ b/bootstrap/kubeadm/config/default/webhookcainjection_patch.yaml
@@ -4,11 +4,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/bootstrap/kubeadm/config/webhook/kustomizeconfig.yaml
+++ b/bootstrap/kubeadm/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -14,14 +14,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - k8s-sig-cluster-lifecycle

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,31 +16,31 @@ resources:
 - bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_clusterclasses.yaml
-- patches/webhook_in_clusters.yaml
-- patches/webhook_in_machinepools.yaml
-- patches/webhook_in_machines.yaml
-- patches/webhook_in_machinesets.yaml
-- patches/webhook_in_machinedeployments.yaml
-- patches/webhook_in_machinehealthchecks.yaml
-- patches/webhook_in_clusterresourcesets.yaml
-- patches/webhook_in_clusterresourcesetbindings.yaml
+- path: patches/webhook_in_clusterclasses.yaml
+- path: patches/webhook_in_clusters.yaml
+- path: patches/webhook_in_machinepools.yaml
+- path: patches/webhook_in_machines.yaml
+- path: patches/webhook_in_machinesets.yaml
+- path: patches/webhook_in_machinedeployments.yaml
+- path: patches/webhook_in_machinehealthchecks.yaml
+- path: patches/webhook_in_clusterresourcesets.yaml
+- path: patches/webhook_in_clusterresourcesetbindings.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_clusterclasses.yaml
-- patches/cainjection_in_clusters.yaml
-- patches/cainjection_in_machinepools.yaml
-- patches/cainjection_in_machines.yaml
-- patches/cainjection_in_machinesets.yaml
-- patches/cainjection_in_machinedeployments.yaml
-- patches/cainjection_in_machinehealthchecks.yaml
-- patches/cainjection_in_clusterresourcesets.yaml
-- patches/cainjection_in_clusterresourcesetbindings.yaml
+- path: patches/cainjection_in_clusterclasses.yaml
+- path: patches/cainjection_in_clusters.yaml
+- path: patches/cainjection_in_machinepools.yaml
+- path: patches/cainjection_in_machines.yaml
+- path: patches/cainjection_in_machinesets.yaml
+- path: patches/cainjection_in_machinedeployments.yaml
+- path: patches/cainjection_in_machinehealthchecks.yaml
+- path: patches/cainjection_in_clusterresourcesets.yaml
+- path: patches/cainjection_in_clusterresourcesetbindings.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -12,6 +12,3 @@ namespace:
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
-
-varReference:
-- path: metadata/annotations

--- a/config/crd/patches/cainjection_in_clusterclasses.yaml
+++ b/config/crd/patches/cainjection_in_clusterclasses.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: clusterclasses.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_clusterresourcesetbindings.yaml
+++ b/config/crd/patches/cainjection_in_clusterresourcesetbindings.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: clusterresourcesetbindings.addons.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_clusterresourcesets.yaml
+++ b/config/crd/patches/cainjection_in_clusterresourcesets.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: clusterresourcesets.addons.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_clusters.yaml
+++ b/config/crd/patches/cainjection_in_clusters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: clusters.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_machinedeployments.yaml
+++ b/config/crd/patches/cainjection_in_machinedeployments.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: machinedeployments.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_machinehealthchecks.yaml
+++ b/config/crd/patches/cainjection_in_machinehealthchecks.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: machinehealthchecks.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_machinepools.yaml
+++ b/config/crd/patches/cainjection_in_machinepools.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: machinepools.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_machines.yaml
+++ b/config/crd/patches/cainjection_in_machines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: machines.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_machinesets.yaml
+++ b/config/crd/patches/cainjection_in_machinesets.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: machinesets.cluster.x-k8s.io

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,55 +6,120 @@ commonLabels:
   cluster.x-k8s.io/provider: "cluster-api"
 
 resources:
-- namespace.yaml
-
-bases:
 - ../crd
 - ../rbac
 - ../manager
 - ../webhook
 - ../certmanager
+- namespace.yaml
 
-patchesStrategicMerge:
+patches:
 # Provide customizable hook for make targets.
-- manager_image_patch.yaml
-- manager_pull_policy.yaml
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
 # Enable webhook.
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 # Inject certificate in the webhook definition.
-- webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
 # Ease the process of providing extra RBAC to the Cluster API manager for
 # non SIG Cluster Lifecycle-sponsored provider subprojects by using an
 # aggregated role
-- manager_role_aggregation_patch.yaml
+- path: manager_role_aggregation_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -6,11 +6,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations

--- a/controlplane/kubeadm/config/certmanager/certificate.yaml
+++ b/controlplane/kubeadm/config/certmanager/certificate.yaml
@@ -15,14 +15,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - k8s-sig-cluster-lifecycle

--- a/controlplane/kubeadm/config/certmanager/kustomizeconfig.yaml
+++ b/controlplane/kubeadm/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/controlplane/kubeadm/config/crd/kustomization.yaml
+++ b/controlplane/kubeadm/config/crd/kustomization.yaml
@@ -11,17 +11,17 @@ resources:
   - bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # patches here are for enabling the conversion webhook for each CRD
-  - patches/webhook_in_kubeadmcontrolplanes.yaml
-  - patches/webhook_in_kubeadmcontrolplanetemplates.yaml
+  - path: patches/webhook_in_kubeadmcontrolplanes.yaml
+  - path: patches/webhook_in_kubeadmcontrolplanetemplates.yaml
   # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
   # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
   # patches here are for enabling the CA injection for each CRD
-  - patches/cainjection_in_kubeadmcontrolplanes.yaml
-  - patches/cainjection_in_kubeadmcontrolplanetemplates.yaml
+  - path: patches/cainjection_in_kubeadmcontrolplanes.yaml
+  - path: patches/cainjection_in_kubeadmcontrolplanetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/controlplane/kubeadm/config/crd/kustomizeconfig.yaml
+++ b/controlplane/kubeadm/config/crd/kustomizeconfig.yaml
@@ -12,6 +12,3 @@ namespace:
     group: apiextensions.k8s.io
     path: spec/conversion/webhook/clientConfig/service/namespace
     create: false
-
-varReference:
-  - path: metadata/annotations

--- a/controlplane/kubeadm/config/crd/patches/cainjection_in_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/patches/cainjection_in_kubeadmcontrolplanes.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io

--- a/controlplane/kubeadm/config/crd/patches/cainjection_in_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/patches/cainjection_in_kubeadmcontrolplanetemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io

--- a/controlplane/kubeadm/config/default/kustomization.yaml
+++ b/controlplane/kubeadm/config/default/kustomization.yaml
@@ -6,53 +6,118 @@ commonLabels:
   cluster.x-k8s.io/provider: "control-plane-kubeadm"
 
 resources:
-- namespace.yaml
-
-bases:
   - ../crd
   - ../rbac
   - ../manager
   - ../webhook
   - ../certmanager
+  - namespace.yaml
 
-patchesStrategicMerge:
+patches:
   # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
+  - path: manager_image_patch.yaml
+  - path: manager_pull_policy.yaml
   # Enable webhook.
-  - manager_webhook_patch.yaml
+  - path: manager_webhook_patch.yaml
   # Inject certificate in the webhook definition.
-  - webhookcainjection_patch.yaml
+  - path: webhookcainjection_patch.yaml
   # Enable aggregated ClusterRole aggregation
-  - manager_role_aggregation_patch.yaml
+  - path: manager_role_aggregation_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/controlplane/kubeadm/config/default/kustomizeconfig.yaml
+++ b/controlplane/kubeadm/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: webhook-service-cert

--- a/controlplane/kubeadm/config/default/webhookcainjection_patch.yaml
+++ b/controlplane/kubeadm/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/controlplane/kubeadm/config/webhook/kustomizeconfig.yaml
+++ b/controlplane/kubeadm/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations

--- a/docs/book/src/developer/providers/implementers-guide/configure.md
+++ b/docs/book/src/developer/providers/implementers-guide/configure.md
@@ -41,9 +41,9 @@ spec:
 And then, we have to add that patch to [`config/kustomization.yaml`][kustomizeyaml]:
 
 ```yaml
-patchesStrategicMerge
-- manager_image_patch.yaml
-- manager_config.yaml
+patches:
+- path: manager_image_patch.yaml
+- path: manager_config.yaml
 ```
 
 [kustomizeyaml]: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/kustomization.yaml
@@ -1,7 +1,7 @@
-bases:
+resources:
   - ../bases/cluster-with-kcp.yaml
   - ../bases/md.yaml
   - ../bases/crs.yaml
 
-patchesStrategicMerge:
-  - ignition.yaml
+patches:
+  - path: ignition.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-ipv6/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-ipv6/kustomization.yaml
@@ -1,9 +1,9 @@
-bases:
+resources:
   - ../bases/cluster-with-kcp.yaml
   - ../bases/md.yaml
   - ../bases/crs.yaml
 
-patchesStrategicMerge:
-  - cluster-ipv6.yaml
-  - md-ipv6.yaml
-  - kcp-ipv6.yaml
+patches:
+  - path: cluster-ipv6.yaml
+  - path: md-ipv6.yaml
+  - path: kcp-ipv6.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-md-remediation/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-md-remediation/kustomization.yaml
@@ -1,8 +1,8 @@
-bases:
+resources:
   - ../bases/cluster-with-kcp.yaml
   - ../bases/md.yaml
   - ../bases/crs.yaml
   - mhc.yaml
 
-patchesStrategicMerge:
-- md.yaml
+patches:
+- path: md.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-node-drain/kustomization.yaml
@@ -1,8 +1,8 @@
-bases:
+resources:
 - ../bases/crs.yaml
 - ../bases/md.yaml
 - ../bases/cluster-with-kcp.yaml
 
-patchesStrategicMerge:
-- md.yaml
-- cluster-with-kcp.yaml
+patches:
+- path: md.yaml
+- path: cluster-with-kcp.yaml

--- a/test/extension/config/certmanager/certificate.yaml
+++ b/test/extension/config/certmanager/certificate.yaml
@@ -12,16 +12,16 @@ kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
 spec:
-  # $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAMESPACE and SERVICE_NAME will be substituted by kustomize
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   # for local testing.
   - localhost
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
     - k8s-sig-cluster-lifecycle

--- a/test/extension/config/certmanager/kustomizeconfig.yaml
+++ b/test/extension/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/test/extension/config/default/kustomization.yaml
+++ b/test/extension/config/default/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
   cluster.x-k8s.io/provider: "runtime-extension-test"
 
 resources:
+- ../certmanager
 - namespace.yaml
 - manager.yaml
 - service.yaml
@@ -15,29 +16,45 @@ resources:
 - role.yaml
 - rolebinding.yaml
 
-bases:
-- ../certmanager
-
-patchesStrategicMerge:
+patches:
 # Enable webhook with corresponding certificate mount.
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 # Provide customizable hook for make targets.
-- manager_image_patch.yaml
-- manager_pull_policy.yaml
+- path: manager_image_patch.yaml
+- path: manager_pull_policy.yaml
 
-vars:
-  - name: SERVICE_NAMESPACE
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/test/extension/config/default/kustomizeconfig.yaml
+++ b/test/extension/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/test/extension/config/default/manager_webhook_patch.yaml
+++ b/test/extension/config/default/manager_webhook_patch.yaml
@@ -18,4 +18,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert
+          secretName: webhook-service-cert

--- a/test/framework/kubernetesversions/data/kustomization.yaml
+++ b/test/framework/kubernetesversions/data/kustomization.yaml
@@ -3,9 +3,8 @@ kind: Kustomization
 namespace: default
 resources:
 - ci-artifacts-source-template.yaml
-patchesStrategicMerge:
-- platform-kustomization.yaml
-patchesJson6902:
+patches:
+- path: platform-kustomization.yaml
 - path: kubeadmcontrolplane-patch.yaml
   target:
     group: controlplane.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/certmanager/certificate.yaml
+++ b/test/infrastructure/docker/config/certmanager/certificate.yaml
@@ -14,14 +14,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - k8s-sig-cluster-lifecycle

--- a/test/infrastructure/docker/config/certmanager/kustomizeconfig.yaml
+++ b/test/infrastructure/docker/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/test/infrastructure/docker/config/crd/kustomization.yaml
+++ b/test/infrastructure/docker/config/crd/kustomization.yaml
@@ -16,22 +16,22 @@ resources:
   - bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # patches here are for enabling the conversion webhook for each CRD
-  - patches/webhook_in_dockermachinepools.yaml
-  - patches/webhook_in_dockermachines.yaml
-  - patches/webhook_in_dockermachinetemplates.yaml
-  - patches/webhook_in_dockerclusters.yaml
-  - patches/webhook_in_dockerclustertemplates.yaml
+  - path: patches/webhook_in_dockermachinepools.yaml
+  - path: patches/webhook_in_dockermachines.yaml
+  - path: patches/webhook_in_dockermachinetemplates.yaml
+  - path: patches/webhook_in_dockerclusters.yaml
+  - path: patches/webhook_in_dockerclustertemplates.yaml
   # +kubebuilder:scaffold:crdkustomizewebhookpatch
   # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
   # patches here are for enabling the CA injection for each CRD
-  - patches/cainjection_in_dockermachinepools.yaml
-  - patches/cainjection_in_dockermachines.yaml
-  - patches/cainjection_in_dockermachinetemplates.yaml
-  - patches/cainjection_in_dockerclusters.yaml
-  - patches/cainjection_in_dockerclustertemplates.yaml
+  - path: patches/cainjection_in_dockermachinepools.yaml
+  - path: patches/cainjection_in_dockermachines.yaml
+  - path: patches/cainjection_in_dockermachinetemplates.yaml
+  - path: patches/cainjection_in_dockerclusters.yaml
+  - path: patches/cainjection_in_dockerclustertemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/test/infrastructure/docker/config/crd/kustomizeconfig.yaml
+++ b/test/infrastructure/docker/config/crd/kustomizeconfig.yaml
@@ -12,6 +12,3 @@ namespace:
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
-
-varReference:
-- path: metadata/annotations

--- a/test/infrastructure/docker/config/crd/patches/cainjection_in_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/patches/cainjection_in_dockerclusters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: dockerclusters.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/crd/patches/cainjection_in_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/patches/cainjection_in_dockerclustertemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: dockerclustertemplates.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachinepools.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: dockermachinepools.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: dockermachines.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/patches/cainjection_in_dockermachinetemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: dockermachinetemplates.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/default/kustomization.yaml
+++ b/test/infrastructure/docker/config/default/kustomization.yaml
@@ -6,51 +6,116 @@ commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-docker"
 
 resources:
-  - namespace.yaml
-
-bases:
   - ../crd
   - ../rbac
   - ../manager
   - ../webhook
   - ../certmanager
+  - namespace.yaml
 
-patchesStrategicMerge:
+patches:
   # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
+  - path: manager_image_patch.yaml
+  - path: manager_pull_policy.yaml
   # Enable webhook.
-  - manager_webhook_patch.yaml
+  - path: manager_webhook_patch.yaml
   # Inject certificate in the webhook definition.
-  - webhookcainjection_patch.yaml
+  - path: webhookcainjection_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/test/infrastructure/docker/config/default/kustomizeconfig.yaml
+++ b/test/infrastructure/docker/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
-
+          secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/test/infrastructure/docker/config/default/webhookcainjection_patch.yaml
+++ b/test/infrastructure/docker/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/test/infrastructure/docker/config/webhook/kustomizeconfig.yaml
+++ b/test/infrastructure/docker/config/webhook/kustomizeconfig.yaml
@@ -13,6 +13,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations

--- a/test/infrastructure/inmemory/config/certmanager/certificate.yaml
+++ b/test/infrastructure/inmemory/config/certmanager/certificate.yaml
@@ -14,14 +14,14 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
   subject:
     organizations:
       - k8s-sig-cluster-lifecycle

--- a/test/infrastructure/inmemory/config/certmanager/kustomizeconfig.yaml
+++ b/test/infrastructure/inmemory/config/certmanager/kustomizeconfig.yaml
@@ -6,14 +6,3 @@ nameReference:
   - kind: Certificate
     group: cert-manager.io
     path: spec/issuerRef/name
-
-varReference:
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/commonName
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/dnsNames
-- kind: Certificate
-  group: cert-manager.io
-  path: spec/secretName

--- a/test/infrastructure/inmemory/config/crd/kustomization.yaml
+++ b/test/infrastructure/inmemory/config/crd/kustomization.yaml
@@ -13,20 +13,20 @@ resources:
   - bases/infrastructure.cluster.x-k8s.io_inmemorymachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # patches here are for enabling the conversion webhook for each CRD
-  - patches/webhook_in_inmemoryclusters.yaml
-  - patches/webhook_in_inmemoryclustertemplates.yaml
-  - patches/webhook_in_inmemorymachines.yaml
-  - patches/webhook_in_inmemorymachinetemplates.yaml
+  - path: patches/webhook_in_inmemoryclusters.yaml
+  - path: patches/webhook_in_inmemoryclustertemplates.yaml
+  - path: patches/webhook_in_inmemorymachines.yaml
+  - path: patches/webhook_in_inmemorymachinetemplates.yaml
   # +kubebuilder:scaffold:crdkustomizewebhookpatch
   # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
   # patches here are for enabling the CA injection for each CRD
-  - patches/cainjection_in_inmemoryclusters.yaml
-  - patches/cainjection_in_inmemoryclustertemplates.yaml
-  - patches/cainjection_in_inmemorymachines.yaml
-  - patches/cainjection_in_inmemorymachinetemplates.yaml
+  - path: patches/cainjection_in_inmemoryclusters.yaml
+  - path: patches/cainjection_in_inmemoryclustertemplates.yaml
+  - path: patches/cainjection_in_inmemorymachines.yaml
+  - path: patches/cainjection_in_inmemorymachinetemplates.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/test/infrastructure/inmemory/config/crd/kustomizeconfig.yaml
+++ b/test/infrastructure/inmemory/config/crd/kustomizeconfig.yaml
@@ -12,6 +12,3 @@ namespace:
   group: apiextensions.k8s.io
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
-
-varReference:
-- path: metadata/annotations

--- a/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemoryclusters.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemoryclusters.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: inmemoryclusters.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemoryclustertemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemoryclustertemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: inmemoryclustertemplates.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemorymachines.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemorymachines.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: inmemorymachines.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemorymachinetemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/cainjection_in_inmemorymachinetemplates.yaml
@@ -4,5 +4,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: inmemorymachinetemplates.infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/default/kustomization.yaml
+++ b/test/infrastructure/inmemory/config/default/kustomization.yaml
@@ -6,51 +6,116 @@ commonLabels:
   cluster.x-k8s.io/provider: "infrastructure-in-memory"
 
 resources:
-  - namespace.yaml
-
-bases:
   - ../crd
   - ../rbac
   - ../manager
   - ../webhook
   - ../certmanager
+  - namespace.yaml
 
-patchesStrategicMerge:
+patches:
   # Provide customizable hook for make targets.
-  - manager_image_patch.yaml
-  - manager_pull_policy.yaml
+  - path: manager_image_patch.yaml
+  - path: manager_pull_policy.yaml
   # Enable webhook.
-  - manager_webhook_patch.yaml
+  - path: manager_webhook_patch.yaml
   # Inject certificate in the webhook definition.
-  - webhookcainjection_patch.yaml
+  - path: webhookcainjection_patch.yaml
 
-vars:
-  - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: CERTIFICATE_NAME
-    objref:
-      kind: Certificate
-      group: cert-manager.io
-      version: v1
-      name: serving-cert # this name should match the one in certificate.yaml
-  - name: SERVICE_NAMESPACE # namespace of the service
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-    fieldref:
-      fieldpath: metadata.namespace
-  - name: SERVICE_NAME
-    objref:
-      kind: Service
-      version: v1
-      name: webhook-service
-
-configurations:
-  - kustomizeconfig.yaml
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 0
+        create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+    - select:
+        kind: ValidatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: MutatingWebhookConfiguration
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+    - select:
+        kind: CustomResourceDefinition
+      fieldPaths:
+        - .metadata.annotations.[cert-manager.io/inject-ca-from]
+      options:
+        delimiter: '/'
+        index: 1
+        create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 0
+        create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+    - select:
+        kind: Certificate
+        group: cert-manager.io
+        version: v1
+      fieldPaths:
+        - .spec.dnsNames.0
+        - .spec.dnsNames.1
+      options:
+        delimiter: '.'
+        index: 1
+        create: true

--- a/test/infrastructure/inmemory/config/default/kustomizeconfig.yaml
+++ b/test/infrastructure/inmemory/config/default/kustomizeconfig.yaml
@@ -1,4 +1,0 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution
-varReference:
-- kind: Deployment
-  path: spec/template/spec/volumes/secret/secretName

--- a/test/infrastructure/inmemory/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/inmemory/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
-
+          secretName: webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/test/infrastructure/inmemory/config/default/webhookcainjection_patch.yaml
+++ b/test/infrastructure/inmemory/config/default/webhookcainjection_patch.yaml
@@ -5,11 +5,11 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/test/infrastructure/inmemory/config/webhook/kustomizeconfig.yaml
+++ b/test/infrastructure/inmemory/config/webhook/kustomizeconfig.yaml
@@ -20,6 +20,3 @@ namespace:
   group: admissionregistration.k8s.io
   path: webhooks/clientConfig/service/namespace
   create: true
-
-varReference:
-- path: metadata/annotations


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit updates the following:

- patchesStrategicMerge -> patches
- patchesJson6902 -> patches
- vars and varReference -> replacements
- bases -> resources

Most of this is straight forward, but the vars -> replacements change is a bit complicated. I have taken inspiration from kubebuilder for how to do the change. In particular I changed the name of the secret that holds the certificate to be static. Previously it was set partially from a variable. I believe it would be unnecessarily complicated to keep this behavior and that a static name does not take away much.

Here is a link to some relevant code in kubebuilder that I used as inspiration: https://github.com/kubernetes-sigs/kubebuilder/blob/68abac1dfb5550f7159dec4ce600cd9b6db925bb/pkg/plugins/common/kustomize/v2/scaffolds/internal/templates/config/kdefault/kustomization.go#L97

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8457.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area dependency