### PR TITLE
:book:  Update jobs.md for newly blocking jobs

### DIFF
--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -19,7 +19,7 @@ Prow Presubmits:
     * GINKGO_FOCUS: `[PR-Blocking]`
 * optional for merge, run if go code changes:
   * [pull-cluster-api-apidiff-main] `./scripts/ci-apidiff.sh`
-* optional for merge, run if manually triggered:
+* mandatory for merge, run if manually triggered:
   * [pull-cluster-api-test-mink8s-main] `./scripts/ci-test.sh`
     * KUBEBUILDER_ENVTEST_KUBERNETES_VERSION: `1.24.2`
   * [pull-cluster-api-e2e-mink8s-main] `./scripts/ci-e2e.sh`
@@ -32,6 +32,7 @@ Prow Presubmits:
     * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]|[IPv6]`
   * [pull-cluster-api-e2e-workload-upgrade-1-28-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.28` TO: `ci/latest-1.29`
     * GINKGO_FOCUS: `[K8s-Upgrade]`
+* optional for merge, run if manually triggered:
   * [pull-cluster-api-e2e-scale-main-experimental] `./scripts/ci-e2e-scale.sh`
 
 GitHub Presubmit Workflows:


### PR DESCRIPTION
PR to reflect the changes made in https://github.com/kubernetes/test-infra/pull/30709 which made many manually triggered jobs blocking.