### PR TITLE
:seedling: Make GO_ARCH explicit in verify_containter script

### DIFF
--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -23,6 +23,7 @@ if [[ "${TRACE-0}" == "1" ]]; then
 fi
 
 VERSION=${1}
+GO_ARCH="$(go env GOARCH)"
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 "${REPO_ROOT}/hack/ensure-trivy.sh" "${VERSION}"


### PR DESCRIPTION
Make the `GO_ARCH` setting explicit in this script.

Follow-on from discussion at https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2299#discussion_r1309889032