### PR TITLE
:seedling: Add synthetic test for ownerReference apiVersion update

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -44,7 +44,7 @@ var _ = Describe("When testing clusterctl upgrades (v0.4=>current)", func() {
 			WorkloadFlavor:            "",
 			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
+				framework.AssertOwnerReferences(namespace, proxy.GetKubeconfigPath(),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -82,17 +82,6 @@ var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 			WorkloadKubernetesVersion: "v1.23.17",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
-			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
-			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
-					framework.CoreOwnerReferenceAssertion,
-					framework.ExpOwnerReferenceAssertions,
-					framework.DockerInfraOwnerReferenceAssertions,
-					framework.KubeadmBootstrapOwnerReferenceAssertions,
-					framework.KubeadmControlPlaneOwnerReferenceAssertions,
-					framework.KubernetesReferenceAssertions,
-				)
-			},
 		}
 	})
 })
@@ -123,17 +112,6 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			WorkloadKubernetesVersion: "v1.26.4",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
-			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
-			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
-					framework.CoreOwnerReferenceAssertion,
-					framework.ExpOwnerReferenceAssertions,
-					framework.DockerInfraOwnerReferenceAssertions,
-					framework.KubeadmBootstrapOwnerReferenceAssertions,
-					framework.KubeadmControlPlaneOwnerReferenceAssertions,
-					framework.KubernetesReferenceAssertions,
-				)
-			},
 		}
 	})
 })
@@ -164,17 +142,6 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			WorkloadKubernetesVersion: "v1.26.4",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
-			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
-			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
-					framework.CoreOwnerReferenceAssertion,
-					framework.ExpOwnerReferenceAssertions,
-					framework.DockerInfraOwnerReferenceAssertions,
-					framework.KubeadmBootstrapOwnerReferenceAssertions,
-					framework.KubeadmControlPlaneOwnerReferenceAssertions,
-					framework.KubernetesReferenceAssertions,
-				)
-			},
 		}
 	})
 })
@@ -195,17 +162,6 @@ var _ = Describe("When testing clusterctl upgrades (v1.4=>current)", func() {
 			WorkloadKubernetesVersion: "v1.27.3",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
-			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
-			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
-					framework.CoreOwnerReferenceAssertion,
-					framework.ExpOwnerReferenceAssertions,
-					framework.DockerInfraOwnerReferenceAssertions,
-					framework.KubeadmBootstrapOwnerReferenceAssertions,
-					framework.KubeadmControlPlaneOwnerReferenceAssertions,
-					framework.KubernetesReferenceAssertions,
-				)
-			},
 		}
 	})
 })
@@ -226,17 +182,6 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.4=>cur
 			WorkloadKubernetesVersion: "v1.27.3",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
-			// This check ensures that ownerReference apiVersions are updated for all types after the upgrade.
-			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesOnUpdate(proxy, namespace,
-					framework.CoreOwnerReferenceAssertion,
-					framework.ExpOwnerReferenceAssertions,
-					framework.DockerInfraOwnerReferenceAssertions,
-					framework.KubeadmBootstrapOwnerReferenceAssertions,
-					framework.KubeadmControlPlaneOwnerReferenceAssertions,
-					framework.KubernetesReferenceAssertions,
-				)
-			},
 		}
 	})
 })

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -47,6 +47,15 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubeadmControlPlaneOwnerReferenceAssertions,
 					framework.KubernetesReferenceAssertions,
 				)
+				// This check ensures that owner references are correctly updated to the correct apiVersion.
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName,
+					framework.CoreOwnerReferenceAssertion,
+					framework.ExpOwnerReferenceAssertions,
+					framework.DockerInfraOwnerReferenceAssertions,
+					framework.KubeadmBootstrapOwnerReferenceAssertions,
+					framework.KubeadmControlPlaneOwnerReferenceAssertions,
+					framework.KubernetesReferenceAssertions,
+				)
 			},
 		}
 	})
@@ -65,6 +74,15 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 			// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName,
+					framework.CoreOwnerReferenceAssertion,
+					framework.ExpOwnerReferenceAssertions,
+					framework.DockerInfraOwnerReferenceAssertions,
+					framework.KubeadmBootstrapOwnerReferenceAssertions,
+					framework.KubeadmControlPlaneOwnerReferenceAssertions,
+					framework.KubernetesReferenceAssertions,
+				)
+				// This check ensures that owner references are correctly updated to the correct apiVersion.
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName,
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -42,8 +42,22 @@ import (
 )
 
 // ValidateOwnerReferencesOnUpdate checks that expected owner references are updated to the correct apiVersion.
-func ValidateOwnerReferencesOnUpdate(proxy ClusterProxy, namespace string, assertFuncs ...map[string]func(reference []metav1.OwnerReference) error) {
-	// Check that the ownerReferences are as expected on the first iteration.
+func ValidateOwnerReferencesOnUpdate(ctx context.Context, proxy ClusterProxy, namespace, clusterName string, assertFuncs ...map[string]func(reference []metav1.OwnerReference) error) {
+	clusterKey := client.ObjectKey{Namespace: namespace, Name: clusterName}
+
+	// Changes the version of all the owner references to v1alpha1. Expect the apiVersion to be updated after reconciliation.
+	setClusterPause(ctx, proxy.GetClient(), clusterKey, true)
+
+	// Change the version of the OwnerReferences on each object in the Graph to "v1alpha1"
+	changeOwnerReferencesAPIVersion(ctx, proxy, namespace)
+
+	setClusterPause(ctx, proxy.GetClient(), clusterKey, false)
+
+	// Annotate the clusterClass, if one is in use, to speed up reconciliation. This ensures ClusterClass ownerReferences
+	// are re-reconciled before asserting the owner reference graph.
+	forceClusterClassReconcile(ctx, proxy.GetClient(), clusterKey)
+
+	// Check that the ownerReferences have updated their apiVersions to current versions after reconciliation.
 	AssertOwnerReferences(namespace, proxy.GetKubeconfigPath(), assertFuncs...)
 }
 
@@ -348,6 +362,34 @@ func forceClusterClassReconcile(ctx context.Context, cli client.Client, clusterK
 		Expect(cli.Get(ctx, client.ObjectKey{Namespace: clusterKey.Namespace, Name: cluster.Spec.Topology.Class}, class)).To(Succeed())
 		annotationPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"metadata\":{\"annotations\":{\"cluster.x-k8s.io/modifiedAt\":\"%v\"}}}", time.Now().Format(time.RFC3339))))
 		Expect(cli.Patch(ctx, class, annotationPatch)).To(Succeed())
+	}
+}
+
+func changeOwnerReferencesAPIVersion(ctx context.Context, proxy ClusterProxy, namespace string) {
+	graph, err := clusterctlcluster.GetOwnerGraph(namespace, proxy.GetKubeconfigPath())
+	Expect(err).ToNot(HaveOccurred())
+	for _, object := range graph {
+		ref := object.Object
+		obj := new(unstructured.Unstructured)
+		obj.SetAPIVersion(ref.APIVersion)
+		obj.SetKind(ref.Kind)
+		obj.SetName(ref.Name)
+
+		Expect(proxy.GetClient().Get(ctx, client.ObjectKey{Namespace: namespace, Name: object.Object.Name}, obj)).To(Succeed())
+		helper, err := patch.NewHelper(obj, proxy.GetClient())
+		Expect(err).ToNot(HaveOccurred())
+
+		newOwners := []metav1.OwnerReference{}
+		for _, owner := range obj.GetOwnerReferences() {
+			gv, err := schema.ParseGroupVersion(owner.APIVersion)
+			Expect(err).To(Succeed())
+			gv.Version = "v1alpha1"
+			owner.APIVersion = gv.String()
+			newOwners = append(newOwners, owner)
+		}
+
+		obj.SetOwnerReferences(newOwners)
+		Expect(helper.Patch(ctx, obj)).To(Succeed())
 	}
 }
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9269

Add an end-to-end test to ensure that the apiVersions of ownerReferences are updated to the current version of the CAPI APIs.  This change allows testing apiVersion bumps when CAPI has no existing apiVersion available to create a cluster with.