### PR TITLE
🌱 Improve Cluster variable defaulting/validation errors

### DIFF
--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -19,6 +19,7 @@ package variables
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -49,8 +50,11 @@ func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []c
 	// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
 	valuesIndex, err := newValuesIndex(values)
 	if err != nil {
-		return nil, append(allErrs, field.Invalid(fldPath, values,
-			fmt.Sprintf("cluster variables not valid: %s", err)))
+		var valueStrings []string
+		for _, v := range values {
+			valueStrings = append(valueStrings, fmt.Sprintf("Name: %s DefinitionFrom: %s", v.Name, v.DefinitionFrom))
+		}
+		return nil, append(allErrs, field.Invalid(fldPath, "["+strings.Join(valueStrings, ",")+"]", fmt.Sprintf("cluster variables not valid: %s", err)))
 	}
 
 	// Get an index for each variable name and definition.

--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -49,7 +49,11 @@ func validateClusterVariables(values []clusterv1.ClusterVariable, definitions []
 	// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
 	valuesMap, err := newValuesIndex(values)
 	if err != nil {
-		return append(allErrs, field.Invalid(fldPath, values, fmt.Sprintf("cluster variables not valid: %s", err)))
+		var valueStrings []string
+		for _, v := range values {
+			valueStrings = append(valueStrings, fmt.Sprintf("Name: %s DefinitionFrom: %s", v.Name, v.DefinitionFrom))
+		}
+		return append(allErrs, field.Invalid(fldPath, "["+strings.Join(valueStrings, ",")+"]", fmt.Sprintf("cluster variables not valid: %s", err)))
 	}
 
 	// Get an index of definitions for each variable name and definition from the ClusterClass variable.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Before

>  The Cluster "my-cluster-2" is invalid: spec.topology.variables: Invalid value: []v1beta1.ClusterVariable{v1beta1.ClusterVariable{Name:"imageRepository", DefinitionFrom:"", Value:v1.JSON{Raw:[]uint8{0x22, 0x6b, 0x38, 0x73, 0x2e, 0x67, 0x63, 0x72, 0x2e, 0x69, 0x6f, 0x22}}}, v1beta1.ClusterVariable{Name:"imageRepository", DefinitionFrom:"", Value:v1.JSON{Raw:[]uint8{0x22, 0x6b, 0x38, 0x73, 0x2e, 0x67, 0x63, 0x72, 0x2e, 0x69, 0x6f, 0x22}}}, v1beta1.ClusterVariable{Name:"lbImage", DefinitionFrom:"", Value:v1.JSON{Raw:[]uint8{0x7b, 0x22, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x52, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x6f, 0x72, 0x79, 0x22, 0x3a, 0x22, 0x6b, 0x69, 0x6e, 0x64, 0x65, 0x73, 0x74, 0x22, 0x2c, 0x22, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x54, 0x61, 0x67, 0x22, 0x3a, 0x22, 0x76, 0x32, 0x30, 0x32, 0x31, 0x30, 0x37, 0x31, 0x35, 0x2d, 0x61, 0x36, 0x64, 0x61, 0x33, 0x34, 0x36, 0x33, 0x22, 0x7d}}}, v1beta1.ClusterVariable{Name:"controlPlaneTaint", DefinitionFrom:"", Value:v1.JSON{Raw:[]uint8{0x66, 0x61, 0x6c, 0x73, 0x65}}}}: cluster variables not valid: variable "imageRepository" from "" is defined more than once


After

> The Cluster "my-cluster-2" is invalid: spec.topology.variables: Invalid value: "[Name: imageRepository DefinitionFrom: ,Name: imageRepository DefinitionFrom: ,Name: lbImage DefinitionFrom: ,Name: controlPlaneTaint DefinitionFrom: ]": cluster variables not valid: variable "imageRepository" from "" is defined more than once

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->