### PR TITLE
🐛 MD controller: use regular random suffix for MachineSets, ensure max length 63

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -240,9 +240,9 @@ func (r *Reconciler) computeDesiredMachineSet(deployment *clusterv1.MachineDeplo
 		// Append a random string at the end of template hash. This is required to distinguish MachineSets that
 		// could be created with the same spec as a result of rolloutAfter. If not, computeDesiredMachineSet
 		// will end up updating the existing MachineSet instead of creating a new one.
-		uniqueIdentifierLabelValue = fmt.Sprintf("%d-%s", templateHash, apirand.String(5))
-
-		name = computeNewMachineSetName(deployment.Name+"-", apirand.SafeEncodeString(uniqueIdentifierLabelValue))
+		var randomSuffix string
+		name, randomSuffix = computeNewMachineSetName(deployment.Name + "-")
+		uniqueIdentifierLabelValue = fmt.Sprintf("%d-%s", templateHash, randomSuffix)
 
 		// Add foregroundDeletion finalizer to MachineSet if the MachineDeployment has it.
 		if sets.New[string](deployment.Finalizers...).Has(metav1.FinalizerDeleteDependents) {
@@ -366,11 +366,12 @@ const (
 // the upstream SimpleNameGenerator.
 // Note: We had to extract the logic as we want to use the MachineSet name suffix as
 // unique identifier for the MachineSet.
-func computeNewMachineSetName(base, suffix string) string {
+func computeNewMachineSetName(base string) (string, string) {
 	if len(base) > maxGeneratedNameLength {
 		base = base[:maxGeneratedNameLength]
 	}
-	return fmt.Sprintf("%s%s", base, suffix)
+	r := apirand.String(randomLength)
+	return fmt.Sprintf("%s%s", base, r), r
 }
 
 // scale scales proportionally in order to mitigate risk. Otherwise, scaling up can increase the size

--- a/internal/controllers/machinedeployment/machinedeployment_sync_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync_test.go
@@ -19,6 +19,7 @@ package machinedeployment
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -797,5 +798,41 @@ func assertCondition(t *testing.T, from conditions.Getter, condition *clusterv1.
 		if condition.Message != "" {
 			g.Expect(conditionToBeAsserted.Message).To(Equal(condition.Message))
 		}
+	}
+}
+
+func Test_computeNewMachineSetName(t *testing.T) {
+	tests := []struct {
+		base       string
+		wantPrefix string
+	}{
+		{
+			"a",
+			"a",
+		},
+		{
+			fmt.Sprintf("%058d", 0),
+			fmt.Sprintf("%058d", 0),
+		},
+		{
+			fmt.Sprintf("%059d", 0),
+			fmt.Sprintf("%058d", 0),
+		},
+		{
+			fmt.Sprintf("%0100d", 0),
+			fmt.Sprintf("%058d", 0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("base=%q, wantPrefix=%q", tt.base, tt.wantPrefix), func(t *testing.T) {
+			got, gotSuffix := computeNewMachineSetName(tt.base)
+			gotPrefix := strings.TrimSuffix(got, gotSuffix)
+			if gotPrefix != tt.wantPrefix {
+				t.Errorf("computeNewMachineSetName() = (%v, %v) wantPrefix %v", got, gotSuffix, tt.wantPrefix)
+			}
+			if len(got) > maxNameLength {
+				t.Errorf("expected %s to be of max length %d", got, maxNameLength)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR drops the templateHash from the MachineSet Name inside the controller for MachineDeployments (responsible to create MachineSets).

It also adjusts `computeNewMachineSetName(...)` to generate and return the suffix with the length of the const so we always return a string of max length 63.

All in all this helps keeping the length of the name of a MachineSet lower or equal to 63, same as we nowadays do for Machines.

Example Created MD, MS and Machine before and afterwards (with maximum name length):

before:

```
❯ kubectl get md,ms,ma -o custom-columns=KIND:kind,NAME:.metadata.name
KIND                NAME
MachineDeployment   development-12400-md-0000000000000000000000000000000000000g6wzr
MachineSet          development-12400-md-00000000000000000000000000000000000006b7fcf948bxpdzkz
Machine             development-12400-md-0000000000000000000000000000000000000nqmkl
```

after:

```
❯ kubectl get md,ms,ma -o custom-columns=KIND:kind,NAME:.metadata.name
KIND                NAME
MachineDeployment   development-12400-md-00000000000000000000000000000000000006bl9r
MachineSet          development-12400-md-00000000000000000000000000000000000005pjqf
Machine             development-12400-md-00000000000000000000000000000000000009gnst
```

Example Created MD, MS and Machine before and afterwards (with "normal" name length):

before:

```
❯ kubectl get md,ms,ma -o custom-columns=KIND:kind,NAME:.metadata.name
KIND                NAME
MachineDeployment   development-12400-md-0-xmv5l
MachineSet          development-12400-md-0-xmv5l-786f45bb8dxdg99b
Machine             development-12400-md-0-xmv5l-786f45bb8dxdg99b-jpqr4
```

after:

```
❯ kubectl get md,ms,ma -o custom-columns=KIND:kind,NAME:.metadata.name
KIND                NAME
MachineDeployment   development-12400-md-0-9zxmd
MachineSet          development-12400-md-0-9zxmd-zmjsh
Machine             development-12400-md-0-9zxmd-zmjsh-8dgvn
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8585


/area machinedeployment