### PR TITLE
📖 Add Cluster API release-1.7 timeline document

### DIFF
--- a/docs/release/releases/release-1.7.md
+++ b/docs/release/releases/release-1.7.md
@@ -1,0 +1,36 @@
+# Cluster API v1.7
+
+## Timeline
+
+The following table shows the preliminary dates for the `v1.7` release cycle.
+
+| **What**                                             | **Who**      | **When**                    | **Week** |
+|------------------------------------------------------|--------------|-----------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 4th December 2023    | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 8th December 2023    | week 1   |
+| Team finalized                                       | Release Lead | Friday 8th December 2023    | week 1   |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 9th January 2024    | week 6   |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 6th February 2024   | week 10  |
+| v1.7.0-beta.0 released                               | Release Lead | Tuesday 5th March 2024      | week 14  |
+| Communicate beta to providers                        | Comms Manager| Tuesday 5th March 2024      | week 14  |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 5th March 2024      | week 14  |
+| v1.7.0-beta.x released                               | Release Lead | Tuesday 12th March 2024     | week 15  |
+| KubeCon idle week                                    |      -       | 19th - 22nd March 2024      | week 16  |
+| release-1.7 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 26th March 2024     | week 17  |
+| v1.7.0-rc.0 released                                 | Release Lead | Tuesday 26th March 2024     | week 17  |
+| release-1.7 jobs created                             | CI Manager   | Tuesday 26th March 2024     | week 17  |
+| v1.7.0-rc.x released                                 | Release Lead | Tuesday 2nd April 2024      | week 18  |
+| **v1.7.0 released**                                  | Release Lead | Tuesday 9th April 2024      | week 19  |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 9th April 2024      | week 19  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 19  |
+
+After the `.0` release monthly patch release will be created.
+
+## Release team
+
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
+| Release Lead                              | TBD | TBD                                    |
+| Communications/Docs/Release Notes Manager | TBD | TBD                                    |
+| CI Signal/Bug Triage/Automation Manager   | TBD | TBD                                    |
+| Maintainer                                | TBD | TBD                                    |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds release-1.7 cycle schedule document with preliminary dates taking into account [Kubecon Europe 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) between March 19-22, 2024 on week 16th in the schedule.

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/9094

/area release
/kind documentation
