### PR TITLE
🌱 MS: improve replica defaulting for autoscaler

### DIFF
--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -41,9 +41,22 @@ type MachineSetSpec struct {
 
 	// Replicas is the number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.
-	// Defaults to 1.
+	//
+	// Defaults to:
+	// * if the Kubernetes autoscaler min size and max size annotations are set:
+	//   - if it's a new MachineSet, use min size
+	//   - if the replicas field of the old MachineSet is < min size, use min size
+	//   - if the replicas field of the old MachineSet is > max size, use max size
+	//   - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS
+	// * otherwise use 1
+	// Note: Defaulting will be run whenever the replicas field is not set:
+	// * A new MachineSet is created with replicas not set.
+	// * On an existing MachineSet the replicas field was first set and is now unset.
+	// Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+	// * A new MachineSet is created and replicas should be managed by the autoscaler
+	// * An existing MachineSet which initially wasn't controlled by the autoscaler
+	//   should be later controlled by the autoscaler
 	// +optional
-	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// MinReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -2877,7 +2877,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSetSpec(ref common.Referenc
 					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+							Description: "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified.\n\nDefaults to: * if the Kubernetes autoscaler min size and max size annotations are set:\n  - if it's a new MachineSet, use min size\n  - if the replicas field of the old MachineSet is < min size, use min size\n  - if the replicas field of the old MachineSet is > max size, use max size\n  - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS\n* otherwise use 1 Note: Defaulting will be run whenever the replicas field is not set: * A new MachineSet is created with replicas not set. * On an existing MachineSet the replicas field was first set and is now unset. Those cases are especially relevant for the following Kubernetes autoscaler use cases: * A new MachineSet is created and replicas should be managed by the autoscaler * An existing MachineSet which initially wasn't controlled by the autoscaler\n  should be later controlled by the autoscaler",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -487,10 +487,22 @@ spec:
                 format: int32
                 type: integer
               replicas:
-                default: 1
-                description: Replicas is the number of desired replicas. This is a
-                  pointer to distinguish between explicit zero and unspecified. Defaults
-                  to 1.
+                description: "Replicas is the number of desired replicas. This is
+                  a pointer to distinguish between explicit zero and unspecified.
+                  \n Defaults to: * if the Kubernetes autoscaler min size and max
+                  size annotations are set: - if it's a new MachineSet, use min size
+                  - if the replicas field of the old MachineSet is < min size, use
+                  min size - if the replicas field of the old MachineSet is > max
+                  size, use max size - if the replicas field of the old MachineSet
+                  is in the (min size, max size) range, keep the value from the oldMS
+                  * otherwise use 1 Note: Defaulting will be run whenever the replicas
+                  field is not set: * A new MachineSet is created with replicas not
+                  set. * On an existing MachineSet the replicas field was first set
+                  and is now unset. Those cases are especially relevant for the following
+                  Kubernetes autoscaler use cases: * A new MachineSet is created and
+                  replicas should be managed by the autoscaler * An existing MachineSet
+                  which initially wasn't controlled by the autoscaler should be later
+                  controlled by the autoscaler"
                 format: int32
                 type: integer
               selector:

--- a/docs/book/src/tasks/automated-machine-management/autoscaling.md
+++ b/docs/book/src/tasks/automated-machine-management/autoscaling.md
@@ -12,17 +12,17 @@ from the [Autoscaler project documentation](https://github.com/kubernetes/autosc
 
 <aside class="note warning">
 
-<h1>Defaulting of the MachineDeployment replicas field</h1>
+<h1>Defaulting of the MachineDeployment, MachineSet replicas field</h1>
 
-Please note that the MachineDeployment replicas field has special defaulting logic to provide a smooth integration with the autoscaler.
-The replica field is defaulted based on the autoscaler min and max size annotations.The goal is to pick a default value which is inside 
+Please note that the MachineDeployment and MachineSet replicas field has special defaulting logic to provide a smooth integration with the autoscaler.
+The replica field is defaulted based on the autoscaler min and max size annotations.The goal is to pick a default value which is inside
 the (min size, max size) range so the autoscaler can take control of the replicase field.
 
 The defaulting logic is as follows:
 * if the autoscaler min size and max size annotations are set:
-  * if it's a new MachineDeployment, use min size
-  * if the replicas field of the old MachineDeployment is < min size, use min size
-  * if the replicas field of the old MachineDeployment is > max size, use max size
-  * if the replicas field of the old MachineDeployment is in the (min size, max size) range, keep the value from the oldMD
+  * if it's a new MachineDeployment or MachineSet, use min size
+  * if the replicas field of the old MachineDeployment or MachineSet is < min size, use min size
+  * if the replicas field of the old MachineDeployment or MachineSet is > max size, use max size
+  * if the replicas field of the old MachineDeployment or MachineSet is in the (min size, max size) range, keep the value from the oldMD or oldMS
 * otherwise, use 1
 </aside>

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
@@ -1249,7 +1250,9 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 				},
 			},
 		}
