### PR TITLE
🌱 Dump all resource information for self-hosted tests

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -65,22 +65,23 @@ func setupSpecNamespace(ctx context.Context, specName string, clusterProxy frame
 	return namespace, cancelWatches
 }
 
-func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace *corev1.Namespace, cancelWatches context.CancelFunc, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, skipCleanup bool) {
+// dumpAllResources dumps all the resources in the spec namespace and the workload cluster.
+func dumpAllResources(ctx context.Context, clusterProxy framework.ClusterProxy, artifactFolder string, namespace *corev1.Namespace, cluster *clusterv1.Cluster) {
 	Byf("Dumping logs from the %q workload cluster", cluster.Name)
 
-	// Dump all the logs from the workload cluster before deleting them.
+	// Dump all the logs from the workload cluster.
 	clusterProxy.CollectWorkloadClusterLogs(ctx, cluster.Namespace, cluster.Name, filepath.Join(artifactFolder, "clusters", cluster.Name))
 
 	Byf("Dumping all the Cluster API resources in the %q namespace", namespace.Name)
 
-	// Dump all Cluster API related resources to artifacts before deleting them.
+	// Dump all Cluster API related resources to artifacts.
 	framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
 		Lister:    clusterProxy.GetClient(),
 		Namespace: namespace.Name,
 		LogPath:   filepath.Join(artifactFolder, "clusters", clusterProxy.GetName(), "resources"),
 	})
 
-	// If the cluster still exists, dump pods and nodes of the workload cluster before deleting the cluster.
+	// If the cluster still exists, dump pods and nodes of the workload cluster.
 	if err := clusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(cluster), &clusterv1.Cluster{}); err == nil {
 		Byf("Dumping Pods and Nodes of Cluster %s", klog.KObj(cluster))
 		framework.DumpResourcesForCluster(ctx, framework.DumpResourcesForClusterInput{
@@ -103,6 +104,12 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 			},
 		})
 	}
+}
+
+// dumpSpecResourcesAndCleanup dumps all the resources in the spec namespace and cleans up the spec namespace.
+func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string, namespace *corev1.Namespace, cancelWatches context.CancelFunc, cluster *clusterv1.Cluster, intervalsGetter func(spec, key string) []interface{}, skipCleanup bool) {
+	// Dump all the resources in the spec namespace and the workload cluster.
+	dumpAllResources(ctx, clusterProxy, artifactFolder, namespace, cluster)
 
 	if !skipCleanup {
 		Byf("Deleting cluster %s", klog.KObj(cluster))

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -391,11 +391,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 	AfterEach(func() {
 		if selfHostedNamespace != nil {
 			// Dump all Cluster API related resources to artifacts before pivoting back.
-			framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
-				Lister:    selfHostedClusterProxy.GetClient(),
-				Namespace: namespace.Name,
-				LogPath:   filepath.Join(input.ArtifactFolder, "clusters", clusterResources.Cluster.Name, "resources"),
-			})
+			dumpAllResources(ctx, selfHostedClusterProxy, input.ArtifactFolder, namespace, clusterResources.Cluster)
 		}
 		if selfHostedCluster != nil {
 			By("Ensure API servers are stable before doing move")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
- The changes added in this PR will capture "destination clusters" nodes and pod info before they get cleaned.
- These changes are added to self_hosted cluster tests.
- Aiming to track down `When testing Cluster API working on self-hosted clusters using ClusterClass with a HA control plane [ClusterClass]`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->