### PR TITLE
🌱 Add ownerRefs to BootstrapConfig/InfraMachinePool in classy Clusters

### DIFF
--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -617,7 +617,7 @@ func computeMachineDeployment(ctx context.Context, s *scope.Scope, machineDeploy
 		currentObjectRef:      currentBootstrapTemplateRef,
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachineDeployment object
-		// with the reference to the ControlPlane object using this template.
+		// with the reference to this template.
 		ownerRef: ownerReferenceTo(s.Current.Cluster),
 	})
 
@@ -642,7 +642,7 @@ func computeMachineDeployment(ctx context.Context, s *scope.Scope, machineDeploy
 		currentObjectRef:      currentInfraMachineTemplateRef,
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachineDeployment object
-		// with the reference to the ControlPlane object using this template.
+		// with the reference to this template.
 		ownerRef: ownerReferenceTo(s.Current.Cluster),
 	})
 
@@ -953,6 +953,10 @@ func computeMachinePool(_ context.Context, s *scope.Scope, machinePoolTopology c
 		cluster:               s.Current.Cluster,
 		namePrefix:            bootstrapConfigNamePrefix(s.Current.Cluster.Name, machinePoolTopology.Name),
 		currentObjectRef:      currentBootstrapConfigRef,
+		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
+		// in case of errors in between creating this template and creating/updating the MachinePool object
+		// with the reference to this template.
+		ownerRef: ownerReferenceTo(s.Current.Cluster),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compute bootstrap object for topology %q", machinePoolTopology.Name)
@@ -977,6 +981,10 @@ func computeMachinePool(_ context.Context, s *scope.Scope, machinePoolTopology c
 		cluster:               s.Current.Cluster,
 		namePrefix:            infrastructureMachinePoolNamePrefix(s.Current.Cluster.Name, machinePoolTopology.Name),
 		currentObjectRef:      currentInfraMachinePoolRef,
+		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
+		// in case of errors in between creating this template and creating/updating the MachinePool object
+		// with the reference to this template.
+		ownerRef: ownerReferenceTo(s.Current.Cluster),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compute infrastructure object for topology %q", machinePoolTopology.Name)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Thought about this for a bit. I think it makes sense to do the same as in the MD case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #5991

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->