### PR TITLE
🐛 Gitlab repository: switch to url.Path instead of url.RawPath

### DIFF
--- a/cmd/clusterctl/client/repository/repository_gitlab.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab.go
@@ -66,12 +66,12 @@ func NewGitLabRepository(providerConfig config.Provider, configVariablesClient c
 		return nil, errors.Wrap(err, "invalid url")
 	}
 
-	urlSplit := strings.Split(strings.TrimPrefix(rURL.RawPath, "/"), "/")
+	urlSplit := strings.Split(strings.TrimPrefix(rURL.Path, "/"), "/")
 
 	// Check if the url is a Gitlab repository
 	if rURL.Scheme != httpsScheme ||
 		len(urlSplit) != 9 ||
-		!strings.HasPrefix(rURL.RawPath, gitlabPackagesAPIPrefix) ||
+		!strings.HasPrefix(rURL.Path, gitlabPackagesAPIPrefix) ||
 		urlSplit[4] != gitlabPackagesAPIPackages ||
 		urlSplit[5] != gitlabPackagesAPIGeneric {
 		return nil, errors.New("invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}")

--- a/cmd/clusterctl/client/repository/repository_gitlab_test.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab_test.go
@@ -148,12 +148,12 @@ func Test_gitLabRepository_getFile(t *testing.T) {
 	defer server.Close()
 	client := server.Client()
 
-	providerURL := fmt.Sprintf("%s/api/v4/projects/group%%2Fproject/packages/generic/my-package/v0.4.1/file.yaml", server.URL)
+	providerURL := fmt.Sprintf("%s/api/v4/projects/group/project/packages/generic/my-package/v0.4.1/file.yaml", server.URL)
 	providerConfig := config.NewProvider("test", providerURL, clusterctlv1.CoreProviderType)
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		if r.URL.RawPath == "/api/v4/projects/group%2Fproject/packages/generic/my-package/v0.4.1/file.yaml" {
+		if r.URL.Path == "/api/v4/projects/group/project/packages/generic/my-package/v0.4.1/file.yaml" {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Content-Disposition", "attachment; filename=file.yaml")
 			fmt.Fprint(w, "content")


### PR DESCRIPTION
What this PR does / why we need it:
For now it's impossible to use non-urlencoded URL with cluster-api gitlab repo client.
After url.Parse call, url.RawPath is used which is optional, and exists only if provided URL has encoded characters.

E.g this url
`https://gitlab.foo.com/api/v4/projects/3441/packages/generic/aws-provider/v0.2.34/infrastructure-components.yaml`
 will result in error
`
invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}
`

/area clusterctl
[area/clusterctl](https://github.com/kubernetes-sigs/cluster-api/labels/area%2Fclusterctl)