### PR TITLE
🐛 Set User Agent for test extension correctly

### DIFF
--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -55,7 +56,8 @@ var (
 	// scheme is a Kubernetes runtime scheme containing all the information about API types used by the test extension.
 	// NOTE: it is not mandatory to use scheme in custom RuntimeExtension, but working with typed API objects makes code
 	// easier to read and less error prone than using unstructured or working with raw json/yaml.
-	scheme = runtime.NewScheme()
+	scheme         = runtime.NewScheme()
+	controllerName = "cluster-api-test-extension-manager"
 
 	// Flags.
 	profilerAddress string
@@ -202,6 +204,7 @@ func main() {
 		setupLog.Error(err, "error getting config for the cluster")
 		os.Exit(1)
 	}
+	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent(controllerName)
 
 	client, err := client.New(restConfig, client.Options{})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Set the user agent for test/extension correctly. More importantly add a constant string to the binary that we can later use with the `strings` command to easily identify the binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->