### PR TITLE
:seedling: Add additional blocks to release note generation

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -73,6 +73,8 @@ var (
 
 	prefixAreaLabel = flag.Bool("prefix-area-label", true, "If enabled, will prefix the area label.")
 
+	preReleaseVersion           = flag.Bool("pre-release-version", false, "If enabled, will add a pre-release warning header. (default false)")
+	deprecation                 = flag.Bool("deprecation", true, "If enabled, will add a templated deprecation warning header.")
 	addKubernetesVersionSupport = flag.Bool("add-kubernetes-version-support", true, "If enabled, will add the Kubernetes version support header.")
 
 	tagRegex = regexp.MustCompile(`^\[release-[\w-\.]*\]`)
@@ -307,14 +309,33 @@ func run() int {
 		}
 	}
 
+	if *preReleaseVersion {
+		fmt.Printf("🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/%s/issues/new).\n", *repo)
+	}
+
 	if *addKubernetesVersionSupport {
-		// TODO Turn this into a link (requires knowing the project name + organization)
 		fmt.Print(`## 👌 Kubernetes version support
 
 - Management Cluster: v1.**X**.x -> v1.**X**.x
 - Workload Cluster: v1.**X**.x -> v1.**X**.x
 
 [More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+`)
+	}
+
+	fmt.Print(`## Highlights
+
+* REPLACE ME
+
+`)
+
+	if *deprecation {
+		fmt.Print(`## Deprecation Warning
+
+REPLACE ME: A couple sentences describing the deprecation, including links to docs.
+
+* [GitHub issue #REPLACE ME](REPLACE ME)
 
 `)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows the existing release notes generation tool to generate (optionally in some cases) commonly used headers that have been manually filled out in the past:

* An optional header when generating a release candidate
* A highlights header with filler to manually replace
* An optional header about deprecation warnings

**Which issue(s) this PR fixes**:

Fixes #9248
Part of #9104

---

Sample header output:
```
❯ go run hack/tools/release/notes.go -from release-1.5 -workers 1 -release-candidate -deprecation
🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
## 👌 Kubernetes version support

- Management Cluster: v1.**X**.x -> v1.**X**.x
- Workload Cluster: v1.**X**.x -> v1.**X**.x

[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)

## Highlights

* REPLACE ME

## Deprecation Warning

REPLACE ME: A couple sentences describing the deprecation, including links to docs.

* [GitHub issue #REPLACE ME](REPLACE ME)

## Changes since release-1.5
```

/area release