### PR TITLE
:seedling: ginkgolinter: forbid focus container

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ linters:
 linters-settings:
   gci:
     local-prefixes: "sigs.k8s.io/cluster-api"
+  ginkgolinter:
+    forbid-focus-container: true
   godot:
     #   declarations - for top level declaration comments (default);
     #   toplevel     - for top level comments;


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable the new ginkgolinter rule to disallow using of focus containers (e.g. `FIt`, `FContext` and so on). This will prevent leaking of debug code from a local debug environment to the code base.

See more info here: https://github.com/nunnatsa/ginkgolinter#focus-container--focus-individual-spec-found-bug


/area test
/area ci
