### PR TITLE
:seedling: Add MachinePool test cases to engine tests

### DIFF
--- a/internal/controllers/topology/cluster/patches/engine_test.go
+++ b/internal/controllers/topology/cluster/patches/engine_test.go
@@ -167,9 +167,6 @@ func TestApply(t *testing.T) {
 									MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
 										Names: []string{"default-worker"},
 									},
-									MachinePoolClass: &clusterv1.PatchSelectorMatchMachinePoolClass{
-										Names: []string{"default-mp-worker"},
-									},
 								},
 							},
 							JSONPatches: []clusterv1.JSONPatch{
@@ -194,7 +191,7 @@ func TestApply(t *testing.T) {
 								{
 									Op:    "add",
 									Path:  "/spec/template/spec/resource",
-									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-worker-infra"`)},
+									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-infra"`)},
 								},
 							},
 						},
@@ -212,7 +209,7 @@ func TestApply(t *testing.T) {
 								{
 									Op:    "add",
 									Path:  "/spec/template/spec/resource",
-									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-worker-bootstrap"`)},
+									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-bootstrap"`)},
 								},
 							},
 						},
@@ -229,12 +226,12 @@ func TestApply(t *testing.T) {
 					"default-worker-topo2": {"spec.template.spec.resource": "default-worker-infra"},
 				},
 				machinePoolBootstrapConfig: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "default-worker-bootstrap"},
-					"default-mp-worker-topo2": {"spec.resource": "default-worker-bootstrap"},
+					"default-mp-worker-topo1": {"spec.resource": "default-mp-worker-bootstrap"},
+					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-bootstrap"},
 				},
 				machinePoolInfrastructureMachinePool: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "default-worker-infra"},
-					"default-mp-worker-topo2": {"spec.resource": "default-worker-infra"},
+					"default-mp-worker-topo1": {"spec.resource": "default-mp-worker-infra"},
+					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-infra"},
 				},
 			},
 		},
@@ -850,11 +847,11 @@ func TestApply(t *testing.T) {
 					"default-worker-topo2": {"spec.template.spec.resource": "default-worker-topo2"},
 				},
 				machinePoolInfrastructureMachinePool: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "value1"},
+					"default-mp-worker-topo1": {"spec.resource": "value2"},
 					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-topo2"},
 				},
 				machinePoolBootstrapConfig: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "value1"},
+					"default-mp-worker-topo1": {"spec.resource": "value2"},
 					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-topo2"},
 				},
 			},
@@ -1105,7 +1102,7 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 									{
 										Name:           "default-mp-worker-infra",
 										DefinitionFrom: "inline",
-										Value:          apiextensionsv1.JSON{Raw: []byte(`"value1"`)},
+										Value:          apiextensionsv1.JSON{Raw: []byte(`"value2"`)},
 									},
 								},
 							},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds tests for the new ClusterClass MachinePool implementation for `internal/controllers/topology/cluster/patches/engine_test.go`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of https://github.com/kubernetes-sigs/cluster-api/issues/5991

/area testing

<sub>Johannes Frey <[johannes.frey@mercedes-benz.com](mailto:johannes.frey@mercedes-benz.com)>, Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>