### PR TITLE
:book: Fixup `from` typo

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -276,7 +276,7 @@ func (r *Reconciler) computeDesiredMachineSet(deployment *clusterv1.MachineDeplo
 		// the finalizer on the MachineSet if it already exists. Because of SSA we should not build
 		// the finalizer information from the MachineDeployment when updating a MachineSet because that could lead
 		// to dropping the finalizer from the MachineSet if it is dropped from the MachineDeployment.
-		// We should not drop the finalizer on the MachineSet if the finalizer is dropped form the MachineDeployment.
+		// We should not drop the finalizer on the MachineSet if the finalizer is dropped from the MachineDeployment.
 		if sets.New[string](existingMS.Finalizers...).Has(metav1.FinalizerDeleteDependents) {
 			finalizers = []string{metav1.FinalizerDeleteDependents}
 		}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -297,7 +297,7 @@ func TestMachineSetReconciler(t *testing.T) {
 			fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource, g)
 		}
 
-		// Verify that in-place mutable fields propagate form MachineSet to Machines.
+		// Verify that in-place mutable fields propagate from MachineSet to Machines.
 		t.Log("Updating NodeDrainTimeout on MachineSet")
 		patchHelper, err := patch.NewHelper(instance, env)
 		g.Expect(err).ToNot(HaveOccurred())

--- a/internal/controllers/topology/cluster/conditions.go
+++ b/internal/controllers/topology/cluster/conditions.go
@@ -214,7 +214,7 @@ func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluste
 	return nil
 }
 
-// computeNameList computes list of names form the given list to be shown in conditions.
+// computeNameList computes list of names from the given list to be shown in conditions.
 // It shortens the list to at most 5 names and adds an ellipsis at the end if the list
 // has more than 5 elements.
 func computeNameList(list []string) any {

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -362,7 +362,7 @@ func ApplyCustomClusterTemplateAndWait(ctx context.Context, input ApplyCustomClu
 	Expect(input.Namespace).NotTo(BeEmpty(), "Invalid argument. input.Namespace can't be empty when calling ApplyCustomClusterTemplateAndWait")
 	Expect(result).ToNot(BeNil(), "Invalid argument. result can't be nil when calling ApplyClusterTemplateAndWait")
 
-	log.Logf("Creating the workload cluster with name %q form the provided yaml", input.ClusterName)
+	log.Logf("Creating the workload cluster with name %q from the provided yaml", input.ClusterName)
 
 	// Ensure we have a Cluster for dump and cleanup steps in AfterEach even if ApplyClusterTemplateAndWait fails.
 	result.Cluster = &clusterv1.Cluster{


### PR DESCRIPTION
Fix `form` instead of `from` in a couple of places across the codebase.