### PR TITLE
🐛 test: pin conformance image to a version which includes a fix for the dualstack tests

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -238,6 +238,8 @@ variables:
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
   KUBERNETES_VERSION_MANAGEMENT: "v1.28.0"
+  # TODO when bumping this version: also remove the pinning of the conformanceImage at the [ipv6] tests in
+  # `test/e2e/quick_start_test.go`.
   KUBERNETES_VERSION: "v1.28.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.3"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.28.0"

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -125,6 +125,9 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
+						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
+						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
+						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
 					},
 				)).To(Succeed())
 			},
@@ -151,6 +154,9 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
+						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
+						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
+						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
 					},
 				)).To(Succeed())
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Pins the container image used for kubernetes conformance tests in our dualstack tests to the version of commit: https://github.com/kubernetes/kubernetes/commit/18290bfdc8f

This is to include the following fixes:

- https://github.com/kubernetes/kubernetes/pull/119928
- https://github.com/kubernetes/kubernetes/pull/119966

Note: this fixes are getting cherry-picked to kubernetes `release-1.28` in:

- https://github.com/kubernetes/kubernetes/pull/119964

And the introduced changes should get dropped when we bump to a newer version than `v1.28.0` at 

https://github.com/kubernetes-sigs/cluster-api/blob/d57f454ab0185966348671a43beb46c1f6da7efd/test/e2e/config/docker.yaml#L241

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9240

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->