### PR TITLE
📖 E2e: Document self hosted machine templates

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -59,6 +59,10 @@ type SelfHostedSpecInput struct {
 	// If true, the variable KUBERNETES_VERSION is expected to be set.
 	// If false, the variables KUBERNETES_VERSION_UPGRADE_FROM, KUBERNETES_VERSION_UPGRADE_TO,
 	// ETCD_VERSION_UPGRADE_TO and COREDNS_VERSION_UPGRADE_TO are expected to be set.
+	// There are also (optional) variables CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO and
+	// WORKERS_MACHINE_TEMPLATE_UPGRADE_TO to change the infrastructure machine template
+	// during the upgrade. Note that these templates need to have the clusterctl.cluster.x-k8s.io/move
+	// label in order to be moved to the self hosted cluster (since they are not part of the owner chain).
 	SkipUpgrade bool
 
 	// ControlPlaneMachineCount is used in `config cluster` to configure the count of the control plane machines used in the test.


### PR DESCRIPTION
I'm unsure if this should be 📖 or 🌱. Please change as needed.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The self hosted test has optional variables that can be used to switch the infrastructure machine template when doing the upgrade. This documents the variables and also explains that the templates will need to be labeled in order to move with the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->