### PR TITLE
🐛 Fix TestReconcileMachinePoolScaleToFromZero flakes

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -1513,11 +1513,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 	}
-	g.Expect(env.Create(ctx, testCluster)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 	defer func(do ...client.Object) {
-		g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
-	}(ns, testCluster)
+		g.Expect(env.CleanupAndWait(ctx, do...)).To(Succeed())
+	}(testCluster)
 
 	defaultMachinePool := expv1.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1593,9 +1593,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(env.Create(ctx, node)).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, node)).To(Succeed())
 		defer func(do ...client.Object) {
-			g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
+			g.Expect(env.CleanupAndWait(ctx, do...)).To(Succeed())
 		}(node)
 
 		kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, kubeconfig.FromEnvTestConfig(env.Config, testCluster))
@@ -1656,7 +1656,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		}
 		g.Expect(env.CreateAndWait(ctx, node)).To(Succeed())
 		defer func(do ...client.Object) {
-			g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
+			g.Expect(env.CleanupAndWait(ctx, do...)).To(Succeed())
 		}(node)
 
 		kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, kubeconfig.FromEnvTestConfig(env.Config, testCluster))
@@ -1780,9 +1780,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 				},
 			},
 		}
-		g.Expect(env.Create(ctx, node)).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, node)).To(Succeed())
 		defer func(do ...client.Object) {
-			g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
+			g.Expect(env.CleanupAndWait(ctx, do...)).To(Succeed())
 		}(node)
 
 		kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, kubeconfig.FromEnvTestConfig(env.Config, testCluster))


### PR DESCRIPTION
**What this PR does / why we need it**:
I've managed to reproduce the flakes on my local machine, it seems that the test flakes due to some random cache sync delays when creating a node with envtest, CAPI Testing documentation recommends using `CreateAndWait` for such cases.

**Which issue(s) this PR fixes**:
Fixes #8993 

/area machinepool