### PR TITLE
🌱  Follow-up fixes: Add MachinePools to Runtime SDK and Rollout tests

### DIFF
--- a/internal/contract/infrastructure_machinepool_template.go
+++ b/internal/contract/infrastructure_machinepool_template.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"sync"
+)
+
+// InfrastructureMachinePoolTemplateContract encodes information about the Cluster API contract for InfrastructureMachinePoolTemplate objects
+// like DockerMachinePoolTemplates, AWSMachinePoolTemplates, etc.
+type InfrastructureMachinePoolTemplateContract struct{}
+
+var infrastructureMachinePoolTemplate *InfrastructureMachinePoolTemplateContract
+var onceInfrastructureMachinePoolTemplate sync.Once
+
+// InfrastructureMachinePoolTemplate provide access to the information about the Cluster API contract for InfrastructureMachinePoolTemplate objects.
+func InfrastructureMachinePoolTemplate() *InfrastructureMachinePoolTemplateContract {
+	onceInfrastructureMachinePoolTemplate.Do(func() {
+		infrastructureMachinePoolTemplate = &InfrastructureMachinePoolTemplateContract{}
+	})
+	return infrastructureMachinePoolTemplate
+}
+
+// Template provides access to the template.
+func (c *InfrastructureMachinePoolTemplateContract) Template() *InfrastructureMachinePoolTemplateTemplate {
+	return &InfrastructureMachinePoolTemplateTemplate{}
+}
+
+// InfrastructureMachinePoolTemplateTemplate provides a helper struct for working with the template in an InfrastructureMachinePoolTemplate.
+type InfrastructureMachinePoolTemplateTemplate struct{}
+
+// Metadata provides access to the metadata of a template.
+func (c *InfrastructureMachinePoolTemplateTemplate) Metadata() *Metadata {
+	return &Metadata{
+		path: Path{"spec", "template", "metadata"},
+	}
+}

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -63,6 +63,29 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
 					},
 				},
 			},
+			// ModifyMachinePoolBootstrapConfigTemplateFields are the fields which will be set on the
+			// BootstrapConfigTemplate of all MachinePoolClasses of the ClusterClass after the initial Cluster creation.
+			// The test verifies that these fields are rolled out to the MachinePools.
+			ModifyMachinePoolBootstrapConfigTemplateFields: map[string]interface{}{
+				"spec.template.spec.verbosity": int64(4),
+			},
+			// ModifyMachinePoolInfrastructureMachineTemplateFields are the fields which will be set on the
+			// InfrastructureMachinePoolTemplate of all MachinePoolClasses of the ClusterClass after the initial Cluster creation.
+			// The test verifies that these fields are rolled out to the MachinePools.
+			ModifyMachinePoolInfrastructureMachinePoolTemplateFields: map[string]interface{}{
+				"spec.template.spec.template.extraMounts": []interface{}{
+					map[string]interface{}{
+						"containerPath": "/var/run/docker.sock",
+						"hostPath":      "/var/run/docker.sock",
+					},
+					map[string]interface{}{
+						// /tmp cannot be used as containerPath as
+						// it already exists.
+						"containerPath": "/test",
+						"hostPath":      "/tmp",
+					},
+				},
+			},
 		}
 	})
 })

--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -186,7 +186,7 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 			},
 			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		})
-		By("Modifying the MachinePool configuration via Cluster topology and wait for changes to be applied to the MachinePool (in-place)")
+		By("Modifying the MachinePool configuration via Cluster topology and wait for changes to be applied to the MachinePools (in-place)")
 		modifyMachinePoolViaClusterAndWait(ctx, modifyMachinePoolViaClusterAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			Cluster:      clusterResources.Cluster,
@@ -203,7 +203,7 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 				topology.NodeVolumeDetachTimeout = &metav1.Duration{Duration: time.Duration(rand.Intn(20)) * time.Second} //nolint:gosec
 				topology.MinReadySeconds = pointer.Int32(rand.Int31n(20))                                                 //nolint:gosec
 			},
