### PR TITLE
🌱Add more helper functions in topologymutation varaible.go to help unmarshal variables

### DIFF
--- a/exp/runtime/topologymutation/errors.go
+++ b/exp/runtime/topologymutation/errors.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymutation
+
+import (
+	patchvariables "sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/patches/variables"
+)
+
+// IsNotFoundError checks if the passed error is a notFoundError.
+// It exposes same function in internal package so that user can directly call.
+func IsNotFoundError(err error) bool {
+	return patchvariables.IsNotFoundError(err)
+}

--- a/exp/runtime/topologymutation/variables.go
+++ b/exp/runtime/topologymutation/variables.go
@@ -17,39 +17,73 @@ limitations under the License.
 package topologymutation
 
 import (
+	"encoding/json"
 	"strconv"
+	"strings"
 
+	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	patchvariables "sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/patches/variables"
 )
 
-// TODO: Add func for validating received variables are of the expected types
-// TODO: Add func for converting complex variables into go structs and/or other basic types.
+// TODO: Add func for validating received variables are of the expected types.
 
 // GetVariable get the variable value.
-func GetVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (*apiextensionsv1.JSON, bool, error) {
+func GetVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (*apiextensionsv1.JSON, error) {
 	value, err := patchvariables.GetVariableValue(templateVariables, variableName)
 	if err != nil {
-		if patchvariables.IsNotFoundError(err) {
-			return nil, false, nil
-		}
-		return nil, false, err
+		return nil, err
 	}
-	return value, true, nil
+	return value, nil
 }
 
 // GetStringVariable get the variable value as a string.
-func GetStringVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (string, bool, error) {
-	value, found, err := GetVariable(templateVariables, variableName)
-	if !found || err != nil {
-		return "", found, err
+func GetStringVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (string, error) {
+	value, err := GetVariable(templateVariables, variableName)
+	if err != nil {
+		return "", err
 	}
 
 	// Unquote the JSON string.
 	stringValue, err := strconv.Unquote(string(value.Raw))
 	if err != nil {
-		return "", true, err
+		return "", err
 	}
-	return stringValue, true, nil
+	return stringValue, nil
+}
+
+// GetBoolVariable get the value as a bool.
+func GetBoolVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (bool, error) {
+	value, err := GetVariable(templateVariables, variableName)
+	if err != nil {
+		return false, err
+	}
+
+	// Parse the JSON bool.
+	boolValue, err := strconv.ParseBool(string(value.Raw))
+	if err != nil {
+		return false, err
+	}
+	return boolValue, nil
+}
+
+// GetObjectVariableInto gets variable's string value then unmarshal it into
+// object passed from 'into'.
+func GetObjectVariableInto(templateVariables map[string]apiextensionsv1.JSON, variableName string, into interface{}) error {
+	value, err := GetVariable(templateVariables, variableName)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(sanitizeJSON(value.Raw), into); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal variable json %q into %q", string(value.Raw), into)
+	}
+
+	return nil
+}
+
+func sanitizeJSON(input []byte) (output []byte) {
+	output = []byte(strings.ReplaceAll(string(input), "\\", ""))
+	return output
 }

--- a/exp/runtime/topologymutation/variables_test.go
+++ b/exp/runtime/topologymutation/variables_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
 )
 
 func Test_GetRawTemplateVariable(t *testing.T) {
@@ -28,50 +29,53 @@ func Test_GetRawTemplateVariable(t *testing.T) {
 
 	varA := apiextensionsv1.JSON{Raw: toJSON("a")}
 	tests := []struct {
-		name          string
-		variables     map[string]apiextensionsv1.JSON
-		variableName  string
-		expectedValue *apiextensionsv1.JSON
-		expectedFound bool
-		expectedErr   bool
+		name                  string
+		variables             map[string]apiextensionsv1.JSON
+		variableName          string
+		expectedValue         *apiextensionsv1.JSON
+		expectedNotFoundError bool
+		expectedErr           bool
 	}{
 		{
-			name:          "Fails for invalid variable reference",
-			variables:     nil,
-			variableName:  "invalid[",
-			expectedValue: nil,
-			expectedFound: false,
-			expectedErr:   true,
+			name:                  "Fails for invalid variable reference",
+			variables:             nil,
+			variableName:          "invalid[",
+			expectedValue:         nil,
+			expectedNotFoundError: false,
+			expectedErr:           true,
 		},
 		{
-			name:          "variable not found",
-			variables:     nil,
-			variableName:  "notEsists",
-			expectedValue: nil,
-			expectedFound: false,
-			expectedErr:   false,
+			name:                  "variable not found",
+			variables:             nil,
+			variableName:          "notExists",
+			expectedValue:         nil,
+			expectedNotFoundError: true,
+			expectedErr:           true,
 		},
 		{
 			name: "return a variable",
 			variables: map[string]apiextensionsv1.JSON{
 				"a": varA,
 			},
-			variableName:  "a",
-			expectedValue: &varA,
-			expectedFound: true,
-			expectedErr:   false,
+			variableName:          "a",
+			expectedValue:         &varA,
+			expectedNotFoundError: false,
+			expectedErr:           false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, found, err := GetVariable(tt.variables, tt.variableName)
+			value, err := GetVariable(tt.variables, tt.variableName)
 
 			g.Expect(value).To(BeComparableTo(tt.expectedValue))
-			g.Expect(found).To(Equal(tt.expectedFound))
 			if tt.expectedErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			if tt.expectedNotFoundError {
+				g.Expect(IsNotFoundError(err)).To(BeTrue())
 			}
 		})
 	}
@@ -82,51 +86,197 @@ func Test_GetStringTemplateVariable(t *testing.T) {
 
 	varA := apiextensionsv1.JSON{Raw: toJSON("a")}
 	tests := []struct {
-		name          string
-		variables     map[string]apiextensionsv1.JSON
-		variableName  string
-		expectedValue string
-		expectedFound bool
-		expectedErr   bool
+		name                  string
+		variables             map[string]apiextensionsv1.JSON
+		variableName          string
+		expectedValue         string
+		expectedNotFoundError bool
+		expectedErr           bool
 	}{
 		{
-			name:          "Fails for invalid variable reference",
-			variables:     nil,
-			variableName:  "invalid[",
-			expectedValue: "",
-			expectedFound: false,
-			expectedErr:   true,
+			name:                  "Fails for invalid variable reference",
+			variables:             nil,
+			variableName:          "invalid[",
+			expectedValue:         "",
+			expectedNotFoundError: false,
+			expectedErr:           true,
 		},
 		{
-			name:          "variable not found",
-			variables:     nil,
-			variableName:  "notEsists",
-			expectedValue: "",
-			expectedFound: false,
-			expectedErr:   false,
+			name:                  "variable not found",
+			variables:             nil,
+			variableName:          "notEsists",
+			expectedValue:         "",
+			expectedNotFoundError: true,
+			expectedErr:           true,
 		},
 		{
-			name: "variable not found",
+			name: "valid variable",
 			variables: map[string]apiextensionsv1.JSON{
 				"a": varA,
 			},
-			variableName:  "a",
-			expectedValue: "a",
-			expectedFound: true,
-			expectedErr:   false,
+			variableName:          "a",
+			expectedValue:         "a",
+			expectedNotFoundError: false,
+			expectedErr:           false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, found, err := GetStringVariable(tt.variables, tt.variableName)
+			value, err := GetStringVariable(tt.variables, tt.variableName)
 
 			g.Expect(value).To(Equal(tt.expectedValue))
-			g.Expect(found).To(Equal(tt.expectedFound))
 			if tt.expectedErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
+
+			if tt.expectedNotFoundError {
+				g.Expect(IsNotFoundError(err)).To(BeTrue())
+			}
+		})
+	}
+}
+
+func Test_GetBoolVariable(t *testing.T) {
+	g := NewWithT(t)
+
+	varA := apiextensionsv1.JSON{Raw: []byte(`true`)}
+	tests := []struct {
+		name                  string
+		variables             map[string]apiextensionsv1.JSON
+		variableName          string
+		expectedValue         bool
+		expectedNotFoundError bool
+		expectedErr           bool
+	}{
+		{
+			name:                  "Fails for invalid variable reference",
+			variables:             nil,
+			variableName:          "invalid[",
+			expectedValue:         false,
+			expectedNotFoundError: false,
+			expectedErr:           true,
+		},
+		{
+			name:                  "variable not found",
+			variables:             nil,
+			variableName:          "notEsists",
+			expectedValue:         false,
+			expectedNotFoundError: true,
+			expectedErr:           true,
+		},
+		{
+			name: "valid variable",
+			variables: map[string]apiextensionsv1.JSON{
+				"a": varA,
+			},
+			variableName:          "a",
+			expectedValue:         true,
+			expectedNotFoundError: false,
+			expectedErr:           false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := GetBoolVariable(tt.variables, tt.variableName)
+			if tt.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			if tt.expectedNotFoundError {
+				g.Expect(IsNotFoundError(err)).To(BeTrue())
+			}
+			g.Expect(value).To(Equal(tt.expectedValue))
+		})
+	}
+}
+
+func Test_GetVariableObjectWithNestedType(t *testing.T) {
+	type AddressesFromPool struct {
+		APIGroup string `json:"apiGroup"`
+		Kind     string `json:"kind"`
+		Name     string `json:"name"`
+	}
+	type Network struct {
+		AddressesFromPools *[]AddressesFromPool `json:"addressesFromPools,omitempty"`
+		Ipv6Primary        *bool                `json:"ipv6Primary,omitempty"`
+	}
+
+	g := NewWithT(t)
+
+	tests := []struct {
+		name                   string
+		variables              map[string]apiextensionsv1.JSON
+		variableName           string
+		expectedNotFoundError  bool
+		expectedErr            bool
+		object                 *Network
+		expectedVariableObject interface{}
+	}{
+		{
+			name:                   "Fails for invalid variable reference",
+			variables:              nil,
+			variableName:           "invalid[",
+			expectedNotFoundError:  false,
+			object:                 &Network{},
+			expectedVariableObject: Network{},
+			expectedErr:            true,
+		},
+		{
+			name:                   "variable not found",
+			variables:              nil,
+			variableName:           "notEsists",
+			expectedNotFoundError:  true,
+			object:                 &Network{},
+			expectedVariableObject: Network{},
+			expectedErr:            true,
+		},
+		{
+			name: "unmarshal error",
+			variables: map[string]apiextensionsv1.JSON{
+				"node":    {Raw: []byte(`{"name": "aadfasdfasd`)},
+				"network": {Raw: []byte(`{"ipv6Primary": true, "addressesFromPools":[{"name":"name"}]asdfasdf`)},
+			},
+			variableName:           "network",
+			expectedNotFoundError:  false,
+			object:                 &Network{},
+			expectedVariableObject: Network{},
+			expectedErr:            true,
+		},
+		{
+			name: "valid variable",
+			variables: map[string]apiextensionsv1.JSON{
+				"node":    {Raw: []byte(`{"name": "a"}`)},
+				"network": {Raw: []byte(`{"ipv6Primary": true, "addressesFromPools":[{"name":"name"}]}`)},
+			},
+			variableName:          "network",
+			expectedNotFoundError: false,
+			expectedErr:           false,
+			object:                &Network{},
+			expectedVariableObject: Network{
+				Ipv6Primary: ptr.To(true),
+				AddressesFromPools: &[]AddressesFromPool{
+					{
+						Name: "name",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GetObjectVariableInto(tt.variables, tt.variableName, tt.object)
+			if tt.expectedErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			if tt.expectedNotFoundError {
+				g.Expect(IsNotFoundError(err)).To(BeTrue())
+			}
+			g.Expect(*tt.object).To(Equal(tt.expectedVariableObject))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add more function. For example to unmarshal nested variable from topology spec, and unmarshal bool variable from topology spec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9669

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->