### PR TITLE
[WIP] 🌱 ClusterCacheTracker: introduce interfaces to allow fake implementations in tests

### DIFF
--- a/bootstrap/kubeadm/controllers/alias.go
+++ b/bootstrap/kubeadm/controllers/alias.go
@@ -41,7 +41,7 @@ type KubeadmConfigReconciler struct {
 	Client              client.Client
 	SecretCachingClient client.Client
 
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -78,7 +78,7 @@ type InitLocker interface {
 type KubeadmConfigReconciler struct {
 	Client              client.Client
 	SecretCachingClient client.Client
-	Tracker             *remote.ClusterCacheTracker
+	Tracker             remote.ClusterCache
 	KubeadmInitLock     InitLocker
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -64,7 +64,7 @@ type MachineReconciler struct {
 	Client                    client.Client
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
-	Tracker                   *remote.ClusterCacheTracker
+	Tracker                   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -89,7 +89,7 @@ type MachineSetReconciler struct {
 	Client                    client.Client
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
-	Tracker                   *remote.ClusterCacheTracker
+	Tracker                   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -127,7 +127,7 @@ func (r *MachineDeploymentReconciler) SetupWithManager(ctx context.Context, mgr 
 // MachineHealthCheckReconciler reconciles a MachineHealthCheck object.
 type MachineHealthCheckReconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -144,7 +144,7 @@ func (r *MachineHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr
 // ClusterTopologyReconciler reconciles a managed topology for a Cluster object.
 type ClusterTopologyReconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
 	APIReader client.Reader

--- a/controllers/remote/cluster_cache_tracker.go
+++ b/controllers/remote/cluster_cache_tracker.go
@@ -64,6 +64,24 @@ const (
 // if the cluster is already locked by another concurrent call.
 var ErrClusterLocked = errors.New("cluster is locked already")
 
+// ClusterCache manages client caches for workload clusters.
+type ClusterCache interface {
+	// GetClient returns a cached client for the given cluster.
+	GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error)
+	// GetRESTConfig returns a cached REST config for the given cluster.
+	GetRESTConfig(ctc context.Context, cluster client.ObjectKey) (*rest.Config, error)
+	// Watch watches a remote cluster for resource events. If the watch already exists based on input.Name, this is a no-op.
+	Watch(ctx context.Context, input WatchInput) error
+}
+
+// EtcdClusterCache manages client caches for workload clusters and their etcd credentials.
+type EtcdClusterCache interface {
+	ClusterCache
+
+	// GetEtcdClientCertificateKey returns a cached certificate key to be used for generating certificates for accessing etcd in the given cluster.
+	GetEtcdClientCertificateKey(ctx context.Context, cluster client.ObjectKey) (*rsa.PrivateKey, error)
+}
+
 // ClusterCacheTracker manages client caches for workload clusters.
 type ClusterCacheTracker struct {
 	log                   logr.Logger

--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -32,7 +32,7 @@ import (
 type KubeadmControlPlaneReconciler struct {
 	Client              client.Client
 	SecretCachingClient client.Client
-	Tracker             *remote.ClusterCacheTracker
+	Tracker             remote.EtcdClusterCache
 
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -54,7 +54,7 @@ type ManagementCluster interface {
 type Management struct {
 	Client              client.Reader
 	SecretCachingClient client.Reader
-	Tracker             *remote.ClusterCacheTracker
+	Tracker             remote.EtcdClusterCache
 	EtcdDialTimeout     time.Duration
 	EtcdCallTimeout     time.Duration
 }

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -75,7 +75,7 @@ type KubeadmControlPlaneReconciler struct {
 	SecretCachingClient client.Client
 	controller          controller.Controller
 	recorder            record.EventRecorder
-	Tracker             *remote.ClusterCacheTracker
+	Tracker             remote.EtcdClusterCache
 
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration

--- a/exp/addons/controllers/alias.go
+++ b/exp/addons/controllers/alias.go
@@ -30,7 +30,7 @@ import (
 // ClusterResourceSetReconciler reconciles a ClusterResourceSet object.
 type ClusterResourceSetReconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -59,7 +59,7 @@ var ErrSecretTypeNotSupported = errors.New("unsupported secret type")
 // ClusterResourceSetReconciler reconciles a ClusterResourceSet object.
 type ClusterResourceSetReconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -31,7 +31,7 @@ import (
 type MachinePoolReconciler struct {
 	Client    client.Client
 	APIReader client.Reader
-	Tracker   *remote.ClusterCacheTracker
+	Tracker   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -63,7 +63,7 @@ const (
 type MachinePoolReconciler struct {
 	Client    client.Client
 	APIReader client.Reader
-	Tracker   *remote.ClusterCacheTracker
+	Tracker   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -77,7 +77,7 @@ type Reconciler struct {
 	Client                    client.Client
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
-	Tracker                   *remote.ClusterCacheTracker
+	Tracker                   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -75,7 +75,7 @@ const (
 // Reconciler reconciles a MachineHealthCheck object.
 type Reconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -82,7 +82,7 @@ type Reconciler struct {
 	Client                    client.Client
 	UnstructuredCachingClient client.Client
 	APIReader                 client.Reader
-	Tracker                   *remote.ClusterCacheTracker
+	Tracker                   remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -67,7 +67,7 @@ import (
 // Reconciler reconciles a managed topology for a Cluster object.
 type Reconciler struct {
 	Client  client.Client
-	Tracker *remote.ClusterCacheTracker
+	Tracker remote.ClusterCache
 	// APIReader is used to list MachineSets directly via the API server to avoid
 	// race conditions caused by an outdated cache.
 	APIReader client.Reader

--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -36,7 +36,7 @@ import (
 type DockerMachineReconciler struct {
 	Client           client.Client
 	ContainerRuntime container.Runtime
-	Tracker          *remote.ClusterCacheTracker
+	Tracker          remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -35,7 +35,7 @@ type DockerMachinePoolReconciler struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
 	ContainerRuntime container.Runtime
-	Tracker          *remote.ClusterCacheTracker
+	Tracker          remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -51,7 +51,7 @@ type DockerMachinePoolReconciler struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
 	ContainerRuntime container.Runtime
-	Tracker          *remote.ClusterCacheTracker
+	Tracker          remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -53,7 +53,7 @@ import (
 type DockerMachineReconciler struct {
 	client.Client
 	ContainerRuntime container.Runtime
-	Tracker          *remote.ClusterCacheTracker
+	Tracker          remote.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR introduces interfaces for the ClusterCacheTracker. This way it will be possible to change the implementation e.g. for testing purposes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clustercachetracker