### PR TITLE
:seedling: refactor SortForCreate to use sort.Slice

### DIFF
--- a/util/resource/resource.go
+++ b/util/resource/resource.go
@@ -17,61 +17,54 @@ limitations under the License.
 // Package resource implements resource utilites.
 package resource
 
-import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+import (
+	"sort"
 
-var defaultCreatePriorities = []string{
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var priorityMap = map[string]int{
 	// Namespaces go first because all namespaced resources depend on them.
-	"Namespace",
+	"Namespace": -100,
 	// Custom Resource Definitions come before Custom Resource so that they can be
 	// restored with their corresponding CRD.
-	"CustomResourceDefinition",
+	"CustomResourceDefinition": -99,
 	// Storage Classes are needed to create PVs and PVCs correctly.
-	"StorageClass",
+	"StorageClass": -98,
 	// PVs go before PVCs because PVCs depend on them.
-	"PersistentVolume",
+	"PersistentVolume": -97,
 	// PVCs go before pods or controllers so they can be mounted as volumes.
-	"PersistentVolumeClaim",
+	"PersistentVolumeClaim": -96,
 	// Secrets and ConfigMaps go before pods or controllers so they can be mounted as volumes.
-	"Secret",
-	"ConfigMap",
+	"Secret":    -95,
+	"ConfigMap": -94,
 	// Service accounts go before pods or controllers so pods can use them.
-	"ServiceAccount",
+	"ServiceAccount": -93,
 	// Limit ranges go before pods or controllers so pods can use them.
-	"LimitRange",
+	"LimitRange": -92,
 	// Pods go before ReplicaSets
-	"Pods",
+	"Pod": -91,
 	// ReplicaSets go before Deployments
-	"ReplicaSet",
-	// Endpoints go before Services
-	"Endpoints",
+	"ReplicaSet": -90,
+	// Endpoints go before Services (and everything else)
+	"Endpoint": -89,
+}
+
+// priorityLess returns true if o1 should be created before o2.
+// To be used in sort.{Slice,SliceStable} to sort manifests in place.
+func priorityLess(o1, o2 unstructured.Unstructured) bool {
+	p1 := priorityMap[o1.GetKind()]
+	p2 := priorityMap[o2.GetKind()]
+	return p1 < p2
 }
 
 // SortForCreate sorts objects by creation priority.
 func SortForCreate(resources []unstructured.Unstructured) []unstructured.Unstructured {
-	var ret []unstructured.Unstructured
-
-	// First get resources by priority
-	for _, p := range defaultCreatePriorities {
-		for _, o := range resources {
-			if o.GetKind() == p {
-				ret = append(ret, o)
-			}
-		}
-	}
-
-	// Then get all the other resources
-	for _, o := range resources {
-		found := false
-		for _, r := range ret {
-			if o.GroupVersionKind() == r.GroupVersionKind() && o.GetNamespace() == r.GetNamespace() && o.GetName() == r.GetName() {
-				found = true
-				break
-			}
-		}
-		if !found {
-			ret = append(ret, o)
-		}
-	}
+	ret := make([]unstructured.Unstructured, len(resources))
+	copy(ret, resources)
+	sort.SliceStable(ret, func(i, j int) bool {
+		return priorityLess(ret[i], ret[j])
+	})
 
 	return ret
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I found [SortForCreate](https://github.com/kubernetes-sigs/cluster-api/blob/4abf44cd85c4590602e4c10543d53cd4ec914845/util/resource/resource.go#L50) to be very inefficient, it's basically O(n^2), it also needlessly allocates. In order to keep the contract (even though this exported function [is not widely used](https://github.com/search?type=code&q=SortForCreate+language%3AGo&l=Go&p=1)), I didn't change this function's behaviour (i.e. its purity), ~~but I did deprecate it~~. (It could've been even faster if we opted for an in-place sort, but I didn't want to change the function's behaviour.)

The function doesn't appear to be used in any tight loops or with a large number of elements, so it's a low prio PR, but it's something that could bite people applying a large number of small resources (see how it falls off a cliff with 10k elements).

**Benchmark comparison**
```
name             old time/op    new time/op    delta
Sort/sort-10       10.0µs ±31%     3.7µs ±55%  -63.11%  (p=0.000 n=10+10)
Sort/sort-100       423µs ±10%      58µs ±28%  -86.35%  (p=0.000 n=10+10)
Sort/sort-1000     45.0ms ±13%     0.5ms ±12%  -98.83%  (p=0.000 n=10+9)
Sort/sort-10000     5.90s ±22%     0.01s ±30%  -99.86%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
Sort/sort-10         248B ± 0%      136B ± 0%  -45.16%  (p=0.000 n=10+10)
Sort/sort-100      2.04kB ± 0%    0.95kB ± 0%  -53.33%  (p=0.000 n=10+10)
Sort/sort-1000     25.2kB ± 0%     8.2kB ± 0%  -67.28%  (p=0.000 n=10+10)
Sort/sort-10000     358kB ± 0%      82kB ± 0%  -77.08%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
Sort/sort-10         5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
Sort/sort-100        8.00 ± 0%      3.00 ± 0%  -62.50%  (p=0.000 n=10+10)
Sort/sort-1000       12.0 ± 0%       3.0 ± 0%  -75.00%  (p=0.000 n=10+10)
Sort/sort-10000      20.0 ± 0%       3.0 ± 0%  -85.00%  (p=0.000 n=10+10)
```

**GH issue**
Fixes #9253

/area util