### PR TITLE
[release-1.5] :book: Update jobs.md for newly blocking jobs

### DIFF
--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -21,7 +21,7 @@ Prow Presubmits:
   * [pull-cluster-api-apidiff-main] `./scripts/ci-apidiff.sh`
   * [pull-cluster-api-e2e-informing-main] `./scripts/ci-e2e.sh`
     * GINKGO_FOCUS: `[PR-Informing]`
-* optional for merge, run if manually triggered:
+* mandatory for merge, run if manually triggered:
   * [pull-cluster-api-test-mink8s-main] `./scripts/ci-test.sh`
     * KUBEBUILDER_ENVTEST_KUBERNETES_VERSION: `1.24.2`
   * [pull-cluster-api-e2e-mink8s-main] `./scripts/ci-e2e.sh`
@@ -34,6 +34,7 @@ Prow Presubmits:
     * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]|[IPv6]`
   * [pull-cluster-api-e2e-workload-upgrade-1-28-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.28` TO: `ci/latest-1.29`
     * GINKGO_FOCUS: `[K8s-Upgrade]`
+* optional for merge, run if manually triggered:
   * [pull-cluster-api-e2e-scale-main-experimental] `./scripts/ci-e2e-scale.sh`
 
 GitHub Presubmit Workflows:


### PR DESCRIPTION
PR to reflect the changes made in https://github.com/kubernetes/test-infra/pull/30709 which made many manually triggered jobs blocking.