### PR TITLE
🌱 Move docker infrastructure API v1beta1 webhooks to separate package 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,13 +334,15 @@ generate-manifests-kubeadm-control-plane: $(CONTROLLER_GEN) ## Generate manifest
 
 .PHONY: generate-manifests-docker-infrastructure
 generate-manifests-docker-infrastructure: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc. for docker infrastructure provider
-	$(MAKE) clean-generated-yaml SRC_DIRS="$(CAPD_DIR)/config/crd/bases"
+	$(MAKE) clean-generated-yaml SRC_DIRS="$(CAPD_DIR)/config/crd/bases,$(CAPD_DIR)/config/webhook/manifests.yaml"
 	cd $(CAPD_DIR); $(CONTROLLER_GEN) \
 		paths=./ \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \
 		paths=./$(EXP_DIR)/internal/controllers/... \
+		paths=./$(EXP_DIR)/internal/webhooks/... \
 		paths=./internal/controllers/... \
+		paths=./internal/webhooks/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \

--- a/test/infrastructure/docker/internal/webhooks/doc.go
+++ b/test/infrastructure/docker/internal/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks implements docker infrastructure webhooks.
+package webhooks

--- a/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook.go
+++ b/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -28,47 +28,48 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/topology"
 )
 
 const dockerMachineTemplateImmutableMsg = "DockerMachineTemplate spec.template.spec field is immutable. Please create a new resource instead."
 
-func (m *DockerMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *DockerMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&DockerMachineTemplate{}).
-		WithValidator(m).
+		For(&infrav1.DockerMachineTemplate{}).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-dockermachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=dockermachinetemplates,versions=v1beta1,name=validation.dockermachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-// DockerMachineTemplateWebhook implements a custom validation webhook for DockerMachineTemplate.
+// DockerMachineTemplate implements a custom validation webhook for DockerMachineTemplate.
 // +kubebuilder:object:generate=false
-type DockerMachineTemplateWebhook struct{}
+type DockerMachineTemplate struct{}
 
