### PR TITLE
:book: Change kubernetes-version in ignition/cluster generation parts of the book

### DIFF
--- a/docs/book/src/clusterctl/commands/generate-cluster.md
+++ b/docs/book/src/clusterctl/commands/generate-cluster.md
@@ -5,7 +5,7 @@ The `clusterctl generate cluster` command returns a YAML template for creating a
 For example
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 --control-plane-machine-count=3 --worker-machine-count=3 > my-cluster.yaml
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 --control-plane-machine-count=3 --worker-machine-count=3 > my-cluster.yaml
 ```
 
 Generates a YAML file named `my-cluster.yaml` with a predefined list of Cluster API objects; Cluster, Machines,
@@ -29,14 +29,14 @@ In case there is more than one infrastructure provider, the following syntax can
 provider to use for the workload cluster:
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
     --infrastructure aws > my-cluster.yaml
 ```
 
 or
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
     --infrastructure aws:v0.4.1 > my-cluster.yaml
 ```
 
@@ -46,7 +46,7 @@ The infrastructure provider authors can provide different types of cluster templ
 to specify which flavor to use; e.g.
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
     --flavor high-availability > my-cluster.yaml
 ```
 
@@ -62,7 +62,7 @@ for cluster templates can be used as well:
 Use the `--from-config-map` flag to read cluster templates stored in a Kubernetes ConfigMap; e.g.
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
     --from-config-map my-templates > my-cluster.yaml
 ```
 
@@ -75,28 +75,28 @@ Use the `--from` flag to read cluster templates stored in a GitHub repository, r
 or from the standard input; e.g.
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
    --from https://github.com/my-org/my-repository/blob/main/my-template.yaml > my-cluster.yaml
 ```
 
 or
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
    --from https://foo.bar/my-template.yaml > my-cluster.yaml
 ```
 
 or
 
 ```bash
-clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
    --from ~/my-template.yaml > my-cluster.yaml
 ```
 
 or
 
 ```bash
-cat ~/my-template.yaml | clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+cat ~/my-template.yaml | clusterctl generate cluster my-cluster --kubernetes-version v1.28.0 \
     --from - > my-cluster.yaml
 ```
 

--- a/docs/book/src/tasks/experimental-features/ignition.md
+++ b/docs/book/src/tasks/experimental-features/ignition.md
@@ -85,10 +85,12 @@ export AWS_NODE_MACHINE_TYPE=t3a.small
 
 clusterctl generate cluster ignition-cluster \
     --from https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/main/templates/cluster-template-flatcar.yaml \
-    --kubernetes-version v1.22.2 \
+    --kubernetes-version v1.28.0 \
     --worker-machine-count 2 \
     > ignition-cluster.yaml
 ```
+
+NOTE: Only certain Kubernetes versions have pre-built Kubernetes AMIs. See [list](https://cluster-api-aws.sigs.k8s.io/topics/images/built-amis) of published pre-built Kubernetes AMIs.
 
 ## Apply the workload cluster
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Currently, there is an incorrect version of `kubernetes-version` flag in the docs for the ignition part as the version that is currently used in the book does not have an AMI for this version.
I also changed all the occurences of `kubernetes-version` that does not reflect the newest stable release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9402 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area docs