### PR TITLE
:seedling: Improve logging for self-hosted e2e test

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -187,7 +187,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 
 		cluster := clusterResources.Cluster
 		// Get a ClusterBroker so we can interact with the workload cluster
-		selfHostedClusterProxy = input.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name)
+		selfHostedClusterProxy = input.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name, framework.WithMachineLogCollector(input.BootstrapClusterProxy.GetLogCollector()))
 
 		Byf("Creating a namespace for hosting the %s test spec", specName)
 		selfHostedNamespace, selfHostedCancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{

--- a/test/framework/machine_helpers.go
+++ b/test/framework/machine_helpers.go
@@ -169,7 +169,7 @@ func WaitForControlPlaneMachinesToBeUpgraded(ctx context.Context, input WaitForC
 			}
 		}
 		if len(machines) > upgraded {
-			return 0, errors.New("old nodes remain")
+			return 0, errors.New("old Machines remain")
 		}
 		return upgraded, nil
 	}, intervals...).Should(Equal(input.MachineCount), "Timed out waiting for all control-plane machines in Cluster %s to be upgraded to kubernetes version %s", klog.KObj(input.Cluster), input.KubernetesUpgradeVersion)
@@ -209,7 +209,7 @@ func WaitForMachineDeploymentMachinesToBeUpgraded(ctx context.Context, input Wai
 			}
 		}
 		if len(machines) > upgraded {
-			return 0, errors.New("old nodes remain")
+			return 0, errors.New("old Machines remain")
 		}
 		return upgraded, nil
 	}, intervals...).Should(Equal(input.MachineCount), "Timed out waiting for all MachineDeployment %s Machines to be upgraded to kubernetes version %s", klog.KObj(&input.MachineDeployment), input.KubernetesUpgradeVersion)


### PR DESCRIPTION
Improve logging for the self-hosted tests by ensuring Machine and Infrastructure logs are collected before performing the move to the bootstrap cluster.

/area e2e-testing