### PR TITLE
🐛 Fix DockerMachine panic

### DIFF
--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -119,6 +119,11 @@ func (r *DockerMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	if cluster.Spec.InfrastructureRef == nil {
+		log.Info("Cluster infrastructureRef is not available yet")
+		return ctrl.Result{}, nil
+	}
+
 	// Fetch the Docker Cluster.
 	dockerCluster := &infrav1.DockerCluster{}
 	dockerClusterName := client.ObjectKey{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The PR fixes panic in the `DockerMachineReconciler` in case `cluster.Spec.InfrastructureRef` doesn't yet exist. 
When using `ClusterClass`, the `Cluster` can contain just `spec.topology` at the beginning, other fields will be added later by the controller manager. 

(the trace below is from the v1.5.3, but the bug still exists in the main branch)
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x11a40ec]

goroutine 229 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:115 +0x1a4
panic({0x13564e0, 0x25cf020})
        runtime/panic.go:884 +0x1f4
sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/controllers.(*DockerMachineReconciler).Reconcile(0x400003a700, {0x183a980, 0x4000946570}, {{{0x4000aa6976?, 0x30?}, {0x4000801b80?, 0xffff71389001?}}})
        sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/controllers/dockermachine_controller.go:124 +0x55c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x183a980?, {0x183a980?, 0x4000946570?}, {{{0x4000aa6976?, 0x12caea0?}, {0x4000801b80?, 0x4000b91e08?}}})
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:118 +0x8c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x4000466460, {0x183a8d8, 0x40000eb5e0}, {0x13e79a0?, 0x4000370360?})
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:314 +0x2cc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x4000466460, {0x183a8d8, 0x40000eb5e0})
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:265 +0x1a0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:226 +0x74
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        sigs.k8s.io/controller-runtime@v0.15.1/pkg/internal/controller/controller.go:222 +0x43c
```