### PR TITLE
🐛 Fix autoscaler image repo

### DIFF
--- a/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
@@ -168,7 +168,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: k8s.gcr.io/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           command:
             - /cluster-autoscaler

--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -374,7 +374,7 @@ func getAuthenticationTokenForAutoscaler(ctx context.Context, managementClusterP
 			{
 				Verbs:     []string{"get", "list", "update", "watch"},
 				APIGroups: []string{"cluster.x-k8s.io"},
-				Resources: []string{"machinedeployments", "machinedeployments/scale", "machines", "machinesets"},
+				Resources: []string{"machinedeployments", "machinedeployments/scale", "machinepools", "machinepools/scale", "machines", "machinesets"},
 			},
 			{
 				Verbs:     []string{"get", "list"},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes the image repo.

Apparently new images are published to the new registry

Broke via #9349 (https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-main/1697533477378854912)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->