### PR TITLE
[release-1.4] :bug: Revert ErrClusterLocked check in Machine controller

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -582,10 +582,6 @@ func (r *Reconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, 
 
 	restConfig, err := remote.RESTConfig(ctx, controllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
-		if errors.Is(err, remote.ErrClusterLocked) {
-			log.V(5).Info("Requeuing drain Node because another worker has the lock on the ClusterCacheTracker")
-			return ctrl.Result{Requeue: true}, nil
-		}
 		log.Error(err, "Error creating a remote client for cluster while draining Node, won't retry")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Reverts a part of https://github.com/kubernetes-sigs/cluster-api/pull/9583 that incorrectly checked for the ErrClusterLocked from a function that never returns it.

Ref: https://github.com/kubernetes-sigs/cluster-api/pull/9583#discussion_r1365927447