### PR TITLE
🌱  Add checks in release workflow files to avoid running in forks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,9 @@ jobs:
   release:
     name: create draft release
     runs-on: ubuntu-latest
+    # This workflow is only of value to the kubernetes-sigs/cluster-api repository and
+    # should not run in forks
+    if: github.repository == 'kubernetes-sigs/cluster-api'
     needs: push_release_tags
     steps:
       - name: Set env

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -18,6 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         branch: [ main, release-1.5, release-1.4 ]
+    # This workflow is only of value to the kubernetes-sigs/cluster-api repository and
+    # should not run in forks
+    if: github.repository == 'kubernetes-sigs/cluster-api'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3


### PR DESCRIPTION
Running release workflows in forks adds no value. This PR makes sure the workflow runs only in upstream. 