### PR TITLE
[release-1.4] 🌱 Bump to Go 1.20.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.19.13
+GO_VERSION ?= 1.20.8
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/Tiltfile
+++ b/Tiltfile
@@ -165,7 +165,7 @@ def load_provider_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.19.13 as tilt-helper
+FROM golang:1.20.8 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -145,6 +145,7 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+	//nolint:staticcheck
 	rand.Seed(time.Now().UnixNano())
 
 	InitFlags(pflag.CommandLine)

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -153,6 +153,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	feature.MutableGates.AddFlag(fs)
 }
 func main() {
+	//nolint:staticcheck
 	rand.Seed(time.Now().UnixNano())
 
 	InitFlags(pflag.CommandLine)

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -38,7 +38,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.19
+  minimum_go_version=go1.20
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+	//nolint:staticcheck
 	rand.Seed(time.Now().UnixNano())
 
 	InitFlags(pflag.CommandLine)

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -111,6 +111,7 @@ func initFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+	//nolint:staticcheck
 	rand.Seed(time.Now().UnixNano())
 	if _, err := os.ReadDir("/tmp/"); err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Bumps `release-1.4` to address new CVE causing our GH action `Weekly Security Scan` to fail ([example](https://github.com/kubernetes-sigs/cluster-api/actions/runs/6146074316/job/16674739006#step:5:659))

Pending merge of [https://github.com/kubernetes-sigs/cluster-api/pull/9415](https://github.com/kubernetes-sigs/cluster-api/pull/9415)

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area dependency