### PR TITLE
🌱 Improve labels/annotations in CAPD test ClusterClass

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -513,9 +513,9 @@ spec:
   template:
     metadata:
       labels:
-        InfraMachinePoolTemplate.machinePool.template.label: "InfraMachinePoolTemplate.machinePool.labelValue"
+        InfraMachinePoolTemplate.machinePool.template.label: "InfraMachinePoolTemplate.machinePool.template.labelValue"
       annotations:
-        InfraMachinePoolTemplate.machinePool.template.annotation: "InfraMachinePoolTemplate.machinePool.annotationValue"
+        InfraMachinePoolTemplate.machinePool.template.annotation: "InfraMachinePoolTemplate.machinePool.template.annotationValue"
     spec:
       template:
         extraMounts:
@@ -548,9 +548,9 @@ kind: KubeadmConfigTemplate
 metadata:
   name: quick-start-mp-default-worker-bootstraptemplate
   labels:
-    BootstrapConfigTemplate.machinePool.label: "BootstrapConfigTemplate.machinePool.template.labelValue"
+    BootstrapConfigTemplate.machinePool.label: "BootstrapConfigTemplate.machinePool.labelValue"
   annotations:
-    BootstrapConfigTemplate.machinePool.annotation: "BootstrapConfigTemplate.machinePool.template.annotationValue"
+    BootstrapConfigTemplate.machinePool.annotation: "BootstrapConfigTemplate.machinePool.annotationValue"
 spec:
   template:
     metadata:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Small follow-up to: #9393

Didn't want to further hold up #9393

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->