### PR TITLE
[release-1.5] :bug: Fix broken e2e test clusterclass

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -113,12 +113,14 @@ spec:
         type: boolean
         default: false
   - name: kubeControlPlaneLogLevel
+    required: false
     schema:
       openAPIV3Schema:
         type: string
         description: "Log level for kube-apiserver, kube-scheduler and kube-controller-manager"
         example: "2"
   - name: kubeletLogLevel
+    required: false
     schema:
       openAPIV3Schema:
         type: string


### PR DESCRIPTION
Issue with required not being defined was introduced in https://github.com/kubernetes-sigs/cluster-api/pull/9501. I'm not sure of the root cause, but `required` only seems to be required on older versions of Kubernetes. 

The test was passing `e2e-min-k8s-main` - which runs with Kubernetes v1.25 - but failing `e2e-min-k8s-release-1-5` - which runs Kubernetes v1.24.

Either way we should make this change in both branches after we see if it fixes the underlying issue here.