### PR TITLE
🌱 Embed ssa.FilterObjectInput into HelperOption to remove duplication

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -68,8 +68,8 @@ func dryRunSSAPatch(ctx context.Context, dryRunCtx *dryRunSSAPatchInput) (bool, 
 	// For dry run we use the same options as for the intent but with adding metadata.managedFields
 	// to ensure that changes to ownership are detected.
 	filterObjectInput := &ssa.FilterObjectInput{
-		AllowedPaths: append(dryRunCtx.helperOptions.allowedPaths, []string{"metadata", "managedFields"}),
-		IgnorePaths:  dryRunCtx.helperOptions.ignorePaths,
+		AllowedPaths: append(dryRunCtx.helperOptions.AllowedPaths, []string{"metadata", "managedFields"}),
+		IgnorePaths:  dryRunCtx.helperOptions.IgnorePaths,
 	}
 
 	// Add TopologyDryRunAnnotation to notify validation webhooks to skip immutability checks.

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -71,10 +71,7 @@ func NewServerSidePatchHelper(ctx context.Context, original, modified client.Obj
 
 	// Filter the modifiedUnstructured object to only contain changes intendet to be done.
 	// The originalUnstructured object will be filtered in dryRunSSAPatch using other options.
-	ssa.FilterObject(modifiedUnstructured, &ssa.FilterObjectInput{
-		AllowedPaths: helperOptions.allowedPaths,
-		IgnorePaths:  helperOptions.ignorePaths,
-	})
+	ssa.FilterObject(modifiedUnstructured, &helperOptions.FilterObjectInput)
 
 	// Carry over uid to match the intent to:
 	// * create (uid==""):

--- a/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
@@ -67,7 +67,7 @@ type TwoWaysPatchHelper struct {
 func NewTwoWaysPatchHelper(original, modified client.Object, c client.Client, opts ...HelperOption) (*TwoWaysPatchHelper, error) {
 	helperOptions := &HelperOptions{}
 	helperOptions = helperOptions.ApplyOptions(opts)
-	helperOptions.allowedPaths = []contract.Path{
+	helperOptions.AllowedPaths = []contract.Path{
 		{"metadata", "labels"},
 		{"metadata", "annotations"},
 		{"spec"}, // NOTE: The handling of managed path requires/assumes spec to be within allowed path.
@@ -76,7 +76,7 @@ func NewTwoWaysPatchHelper(original, modified client.Object, c client.Client, op
 	// metadata.name, metadata.namespace (who are required by the API server) and metadata.ownerReferences
 	// that gets set to avoid orphaned objects.
 	if util.IsNil(original) {
-		helperOptions.allowedPaths = append(helperOptions.allowedPaths,
+		helperOptions.AllowedPaths = append(helperOptions.AllowedPaths,
 			contract.Path{"apiVersion"},
 			contract.Path{"kind"},
 			contract.Path{"metadata", "name"},
@@ -166,24 +166,24 @@ func applyOptions(in *applyOptionsInput) ([]byte, error) {
 
 	// drop changes for exclude paths (fields to not consider, e.g. status);
 	// Note: for everything not allowed it sets modified equal to original, so the generated patch doesn't include this change
-	if len(in.options.allowedPaths) > 0 {
+	if len(in.options.AllowedPaths) > 0 {
 		dropDiff(&dropDiffInput{
 			path:               contract.Path{},
 			original:           originalMap,
 			modified:           modifiedMap,
-			shouldDropDiffFunc: ssa.IsPathNotAllowed(in.options.allowedPaths),
+			shouldDropDiffFunc: ssa.IsPathNotAllowed(in.options.AllowedPaths),
 		})
 	}
 
 	// drop changes for ignore paths (well known fields owned by something else, e.g.
 	//   spec.controlPlaneEndpoint in the InfrastructureCluster object);
 	// Note: for everything ignored it sets  modified equal to original, so the generated patch doesn't include this change
-	if len(in.options.ignorePaths) > 0 {
+	if len(in.options.IgnorePaths) > 0 {
 		dropDiff(&dropDiffInput{
 			path:               contract.Path{},
 			original:           originalMap,
 			modified:           modifiedMap,
-			shouldDropDiffFunc: ssa.IsPathIgnored(in.options.ignorePaths),
+			shouldDropDiffFunc: ssa.IsPathIgnored(in.options.IgnorePaths),
 		})
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:  
`HelperOption` is defined with the same fields as ssa.FilterObjectInput, which is redundant. This PR removes the duplication by embedding `ssa.FilterObjectInput` into `HelperOption` instead.  
The original request of the issue is `drop HelperOptions and replace all of it uses with ssa.FilterObjectInput`, but that would introduce a lot of diffs. I'd say it would be enough to replace duplicated fields by embedding `ssa.FilterObjectInput` directly, which makes the diffs small.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:  
Fixes #8395

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->