### PR TITLE
🌱 Remove extra separator after title in release notes

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -341,7 +341,7 @@ REPLACE ME: A couple sentences describing the deprecation, including links to do
 `)
 	}
 
-	fmt.Printf("## Changes since %v\n---\n", commitRange)
+	fmt.Printf("## Changes since %v\n", commitRange)
 
 	fmt.Printf("## :chart_with_upwards_trend: Overview\n")
 	if count := len(commits); count == 1 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Historically we always added a line separator after the `Changes since` heading. This doesn't make the text more readable and it kind of looks misformatted. GitHub already adds a line separator after `##` headings.


/area release