### PR TITLE
🌱 Move inmemory infrastructure API v1beta1 webhooks to separate package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,11 +350,12 @@ generate-manifests-docker-infrastructure: $(CONTROLLER_GEN) ## Generate manifest
 
 .PHONY: generate-manifests-in-memory-infrastructure
 generate-manifests-in-memory-infrastructure: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc. for in-memory infrastructure provider
-	$(MAKE) clean-generated-yaml SRC_DIRS="$(CAPIM_DIR)/config/crd/bases"
+	$(MAKE) clean-generated-yaml SRC_DIRS="$(CAPIM_DIR)/config/crd/bases,$(CAPIM_DIR)/config/webhook/manifests.yaml"
 	cd $(CAPIM_DIR); $(CONTROLLER_GEN) \
 		paths=./ \
 		paths=./api/... \
 		paths=./internal/controllers/... \
+		paths=./internal/webhooks/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \

--- a/test/infrastructure/inmemory/internal/webhooks/doc.go
+++ b/test/infrastructure/inmemory/internal/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks implements inmemory infrastructure webhooks.
+package webhooks

--- a/test/infrastructure/inmemory/internal/webhooks/inmemorycluster_webhook.go
+++ b/test/infrastructure/inmemory/internal/webhooks/inmemorycluster_webhook.go
@@ -14,45 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package webhooks
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/api/v1alpha1"
 )
 
