### PR TITLE
🌱 Fail tests if test env version check fails

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -143,11 +143,11 @@ func Run(ctx context.Context, input RunInput) int {
 
 	if input.MinK8sVersion != "" {
 		if err := version.CheckKubernetesVersion(env.Config, input.MinK8sVersion); err != nil {
-			fmt.Printf("[IMPORTANT] skipping tests after failing version check: %v\n", err)
+			fmt.Printf("[ERROR] Cannot run tests after failing version check: %v\n", err)
 			if err := env.stop(); err != nil {
 				fmt.Println("[WARNING] Failed to stop the test environment")
 			}
-			return 0
+			return 1
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We currently use MinK8sVersion only for ClusterClass tests to ensure we use Kubernetes >=1.22 testenv binaries. I think in this case we should fail now as there are no cases where we just want to silently skip the tests in that case.

Going forward if we have the use cases we could evolve the API to differentiate between "skip" and "fail", but I think that is not necessary for now

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->