### PR TITLE
:bug: Drop MachinePools from Dualstack tests

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/drop-machinepools.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/drop-machinepools.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/topology/workers/machinePools

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/kustomization.yaml
@@ -2,5 +2,11 @@ bases:
   - ../bases/cluster-with-topology.yaml
   - ../bases/crs.yaml
 
+patchesStrategicMerge:
+  -  cluster.yaml
 patches:
-  - cluster.yaml
+  - path: ./drop-machinepools.yaml
+    target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: Cluster

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/drop-machinepools.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/drop-machinepools.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/topology/workers/machinePools

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/kustomization.yaml
@@ -2,5 +2,11 @@ bases:
   - ../bases/cluster-with-topology.yaml
   - ../bases/crs.yaml
 
+patchesStrategicMerge:
+  -  cluster.yaml
 patches:
-  - cluster.yaml
+  - path: ./drop-machinepools.yaml
+    target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: Cluster


### PR DESCRIPTION
Fixes a failure in the dualstack e2e tests caused by the introduction of MachinePools in https://github.com/kubernetes-sigs/cluster-api/pull/9393

This PR drops the MachinePools in the templates. I'll add info on the umbrella issue for how to make the dualstack e2e tests work with MachinePools.

Related to https://github.com/kubernetes-sigs/cluster-api/issues/5991

