### PR TITLE
🐛 Bubble up machine drain condition in `MachinesReadyCondition`

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -242,6 +242,7 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 			// MHC reported condition should take precedence over the remediation progress
 			clusterv1.MachineHealthCheckSucceededCondition,
 			clusterv1.MachineOwnerRemediatedCondition,
+			clusterv1.DrainingSucceededCondition,
 		),
 		conditions.WithStepCounterIf(machine.ObjectMeta.DeletionTimestamp.IsZero() && machine.Spec.ProviderID == nil),
 		conditions.WithStepCounterIfOnly(

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -974,6 +974,17 @@ func TestMachineConditions(t *testing.T) {
 				conditions.UnknownCondition(clusterv1.MachineNodeHealthyCondition, clusterv1.NodeInspectionFailedReason, "Failed to get the Node for this Machine by ProviderID"),
 			},
 		},
+		{
+			name:           "ready condition summary consumes reason from the draining succeeded condition",
+			infraReady:     true,
+			bootstrapReady: true,
+			beforeFunc: func(bootstrap, infra *unstructured.Unstructured, m *clusterv1.Machine) {
+				conditions.MarkFalse(m, clusterv1.DrainingSucceededCondition, clusterv1.DrainingFailedReason, clusterv1.ConditionSeverityWarning, "")
+			},
+			conditionsToAssert: []*clusterv1.Condition{
+				conditions.FalseCondition(clusterv1.ReadyCondition, clusterv1.DrainingFailedReason, clusterv1.ConditionSeverityWarning, ""),
+			},
+		},
 	}
 
 	for _, tt := range testcases {


### PR DESCRIPTION
**What this PR does / why we need it**:
As described in the issue, a failing drain can currently block a scalable resource scale down / delete operation transparently.
This PR attemps to fix this issue by adding `DrainingSucceededCondition` to the summary of `MachinesReadyCondition`, bubbling up the drain result in the `MachineSet` and in the `MachineDeployment` after https://github.com/kubernetes-sigs/cluster-api/pull/9262.

**Which issue(s) this PR fixes**:
Fixes #9285

/area machine
