### PR TITLE
🌱 Verify plantuml image generation in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,7 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences
 	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
-ALL_VERIFY_CHECKS = licenses boilerplate shellcheck tiltfile modules gen conversions doctoc capi-book-summary
+ALL_VERIFY_CHECKS = licenses boilerplate shellcheck tiltfile modules gen conversions doctoc capi-book-summary diagrams
 
 .PHONY: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) lint-dockerfiles ## Run all verify-* targets
@@ -672,6 +672,13 @@ verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
 	$(GOVULNCHECK) -C "$(TEST_DIR)" ./... && R3=$$? || R3=$$?; \
 	if [ "$$R1" -ne "0" ] || [ "$$R2" -ne "0" ] || [ "$$R3" -ne "0" ]; then \
 		exit 1; \
+	fi
+
+.PHONY: verify-diagrams
+verify-diagrams: generate-diagrams ## Verify generated diagrams are up to date
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated diagrams are out of date, run make generate-diagrams"; exit 1; \
 	fi
 
 .PHONY: verify-security


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds generation of the plantuml images to CI through a new job, which runs on PRs. The job fails in case the generated images differ from the contained images in PRs. 

This solution is not ideal:
1. I'm reinstalling git in CI, as I couldn't find an image containing plantuml and git, and am not sure if we should be building it ourselves.
2. The job refers to variables that are set in the `Makefile`, if e.g. the `PLANTUML_VER` changes, we might forget about this job.

**Which issue(s) this PR fixes**:
Fixes #9331 