### PR TITLE
🌱 Import Boss API restrictions should be transitive

### DIFF
--- a/api/.import-restrictions
+++ b/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/api/v1beta1/.import-restrictions
+++ b/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/api/v1beta1/index/.import-restrictions
+++ b/api/v1beta1/index/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime"
     forbiddenPrefixes: []
+    transitive: true

--- a/bootstrap/kubeadm/api/.import-restrictions
+++ b/bootstrap/kubeadm/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/bootstrap/kubeadm/api/v1beta1/.import-restrictions
+++ b/bootstrap/kubeadm/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/cmd/clusterctl/api/.import-restrictions
+++ b/cmd/clusterctl/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/controlplane/kubeadm/api/.import-restrictions
+++ b/controlplane/kubeadm/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/controlplane/kubeadm/api/v1beta1/.import-restrictions
+++ b/controlplane/kubeadm/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/exp/addons/api/.import-restrictions
+++ b/exp/addons/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/exp/addons/api/v1beta1/.import-restrictions
+++ b/exp/addons/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/exp/api/.import-restrictions
+++ b/exp/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/exp/api/v1beta1/.import-restrictions
+++ b/exp/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/exp/ipam/api/.import-restrictions
+++ b/exp/ipam/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/exp/ipam/api/v1alpha1/.import-restrictions
+++ b/exp/ipam/api/v1alpha1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/exp/runtime/api/.import-restrictions
+++ b/exp/runtime/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/exp/runtime/api/v1alpha1/.import-restrictions
+++ b/exp/runtime/api/v1alpha1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/test/infrastructure/docker/api/.import-restrictions
+++ b/test/infrastructure/docker/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/test/infrastructure/docker/api/v1beta1/.import-restrictions
+++ b/test/infrastructure/docker/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/test/infrastructure/docker/exp/api/.import-restrictions
+++ b/test/infrastructure/docker/exp/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/test/infrastructure/docker/exp/api/v1beta1/.import-restrictions
+++ b/test/infrastructure/docker/exp/api/v1beta1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true

--- a/test/infrastructure/inmemory/api/.import-restrictions
+++ b/test/infrastructure/inmemory/api/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes:
       - "sigs.k8s.io/controller-runtime/pkg/conversion"
     forbiddenPrefixes: []
+    transitive: true

--- a/test/infrastructure/inmemory/api/v1alpha1/.import-restrictions
+++ b/test/infrastructure/inmemory/api/v1alpha1/.import-restrictions
@@ -3,3 +3,4 @@ rules:
     allowedPrefixes: []
     forbiddenPrefixes:
       - "sigs.k8s.io/controller-runtime"
+    transitive: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We need to make sure that the packages transitive dependencies also don't import controller runtime for proper cleanliness and to prevent regressions.

Part of #9011 

cc @sbueringer 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->