### PR TITLE
:seedling: check minimum version of `kind` tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ tmp
 
 # Development container configurations (https://containers.dev/)
 .devcontainer
+
+# .envrc for setting env vars. https://direnv.net/
+.envrc

--- a/hack/check-kind-version.sh
+++ b/hack/check-kind-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if ! command -v kind &> /dev/null; then
+    echo "😭 kind is not installed. Get it here: https://kind.sigs.k8s.io/"
+    exit 1
+fi
+
+# Get the version of kind
+VERSION=$(kind version | cut -d ' ' -f2 | tr -d 'v')
+
+# Split the version into major and minor parts
+IFS='.' read -ra VER_PARTS <<< "$VERSION"
+
+MIN_VERSION="20"
+
+# Check the version
+if [ "${VER_PARTS[0]}" -gt "0" ] || ([ "${VER_PARTS[0]}" -eq "0" ] && [ "${VER_PARTS[1]}" -ge "$MIN_VERSION" ]); then
+    echo "👍 kind is version 0.$MIN_VERSION or newer."
+else
+    echo "😭 kind is older than version 0.$MIN_VERSION"
+    exit 1
+fi

--- a/hack/kind-install-for-capd.sh
+++ b/hack/kind-install-for-capd.sh
@@ -30,6 +30,8 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
+"$(dirname "$0")/check-kind-version.sh"
+
 KIND_CLUSTER_NAME=${CAPI_KIND_CLUSTER_NAME:-"capi-test"}
 # See: https://kind.sigs.k8s.io/docs/user/configuration/#ip-family
 KIND_NETWORK_IPFAMILY=${KIND_NETWORK_IPFAMILY:-"dual"}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

If you start `hack/kind-install-for-capd.sh` with an not supported `kind` version, then you get strange errors
which can't be resolved by people new to the topic.

This PR adds a script which checks that `kind` is at least in version 0.20.
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area devtools
