### PR TITLE
🌱 Exclude release trigger PRs from release notes

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -298,7 +298,7 @@ func run() int {
 			os.Exit(0)
 		}
 
-		if result.prEntry.title == "" {
+		if result.prEntry == nil || result.prEntry.title == "" {
 			continue
 		}
 
@@ -512,12 +512,16 @@ func generateReleaseNoteEntry(c *commit) (*releaseNoteEntry, error) {
 		if strings.Contains(entry.title, "CAEP") || strings.Contains(entry.title, "proposal") {
 			entry.section = proposals
 		}
-	case strings.HasPrefix(entry.title, ":seedling:"), strings.HasPrefix(entry.title, "🌱"):
-		entry.section = other
-		entry.title = removePrefixes(entry.title, []string{":seedling:", "🌱"})
 	case strings.HasPrefix(entry.title, ":warning:"), strings.HasPrefix(entry.title, "⚠️"):
 		entry.section = warning
 		entry.title = removePrefixes(entry.title, []string{":warning:", "⚠️"})
+	case strings.HasPrefix(entry.title, "🚀"), strings.HasPrefix(entry.title, "🌱 Release v1."):
+		// TODO(g-gaston): remove the second condition using 🌱 prefix once 1.6 is released
+		// Release trigger PRs from previous releases are not included in the release notes
+		return nil, nil
+	case strings.HasPrefix(entry.title, ":seedling:"), strings.HasPrefix(entry.title, "🌱"):
+		entry.section = other
+		entry.title = removePrefixes(entry.title, []string{":seedling:", "🌱"})
 	default:
 		entry.section = unknown
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We now trigger the release process (branches, tags, github draft PR, etc.) by merging a PR in main containing the release notes in markdown file.

This changes exclude these "trigger" PRs from the release notes, since they are not really changes we are shipping. All future trigger PRs will start with 🚀. We use "🌱 Release v1." as a fallback since the are existing PRs that didn't use the rocket emoji because they were created before we came up with the 🚀 idea.

**Which issue(s) this PR fixes**
Part of https://github.com/kubernetes-sigs/cluster-api/issues/9104
/area release