### PR TITLE
[release-1.4] 🌱 Bump Go version to v1.20.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.20.10
+GO_VERSION ?= 1.20.11
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/Tiltfile
+++ b/Tiltfile
@@ -165,7 +165,7 @@ def load_provider_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.20.10 as tilt-helper
+FROM golang:1.20.11 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
@@ -175,7 +175,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.19.13 as tilt
+FROM golang:1.20.11 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9683

Bump the go version used to build CAPI to v1.20.11
xref: https://go.dev/doc/devel/release#go1.20.11

/area dependency

