### PR TITLE
🌱 Fix some nits in Cluster topology engine tests

### DIFF
--- a/internal/controllers/topology/cluster/patches/engine_test.go
+++ b/internal/controllers/topology/cluster/patches/engine_test.go
@@ -866,7 +866,7 @@ func TestApply(t *testing.T) {
 			//   * A ClusterClass with its corresponding templates:
 			//     * ControlPlaneTemplate with a corresponding ControlPlane InfrastructureMachineTemplate.
 			//     * MachineDeploymentClass "default-worker" with corresponding BootstrapTemplate and InfrastructureMachineTemplate.
-			//     * MachinePoolClass "default-mp-worker" with corresponding BootstrapTemplate and InfrastructureMachineTemplate.
+			//     * MachinePoolClass "default-mp-worker" with corresponding BootstrapTemplate and InfrastructureMachinePoolTemplate.
 			//   * The corresponding Cluster.spec.topology:
 			//     * with 3 ControlPlane replicas
 			//     * with a "default-worker-topo1" MachineDeploymentTopology without replicas (based on "default-worker")
@@ -988,13 +988,13 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 
 	workerInfrastructureMachineTemplate := builder.InfrastructureMachineTemplate(metav1.NamespaceDefault, "linux-worker-inframachinetemplate").
 		Build()
-	workerInfrastructureMachinePoolTemplate := builder.InfrastructureMachinePoolTemplate(metav1.NamespaceDefault, "linux-worker-inframachinetemplate").
+	workerInfrastructureMachinePoolTemplate := builder.InfrastructureMachinePoolTemplate(metav1.NamespaceDefault, "linux-worker-inframachinepooltemplate").
 		Build()
-	workerInfrastructureMachinePool := builder.InfrastructureMachinePool(metav1.NamespaceDefault, "linux-worker-inframachinetemplate").
+	workerInfrastructureMachinePool := builder.InfrastructureMachinePool(metav1.NamespaceDefault, "linux-worker-inframachinepool").
 		Build()
-	workerBootstrapTemplate := builder.BootstrapTemplate(metav1.NamespaceDefault, "linux-worker-bootstraptemplate").
+	workerBootstrapTemplate := builder.BootstrapTemplate(metav1.NamespaceDefault, "linux-worker-bootstrapconfigtemplate").
 		Build()
-	workerBootstrapConfig := builder.BootstrapConfig(metav1.NamespaceDefault, "linux-worker-bootstraptemplate").
+	workerBootstrapConfig := builder.BootstrapConfig(metav1.NamespaceDefault, "linux-worker-bootstrapconfig").
 		Build()
 	mdClass1 := builder.MachineDeploymentClass("default-worker").
 		WithInfrastructureTemplate(workerInfrastructureMachineTemplate).
@@ -1064,7 +1064,7 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					},
 					{
 						Name: "default-mp-worker-infra",
-						// This value should be overwritten for the default-mp-worker-topo1 MachineDeployment.
+						// This value should be overwritten for the default-mp-worker-topo1 MachinePool.
 						Value:          apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-topo2"`)},
 						DefinitionFrom: "inline",
 					},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Some minor fixes as follow-up to #9373

I would have pushed a commit to #9373 directly, but I didn't have the permissions

(Johannes is on PTO and we decided that I take over his PR's while he's away)

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->