### PR TITLE
🌱 Move experimental addons API v1beta1 webhooks to separate package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,7 @@ generate-manifests-core: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Generate manifests e.
 		paths=./$(EXP_DIR)/internal/webhooks/... \
 		paths=./$(EXP_DIR)/addons/api/... \
 		paths=./$(EXP_DIR)/addons/internal/controllers/... \
+		paths=./$(EXP_DIR)/addons/internal/webhooks/... \
 		paths=./$(EXP_DIR)/ipam/api/... \
 		paths=./$(EXP_DIR)/ipam/internal/webhooks/... \
 		paths=./$(EXP_DIR)/runtime/api/... \

--- a/exp/addons/internal/webhooks/clusterresourceset_webhook.go
+++ b/exp/addons/internal/webhooks/clusterresourceset_webhook.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -28,49 +29,68 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 )
 
-func (m *ClusterResourceSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// ClusterResourceSet implements a validation and defaulting webhook for ClusterResourceSet.
+type ClusterResourceSet struct{}
+
+func (webhook *ClusterResourceSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(m).
+		For(&addonsv1.ClusterResourceSet{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,versions=v1beta1,name=validation.clusterresourceset.addons.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,versions=v1beta1,name=default.clusterresourceset.addons.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &ClusterResourceSet{}
-var _ webhook.Validator = &ClusterResourceSet{}
+var _ webhook.CustomDefaulter = &ClusterResourceSet{}
+var _ webhook.CustomValidator = &ClusterResourceSet{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (m *ClusterResourceSet) Default() {
-	// ClusterResourceSet Strategy defaults to ApplyOnce.
-	if m.Spec.Strategy == "" {
-		m.Spec.Strategy = string(ClusterResourceSetStrategyApplyOnce)
+func (webhook *ClusterResourceSet) Default(_ context.Context, obj runtime.Object) error {
+	crs, ok := obj.(*addonsv1.ClusterResourceSet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterResourceSet but got a %T", obj))
 	}
+	// ClusterResourceSet Strategy defaults to ApplyOnce.
+	if crs.Spec.Strategy == "" {
+		crs.Spec.Strategy = string(addonsv1.ClusterResourceSetStrategyApplyOnce)
+	}
+	return nil
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (m *ClusterResourceSet) ValidateCreate() (admission.Warnings, error) {
-	return nil, m.validate(nil)
+func (webhook *ClusterResourceSet) ValidateCreate(_ context.Context, newObj runtime.Object) (admission.Warnings, error) {
+	newCRS, ok := newObj.(*addonsv1.ClusterResourceSet)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterResourceSet but got a %T", newObj))
+	}
+	return nil, webhook.validate(nil, newCRS)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (m *ClusterResourceSet) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	oldCRS, ok := old.(*ClusterResourceSet)
+func (webhook *ClusterResourceSet) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldCRS, ok := oldObj.(*addonsv1.ClusterResourceSet)
 	if !ok {
-		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterResourceSet but got a %T", old))
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterResourceSet but got a %T", oldObj))
 	}
-	return nil, m.validate(oldCRS)
+	newCRS, ok := newObj.(*addonsv1.ClusterResourceSet)
+	if !ok {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterResourceSet but got a %T", newObj))
+	}
+	return nil, webhook.validate(oldCRS, newCRS)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (m *ClusterResourceSet) ValidateDelete() (admission.Warnings, error) {
+func (webhook *ClusterResourceSet) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (m *ClusterResourceSet) validate(old *ClusterResourceSet) error {
+func (webhook *ClusterResourceSet) validate(oldCRS, newCRS *addonsv1.ClusterResourceSet) error {
 	// NOTE: ClusterResourceSet is behind ClusterResourceSet feature gate flag; the web hook
 	// must prevent creating new objects when the feature flag is disabled.
 	if !feature.Gates.Enabled(feature.ClusterResourceSet) {
@@ -80,12 +100,13 @@ func (m *ClusterResourceSet) validate(old *ClusterResourceSet) error {
 		)
 	}
 	var allErrs field.ErrorList
+
 	// Validate selector parses as Selector
-	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.ClusterSelector)
+	selector, err := metav1.LabelSelectorAsSelector(&newCRS.Spec.ClusterSelector)
 	if err != nil {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "clusterSelector"), m.Spec.ClusterSelector, err.Error()),
+			field.Invalid(field.NewPath("spec", "clusterSelector"), newCRS.Spec.ClusterSelector, err.Error()),
 		)
 	}
 
@@ -93,26 +114,27 @@ func (m *ClusterResourceSet) validate(old *ClusterResourceSet) error {
 	if selector != nil && selector.Empty() {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "clusterSelector"), m.Spec.ClusterSelector, "selector must not be empty"),
+			field.Invalid(field.NewPath("spec", "clusterSelector"), newCRS.Spec.ClusterSelector, "selector must not be empty"),
 		)
 	}
 
-	if old != nil && old.Spec.Strategy != "" && old.Spec.Strategy != m.Spec.Strategy {
+	if oldCRS != nil && oldCRS.Spec.Strategy != "" && oldCRS.Spec.Strategy != newCRS.Spec.Strategy {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "strategy"), m.Spec.Strategy, "field is immutable"),
+			field.Invalid(field.NewPath("spec", "strategy"), newCRS.Spec.Strategy, "field is immutable"),
 		)
 	}
 
-	if old != nil && !reflect.DeepEqual(old.Spec.ClusterSelector, m.Spec.ClusterSelector) {
+	if oldCRS != nil && !reflect.DeepEqual(oldCRS.Spec.ClusterSelector, newCRS.Spec.ClusterSelector) {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "clusterSelector"), m.Spec.ClusterSelector, "field is immutable"),
+			field.Invalid(field.NewPath("spec", "clusterSelector"), newCRS.Spec.ClusterSelector, "field is immutable"),
 		)
 	}
 
 	if len(allErrs) == 0 {
 		return nil
 	}
-	return apierrors.NewInvalid(GroupVersion.WithKind("ClusterResourceSet").GroupKind(), m.Name, allErrs)
+
+	return apierrors.NewInvalid(addonsv1.GroupVersion.WithKind("ClusterResourceSet").GroupKind(), newCRS.Name, allErrs)
 }

--- a/exp/addons/internal/webhooks/clusterresourcesetbinding_webhook_test.go
+++ b/exp/addons/internal/webhooks/clusterresourcesetbinding_webhook_test.go
@@ -14,12 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 )
 
 func TestClusterResourceSetBindingClusterNameImmutable(t *testing.T) {
@@ -65,27 +67,28 @@ func TestClusterResourceSetBindingClusterNameImmutable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			newClusterResourceSetBinding := &ClusterResourceSetBinding{
-				Spec: ClusterResourceSetBindingSpec{
+			newClusterResourceSetBinding := &addonsv1.ClusterResourceSetBinding{
+				Spec: addonsv1.ClusterResourceSetBindingSpec{
 					ClusterName: tt.newClusterName,
 				},
 			}
 
-			oldClusterResourceSetBinding := &ClusterResourceSetBinding{
-				Spec: ClusterResourceSetBindingSpec{
+			oldClusterResourceSetBinding := &addonsv1.ClusterResourceSetBinding{
+				Spec: addonsv1.ClusterResourceSetBindingSpec{
 					ClusterName: tt.oldClusterName,
 				},
 			}
+			webhook := ClusterResourceSetBinding{}
 
-			warnings, err := newClusterResourceSetBinding.ValidateCreate()
+			warnings, err := webhook.ValidateCreate(ctx, newClusterResourceSetBinding)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(warnings).To(BeEmpty())
 			if tt.expectErr {
-				warnings, err = newClusterResourceSetBinding.ValidateUpdate(oldClusterResourceSetBinding)
+				warnings, err = webhook.ValidateUpdate(ctx, oldClusterResourceSetBinding, newClusterResourceSetBinding)
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(warnings).To(BeEmpty())
 			} else {
-				warnings, err = newClusterResourceSetBinding.ValidateUpdate(oldClusterResourceSetBinding)
+				warnings, err = webhook.ValidateUpdate(ctx, oldClusterResourceSetBinding, newClusterResourceSetBinding)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(warnings).To(BeEmpty())
 			}

--- a/exp/addons/internal/webhooks/doc.go
+++ b/exp/addons/internal/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks implements experimental addon webhooks.
+package webhooks

--- a/exp/addons/webhooks/alias.go
+++ b/exp/addons/webhooks/alias.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/exp/addons/internal/webhooks"
+)
+
+// ClusterResourceSet implements a validating and defaulting webhook for ClusterResourceSet.
+type ClusterResourceSet struct{}
+
+// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+func (webhook *ClusterResourceSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.ClusterResourceSet{}).SetupWebhookWithManager(mgr)
+}
+
+// ClusterResourceSetBinding implements a validating webhook for ClusterResourceSetBinding.
+type ClusterResourceSetBinding struct{}
+
+// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+func (webhook *ClusterResourceSetBinding) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.ClusterResourceSetBinding{}).SetupWebhookWithManager(mgr)
+}

--- a/exp/addons/webhooks/doc.go
+++ b/exp/addons/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains external addons webhook implementations for some of our API types.
+package webhooks

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	addonswebhooks "sigs.k8s.io/cluster-api/exp/addons/webhooks"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
 	expipamwebhooks "sigs.k8s.io/cluster-api/exp/ipam/webhooks"
@@ -304,10 +305,10 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 	if err := (&controlplanev1.KubeadmControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook: %+v", err)
 	}
-	if err := (&addonsv1.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&addonswebhooks.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for crs: %+v", err)
 	}
-	if err := (&addonsv1.ClusterResourceSetBinding{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&addonswebhooks.ClusterResourceSetBinding{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for ClusterResourceSetBinding: %+v", err)
 	}
 	if err := (&expapiwebhooks.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	addonsv1alpha4 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	addonscontrollers "sigs.k8s.io/cluster-api/exp/addons/controllers"
+	addonswebhooks "sigs.k8s.io/cluster-api/exp/addons/webhooks"
 	expv1alpha4 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	expcontrollers "sigs.k8s.io/cluster-api/exp/controllers"
@@ -599,13 +600,13 @@ func setupWebhooks(mgr ctrl.Manager) {
 
 	// NOTE: ClusterResourceSet is behind ClusterResourceSet feature gate flag; the webhook
 	// is going to prevent creating or updating new objects in case the feature flag is disabled
-	if err := (&addonsv1.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&addonswebhooks.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceSet")
 		os.Exit(1)
 	}
 	// NOTE: ClusterResourceSetBinding is behind ClusterResourceSet feature gate flag; the webhook
 	// is going to prevent creating or updating new objects in case the feature flag is disabled
-	if err := (&addonsv1.ClusterResourceSetBinding{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&addonswebhooks.ClusterResourceSetBinding{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceSetBinding")
 		os.Exit(1)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

To work towards https://github.com/kubernetes-sigs/cluster-api/issues/9011, we need to remove the reliance on controller-runtime from the API packages.
This updates the webhooks to use the CustomDefaulter and CustomValidator pattern and moves them to match the Cluster and ClusterClass webhooks. This Is a more major lift but removes quite a bit of the code from the API package itself, making it's reliance on controller-runtime a lot smaller.

**Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)**:
Fixes #