### PR TITLE
:bug: Fix tilt-prepare leader-elect setting

### DIFF
--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -806,7 +806,7 @@ func prepareWorkload(name, prefix, binaryName, containerName string, objs []unst
 				debugArgs := make([]string, 0, len(args))
 				for _, a := range args {
 					if a == "--leader-elect" || a == "--leader-elect=true" {
-						continue
+						a = "--leader-elect=false"
 					}
 					debugArgs = append(debugArgs, a)
 				}


### PR DESCRIPTION
Explicitly set `--leader-elect` to false instead of removing it when running tilt-prepare. This helps for providers which set leader-elect to true by default.

/area devtools