### PR TITLE
:seedling: Fix broken e2e test clusterclass

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -131,12 +131,14 @@ spec:
         type: boolean
         default: false
   - name: kubeControlPlaneLogLevel
+    required: false
     schema:
       openAPIV3Schema:
         type: string
         description: "Log level for kube-apiserver, kube-scheduler and kube-controller-manager"
         example: "2"
   - name: kubeletLogLevel
+    required: false
     schema:
       openAPIV3Schema:
         type: string


### PR DESCRIPTION
Reverse cherry-pick for this one. The tests were failing on release-1.5, but I'd like to keep these ClusterClasses in sync where it makes sense.

Cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9504