-var _ webhook.CustomValidator = &DockerMachineTemplateWebhook{}
+var _ webhook.CustomValidator = &DockerMachineTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (*DockerMachineTemplateWebhook) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
-	obj, ok := raw.(*DockerMachineTemplate)
+func (webhook *DockerMachineTemplate) ValidateCreate(_ context.Context, raw runtime.Object) (admission.Warnings, error) {
+	obj, ok := raw.(*infrav1.DockerMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a DockerMachineTemplate but got a %T", raw))
 	}
 	// Validate the metadata of the template.
 	allErrs := obj.Spec.Template.ObjectMeta.Validate(field.NewPath("spec", "template", "metadata"))
 	if len(allErrs) > 0 {
-		return nil, apierrors.NewInvalid(GroupVersion.WithKind("DockerClusterTemplate").GroupKind(), obj.Name, allErrs)
+		return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("DockerClusterTemplate").GroupKind(), obj.Name, allErrs)
 	}
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (*DockerMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
-	newObj, ok := newRaw.(*DockerMachineTemplate)
+func (webhook *DockerMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) (admission.Warnings, error) {
+	newObj, ok := newRaw.(*infrav1.DockerMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a DockerMachineTemplate but got a %T", newRaw))
 	}
-	oldObj, ok := oldRaw.(*DockerMachineTemplate)
+	oldObj, ok := oldRaw.(*infrav1.DockerMachineTemplate)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a DockerMachineTemplate but got a %T", oldRaw))
 	}
@@ -89,10 +90,10 @@ func (*DockerMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw 
 	if len(allErrs) == 0 {
 		return nil, nil
 	}
-	return nil, apierrors.NewInvalid(GroupVersion.WithKind("DockerMachineTemplate").GroupKind(), newObj.Name, allErrs)
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("DockerMachineTemplate").GroupKind(), newObj.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (*DockerMachineTemplateWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (webhook *DockerMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook_test.go
+++ b/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package webhooks
 
 import (
 	"context"
@@ -28,18 +28,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 )
 
 func TestDockerMachineTemplateInvalid(t *testing.T) {
-	oldTemplate := DockerMachineTemplate{
+	oldTemplate := infrav1.DockerMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{},
-		Spec: DockerMachineTemplateSpec{
-			Template: DockerMachineTemplateResource{},
+		Spec: infrav1.DockerMachineTemplateSpec{
+			Template: infrav1.DockerMachineTemplateResource{},
 		},
 	}
 
 	newTemplate := oldTemplate.DeepCopy()
-	newTemplate.Spec.Template.Spec.ExtraMounts = append(newTemplate.Spec.Template.Spec.ExtraMounts, []Mount{{ContainerPath: "/var/run/docker.sock", HostPath: "/var/run/docker.sock"}}...)
+	newTemplate.Spec.Template.Spec.ExtraMounts = append(newTemplate.Spec.Template.Spec.ExtraMounts, []infrav1.Mount{{ContainerPath: "/var/run/docker.sock", HostPath: "/var/run/docker.sock"}}...)
 	newTemplateSkipImmutabilityAnnotationSet := newTemplate.DeepCopy()
 	newTemplateSkipImmutabilityAnnotationSet.SetAnnotations(map[string]string{clusterv1.TopologyDryRunAnnotation: ""})
 
@@ -57,8 +58,8 @@ func TestDockerMachineTemplateInvalid(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		newTemplate *DockerMachineTemplate
-		oldTemplate *DockerMachineTemplate
+		newTemplate *infrav1.DockerMachineTemplate
+		oldTemplate *infrav1.DockerMachineTemplate
 		req         *admission.Request
 		wantError   bool
 	}{
@@ -108,7 +109,7 @@ func TestDockerMachineTemplateInvalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			wh := &DockerMachineTemplateWebhook{}
+			wh := &DockerMachineTemplate{}
 			ctx := context.Background()
 			if tt.req != nil {
 				ctx = admission.NewContextWithRequest(ctx, *tt.req)

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -55,7 +55,8 @@ import (
 	infraexpv1alpha4 "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha4"
 	infraexpv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1"
 	expcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/controllers"
-	"sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/webhooks"
+	infraexpwebhooks "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/webhooks"
+	infrawebhooks "sigs.k8s.io/cluster-api/test/infrastructure/docker/webhooks"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
 )
@@ -362,23 +363,23 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&infrav1.DockerMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrawebhooks.DockerMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "DockerMachineTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1.DockerCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrawebhooks.DockerCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "DockerCluster")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1.DockerClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrawebhooks.DockerClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "DockerClusterTemplate")
 		os.Exit(1)
 	}
 
 	if feature.Gates.Enabled(feature.MachinePool) {
-		if err := (&webhooks.DockerMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+		if err := (&infraexpwebhooks.DockerMachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DockerMachinePool")
 			os.Exit(1)
 		}

--- a/test/infrastructure/docker/webhooks/alias.go
+++ b/test/infrastructure/docker/webhooks/alias.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/webhooks"
+)
+
+// DockerCluster implements a validating and defaulting webhook for DockerCluster.
+type DockerCluster struct{}
+
+// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+func (webhook *DockerCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.DockerCluster{}).SetupWebhookWithManager(mgr)
+}
+
+// DockerClusterTemplate implements a validating webhook for DockerClusterTemplate.
+type DockerClusterTemplate struct{}
+
+// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+func (webhook *DockerClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.DockerClusterTemplate{}).SetupWebhookWithManager(mgr)
+}
+
+// DockerMachineTemplate implements a validating webhook for DockerMachineTemplate.
+type DockerMachineTemplate struct{}
+
+// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+func (webhook *DockerMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.DockerMachineTemplate{}).SetupWebhookWithManager(mgr)
+}

--- a/test/infrastructure/docker/webhooks/doc.go
+++ b/test/infrastructure/docker/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains docker infrastructure webhook implementations for some of our API types.
+package webhooks


### PR DESCRIPTION
**What this PR does / why we need it**:

To work towards https://github.com/kubernetes-sigs/cluster-api/issues/9011, we need to remove the reliance on controller-runtime from the API packages.
This updates the webhooks to use the CustomDefaulter and CustomValidator pattern and moves them to match the Cluster and ClusterClass webhooks. This Is a more major lift but removes quite a bit of the code from the API package itself, making it's reliance on controller-runtime a lot smaller.

**Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)**:
Fixes #

/area api