### PR TITLE
✨ Add MachineSetReady condition to MachineDeployment

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -228,6 +228,14 @@ const (
 	// machines required (i.e. Spec.Replicas-MaxUnavailable when MachineDeploymentStrategyType = RollingUpdate) are up and running for at least minReadySeconds.
 	MachineDeploymentAvailableCondition ConditionType = "Available"
 
+	// MachineSetReadyCondition reports a summary of current status of the MachineSet owned by the MachineDeployment.
+	MachineSetReadyCondition ConditionType = "MachineSetReady"
+
+	// WaitingForMachineSetFallbackReason (Severity=Info) documents a MachineDeployment waiting for the underlying MachineSet
+	// to be available.
+	// NOTE: This reason is used only as a fallback when the MachineSet object is not reporting its own ready condition.
+	WaitingForMachineSetFallbackReason = "WaitingForMachineSet"
+
 	// WaitingForAvailableMachinesReason (Severity=Warning) reflects the fact that the required minimum number of machines for a machinedeployment are not available.
 	WaitingForAvailableMachinesReason = "WaitingForAvailableMachines"
 )

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -499,6 +499,17 @@ func (r *Reconciler) syncDeploymentStatus(allMSs []*clusterv1.MachineSet, newMS 
 	} else {
 		conditions.MarkFalse(md, clusterv1.MachineDeploymentAvailableCondition, clusterv1.WaitingForAvailableMachinesReason, clusterv1.ConditionSeverityWarning, "Minimum availability requires %d replicas, current %d available", minReplicasNeeded, md.Status.AvailableReplicas)
 	}
+
+	if newMS != nil {
+		// Report a summary of current status of the MachineSet object owned by this MachineDeployment.
+		conditions.SetMirror(md, clusterv1.MachineSetReadyCondition,
+			newMS,
+			conditions.WithFallbackValue(false, clusterv1.WaitingForMachineSetFallbackReason, clusterv1.ConditionSeverityInfo, ""),
+		)
+	} else {
+		conditions.MarkFalse(md, clusterv1.MachineSetReadyCondition, clusterv1.WaitingForMachineSetFallbackReason, clusterv1.ConditionSeverityInfo, "MachineSet not found")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For example, when the AWSMachine (InfraMachine) fails to be created/provisioned, the MachineSet will propagate that error into the `MachinesReady` condition which is included in the `Ready` condition summary:
```yaml
status:
  conditions:
  - lastTransitionTime: "2023-07-28T09:13:11Z"
    message: 1 of 2 completed
    reason: InstanceProvisionFailed @ /capi-quickstart-md-0-56858f78bxjck8s-7jskm
    severity: Error
    status: "False"
    type: Ready
  - lastTransitionTime: "2023-07-28T09:13:11Z"
    message: 1 of 2 completed
    reason: InstanceProvisionFailed @ /capi-quickstart-md-0-56858f78bxjck8s-7jskm
    severity: Error
    status: "False"
    type: MachinesReady
```

However, looking at the MachineDeployment, it wouldn't be clear what is failing
```yaml
status:
  conditions:
  - lastTransitionTime: "2023-07-28T09:13:02Z"
    message: Minimum availability requires 2 replicas, current 0 available
    reason: WaitingForAvailableMachines
    severity: Warning
    status: "False"
    type: Ready
```

This PR adds a new condition `MachineSetReady` to MachineDeployment which mirrors the underlying MachineSet Ready condition to provide meaningful errors.
Given the example above, the new condition will look like the following:
```yaml
status:
  conditions:
  - lastTransitionTime: "2023-07-28T09:13:02Z"
    message: 1 of 2 completed
    reason: InstanceProvisionFailed @ /capi-quickstart-md-0-56858f78bxjck8s-7jskm
    severity: Error
    status: "False"
    type: MachineSetReady
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api/issues/3486

/area machinedeployment