-func (c *InMemoryCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// InMemoryCluster implements a validating and defaulting webhook for InMemoryCluster.
+type InMemoryCluster struct{}
+
+func (webhook *InMemoryCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(c).
+		For(&v1alpha1.InMemoryCluster{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorycluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemoryclusters,versions=v1alpha1,name=default.inmemorycluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &InMemoryCluster{}
+var _ webhook.CustomDefaulter = &InMemoryCluster{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (c *InMemoryCluster) Default() {
-
+func (webhook *InMemoryCluster) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorycluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemoryclusters,versions=v1alpha1,name=validation.inmemorycluster.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Validator = &InMemoryCluster{}
+var _ webhook.CustomValidator = &InMemoryCluster{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryCluster) ValidateCreate() (admission.Warnings, error) {
+func (webhook *InMemoryCluster) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryCluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (webhook *InMemoryCluster) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryCluster) ValidateDelete() (admission.Warnings, error) {
+func (webhook *InMemoryCluster) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/test/infrastructure/inmemory/internal/webhooks/inmemoryclustertemplate_webhook.go
+++ b/test/infrastructure/inmemory/internal/webhooks/inmemoryclustertemplate_webhook.go
@@ -14,45 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package webhooks
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/api/v1alpha1"
 )
 
-func (c *InMemoryClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// InMemoryClusterTemplate implements a validating and defaulting webhook for InMemoryClusterTemplate.
+type InMemoryClusterTemplate struct{}
+
+func (webhook *InMemoryClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(c).
+		For(&v1alpha1.InMemoryClusterTemplate{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemoryclustertemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemoryclustertemplates,versions=v1alpha1,name=default.inmemoryclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &InMemoryClusterTemplate{}
+var _ webhook.CustomDefaulter = &InMemoryClusterTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (c *InMemoryClusterTemplate) Default() {
-
+func (webhook *InMemoryClusterTemplate) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemoryclustertemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemoryclustertemplates,versions=v1alpha1,name=validation.inmemoryclustertemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Validator = &InMemoryClusterTemplate{}
+var _ webhook.CustomValidator = &InMemoryClusterTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryClusterTemplate) ValidateCreate() (admission.Warnings, error) {
+func (webhook *InMemoryClusterTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryClusterTemplate) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (webhook *InMemoryClusterTemplate) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryClusterTemplate) ValidateDelete() (admission.Warnings, error) {
+func (webhook *InMemoryClusterTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/test/infrastructure/inmemory/internal/webhooks/inmemorymachine_webhook.go
+++ b/test/infrastructure/inmemory/internal/webhooks/inmemorymachine_webhook.go
@@ -14,45 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package webhooks
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/api/v1alpha1"
 )
 
-func (c *InMemoryMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// InMemoryMachine implements a validating and defaulting webhook for InMemoryMachine.
+type InMemoryMachine struct{}
+
+func (webhook *InMemoryMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(c).
+		For(&v1alpha1.InMemoryMachine{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorymachine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachines,versions=v1alpha1,name=default.inmemorymachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &InMemoryMachine{}
+var _ webhook.CustomDefaulter = &InMemoryMachine{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (c *InMemoryMachine) Default() {
-
+func (webhook *InMemoryMachine) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorymachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachines,versions=v1alpha1,name=validation.inmemorymachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Validator = &InMemoryMachine{}
+var _ webhook.CustomValidator = &InMemoryMachine{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachine) ValidateCreate() (admission.Warnings, error) {
+func (webhook *InMemoryMachine) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachine) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (webhook *InMemoryMachine) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachine) ValidateDelete() (admission.Warnings, error) {
+func (webhook *InMemoryMachine) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/test/infrastructure/inmemory/internal/webhooks/inmemorymachinetemplate_webhook.go
+++ b/test/infrastructure/inmemory/internal/webhooks/inmemorymachinetemplate_webhook.go
@@ -14,45 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package webhooks
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/api/v1alpha1"
 )
 
-func (c *InMemoryMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+// InMemoryMachineTemplate implements a validating and defaulting webhook for InMemoryMachineTemplate.
+type InMemoryMachineTemplate struct{}
+
+func (webhook *InMemoryMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(c).
+		For(&v1alpha1.InMemoryMachineTemplate{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorymachinetemplate,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachinetemplates,versions=v1alpha1,name=default.inmemorymachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Defaulter = &InMemoryMachineTemplate{}
+var _ webhook.CustomDefaulter = &InMemoryMachineTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (c *InMemoryMachineTemplate) Default() {
-
+func (webhook *InMemoryMachineTemplate) Default(_ context.Context, _ runtime.Object) error {
+	return nil
 }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha1-inmemorymachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=inmemorymachinetemplates,versions=v1alpha1,name=validation.inmemorymachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
-var _ webhook.Validator = &InMemoryMachineTemplate{}
+var _ webhook.CustomValidator = &InMemoryMachineTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachineTemplate) ValidateCreate() (admission.Warnings, error) {
+func (webhook *InMemoryMachineTemplate) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachineTemplate) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+func (webhook *InMemoryMachineTemplate) ValidateUpdate(_ context.Context, _, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (c *InMemoryMachineTemplate) ValidateDelete() (admission.Warnings, error) {
+func (webhook *InMemoryMachineTemplate) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -51,6 +51,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/cloud"
 	cloudv1 "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/cloud/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/server"
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/webhooks"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
 )
@@ -309,22 +310,22 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&infrav1.InMemoryCluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.InMemoryCluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "InMemoryCluster")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1.InMemoryClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.InMemoryClusterTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "InMemoryClusterTemplate")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1.InMemoryMachine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.InMemoryMachine{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "InMemoryMachine")
 		os.Exit(1)
 	}
 
-	if err := (&infrav1.InMemoryMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.InMemoryMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "InMemoryMachineTemplate")
 		os.Exit(1)
 	}

--- a/test/infrastructure/inmemory/webhooks/alias.go
+++ b/test/infrastructure/inmemory/webhooks/alias.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks implements inmemory infrastructure webhooks.
+package webhooks
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/inmemory/internal/webhooks"
+)
+
+// InMemoryCluster implements a validating and defaulting webhook for InMemoryCluster.
+type InMemoryCluster struct{}
+
+// SetupWebhookWithManager sets up InMemoryCluster webhooks.
+func (webhook *InMemoryCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.InMemoryCluster{}).SetupWebhookWithManager(mgr)
+}
+
+// InMemoryClusterTemplate implements a validating and defaulting webhook for InMemoryClusterTemplate.
+type InMemoryClusterTemplate struct{}
+
+// SetupWebhookWithManager sets up InMemoryClusterTemplate webhooks.
+func (webhook *InMemoryClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.InMemoryClusterTemplate{}).SetupWebhookWithManager(mgr)
+}
+
+// InMemoryMachine implements a validating and defaulting webhook for InMemoryMachine.
+type InMemoryMachine struct{}
+
+// SetupWebhookWithManager sets up InMemoryMachine webhooks.
+func (webhook *InMemoryMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.InMemoryMachine{}).SetupWebhookWithManager(mgr)
+}
+
+// InMemoryMachineTemplate implements a validating and defaulting webhook for InMemoryMachineTemplate.
+type InMemoryMachineTemplate struct{}
+
+// SetupWebhookWithManager sets up InMemoryMachineTemplate webhooks.
+func (webhook *InMemoryMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.InMemoryMachineTemplate{}).SetupWebhookWithManager(mgr)
+}

--- a/test/infrastructure/inmemory/webhooks/doc.go
+++ b/test/infrastructure/inmemory/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks implements inmemory infrastructure webhooks.
+package webhooks


### PR DESCRIPTION
**What this PR does / why we need it**:

To work towards https://github.com/kubernetes-sigs/cluster-api/issues/9011, we need to remove the reliance on controller-runtime from the API packages.
This updates the webhooks to use the CustomDefaulter and CustomValidator pattern and moves them to match the Cluster and ClusterClass webhooks. This Is a more major lift but removes quite a bit of the code from the API package itself, making it's reliance on controller-runtime a lot smaller.

**Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)**:
Fixes #

/area api