### PR TITLE
:seedling: Update kubebuilder-release-tools to v0.4.0

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - name: Verifier action
       id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@4f3d1085b4458a49ed86918b4b55505716715b77 # tag=v0.3.0
+      uses: kubernetes-sigs/kubebuilder-release-tools@d8367c29de8af903319d3a76de2436672515729b # tag=v0.4.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow us to use the :rocket: emoji to indicate PRs that will trigger a new release. Related to #9444 where we found that we needed https://github.com/kubernetes-sigs/kubebuilder-release-tools/pull/55 in order to leverage the new process fully. It has since been released in v0.4.0 and this PR is just getting ahead of dependabot to make sure we can have this available before the next release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #9104

/area release