### PR TITLE
🌱 golangci-lint: replace deprecated local-prefixes setting for gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,11 @@ linters:
 
 linters-settings:
   gci:
-    local-prefixes: "sigs.k8s.io/cluster-api"
+    sections:
+      - standard
+      - default
+      - prefix(sigs.k8s.io/cluster-api)
+    custom-order: true
   ginkgolinter:
     forbid-focus-container: true
   godot:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The local-prefixes setting is deprecated. (see the [docs](https://golangci-lint.run/usage/linters/#gci)).

This replaces it by the custom-order and sections setting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area ci