### PR TITLE
:seedling: Revert ErrClusterLocked check in Machine controller

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -604,11 +604,7 @@ func (r *Reconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, 
 
 	restConfig, err := r.Tracker.GetRESTConfig(ctx, util.ObjectKey(cluster))
 	if err != nil {
-		if errors.Is(err, remote.ErrClusterLocked) {
-			log.V(5).Info("Requeuing drain Node because another worker has the lock on the ClusterCacheTracker")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		log.Error(err, "Error creating a remote client for cluster while draining Node, won't retry")
+		log.Error(err, "Error creating a remote client while deleting Machine, won't retry")
 		return ctrl.Result{}, nil
 	}
 	restConfig = rest.CopyConfig(restConfig)


### PR DESCRIPTION
Reverts a part of https://github.com/kubernetes-sigs/cluster-api/pull/9570 that incorrectly checked for the ErrClusterLocked from a function that never returns it. 

Ref: https://github.com/kubernetes-sigs/cluster-api/pull/9583#discussion_r1365927447