### PR TITLE
:seedling: Add unit tests for CC MP blueprint, current_state, & desired_state

### DIFF
--- a/internal/test/builder/infrastructure.go
+++ b/internal/test/builder/infrastructure.go
@@ -37,9 +37,13 @@ var (
 
 	// GenericInfrastructureMachinePoolTemplateKind is the Kind for the GenericInfrastructureMachinePoolTemplate.
 	GenericInfrastructureMachinePoolTemplateKind = "GenericInfrastructureMachinePoolTemplate"
+	// GenericInfrastructureMachinePoolTemplateCRD is a generic infrastructure machine pool template CRD.
+	GenericInfrastructureMachinePoolTemplateCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachinePoolTemplateKind))
 
 	// GenericInfrastructureMachinePoolKind is the Kind for the GenericInfrastructureMachinePool.
 	GenericInfrastructureMachinePoolKind = "GenericInfrastructureMachinePool"
+	// GenericInfrastructureMachinePoolCRD is a generic infrastructure machine pool CRD.
+	GenericInfrastructureMachinePoolCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachinePoolKind))
 
 	// GenericInfrastructureClusterKind is the kind for the GenericInfrastructureCluster type.
 	GenericInfrastructureClusterKind = "GenericInfrastructureCluster"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds tests for the new ClusterClass MachinePool implementation for the following files:
- internal/controllers/topology/cluster/blueprint_test.go
- internal/controllers/topology/cluster/current_state_test.go
- internal/controllers/topology/cluster/desired_state_test.go

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #5991

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing