### PR TITLE
:warning: : Remove go-vcs dependency from releaselink tool

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
+++ b/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
@@ -33,7 +33,7 @@ maintainers of providers and consumers of our Go API.
 
 ### Other
 - `clusterctl move` can be blocked temporarily by a provider when an object to be moved is annotated with `clusterctl.cluster.x-k8s.io/block-move`.
-
+- `mdbook releaselink` has been changed to require a `repo` tag when used in markdown files for generating a book with `mdbook`.
 
 ### Suggested changes for providers
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -161,17 +161,17 @@ If you are unsure you can determine your computers architecture by running `unam
 
 Download for AMD64:
 ```bash
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"1.5.x"}} -o clusterctl
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"1.5.x"}} -o clusterctl
 ```
 
 Download for ARM64:
 ```bash
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-arm64" version:"1.5.x"}} -o clusterctl
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-arm64" version:"1.5.x"}} -o clusterctl
 ```
 
 Download for PPC64LE:
 ```bash
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-ppc64le" version:"1.5.x"}} -o clusterctl
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-ppc64le" version:"1.5.x"}} -o clusterctl
 ```
 
 Install clusterctl:
@@ -191,12 +191,12 @@ If you are unsure you can determine your computers architecture by running `unam
 
 Download for AMD64:
 ```bash
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"1.5.x"}} -o clusterctl
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"1.5.x"}} -o clusterctl
 ```
 
 Download for M1 CPU ("Apple Silicon") / ARM64:
 ```bash
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-arm64" version:"1.5.x"}} -o clusterctl
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-arm64" version:"1.5.x"}} -o clusterctl
 ```
 
 Make the clusterctl binary executable.
@@ -235,7 +235,7 @@ Go to the working directory where you want clusterctl downloaded.
 
 Download the latest release; on Windows, type:
 ```powershell
-curl.exe -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-windows-amd64.exe" version:"1.5.x"}} -o clusterctl.exe
+curl.exe -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-windows-amd64.exe" version:"1.5.x"}} -o clusterctl.exe
 ```
 Append or prepend the path of that directory to the `PATH` environment variable.
 
@@ -281,7 +281,7 @@ Download the latest binary of `clusterawsadm` from the [AWS provider releases]. 
 
 Download the latest release; on Linux, type:
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-linux-amd64" version:">=2.0.0"}} -o clusterawsadm
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-linux-amd64" version:">=2.0.0"}} -o clusterawsadm
 ```
 
 Make it executable
@@ -325,12 +325,12 @@ clusterctl init --infrastructure aws
 
 Download the latest release; on macOs, type:
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-amd64" version:">=2.0.0"}} -o clusterawsadm
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-amd64" version:">=2.0.0"}} -o clusterawsadm
 ```
 
 Or if your Mac has an M1 CPU (”Apple Silicon”):
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-arm64" version:">=2.0.0"}} -o clusterawsadm
+curl -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-arm64" version:">=2.0.0"}} -o clusterawsadm
 ```
 
 Make it executable
@@ -407,7 +407,7 @@ clusterctl init --infrastructure aws
 
 Download the latest release; on Windows, type:
 ```
-curl.exe -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-windows-amd64" version:">=2.0.0"}} -o clusterawsadm.exe
+curl.exe -L {{#releaselink repo:"https://github.com/kubernetes-sigs/cluster-api" gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-windows-amd64" version:">=2.0.0"}} -o clusterawsadm.exe
 ```
 
 Append or prepend the path of that directory to the `PATH` environment variable.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/valyala/fastjson v1.6.4
-	golang.org/x/tools v0.9.3
 	google.golang.org/api v0.138.0
 	k8s.io/api v0.28.0
 	k8s.io/apiextensions-apiserver v0.28.0
@@ -118,6 +117,7 @@ require (
 	golang.org/x/term v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.9.3 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"golang.org/x/tools/go/vcs"
 	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
 
 	"sigs.k8s.io/cluster-api/internal/goproxy"
@@ -49,10 +48,19 @@ func (ReleaseLink) SupportsOutput(_ string) bool { return true }
 // Process modifies the book in the input, which gets returned as the result of the plugin.
 func (l ReleaseLink) Process(input *plugin.Input) error {
 	return plugin.EachCommand(&input.Book, "releaselink", func(chapter *plugin.BookChapter, args string) (string, error) {
-		tags := reflect.StructTag(strings.TrimSpace(args))
+		var gomodule, asset, repo string
+		var found bool
 
-		gomodule := tags.Get("gomodule")
-		asset := tags.Get("asset")
+		tags := reflect.StructTag(strings.TrimSpace(args))
+		if gomodule, found = tags.Lookup("gomodule"); !found {
+			return "", fmt.Errorf("releaselink requires tag \"gomodule\" to be set")
+		}
+		if asset, found = tags.Lookup("asset"); !found {
+			return "", fmt.Errorf("releaselink requires tag \"asset\" to be set")
+		}
+		if repo, found = tags.Lookup("repo"); !found {
+			return "", fmt.Errorf("releaselink requires tag \"repo\" to be set")
+		}
 		versionRange := semver.MustParseRange(tags.Get("version"))
 		includePrereleases := tags.Get("prereleases") == "true"
 
@@ -65,11 +73,6 @@ func (l ReleaseLink) Process(input *plugin.Input) error {
 		}
 
 		goproxyClient := goproxy.NewClient(scheme, host)
-
-		repo, err := vcs.RepoRootForImportPath(gomodule, false)
-		if err != nil {
-			return "", err
-		}
 
 		parsedTags, err := goproxyClient.GetVersions(context.Background(), gomodule)
 		if err != nil {
@@ -86,7 +89,7 @@ func (l ReleaseLink) Process(input *plugin.Input) error {
 			}
 		}
 
-		return fmt.Sprintf("%s/releases/download/v%s/%s", repo.Repo, picked, asset), nil
+		return fmt.Sprintf("%s/releases/download/v%s/%s", repo, picked, asset), nil
 	})
 }
 


### PR DESCRIPTION
Add a required "repo" tag to passed into usages of the `releaselink` tool. This is required in order to get rid of the deprecated `"golang.org/x/tools/go/vcs"`

This is a breaking change for downstream users of this tool who will have to add the new var - but it seemed simpler and easier to maintain than copying over the module -> repo resolution code from the go VCS tool.


Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9063
