### PR TITLE
[release-1.4] 🐛 fix provider namespace secret not included in clusterctl move

### DIFF
--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -432,7 +432,7 @@ func (o *objectGraph) Discovery(namespace string) error {
 		}
 
 		// if we are discovering Secrets, also secrets from the providers namespace should be included.
-		if discoveryType.typeMeta.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("SecretList").GroupKind() {
+		if discoveryType.typeMeta.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("Secret").GroupKind() {
 			providers, err := o.providerInventory.List()
 			if err != nil {
 				return err

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1695,15 +1695,7 @@ func getFakeProxyWithCRDs() *test.FakeProxy {
 }
 
 func getFakeDiscoveryTypes(graph *objectGraph) error {
-	if err := graph.getDiscoveryTypes(); err != nil {
-		return err
-	}
-
-	// Given that the Fake client behaves in a different way than real client, for this test we are required to add the List suffix to all the types.
-	for _, discoveryType := range graph.types {
-		discoveryType.typeMeta.Kind = fmt.Sprintf("%sList", discoveryType.typeMeta.Kind)
-	}
-	return nil
+	return graph.getDiscoveryTypes()
 }
 
 func TestObjectGraph_Discovery(t *testing.T) {


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9694
Note: In order to minimize the impact, I backported only the actual changes, not the cleanup in the tests

/area clusterctl