### PR TITLE
:bug: fix provider namespace secret not included in clusterctl move

### DIFF
--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -735,7 +735,7 @@ func Test_objectMover_backupTargetObject(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -826,7 +826,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 			graph := getObjectGraph()
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -934,7 +934,7 @@ func Test_objectMover_toDirectory(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1077,7 +1077,7 @@ func Test_objectMover_fromDirectory(t *testing.T) {
 			graph := getObjectGraph()
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// gets a fakeProxy to an empty cluster with all the required CRDs
 			toProxy := getFakeProxyWithCRDs()
@@ -1155,7 +1155,7 @@ func Test_getMoveSequence(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1188,7 +1188,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1263,7 +1263,7 @@ func Test_objectMover_move(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1375,7 +1375,7 @@ func Test_objectMover_move_with_Mutator(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1660,7 +1660,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -1906,7 +1906,7 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// Trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())
@@ -2385,7 +2385,7 @@ func TestWaitReadyForMove(t *testing.T) {
 			}
 
 			// Get all the types to be considered for discovery
-			g.Expect(getFakeDiscoveryTypes(ctx, graph)).To(Succeed())
+			g.Expect(graph.getDiscoveryTypes(ctx)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery(ctx, "")).To(Succeed())

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -439,7 +439,7 @@ func (o *objectGraph) Discovery(ctx context.Context, namespace string) error {
 		}
 
 		// if we are discovering Secrets, also secrets from the providers namespace should be included.
-		if discoveryType.typeMeta.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("SecretList").GroupKind() {
+		if discoveryType.typeMeta.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("Secret").GroupKind() {
 			providers, err := o.providerInventory.List(ctx)
 			if err != nil {
 				return err

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1774,18 +1774,6 @@ func getFakeProxyWithCRDs() *test.FakeProxy {
 	return proxy
 }
 
-func getFakeDiscoveryTypes(ctx context.Context, graph *objectGraph) error {
-	if err := graph.getDiscoveryTypes(ctx); err != nil {
-		return err
-	}
-
-	// Given that the Fake client behaves in a different way than real client, for this test we are required to add the List suffix to all the types.
-	for _, discoveryType := range graph.types {
-		discoveryType.typeMeta.Kind = fmt.Sprintf("%sList", discoveryType.typeMeta.Kind)
-	}
-	return nil
-}
-
 func TestObjectGraph_Discovery(t *testing.T) {
 	// NB. we are testing the graph is properly built starting from objects (TestGraphBuilder_addObj_WithFakeObjects) or from the same objects read from the cluster (this test).
 	for _, tt := range objectGraphsTests {
@@ -1798,7 +1786,7 @@ func TestObjectGraph_Discovery(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.args.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(ctx, graph)
+			err := graph.getDiscoveryTypes(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// finally test discovery
@@ -1956,7 +1944,7 @@ func TestObjectGraph_DiscoveryByNamespace(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.args.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(ctx, graph)
+			err := graph.getDiscoveryTypes(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// finally test discovery


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
`clusterclt move` didn't include secrets in provider namespace, for example:
I have claimed `AWSClusterStaticIdentity` for cluster A, and add the reference secret to `capa-system`. But when I tried to use `clusterclt move` to migrate the cluster, only the AWSClusterStaticIdentity will be included, but the secret for the identity not included and causing issue in target management cluster after move.

The root cause of this is that the `discoveryType`  is `Secret` but the filter set for provider namespace check is `SecretList` , so that part of logic will never run into.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of  #9630

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->