### PR TITLE
🌱 Tiltfile: rename deploy_kustomizations to additional_kustomizations

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -482,8 +482,8 @@ def deploy_observability():
             objects = ["capi-visualizer:serviceaccount"],
         )
 
-def deploy_kustomizations():
-    for name in settings.get("deploy_kustomizations", []):
+def deploy_additional_kustomizations():
+    for name in settings.get("additional_kustomizations", []):
         yaml = read_file("./.tiltbuild/yaml/{}.kustomization.yaml".format(name))
         k8s_yaml(yaml)
         objs = decode_yaml_stream(yaml)
@@ -653,7 +653,7 @@ deploy_provider_crds()
 
 deploy_observability()
 
-deploy_kustomizations()
+deploy_additional_kustomizations()
 
 enable_providers()
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -214,11 +214,10 @@ Supported values are:
 
 \*: Note: the UI will be accessible via a link in the tilt console
 
-**deploy_kustomizations** (map[string]string, default={}): If set, installs the additional kustomizations to the cluster.
-
+**additional_kustomizations** (map[string]string, default={}): If set, install the additional resources built using kustomize to the cluster.
 Example:
 ```yaml
-deploy_kustomizations:
+additional_kustomizations:
   capv-metrics: ../cluster-api-provider-vsphere/config/metrics
 ```
 

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -104,14 +104,14 @@ var (
 // Types used to de-serialize the tilt-settings.yaml/json file from the Cluster API repository.
 
 type tiltSettings struct {
-	Debug                map[string]tiltSettingsDebugConfig `json:"debug,omitempty"`
-	ExtraArgs            map[string]tiltSettingsExtraArgs   `json:"extra_args,omitempty"`
-	DeployCertManager    *bool                              `json:"deploy_cert_manager,omitempty"`
-	DeployObservability  []string                           `json:"deploy_observability,omitempty"`
-	DeployKustomizations map[string]string                  `json:"deploy_kustomizations,omitempty"`
-	EnableProviders      []string                           `json:"enable_providers,omitempty"`
-	AllowedContexts      []string                           `json:"allowed_contexts,omitempty"`
-	ProviderRepos        []string                           `json:"provider_repos,omitempty"`
+	Debug                    map[string]tiltSettingsDebugConfig `json:"debug,omitempty"`
+	ExtraArgs                map[string]tiltSettingsExtraArgs   `json:"extra_args,omitempty"`
+	DeployCertManager        *bool                              `json:"deploy_cert_manager,omitempty"`
+	DeployObservability      []string                           `json:"deploy_observability,omitempty"`
+	EnableProviders          []string                           `json:"enable_providers,omitempty"`
+	AllowedContexts          []string                           `json:"allowed_contexts,omitempty"`
+	ProviderRepos            []string                           `json:"provider_repos,omitempty"`
+	AdditionalKustomizations map[string]string                  `json:"additional_kustomizations,omitempty"`
 }
 
 type tiltSettingsDebugConfig struct {
@@ -309,7 +309,7 @@ func tiltResources(ctx context.Context, ts *tiltSettings) error {
 		)
 	}
 
-	for name, path := range ts.DeployKustomizations {
+	for name, path := range ts.AdditionalKustomizations {
 		name := fmt.Sprintf("%s.kustomization", name)
 		tasks[name] = sequential(
 			kustomizeTask(path, fmt.Sprintf("%s.yaml", name)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

After short discussions we considered renaming `deploy_kustomizations` to `additional_kustomizations` instead (which was added in #9390 )

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->