### PR TITLE
🌱 hack: bump kube-state-metrics and prometheus charts

### DIFF
--- a/hack/observability/kube-state-metrics/chart/kustomization.yaml
+++ b/hack/observability/kube-state-metrics/chart/kustomization.yaml
@@ -4,7 +4,7 @@ helmCharts:
     namespace: observability
     releaseName: kube-state-metrics
     valuesFile: values.yaml
-    version: 5.8.1
+    version: 5.12.1
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/prometheus/kustomization.yaml
+++ b/hack/observability/prometheus/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     releaseName: prometheus
     namespace: observability
     valuesFile: values.yaml
-    version: 22.6.2
+    version: 24.1.0
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This bumps the prometheus and kube-state-metrics helm charts.

Especially this includes fixes for kube-state-metrics by bumping it to v2.10.0:

- https://github.com/kubernetes/kube-state-metrics/issues/2142
- Also the initialisation of custom resource metrics is now way faster on startup

Make sure to run `make clean-charts`!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8951

/area metrics