### PR TITLE
:seedling: propagate ctx to retryWithExponentialBackoff in clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -187,7 +187,7 @@ func (cm *certManagerClient) install(ctx context.Context) error {
 		o := objs[i]
 		// Create the Kubernetes object.
 		// Nb. The operation is wrapped in a retry loop to make ensureCerts more resilient to unexpected conditions.
-		if err := retryWithExponentialBackoff(createCertManagerBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, createCertManagerBackoff, func(ctx context.Context) error {
 			return cm.createObj(ctx, o)
 		}); err != nil {
 			return err
@@ -306,7 +306,7 @@ func (cm *certManagerClient) deleteObjs(ctx context.Context, objs []unstructured
 			continue
 		}
 
-		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, deleteCertManagerBackoff, func(ctx context.Context) error {
 			if err := cm.deleteObj(ctx, obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
 				if apierrors.IsNotFound(err) {
@@ -560,7 +560,7 @@ func (cm *certManagerClient) waitForAPIReady(ctx context.Context, retry bool) er
 	deleteCertManagerBackoff := newWriteBackoff()
 	for i := range testObjs {
 		obj := testObjs[i]
-		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, deleteCertManagerBackoff, func(ctx context.Context) error {
 			if err := cm.deleteObj(ctx, obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
 				if apierrors.IsNotFound(err) {

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -219,13 +219,13 @@ func newClusterClient(kubeconfig Kubeconfig, configClient config.Client, options
 }
 
 // retryWithExponentialBackoff repeats an operation until it passes or the exponential backoff times out.
-func retryWithExponentialBackoff(opts wait.Backoff, operation func() error) error {
+func retryWithExponentialBackoff(ctx context.Context, opts wait.Backoff, operation func(ctx context.Context) error) error {
 	log := logf.Log
 
 	i := 0
-	err := wait.ExponentialBackoff(opts, func() (bool, error) {
+	err := wait.ExponentialBackoffWithContext(ctx, opts, func(ctx context.Context) (bool, error) {
 		i++
-		if err := operation(); err != nil {
+		if err := operation(ctx); err != nil {
 			if i < opts.Steps {
 				log.V(5).Info("Retrying with backoff", "Cause", err.Error())
 				return false, nil

--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -80,7 +80,7 @@ func (p *providerComponents) Create(ctx context.Context, objs []unstructured.Uns
 
 		// Create the Kubernetes object.
 		// Nb. The operation is wrapped in a retry loop to make Create more resilient to unexpected conditions.
-		if err := retryWithExponentialBackoff(createComponentObjectBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, createComponentObjectBackoff, func(ctx context.Context) error {
 			return p.createObj(ctx, obj)
 		}); err != nil {
 			return err
@@ -217,7 +217,7 @@ func (p *providerComponents) Delete(ctx context.Context, options DeleteOptions) 
 		// Otherwise delete the object
 		log.V(5).Info("Deleting", logf.UnstructuredToValues(obj)...)
 		deleteBackoff := newWriteBackoff()
-		if err := retryWithExponentialBackoff(deleteBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, deleteBackoff, func(ctx context.Context) error {
 			if err := cs.Delete(ctx, &obj); err != nil {
 				if apierrors.IsNotFound(err) {
 					// Tolerate IsNotFound error that might happen because we are not enforcing a deletion order

--- a/cmd/clusterctl/client/cluster/inventory.go
+++ b/cmd/clusterctl/client/cluster/inventory.go
@@ -162,7 +162,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions(ctx context.Context) e
 	// Nb. The operation is wrapped in a retry loop to make EnsureCustomResourceDefinitions more resilient to unexpected conditions.
 	var crdIsIstalled bool
 	listInventoryBackoff := newReadBackoff()
-	if err := retryWithExponentialBackoff(listInventoryBackoff, func() error {
+	if err := retryWithExponentialBackoff(ctx, listInventoryBackoff, func(ctx context.Context) error {
 		var err error
 		crdIsIstalled, err = checkInventoryCRDs(ctx, p.proxy)
 		return err
@@ -189,7 +189,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions(ctx context.Context) e
 
 		// Create the Kubernetes object.
 		// Nb. The operation is wrapped in a retry loop to make EnsureCustomResourceDefinitions more resilient to unexpected conditions.
-		if err := retryWithExponentialBackoff(createInventoryObjectBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, createInventoryObjectBackoff, func(ctx context.Context) error {
 			return p.createObj(ctx, o)
 		}); err != nil {
 			return err
@@ -272,7 +272,7 @@ func (p *inventoryClient) createObj(ctx context.Context, o unstructured.Unstruct
 func (p *inventoryClient) Create(ctx context.Context, m clusterctlv1.Provider) error {
 	// Create the Kubernetes object.
 	createInventoryObjectBackoff := newWriteBackoff()
-	return retryWithExponentialBackoff(createInventoryObjectBackoff, func() error {
+	return retryWithExponentialBackoff(ctx, createInventoryObjectBackoff, func(ctx context.Context) error {
 		cl, err := p.proxy.NewClient()
 		if err != nil {
 			return err
@@ -310,7 +310,7 @@ func (p *inventoryClient) List(ctx context.Context) (*clusterctlv1.ProviderList,
 	providerList := &clusterctlv1.ProviderList{}
 
 	listProvidersBackoff := newReadBackoff()
-	if err := retryWithExponentialBackoff(listProvidersBackoff, func() error {
+	if err := retryWithExponentialBackoff(ctx, listProvidersBackoff, func(ctx context.Context) error {
 		return listProviders(ctx, p.proxy, providerList)
 	}); err != nil {
 		return nil, err

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -333,7 +333,7 @@ func (o *objectGraph) objMetaToNode(obj *unstructured.Unstructured, n *node) {
 func (o *objectGraph) getDiscoveryTypes(ctx context.Context) error {
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 	getDiscoveryTypesBackoff := newReadBackoff()
-	if err := retryWithExponentialBackoff(getDiscoveryTypesBackoff, func() error {
+	if err := retryWithExponentialBackoff(ctx, getDiscoveryTypesBackoff, func(ctx context.Context) error {
 		return getCRDList(ctx, o.proxy, crdList)
 	}); err != nil {
 		return err
@@ -432,7 +432,7 @@ func (o *objectGraph) Discovery(ctx context.Context, namespace string) error {
 		typeMeta := discoveryType.typeMeta
 		objList := new(unstructured.UnstructuredList)
 
-		if err := retryWithExponentialBackoff(discoveryBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
 			return getObjList(ctx, o.proxy, typeMeta, selectors, objList)
 		}); err != nil {
 			return err
@@ -448,7 +448,7 @@ func (o *objectGraph) Discovery(ctx context.Context, namespace string) error {
 				if p.Type == string(clusterctlv1.InfrastructureProviderType) {
 					providerNamespaceSelector := []client.ListOption{client.InNamespace(p.Namespace)}
 					providerNamespaceSecretList := new(unstructured.UnstructuredList)
-					if err := retryWithExponentialBackoff(discoveryBackoff, func() error {
+					if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
 						return getObjList(ctx, o.proxy, typeMeta, providerNamespaceSelector, providerNamespaceSecretList)
 					}); err != nil {
 						return err

--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -76,7 +76,7 @@ func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph) (
 		typeMeta := discoveryType.typeMeta
 		objList := new(unstructured.UnstructuredList)
 
-		if err := retryWithExponentialBackoff(discoveryBackoff, func() error {
+		if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
 			return getObjList(ctx, o.proxy, typeMeta, selectors, objList)
 		}); err != nil {
 			return nil, err
@@ -92,7 +92,7 @@ func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph) (
 				if p.Type == string(clusterctlv1.InfrastructureProviderType) {
 					providerNamespaceSelector := []client.ListOption{client.InNamespace(p.Namespace)}
 					providerNamespaceSecretList := new(unstructured.UnstructuredList)
-					if err := retryWithExponentialBackoff(discoveryBackoff, func() error {
+					if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
 						return getObjList(ctx, o.proxy, typeMeta, providerNamespaceSelector, providerNamespaceSecretList)
 					}); err != nil {
 						return nil, err

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -484,7 +484,7 @@ func (u *providerUpgrader) scaleDownProvider(ctx context.Context, provider clust
 
 // scaleDownDeployment scales down a Deployment to 0 and waits until all replicas have been deleted.
 func scaleDownDeployment(ctx context.Context, c client.Client, deploy appsv1.Deployment) error {
-	if err := retryWithExponentialBackoff(newWriteBackoff(), func() error {
+	if err := retryWithExponentialBackoff(ctx, newWriteBackoff(), func(ctx context.Context) error {
 		deployment := &appsv1.Deployment{}
 		if err := c.Get(ctx, client.ObjectKeyFromObject(&deploy), deployment); err != nil {
 			return errors.Wrapf(err, "failed to get Deployment/%s", deploy.GetName())
@@ -511,7 +511,7 @@ func scaleDownDeployment(ctx context.Context, c client.Client, deploy appsv1.Dep
 		Steps:    60,
 		Jitter:   0.4,
 	}
-	if err := retryWithExponentialBackoff(deploymentScaleToZeroBackOff, func() error {
+	if err := retryWithExponentialBackoff(ctx, deploymentScaleToZeroBackOff, func(ctx context.Context) error {
 		deployment := &appsv1.Deployment{}
 		if err := c.Get(ctx, client.ObjectKeyFromObject(&deploy), deployment); err != nil {
 			return errors.Wrapf(err, "failed to get Deployment/%s", deploy.GetName())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: In the spirit of of #8733, this PR adds a `context.Context` parameter to the `retryWithExponentialBackoff` helper used throughout clusterctl. This allows backoff to short circuit if a context is canceled during a sleep between retries instead of only while the retried function is running. The primary change is to call apimachinery's `wait.ExponentialBackoffWithContext` instead of `wait.ExponentialBackoff`.

Almost every call to this helper already had a context available, but there are a couple that needed `context.Background()`s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl