### PR TITLE
🌱 Make ClusterClass generated object names consistent

### DIFF
--- a/cmd/clusterctl/client/cluster/topology_test.go
+++ b/cmd/clusterctl/client/cluster/topology_test.go
@@ -96,9 +96,9 @@ func Test_topologyClient_Plan(t *testing.T) {
 					{kind: "DockerCluster", namespace: "default", namePrefix: "my-cluster-"},
 					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-md-0-"},
 					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-md-1-"},
-					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-control-plane-"},
-					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-0-bootstrap-"},
-					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-1-bootstrap-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-"},
+					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-0-"},
+					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-1-"},
 					{kind: "KubeadmControlPlane", namespace: "default", namePrefix: "my-cluster-"},
 					{kind: "MachineDeployment", namespace: "default", namePrefix: "my-cluster-md-0-"},
 					{kind: "MachineDeployment", namespace: "default", namePrefix: "my-cluster-md-1-"},
@@ -170,7 +170,7 @@ func Test_topologyClient_Plan(t *testing.T) {
 				created: []item{
 					// Modifying the DockerClusterTemplate will result in template rotation. A new template will be created
 					// and used by KCP.
-					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-control-plane-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-"},
 				},
 				reconciledCluster: &client.ObjectKey{Namespace: "default", Name: "my-cluster"},
 			},
@@ -235,7 +235,7 @@ func Test_topologyClient_Plan(t *testing.T) {
 				created: []item{
 					// Modifying the DockerClusterTemplate will result in template rotation. A new template will be created
 					// and used by KCP.
-					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-control-plane-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-"},
 				},
 				reconciledCluster: &client.ObjectKey{Namespace: "default", Name: "my-cluster"},
 			},

--- a/internal/controllers/topology/cluster/util.go
+++ b/internal/controllers/topology/cluster/util.go
@@ -29,17 +29,17 @@ import (
 
 // bootstrapTemplateNamePrefix calculates the name prefix for a BootstrapTemplate.
 func bootstrapTemplateNamePrefix(clusterName, machineDeploymentTopologyName string) string {
-	return fmt.Sprintf("%s-%s-bootstrap-", clusterName, machineDeploymentTopologyName)
+	return fmt.Sprintf("%s-%s-", clusterName, machineDeploymentTopologyName)
 }
 
 // infrastructureMachineTemplateNamePrefix calculates the name prefix for a InfrastructureMachineTemplate.
 func infrastructureMachineTemplateNamePrefix(clusterName, machineDeploymentTopologyName string) string {
-	return fmt.Sprintf("%s-%s-infra-", clusterName, machineDeploymentTopologyName)
+	return fmt.Sprintf("%s-%s-", clusterName, machineDeploymentTopologyName)
 }
 
 // infrastructureMachineTemplateNamePrefix calculates the name prefix for a InfrastructureMachineTemplate.
 func controlPlaneInfrastructureMachineTemplateNamePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-control-plane-", clusterName)
+	return fmt.Sprintf("%s-", clusterName)
 }
 
 // getReference gets the object referenced in ref.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #9135

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->