### PR TITLE
 🌱 Update ensure-kubectl.sh to 1.28

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -27,7 +27,7 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.19.0
+MINIMUM_KUBECTL_VERSION=v1.28.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 
@@ -51,7 +51,7 @@ verify_kubectl_version() {
   fi
 
   local kubectl_version
-  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client)"
   if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
     cat <<EOF
 Detected kubectl version: ${kubectl_version[2]}.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We recently bumped to kubekins 1.28 images which contain kubectl 1.28. With 1.28 the short flag has been removed (it's default now)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->