### PR TITLE
🌱 Add Release Team OWNERS file to docs/release folder

### DIFF
--- a/docs/release/OWNERS
+++ b/docs/release/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-release-lead
+
+reviewers:
+  - cluster-api-release-team


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the suggestion in https://github.com/kubernetes-sigs/cluster-api/pull/9270#issuecomment-1690394995, this PR proposes to add CAPI Release Team members: "cluster-api-release-team" as reviewers and "cluster-api-relase-lead" as approver to the **docs/release** folder in the repo

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area release
