### PR TITLE
🌱 Add MachinePools to topology upgrade test

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -161,6 +161,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 				EtcdImageTag:                input.E2EConfig.GetVariable(EtcdVersionUpgradeTo),
 				DNSImageTag:                 input.E2EConfig.GetVariable(CoreDNSVersionUpgradeTo),
 				MachineDeployments:          clusterResources.MachineDeployments,
+				MachinePools:                clusterResources.MachinePools,
 				KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
 				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -221,6 +221,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 			Cluster:                     clusterResources.Cluster,
 			ControlPlane:                clusterResources.ControlPlane,
 			MachineDeployments:          clusterResources.MachineDeployments,
+			MachinePools:                clusterResources.MachinePools,
 			KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
 			WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 			WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
@@ -233,7 +234,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 					input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
 					input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"))
 			},
-			PreWaitForMachineDeploymentToBeUpgraded: func() {
+			PreWaitForWorkersToBeUpgraded: func() {
 				machineSetPreflightChecksTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
 					clusterRef)

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
@@ -26,6 +26,15 @@ spec:
           nodeDeletionTimeout: "30s"
           replicas: ${WORKER_MACHINE_COUNT}
           failureDomain: fd4
+      machinePools:
+        - class: "default-worker"
+          name: "mp-0"
+          nodeDeletionTimeout: "30s"
+          nodeVolumeDetachTimeout: "5m"
+          minReadySeconds: 5
+          replicas: ${WORKER_MACHINE_COUNT}
+          failureDomains:
+          - fd4
     variables:
       - name: kubeadmControlPlaneMaxSurge
         value: "1"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/kustomization.yaml
@@ -1,4 +1,3 @@
 resources:
   - ../bases/crs.yaml
-  - ../bases/mp.yaml
   - cluster-runtimesdk.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades/kustomization.yaml
@@ -1,4 +1,3 @@
 resources:
   - ../bases/cluster-with-topology.yaml
   - ../bases/crs.yaml
-  - ../bases/mp.yaml

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -313,6 +313,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 				EtcdImageTag:                input.E2EConfig.GetVariable(EtcdVersionUpgradeTo),
 				DNSImageTag:                 input.E2EConfig.GetVariable(CoreDNSVersionUpgradeTo),
 				MachineDeployments:          clusterResources.MachineDeployments,
+				MachinePools:                clusterResources.MachinePools,
 				KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
 				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds checks for MachinePools in the cluster topology upgrade test. Template flavors `upgrade`, `topology`, and `kcp-scale-in` already contain MachinePools using the `cluster-with-topology.yaml` base.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #5991 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing