### PR TITLE
📖 Bump go minor versions in release branches if they are out of support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,9 @@ We generally allow backports of following changes to all supported branches:
 - Dependency bumps for CVE (usually limited to CVE resolution; backports of non-CVE related version bumps are considered exceptions to be evaluated case by case)
 - Cert-manager version bumps (to avoid having releases with cert-manager versions that are out of support, when possible)
 - Changes required to support new Kubernetes versions, when possible. See [supported Kubernetes versions](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions) for more details.
-- Changes to use the latest Go patch release. If the Go minor version of a supported branch goes out of support, we will consider on a case-by-case basis
-  to bump to a newer Go minor version (e.g. to pick up CVE fixes). This could have impact on everyone importing Cluster API.
+- Changes to use the latest Go patch version to build controller images.
+- Changes to bump the Go minor version used to build controller images, if the Go minor version of a supported branch goes out of support (e.g. to pick up bug and CVE fixes). 
+  This has no impact on folks importing Cluster API as we won't modify the version in `go.mod` and the version in the `Makefile` does not affect them.
 
 We generally allow backports of following changes only to the latest supported branch:
 - Improvements to existing docs (the latest supported branch hosts the current version of the book)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I would like to propose to change our backport policy. tl;dr is:
* On main: let's align to the Go minor version used by our k/k dependencies  (Makefile + go.mod)
* On release-branches: let's bump the Go minor version used to build our controller images if the Go minor version goes out of support (only Makefile)

The reason why I'm bringing this up is because Go 1.19 is out of support as of now but we still use it on the release-1.4 branch.

The idea would be to only bump the Go version we use to build our controller images. This means bumping the version in the Makefile, but not in go.mod (go.mod would break library consumers), similar to what Kubernetes is doing (they also don't bump the go.mod file after the minor release is out).

In my opinion it is absolutely safe to do so as our Makefile version doesn't affect anyone that consumes our go code / module.

Overall we're aligning to the way Kubernetes is handling this, for more context see: https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3744-stay-on-supported-go-versions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7974

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->