### PR TITLE
:bug: Allow duplicate objects in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -368,7 +368,7 @@ def enable_provider(name, debug):
 
     if p.get("kustomize_config", True):
         yaml = read_file("./.tiltbuild/yaml/{}.provider.yaml".format(name))
-        k8s_yaml(yaml)
+        k8s_yaml(yaml, allow_duplicates = True)
         objs = decode_yaml_stream(yaml)
         k8s_resource(
             workload = find_object_name(objs, "Deployment"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Support for duplicated resources when debugging with Tilt.

Providers could require add-ons which have duplicated Namespace objects, thus breaking the Tilt setup.

**Which issue(s) this PR fixes**:
Fixes #9300
