### PR TITLE
🐛 KCP should defer remediation when a control plane machine is still provisioning

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -253,6 +253,11 @@ func (c *ControlPlane) HasUnhealthyMachine() bool {
 	return len(c.UnhealthyMachines()) > 0
 }
 
+// HasHealthyMachineStillProvisioning returns true if any healthy machine in the control plane is still in the process of being provisioned.
+func (c *ControlPlane) HasHealthyMachineStillProvisioning() bool {
+	return len(c.HealthyMachines().Filter(collections.Not(collections.HasNode()))) > 0
+}
+
 // PatchMachines patches all the machines conditions.
 func (c *ControlPlane) PatchMachines(ctx context.Context) error {
 	errList := []error{}

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -64,29 +65,90 @@ func TestControlPlane(t *testing.T) {
 
 func TestHasUnhealthyMachine(t *testing.T) {
 	// healthy machine (without MachineHealthCheckSucceded condition)
-	healthyMachine1 := &clusterv1.Machine{}
+	healthyMachine1 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "healthyMachine1"}}
 	// healthy machine (with MachineHealthCheckSucceded == true)
-	healthyMachine2 := &clusterv1.Machine{}
+	healthyMachine2 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "healthyMachine2"}}
 	conditions.MarkTrue(healthyMachine2, clusterv1.MachineHealthCheckSucceededCondition)
 	// unhealthy machine NOT eligible for KCP remediation (with MachineHealthCheckSucceded == False, but without MachineOwnerRemediated condition)
-	unhealthyMachineNOTOwnerRemediated := &clusterv1.Machine{}
-	conditions.MarkFalse(unhealthyMachineNOTOwnerRemediated, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "")
+	unhealthyMachineNOTOwnerRemediated := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "unhealthyMachineNOTOwnerRemediated"}}
+	conditions.MarkFalse(unhealthyMachineNOTOwnerRemediated, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "Something is wrong")
 	// unhealthy machine eligible for KCP remediation (with MachineHealthCheckSucceded == False, with MachineOwnerRemediated condition)
-	unhealthyMachineOwnerRemediated := &clusterv1.Machine{}
-	conditions.MarkFalse(unhealthyMachineOwnerRemediated, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "")
-	conditions.MarkFalse(unhealthyMachineOwnerRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "")
+	unhealthyMachineOwnerRemediated := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "unhealthyMachineOwnerRemediated"}}
+	conditions.MarkFalse(unhealthyMachineOwnerRemediated, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "Something is wrong")
+	conditions.MarkFalse(unhealthyMachineOwnerRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KCP should remediate this issue")
 
-	c := ControlPlane{
-		Machines: collections.FromMachines(
-			healthyMachine1,
-			healthyMachine2,
-			unhealthyMachineNOTOwnerRemediated,
-			unhealthyMachineOwnerRemediated,
-		),
-	}
+	t.Run("One unhealthy machine to be remediated by KCP", func(t *testing.T) {
+		c := ControlPlane{
+			Machines: collections.FromMachines(
+				healthyMachine1,                    // healthy machine, should be ignored
+				healthyMachine2,                    // healthy machine, should be ignored (the MachineHealthCheckSucceededCondition is true)
+				unhealthyMachineNOTOwnerRemediated, // unhealthy machine, but KCP should not remediate it, should be ignored.
+				unhealthyMachineOwnerRemediated,
+			),
+		}
 
-	g := NewWithT(t)
-	g.Expect(c.HasUnhealthyMachine()).To(BeTrue())
+		g := NewWithT(t)
+		g.Expect(c.HasUnhealthyMachine()).To(BeTrue())
+	})
+
+	t.Run("No unhealthy machine to be remediated by KCP", func(t *testing.T) {
+		c := ControlPlane{
+			Machines: collections.FromMachines(
+				healthyMachine1,                    // healthy machine, should be ignored
+				healthyMachine2,                    // healthy machine, should be ignored (the MachineHealthCheckSucceededCondition is true)
+				unhealthyMachineNOTOwnerRemediated, // unhealthy machine, but KCP should not remediate it, should be ignored.
+			),
+		}
+
+		g := NewWithT(t)
+		g.Expect(c.HasUnhealthyMachine()).To(BeFalse())
+	})
+}
+
+func TestHasHealthyMachineStillProvisioning(t *testing.T) {
+	// healthy machine (without MachineHealthCheckSucceded condition) still provisioning (without NodeRef)
+	healthyMachineStillProvisioning1 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "healthyMachineStillProvisioning1"}}
+
+	// healthy machine (without MachineHealthCheckSucceded condition) provisioned (with NodeRef)
+	healthyMachineProvisioned1 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "healthyMachineProvisioned1"}}
+	healthyMachineProvisioned1.Status.NodeRef = &corev1.ObjectReference{}
+
+	// unhealthy machine (with MachineHealthCheckSucceded condition) still provisioning (without NodeRef)
+	unhealthyMachineStillProvisioning1 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "unhealthyMachineStillProvisioning1"}}
+	conditions.MarkFalse(unhealthyMachineStillProvisioning1, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "Something is wrong")
+	conditions.MarkFalse(unhealthyMachineStillProvisioning1, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KCP should remediate this issue")
+
+	// unhealthy machine (with MachineHealthCheckSucceded condition) provisioned (with NodeRef)
+	unhealthyMachineProvisioned1 := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "unhealthyMachineProvisioned1"}}
+	unhealthyMachineProvisioned1.Status.NodeRef = &corev1.ObjectReference{}
+	conditions.MarkFalse(unhealthyMachineProvisioned1, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.MachineHasFailureReason, clusterv1.ConditionSeverityWarning, "Something is wrong")
+	conditions.MarkFalse(unhealthyMachineProvisioned1, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KCP should remediate this issue")
+
+	t.Run("Healthy machine still provisioning", func(t *testing.T) {
+		c := ControlPlane{
+			Machines: collections.FromMachines(
+				healthyMachineStillProvisioning1,
+				unhealthyMachineStillProvisioning1, // unhealthy, should be ignored
+				healthyMachineProvisioned1,         // already provisioned, should be ignored
+				unhealthyMachineProvisioned1,       // unhealthy and already provisioned, should be ignored
+			),
+		}
+
+		g := NewWithT(t)
+		g.Expect(c.HasHealthyMachineStillProvisioning()).To(BeTrue())
+	})
+	t.Run("No machines still provisioning", func(t *testing.T) {
+		c := ControlPlane{
+			Machines: collections.FromMachines(
+				unhealthyMachineStillProvisioning1, // unhealthy, should be ignored
+				healthyMachineProvisioned1,         // already provisioned, should be ignored
+				unhealthyMachineProvisioned1,       // unhealthy and already provisioned, should be ignored
+			),
+		}
+
+		g := NewWithT(t)
+		g.Expect(c.HasHealthyMachineStillProvisioning()).To(BeFalse())
+	})
 }
 
 type machineOpt func(*clusterv1.Machine)

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -34,6 +34,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -80,12 +81,13 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		return ctrl.Result{}, nil
 	}
 
