### PR TITLE
🌱 Bump golangci-lint to v1.55.1

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -30,6 +30,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # tag=v3.7.0
         with:
-          version: v1.54.1
+          version: v1.55.1
           args: --out-format=colored-line-number
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -200,6 +200,8 @@ linters-settings:
       #
       - name: bool-literal-in-expr
       - name: constant-logical-expr
+  goconst:
+    ignore-tests: true
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -70,9 +70,9 @@ func (c *clusterctlClient) Move(ctx context.Context, options MoveOptions) error 
 		return c.toDirectory(ctx, options)
 	} else if options.FromDirectory != "" {
 		return c.fromDirectory(ctx, options)
-	} else {
-		return c.move(ctx, options)
 	}
+
+	return c.move(ctx, options)
 }
 
 func (c *clusterctlClient) move(ctx context.Context, options MoveOptions) error {

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -18,6 +18,7 @@ package remote
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -44,10 +45,14 @@ func mapper(_ context.Context, i client.Object) []reconcile.Request {
 		{
 			NamespacedName: types.NamespacedName{
 				Namespace: i.GetNamespace(),
-				Name:      "mapped-" + i.GetName(),
+				Name:      getMappedName(i.GetName()),
 			},
 		},
 	}
+}
+
+func getMappedName(name string) string {
+	return fmt.Sprintf("mapped-%s", name)
 }
 
 func TestClusterCacheTracker(t *testing.T) {
@@ -127,7 +132,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
 			t.Log("Deleting any Clusters")
 			g.Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
-			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
+			g.Expect(<-c.ch).To(Equal(getMappedName(clusterA.Name)))
 			g.Consistently(c.ch).ShouldNot(Receive())
 			t.Log("Deleting Namespace")
 			g.Expect(env.Delete(ctx, ns)).To(Succeed())
@@ -150,7 +155,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			})).To(Succeed())
 
 			t.Log("Waiting to receive the watch notification")
-			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
+			g.Expect(<-c.ch).To(Equal(getMappedName(clusterA.Name)))
 
 			t.Log("Ensuring no additional watch notifications arrive")
 			g.Consistently(c.ch).ShouldNot(Receive())
@@ -162,7 +167,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(k8sClient.Update(ctx, clusterA)).To(Succeed())
 
 			t.Log("Waiting to receive the watch notification")
-			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
+			g.Expect(<-c.ch).To(Equal(getMappedName(clusterA.Name)))
 
 			t.Log("Ensuring no additional watch notifications arrive")
 			g.Consistently(c.ch).ShouldNot(Receive())
@@ -184,7 +189,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(k8sClient.Update(ctx, clusterA)).To(Succeed())
 
 			t.Log("Waiting to receive the watch notification")