-		g.Expect((&webhooks.MachineSet{}).Default(ctx, machineSet)).Should(Succeed())
+
+		reqCtx := admission.NewContextWithRequest(ctx, admission.Request{})
+		g.Expect((&webhooks.MachineSet{}).Default(reqCtx, machineSet)).Should(Succeed())
 		g.Expect(env.Create(ctx, machineSet)).To(Succeed())
 
 		// Ensure machines have been created.

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -3241,9 +3241,8 @@ func newFakeMachineDeploymentTopologyState(name string, infrastructureMachineTem
 
 	scheme := runtime.NewScheme()
 	_ = clusterv1.AddToScheme(scheme)
-	if err := (&webhooks.MachineDeployment{
-		Decoder: admission.NewDecoder(scheme),
-	}).Default(admission.NewContextWithRequest(ctx, admission.Request{}), mdState.Object); err != nil {
+	if err := (&webhooks.MachineDeployment{}).
+		Default(admission.NewContextWithRequest(ctx, admission.Request{}), mdState.Object); err != nil {
 		panic(err)
 	}
 	return mdState

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -42,8 +42,8 @@ import (
 )
 
 func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	if webhook.Decoder == nil {
-		webhook.Decoder = admission.NewDecoder(mgr.GetScheme())
+	if webhook.decoder == nil {
+		webhook.decoder = admission.NewDecoder(mgr.GetScheme())
 	}
 
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -58,7 +58,7 @@ func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) erro
 
 // MachineDeployment implements a validation and defaulting webhook for MachineDeployment.
 type MachineDeployment struct {
-	Decoder *admission.Decoder
+	decoder *admission.Decoder
 }
 
 var _ webhook.CustomDefaulter = &MachineDeployment{}
@@ -83,7 +83,7 @@ func (webhook *MachineDeployment) Default(ctx context.Context, obj runtime.Objec
 	var oldMD *clusterv1.MachineDeployment
 	if req.Operation == v1.Update {
 		oldMD = &clusterv1.MachineDeployment{}
-		if err := webhook.Decoder.DecodeRaw(req.OldObject, oldMD); err != nil {
+		if err := webhook.decoder.DecodeRaw(req.OldObject, oldMD); err != nil {
 			return errors.Wrapf(err, "failed to decode oldObject to MachineDeployment")
 		}
 	}

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -52,7 +52,7 @@ func TestMachineDeploymentDefault(t *testing.T) {
 	scheme := runtime.NewScheme()
 	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 	webhook := &MachineDeployment{
-		Decoder: admission.NewDecoder(scheme),
+		decoder: admission.NewDecoder(scheme),
 	}
 
 	reqCtx := admission.NewContextWithRequest(ctx, admission.Request{
@@ -403,7 +403,7 @@ func TestMachineDeploymentValidation(t *testing.T) {
 			scheme := runtime.NewScheme()
 			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 			webhook := MachineDeployment{
-				Decoder: admission.NewDecoder(scheme),
+				decoder: admission.NewDecoder(scheme),
 			}
 
 			if tt.expectErr {
@@ -475,7 +475,7 @@ func TestMachineDeploymentVersionValidation(t *testing.T) {
 			scheme := runtime.NewScheme()
 			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 			webhook := MachineDeployment{
-				Decoder: admission.NewDecoder(scheme),
+				decoder: admission.NewDecoder(scheme),
 			}
 
 			if tt.expectErr {
@@ -537,7 +537,7 @@ func TestMachineDeploymentClusterNameImmutable(t *testing.T) {
 			scheme := runtime.NewScheme()
 			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 			webhook := MachineDeployment{
-				Decoder: admission.NewDecoder(scheme),
+				decoder: admission.NewDecoder(scheme),
 			}
 
 			warnings, err := webhook.ValidateUpdate(ctx, oldMD, newMD)
@@ -589,7 +589,7 @@ func TestMachineDeploymentTemplateMetadataValidation(t *testing.T) {
 			scheme := runtime.NewScheme()
 			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 			webhook := MachineDeployment{
-				Decoder: admission.NewDecoder(scheme),
+				decoder: admission.NewDecoder(scheme),
 			}
 
 			if tt.expectErr {

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -19,7 +19,6 @@ package webhooks
 import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/cluster-api/internal/webhooks"
 )
@@ -57,15 +56,11 @@ func (webhook *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // MachineDeployment implements a validating and defaulting webhook for MachineDeployment.
-type MachineDeployment struct {
-	Decoder *admission.Decoder
-}
+type MachineDeployment struct{}
 
 // SetupWebhookWithManager sets up MachineDeployment webhooks.
 func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return (&webhooks.MachineDeployment{
-		Decoder: webhook.Decoder,
-	}).SetupWebhookWithManager(mgr)
+	return (&webhooks.MachineDeployment{}).SetupWebhookWithManager(mgr)
 }
 
 // MachineSet implements a validating and defaulting webhook for MachineSet.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: MachineSet.spec.replicas defaulting should take into account autoscaler min/max size if defined. This PR applies the same default replicas policy of MD to MS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8085

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->