-	// Select the machine to be remediated, which is the oldest machine marked as unhealthy.
+	// Select the machine to be remediated, which is the oldest machine marked as unhealthy not yet provisioned (if any)
+	// or the oldest machine marked as unhealthy.
 	//
 	// NOTE: The current solution is considered acceptable for the most frequent use case (only one unhealthy machine),
 	// however, in the future this could potentially be improved for the scenario where more than one unhealthy machine exists
 	// by considering which machine has lower impact on etcd quorum.
-	machineToBeRemediated := unhealthyMachines.Oldest()
+	machineToBeRemediated := getMachineToBeRemediated(unhealthyMachines)
 
 	// Returns if the machine is in the process of being deleted.
 	if !machineToBeRemediated.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -143,6 +145,13 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		if controlPlane.Machines.Len() <= 1 {
 			log.Info("A control plane machine needs remediation, but the number of current replicas is less or equal to 1. Skipping remediation", "Replicas", controlPlane.Machines.Len())
 			conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KCP can't remediate if current replicas are less or equal to 1")
+			return ctrl.Result{}, nil
+		}
+
+		// The cluster MUST NOT have healthy machines still being provisioned. This rule prevents KCP taking actions while the cluster is in a transitional state.
+		if controlPlane.HasHealthyMachineStillProvisioning() {
+			log.Info("A control plane machine needs remediation, but there are other control-plane machines being provisioned. Skipping remediation")
+			conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KCP waiting for control plane machine provisioning to complete before triggering remediation")
 			return ctrl.Result{}, nil
 		}
 
@@ -236,6 +245,16 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	})
 
 	return ctrl.Result{Requeue: true}, nil
+}
+
+// Gets the machine to be remediated, which is the oldest machine marked as unhealthy not yet provisioned (if any)
+// or the oldest machine marked as unhealthy.
+func getMachineToBeRemediated(unhealthyMachines collections.Machines) *clusterv1.Machine {
+	machineToBeRemediated := unhealthyMachines.Filter(collections.Not(collections.HasNode())).Oldest()
+	if machineToBeRemediated == nil {
+		machineToBeRemediated = unhealthyMachines.Oldest()
+	}
+	return machineToBeRemediated
 }
 
 // checkRetryLimits checks if KCP is allowed to remediate considering retry limits:

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -472,7 +472,8 @@ When `MaxSurge` is set to 0 the rollout algorithm is as follows:
 
 - KCP remediation is triggered by the MachineHealthCheck controller marking a machine for remediation. See
   [machine-health-checking proposal](https://github.com/kubernetes-sigs/cluster-api/blob/11485f4f817766c444840d8ea7e4e7d1a6b94cc9/docs/proposals/20191030-machine-health-checking.md)
-  for additional details. When there are multiple machines that are marked for remediation, the oldest one will be remediated first.
+  for additional details. When there are multiple machines that are marked for remediation, the oldest machine marked as unhealthy not yet provisioned (if any)
+  or the oldest machine marked as unhealthy will be remediated first.
 
 - Following rules should be satisfied in order to start remediation
   - One of the following apply:
@@ -480,6 +481,7 @@ When `MaxSurge` is set to 0 the rollout algorithm is as follows:
     - The cluster MUST have at least two control plane machines, because this is the smallest cluster size that can be remediated.
   - Previous remediation (delete and re-create) MUST have been completed. This rule prevents KCP to remediate more machines while the
     replacement for the previous machine is not yet created. 
+  - The cluster MUST NOT have healthy machines still provisioning (without a node). This rule prevents KCP taking actions while the cluster is in a transitional state.
   - The cluster MUST have no machines with a deletion timestamp. This rule prevents KCP taking actions while the cluster is in a transitional state.
   - Remediation MUST preserve etcd quorum. This rule ensures that we will not remove a member that would result in etcd
     losing a majority of members and thus become unable to field new requests (note: this rule applies only to CP already

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -264,3 +264,13 @@ func HealthyAPIServer() Func {
 		return conditions.IsTrue(machine, controlplanev1.MachineAPIServerPodHealthyCondition)
 	}
 }
+
+// HasNode returns a filter to find all machines that have a corresponding Kubernetes node.
+func HasNode() Func {
+	return func(machine *clusterv1.Machine) bool {
+		if machine == nil {
+			return false
+		}
+		return machine.Status.NodeRef != nil
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR KCP defers remediation when another control plane machine is still provisioning

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9398

/area control-plane