### PR TITLE
:seedling: Dump all pods in e2e test clusters

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
+++ b/docs/book/src/developer/providers/migrations/v1.5-to-v1.6.md
@@ -34,7 +34,7 @@ maintainers of providers and consumers of our Go API.
 ### Other
 - `clusterctl move` can be blocked temporarily by a provider when an object to be moved is annotated with `clusterctl.cluster.x-k8s.io/block-move`.
 - `mdbook releaselink` has been changed to require a `repo` tag when used in markdown files for generating a book with `mdbook`.
-- `framework.DumpKubeSystemPodsForCluster` was renamed to `framework.DumpResourcesForCluster` to facilitate the gathering of additional workload cluster resources. Pods in `kube-system` and Nodes are gathered from workload clusters. `kube-system` Pod yaml available in `clusters/*/resources/Pod` and Node yaml is available in `clusters/*/resources/Node`.
+- `framework.DumpKubeSystemPodsForCluster` was renamed to `framework.DumpResourcesForCluster` to facilitate the gathering of additional workload cluster resources. Pods in all namespaces and Nodes are gathered from workload clusters. Pod yamls are available in `clusters/*/resources/Pod` and Node yaml is available in `clusters/*/resources/Node`.
 
 ### Suggested changes for providers
 

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,9 +80,9 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 		LogPath:   filepath.Join(artifactFolder, "clusters", clusterProxy.GetName(), "resources"),
 	})
 
-	// If the cluster still exists, dump kube-system pods and nodes of the workload cluster before deleting the cluster.
+	// If the cluster still exists, dump pods and nodes of the workload cluster before deleting the cluster.
 	if err := clusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(cluster), &clusterv1.Cluster{}); err == nil {
-		Byf("Dumping kube-system Pods and Nodes of Cluster %s", klog.KObj(cluster))
+		Byf("Dumping Pods and Nodes of Cluster %s", klog.KObj(cluster))
 		framework.DumpResourcesForCluster(ctx, framework.DumpResourcesForClusterInput{
 			Lister:  clusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name).GetClient(),
 			Cluster: cluster,
@@ -94,7 +93,6 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 						Version: corev1.SchemeGroupVersion.Version,
 						Kind:    "Pod",
 					},
-					Namespace: metav1.NamespaceSystem,
 				},
 				{
 					GVK: schema.GroupVersionKind{


### PR DESCRIPTION
Dump all pods when running e2e tests. Previously only kube-system pods had their pod yamls dumped in the artifacts folder.