-			WaitForMachinePools: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			WaitForMachinePools: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 		By("Verifying there are no unexpected rollouts through in-place rollout")
 		Consistently(func(g Gomega) {
@@ -242,7 +242,7 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 			ModifyBootstrapConfigTemplateFields: map[string]interface{}{
 				"spec.template.spec.verbosity": int64(4),
 			},
-			WaitForMachinePools: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			WaitForMachinePools: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 		By("Verifying all Machines are replaced through rollout")
 		Eventually(func(g Gomega) {
@@ -644,7 +644,7 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 		g.Expect(
 			union(
 				machinePool.Annotations,
-			).without(g, clusterv1.RevisionAnnotation),
+			),
 		).To(BeEquivalentTo(
 			union(
 				mpTopology.Metadata.Annotations,
@@ -671,68 +671,52 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 			),
 		))
 
-		// MachinePool InfrastructureMachineTemplate.metadata
-		ccInfrastructureMachineTemplate := clusterClassObjects.InfrastructureMachinePoolTemplateByMachinePoolClass[mpClass.Class]
-		ccInfrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(ccInfrastructureMachineTemplate))
-		infrastructureMachineTemplate := clusterObjects.InfrastructureMachinePoolTemplateByMachinePool[machinePool.Name]
-		infrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(infrastructureMachineTemplate))
-		g.Expect(infrastructureMachineTemplate.GetLabels()).To(BeEquivalentTo(
+		// MachinePool InfrastructureMachinePool.metadata
+		ccInfrastructureMachinePoolTemplate := clusterClassObjects.InfrastructureMachinePoolTemplateByMachinePoolClass[mpClass.Class]
+		ccInfrastructureMachinePoolTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachinePoolTemplate().Template().Metadata().Get(ccInfrastructureMachinePoolTemplate))
+		infrastructureMachinePool := clusterObjects.InfrastructureMachinePoolByMachinePool[machinePool.Name]
+		g.Expect(infrastructureMachinePool.GetLabels()).To(BeEquivalentTo(
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                    cluster.Name,
 					clusterv1.ClusterTopologyOwnedLabel:           "",
 					clusterv1.ClusterTopologyMachinePoolNameLabel: mpTopology.Name,
 				},
-				ccInfrastructureMachineTemplate.GetLabels(),
+				ccInfrastructureMachinePoolTemplateTemplateMetadata.Labels,
 			),
 		))
-		g.Expect(infrastructureMachineTemplate.GetAnnotations()).To(BeEquivalentTo(
+		g.Expect(infrastructureMachinePool.GetAnnotations()).To(BeEquivalentTo(
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: groupKind(mpClass.Template.Infrastructure.Ref),
 					clusterv1.TemplateClonedFromNameAnnotation:      mpClass.Template.Infrastructure.Ref.Name,
 				},
-				ccInfrastructureMachineTemplate.GetAnnotations(),
-			).without(g, corev1.LastAppliedConfigAnnotation),
-		))
-		// MachinePool InfrastructureMachineTemplate.spec.template.metadata
-		g.Expect(infrastructureMachineTemplateTemplateMetadata.Labels).To(BeEquivalentTo(
-			ccInfrastructureMachineTemplateTemplateMetadata.Labels,
-		))
-		g.Expect(infrastructureMachineTemplateTemplateMetadata.Annotations).To(BeEquivalentTo(
-			ccInfrastructureMachineTemplateTemplateMetadata.Annotations,
+				ccInfrastructureMachinePoolTemplateTemplateMetadata.Annotations,
+			),
 		))
 
-		// MachinePool BootstrapConfigTemplate.metadata
+		// MachinePool BootstrapConfig.metadata
 		ccBootstrapConfigTemplate := clusterClassObjects.BootstrapConfigTemplateByMachinePoolClass[mpClass.Class]
 		ccBootstrapConfigTemplateTemplateMetadata := mustMetadata(contract.BootstrapConfigTemplate().Template().Metadata().Get(ccBootstrapConfigTemplate))
-		bootstrapConfigTemplate := clusterObjects.BootstrapConfigTemplateByMachinePool[machinePool.Name]
-		bootstrapConfigTemplateTemplateMetadata := mustMetadata(contract.BootstrapConfigTemplate().Template().Metadata().Get(bootstrapConfigTemplate))
-		g.Expect(bootstrapConfigTemplate.GetLabels()).To(BeEquivalentTo(
+		bootstrapConfig := clusterObjects.BootstrapConfigByMachinePool[machinePool.Name]
+		g.Expect(bootstrapConfig.GetLabels()).To(BeEquivalentTo(
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                    cluster.Name,
 					clusterv1.ClusterTopologyOwnedLabel:           "",
 					clusterv1.ClusterTopologyMachinePoolNameLabel: mpTopology.Name,
 				},
-				ccBootstrapConfigTemplate.GetLabels(),
+				ccBootstrapConfigTemplateTemplateMetadata.Labels,
 			),
 		))
-		g.Expect(bootstrapConfigTemplate.GetAnnotations()).To(BeEquivalentTo(
+		g.Expect(bootstrapConfig.GetAnnotations()).To(BeEquivalentTo(
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: groupKind(mpClass.Template.Bootstrap.Ref),
 					clusterv1.TemplateClonedFromNameAnnotation:      mpClass.Template.Bootstrap.Ref.Name,
 				},
-				ccBootstrapConfigTemplate.GetAnnotations(),
-			).without(g, corev1.LastAppliedConfigAnnotation),
-		))
-		// MachinePool BootstrapConfigTemplate.spec.template.metadata
-		g.Expect(bootstrapConfigTemplateTemplateMetadata.Labels).To(BeEquivalentTo(
-			ccBootstrapConfigTemplateTemplateMetadata.Labels,
-		))
-		g.Expect(bootstrapConfigTemplateTemplateMetadata.Annotations).To(BeEquivalentTo(
-			ccBootstrapConfigTemplateTemplateMetadata.Annotations,
+				ccBootstrapConfigTemplateTemplateMetadata.Annotations,
+			),
 		))
 	}
 }
