### PR TITLE
:book: Fix broken link to docker webhook and d2iq

### DIFF
--- a/docs/book/src/developer/providers/webhooks.md
+++ b/docs/book/src/developer/providers/webhooks.md
@@ -23,7 +23,7 @@ validation behavior for all other cases.
 See [the DockerMachineTemplate webhook] as a reference for a compatible implementation.
 
 [Server Side Apply]: https://kubernetes.io/docs/reference/using-api/server-side-apply/
-[the DockerMachineTemplate webhook]: https://github.com/kubernetes-sigs/cluster-api/blob/main/test/infrastructure/docker/api/v1beta1/dockermachinetemplate_webhook.go
+[the DockerMachineTemplate webhook]: https://github.com/kubernetes-sigs/cluster-api/blob/main/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook.go
 
 </aside>
 

--- a/docs/proposals/20200423-etcd-data-disk.md
+++ b/docs/proposals/20200423-etcd-data-disk.md
@@ -60,8 +60,7 @@ A "side effect" motivation is to open up the option of putting other directories
 
 References:
 https://docs.microsoft.com/en-us/archive/blogs/xiangwu/azure-vm-storage-performance-and-throttling-demystify
-https://archive-docs.d2iq.com/mesosphere/dcos/1.13/installing/production/system-requirements/azure-recommendations/#disk-configurations
-
+https://github.com/mesosphere/dcos-docs-site/blob/f15c4d9cd8c36c8a406a22b76b825b49d9fe577d/pages/mesosphere/dcos/1.13/installing/production/system-requirements/azure-recommendations/index.md#disk-configurations
 ### Goals
 
 - Allow running etcd on its own disk


### PR DESCRIPTION
Fix a couple of broken links in the book caught by the weekly markdown scanner.