### PR TITLE
🌱 Capitalize area prefix in release notes by default

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -102,6 +102,8 @@ var (
 		"runtime-sdk":                       "Runtime SDK",
 		"ci":                                "CI",
 		"machinehealthcheck":                "MachineHealthCheck",
+		"clusterctl":                        "clusterctl", // Preserve lowercase
+		"util":                              "util",       // Preserve lowercase
 	}
 
 	releaseBackportMarker = regexp.MustCompile(`(?m)^\[release-\d\.\d\]\s*`)
@@ -180,6 +182,8 @@ func getAreaLabel(merge string) (string, error) {
 		if area, ok := trimAreaLabel(label.Name); ok {
 			if userFriendlyArea, ok := userFriendlyAreas[area]; ok {
 				area = userFriendlyArea
+			} else {
+				area = capitalize(area)
 			}
 
 			areaLabels = append(areaLabels, area)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Now all areas will be capitalize by default except the ones that have an explicit "user friendly" substitution.

/area release