@@ -1040,6 +1024,8 @@ func getClusterClassObjects(ctx context.Context, g Gomega, clusterProxy framewor
 	res := clusterClassObjects{
 		InfrastructureMachineTemplateByMachineDeploymentClass: map[string]*unstructured.Unstructured{},
 		BootstrapConfigTemplateByMachineDeploymentClass:       map[string]*unstructured.Unstructured{},
+		InfrastructureMachinePoolTemplateByMachinePoolClass:   map[string]*unstructured.Unstructured{},
+		BootstrapConfigTemplateByMachinePoolClass:             map[string]*unstructured.Unstructured{},
 	}
 	var err error
 
@@ -1062,6 +1048,16 @@ func getClusterClassObjects(ctx context.Context, g Gomega, clusterProxy framewor
 		res.BootstrapConfigTemplateByMachineDeploymentClass[mdClass.Class] = bootstrapConfigTemplate
 	}
 
+	for _, mpClass := range clusterClass.Spec.Workers.MachinePools {
+		infrastructureMachinePoolTemplate, err := external.Get(ctx, mgmtClient, mpClass.Template.Infrastructure.Ref, clusterClass.Namespace)
+		g.Expect(err).ToNot(HaveOccurred())
+		res.InfrastructureMachinePoolTemplateByMachinePoolClass[mpClass.Class] = infrastructureMachinePoolTemplate
+
+		bootstrapConfigTemplate, err := external.Get(ctx, mgmtClient, mpClass.Template.Bootstrap.Ref, clusterClass.Namespace)
+		g.Expect(err).ToNot(HaveOccurred())
+		res.BootstrapConfigTemplateByMachinePoolClass[mpClass.Class] = bootstrapConfigTemplate
+	}
+
 	return res
 }
 
@@ -1082,8 +1078,8 @@ type clusterObjects struct {
 	InfrastructureMachineTemplateByMachineDeployment map[string]*unstructured.Unstructured
 	BootstrapConfigTemplateByMachineDeployment       map[string]*unstructured.Unstructured
 
-	InfrastructureMachinePoolTemplateByMachinePool map[string]*unstructured.Unstructured
-	BootstrapConfigTemplateByMachinePool           map[string]*unstructured.Unstructured
+	InfrastructureMachinePoolByMachinePool map[string]*unstructured.Unstructured
+	BootstrapConfigByMachinePool           map[string]*unstructured.Unstructured
 
 	InfrastructureMachineByMachine map[string]*unstructured.Unstructured
 	BootstrapConfigByMachine       map[string]*unstructured.Unstructured
@@ -1102,6 +1098,8 @@ func getClusterObjects(ctx context.Context, g Gomega, clusterProxy framework.Clu
 		InfrastructureMachineTemplateByMachineDeployment: map[string]*unstructured.Unstructured{},
 		BootstrapConfigByMachine:                         map[string]*unstructured.Unstructured{},
 		InfrastructureMachineByMachine:                   map[string]*unstructured.Unstructured{},
+		BootstrapConfigByMachinePool:                     map[string]*unstructured.Unstructured{},
+		InfrastructureMachinePoolByMachinePool:           map[string]*unstructured.Unstructured{},
 	}
 	var err error
 
@@ -1168,6 +1166,26 @@ func getClusterObjects(ctx context.Context, g Gomega, clusterProxy framework.Clu
 				res.MachinesByMachineSet[machine.Labels[clusterv1.MachineSetNameLabel]], &machine)
 			addMachineObjects(ctx, mgmtClient, workloadClient, g, res, cluster, &machine)
 		}
+	}
+
+	// MachinePools.
+	for _, mpTopology := range cluster.Spec.Topology.Workers.MachinePools {
+		// Get MachinePool for the current MachinePoolTopology.
+		mpList := &expv1.MachinePoolList{}
+		g.Expect(mgmtClient.List(ctx, mpList, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+			clusterv1.ClusterTopologyMachinePoolNameLabel: mpTopology.Name,
+		})).To(Succeed())
+		g.Expect(mpList.Items).To(HaveLen(1), fmt.Sprintf("expected one MachinePool for topology %q, but got %d", mpTopology.Name, len(mpList.Items)))
+		mp := mpList.Items[0]
+		res.MachinePools = append(res.MachinePools, &mp)
+
+		bootstrapConfig, err := external.Get(ctx, mgmtClient, mp.Spec.Template.Spec.Bootstrap.ConfigRef, cluster.Namespace)
+		g.Expect(err).ToNot(HaveOccurred())
+		res.BootstrapConfigByMachinePool[mp.Name] = bootstrapConfig
+
+		infrastructureMachinePool, err := external.Get(ctx, mgmtClient, &mp.Spec.Template.Spec.InfrastructureRef, cluster.Namespace)
+		g.Expect(err).ToNot(HaveOccurred())
+		res.InfrastructureMachinePoolByMachinePool[mp.Name] = infrastructureMachinePool
 	}
 
 	return res


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR follows up #9703 with fixes listed here: https://github.com/kubernetes-sigs/cluster-api/pull/9703#pullrequestreview-1729685341

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing