### PR TITLE
🌱 Drop PR-Informing test tag and job description

### DIFF
--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -19,8 +19,6 @@ Prow Presubmits:
     * GINKGO_FOCUS: `[PR-Blocking]`
 * optional for merge, run if go code changes:
   * [pull-cluster-api-apidiff-main] `./scripts/ci-apidiff.sh`
-  * [pull-cluster-api-e2e-informing-main] `./scripts/ci-e2e.sh`
-    * GINKGO_FOCUS: `[PR-Informing]`
 * optional for merge, run if manually triggered:
   * [pull-cluster-api-test-mink8s-main] `./scripts/ci-test.sh`
     * KUBEBUILDER_ENVTEST_KUBERNETES_VERSION: `1.24.2`

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [PR-Informing] [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [ClusterClass]", func() {
 	clusterUpgradeWithRuntimeSDKSpec(ctx, func() clusterUpgradeWithRuntimeSDKSpecInput {
 		version, err := semver.ParseTolerant(e2eConfig.GetVariable(KubernetesVersionUpgradeFrom))
 		Expect(err).ToNot(HaveOccurred(), "Invalid argument, KUBERNETES_VERSION_UPGRADE_FROM is not a valid version")


### PR DESCRIPTION
This test tag is currently used only to run Runtime SDK tests which was useful when there were a lot of new PRs around that feature. Now that there isn't we can drop the tag - over at test infra - and reduce the number of jobs we run.


