### PR TITLE
:seedling: allow non-provider Deployments in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -382,7 +382,8 @@ def enable_provider(name, debug):
 
 def find_object_name(objs, kind):
     for o in objs:
-        if o["kind"] == kind:
+        # Ignore objects that are not part of the provider, e.g. the ASO Deployment in CAPZ.
+        if o["kind"] == kind and "cluster.x-k8s.io/provider" in o["metadata"]["labels"]:
             return o["metadata"]["name"]
     return ""
 

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -871,6 +871,10 @@ func updateDeployment(prefix string, objs []unstructured.Unstructured, f updateD
 		if obj.GetKind() != "Deployment" {
 			continue
 		}
+		// Ignore Deployments that are not part of the provider, eg. ASO in CAPZ.
+		if _, exists := obj.GetLabels()[clusterv1.ProviderNameLabel]; !exists {
+			continue
+		}
 
 		// Convert Unstructured into a typed object
 		d := &appsv1.Deployment{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR updates the Tilt dev setup to still install, but otherwise ignore, Deployment resources without a `cluster.x-k8s.io/provider` that come with a provider. CAPI may overwrite the `command` for the container in a way that isn't compatible with the image, for example if the image doesn't contain `sh`, such that the container fails to start.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area devtools
-->

/area devtools