### PR TITLE
[release-1.4] :seedling: Fix delve version in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -166,8 +166,9 @@ def load_provider_tiltfiles():
 tilt_helper_dockerfile_header = """
 # Tilt image
 FROM golang:1.20.11 as tilt-helper
+# Install delve. Note this should be kept in step with the Go release minor version.
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.20
 # Support live reloading with Tilt
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/start.sh && \
     chmod +x /start.sh && chmod +x /restart.sh && chmod +x /go/bin/dlv && \


### PR DESCRIPTION
We updated the Go version in this file in https://github.com/kubernetes-sigs/cluster-api/pull/9687 but never updated the delve version to be compatible.