-			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
+			g.Expect(<-c.ch).To(Equal(getMappedName(clusterA.Name)))
 
 			t.Log("Ensuring no additional watch notifications arrive")
 			g.Consistently(c.ch).ShouldNot(Receive())

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -374,7 +374,8 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 	g.Expect(env.GetAPIReader().List(ctx, machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
 	g.Expect(machineList.Items).To(HaveLen(1))
 
-	for _, m := range machineList.Items {
+	for i := range machineList.Items {
+		m := machineList.Items[i]
 		g.Expect(m.Namespace).To(Equal(cluster.Namespace))
 		g.Expect(m.Name).NotTo(BeEmpty())
 		g.Expect(m.Name).To(HavePrefix(kcp.Name))

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -1369,7 +1369,8 @@ func TestGetCoreDNSInfo(t *testing.T) {
 				expectErr:     true,
 			},
 		}
-		for _, tt := range tests {
+		for i := range tests {
+			tt := tests[i]
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				fakeClient := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
@@ -1433,7 +1434,8 @@ func TestUpdateCoreDNSImageInfoInKubeadmConfigMap(t *testing.T) {
 				`),
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			fakeClient := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -218,7 +218,8 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			gs := NewWithT(t)
 

--- a/exp/internal/controllers/machinepool_controller_test.go
+++ b/exp/internal/controllers/machinepool_controller_test.go
@@ -409,7 +409,8 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		t.Run("machinePool should be "+tc.machinePool.Name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/exp/internal/webhooks/machinepool_test.go
+++ b/exp/internal/webhooks/machinepool_test.go
@@ -296,7 +296,8 @@ func TestMachinePoolVersionValidation(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/exp/ipam/internal/webhooks/ipaddress_test.go
+++ b/exp/ipam/internal/webhooks/ipaddress_test.go
@@ -156,7 +156,8 @@ func TestIPAddressValidateCreate(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			scheme := runtime.NewScheme()
@@ -214,7 +215,8 @@ func TestIPAddressValidateUpdate(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			scheme := runtime.NewScheme()

--- a/exp/ipam/internal/webhooks/ipaddressclaim_test.go
+++ b/exp/ipam/internal/webhooks/ipaddressclaim_test.go
@@ -61,7 +61,8 @@ func TestIPAddressClaimValidateCreate(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			wh := IPAddressClaim{}
@@ -111,7 +112,8 @@ func TestIPAddressClaimValidateUpdate(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			wh := IPAddressClaim{}

--- a/exp/runtime/hooks/api/v1alpha1/discovery_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/discovery_types.go
@@ -100,7 +100,7 @@ func init() {
 			"Runtime Extension implementers must use this hook to inform the Cluster API runtime about all the handlers " +
 			"that are defined in an external component implementing Runtime Extensions.\n" +
 			"\n" +
-			"Notes:\n" +
+			"Notes:\n" + //nolint:goconst
 			"- When using Runtime SDK utils, a handler for this hook is automatically generated",
 		Singleton: true,
 	})

--- a/exp/runtime/hooks/api/v1alpha1/lifecyclehooks_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/lifecyclehooks_types.go
@@ -204,7 +204,7 @@ func init() {
 			"all the objects which are part of a Cluster's topology are going to be created.\n" +
 			"\n" +
 			"Notes:\n" +
-			"- This hook will be called only for Clusters with a managed topology\n" +
+			"- This hook will be called only for Clusters with a managed topology\n" + //nolint:goconst
 			"- The call's request contains the Cluster object\n" +
 			"- This is a blocking hook; Runtime Extension implementers can use this hook to execute\n" +
 			"tasks before the objects which are part of a Cluster's topology are created",

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -717,7 +717,8 @@ func TestReconcileRequest(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		t.Run("machine should be "+tc.machine.Name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -362,8 +362,8 @@ func (r *Reconciler) getMachineDeploymentsForMachineSet(ctx context.Context, ms 
 	}
 
 	deployments := make([]*clusterv1.MachineDeployment, 0, len(dList.Items))
-	for idx, d := range dList.Items {
-		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
+	for idx := range dList.Items {
+		selector, err := metav1.LabelSelectorAsSelector(&dList.Items[idx].Spec.Selector)
 		if err != nil {
 			continue
 		}

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -799,7 +799,8 @@ func TestGetMachineDeploymentsForMachineSet(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		var got []client.Object
 		for _, x := range r.getMachineDeploymentsForMachineSet(ctx, &tc.machineSet) {
 			got = append(got, x)
@@ -948,7 +949,8 @@ func TestGetMachineSetsForDeployment(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -384,7 +384,8 @@ func TestFindNewMachineSet(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.Name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -478,7 +479,8 @@ func TestFindOldMachineSets(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.Name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -716,7 +718,8 @@ func TestDeploymentComplete(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	for i := range tests {
+		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -469,9 +469,10 @@ func TestHealthCheckTargets(t *testing.T) {
 			gs.Expect(healthy).To(ConsistOf(tc.expectedHealthy))
 			gs.Expect(unhealthy).To(ConsistOf(tc.expectedNeedsRemediation))
 			gs.Expect(nextCheckTimes).To(WithTransform(roundDurations, ConsistOf(tc.expectedNextCheckTimes)))
-			for i, expectedMachineConditions := range tc.expectedNeedsRemediationCondition {
+			for i, expectedMachineCondition := range tc.expectedNeedsRemediationCondition {
 				actualConditions := unhealthy[i].Machine.GetConditions()
-				gs.Expect(actualConditions).To(WithTransform(removeLastTransitionTimes, ContainElements(expectedMachineConditions)))
+				conditionsMatcher := WithTransform(removeLastTransitionTimes, ContainElements(expectedMachineCondition))
+				gs.Expect(actualConditions).To(conditionsMatcher)
 			}
 		})
 	}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -754,7 +754,8 @@ func TestShouldExcludeMachine(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		g := NewWithT(t)
 
 		got := shouldExcludeMachine(&tc.machineSet, &tc.machine)
@@ -804,7 +805,8 @@ func TestAdoptOrphan(t *testing.T) {
 		Client:                    c,
 		UnstructuredCachingClient: c,
 	}
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		g.Expect(r.adoptOrphan(ctx, tc.machineSet.DeepCopy(), tc.machine.DeepCopy())).To(Succeed())
 
 		key := client.ObjectKey{Namespace: tc.machine.Namespace, Name: tc.machine.Name}

--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -450,14 +450,16 @@ func ClusterClassReferencesAreValid(clusterClass *clusterv1.ClusterClass) field.
 		allErrs = append(allErrs, LocalObjectTemplateIsValid(clusterClass.Spec.ControlPlane.MachineInfrastructure, clusterClass.Namespace, field.NewPath("spec", "controlPlane", "machineInfrastructure"))...)
 	}
 
-	for i, mdc := range clusterClass.Spec.Workers.MachineDeployments {
+	for i := range clusterClass.Spec.Workers.MachineDeployments {
+		mdc := clusterClass.Spec.Workers.MachineDeployments[i]
 		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mdc.Template.Bootstrap, clusterClass.Namespace,
 			field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "bootstrap"))...)
 		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mdc.Template.Infrastructure, clusterClass.Namespace,
 			field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "infrastructure"))...)
 	}
 
-	for i, mpc := range clusterClass.Spec.Workers.MachinePools {
+	for i := range clusterClass.Spec.Workers.MachinePools {
+		mpc := clusterClass.Spec.Workers.MachinePools[i]
 		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mpc.Template.Bootstrap, clusterClass.Namespace,
 			field.NewPath("spec", "workers", "machinePools").Index(i).Child("template", "bootstrap"))...)
 		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mpc.Template.Infrastructure, clusterClass.Namespace,

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -431,7 +431,8 @@ func validateMachineHealthChecks(cluster *clusterv1.Cluster, clusterClass *clust
 	}
 
 	if cluster.Spec.Topology.Workers != nil {
-		for i, md := range cluster.Spec.Topology.Workers.MachineDeployments {
+		for i := range cluster.Spec.Topology.Workers.MachineDeployments {
+			md := cluster.Spec.Topology.Workers.MachineDeployments[i]
 			if md.MachineHealthCheck != nil {
 				fldPath := field.NewPath("spec", "topology", "workers", "machineDeployments", "machineHealthCheck").Index(i)
 

--- a/internal/webhooks/machine_test.go
+++ b/internal/webhooks/machine_test.go
@@ -263,7 +263,8 @@ func TestIsMachinePoolMachine(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
@@ -306,7 +307,8 @@ func TestMachineVersionValidation(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -380,7 +380,8 @@ func TestMachineDeploymentValidation(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			md := &clusterv1.MachineDeployment{

--- a/internal/webhooks/patch_validation_test.go
+++ b/internal/webhooks/patch_validation_test.go
@@ -1514,7 +1514,8 @@ func TestValidatePatches(t *testing.T) {
 			wantErr:    true,
 		},
 	}
-	for _, tt := range tests {
+	for i := range tests {
+		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, tt.runtimeSDK)()
 

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -152,7 +152,8 @@ func AssertMachineDeploymentFailureDomains(ctx context.Context, input AssertMach
 		return input.Lister.List(ctx, ms, client.InNamespace(input.Cluster.Namespace), client.MatchingLabels(selectorMap))
 	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to list MachineSets for Cluster %s", klog.KObj(input.Cluster))
 
-	for _, machineSet := range ms.Items {
+	for i := range ms.Items {
+		machineSet := ms.Items[i]
 		machineSetFD := pointer.StringDeref(machineSet.Spec.Template.Spec.FailureDomain, "<None>")
 		Expect(machineSetFD).To(Equal(machineDeploymentFD), "MachineSet %s is in the %q failure domain, expecting %q", machineSet.Name, machineSetFD, machineDeploymentFD)
 

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller_test.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller_test.go
@@ -313,7 +313,7 @@ func TestReconcileNormalEtcd(t *testing.T) {
 
 		manager := cmanager.New(scheme)
 
-		host := "127.0.0.1" //nolint:goconst
+		host := "127.0.0.1"
 		wcmux, err := server.NewWorkloadClustersMux(manager, host, server.CustomPorts{
 			// NOTE: make sure to use ports different than other tests, so we can run tests in parallel
 			MinPort:   server.DefaultMinPort + 1000,

--- a/test/infrastructure/inmemory/internal/server/mux_test.go
+++ b/test/infrastructure/inmemory/internal/server/mux_test.go
@@ -67,7 +67,7 @@ func TestMux(t *testing.T) {
 	manager := cmanager.New(scheme)
 
 	wcl := "workload-cluster"
-	host := "127.0.0.1" //nolint:goconst
+	host := "127.0.0.1"
 	wcmux, err := NewWorkloadClustersMux(manager, host, CustomPorts{
 		// NOTE: make sure to use ports different than other tests, so we can run tests in parallel
 		MinPort:   DefaultMinPort,

--- a/util/predicates/cluster_predicates_test.go
+++ b/util/predicates/cluster_predicates_test.go
@@ -85,7 +85,8 @@ func TestClusterControlplaneInitializedPredicate(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for i := range testcases {
+		tc := testcases[i]
 		t.Run(tc.name, func(t *testing.T) {
 			ev := event.UpdateEvent{
 				ObjectOld: &tc.oldCluster,

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -115,9 +115,9 @@ func (v buildIdentifiers) compare(o buildIdentifiers) int {
 		return 0
 	} else if i == len(v) && i < len(o) {
 		return -1
-	} else {
-		return 1
 	}
+
+	return 1
 }
 
 type buildIdentifier struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: 
This PR bumps the golangci-lint from v1.54.1 -> v1.55.1

The major changes proposed in this PR include version updates to the following linters:
`gosec` - _G601: Implicit memory aliasing in for loop._ 
`goconst` - _string `xyz` has X occurrences, make it a constant_ 



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/9589

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->