### PR TITLE
:seedling: check resource blocking clusterctl move during discovery

### DIFF
--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -92,6 +92,10 @@ type node struct {
 	// E.g. for the cluster object we capture information to see if the cluster uses a manged topology
 	// and the cluster class used.
 	additionalInfo map[string]interface{}
+
+	// blockingMove is true when the object should prevent a move operation from proceeding as indicated by
+	// the presence of the block-move annotation.
+	blockingMove bool
 }
 
 type discoveryTypeInfo struct {
@@ -320,6 +324,8 @@ func (o *objectGraph) objMetaToNode(obj *unstructured.Unstructured, n *node) {
 			n.isGlobal = true
 		}
 	}
+
+	_, n.blockingMove = obj.GetAnnotations()[clusterctlv1.BlockMoveAnnotation]
 }
 
 // getDiscoveryTypes returns the list of TypeMeta to be considered for the move discovery phase.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds a check to the discovery phase of `clusterctl move` to collect whether the resource is blocking the move with the `clusterctl.cluster.x-k8s.io/block-move` annotation. This eliminates one extraneous API call during the actual move operation for all resources which already do not have the annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9196

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl