### PR TITLE
:book: add release 1.5 book link

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -40,8 +40,9 @@ contributing guide for more details.
 
 <h1>ClusterAPI documentation versions</h1>
 
-This book documents ClusterAPI v1.5. For other Cluster API versions please see the corresponding documentation:
+This book documents ClusterAPI v1.6. For other Cluster API versions please see the corresponding documentation:
 * [main.cluster-api.sigs.k8s.io](https://main.cluster-api.sigs.k8s.io)
+* [release-1-5.cluster-api.sigs.k8s.io](https://release-1-5.cluster-api.sigs.k8s.io)
 * [release-1-4.cluster-api.sigs.k8s.io](https://release-1-4.cluster-api.sigs.k8s.io)
 * [release-1-3.cluster-api.sigs.k8s.io](https://release-1-3.cluster-api.sigs.k8s.io)
 * [release-1-2.cluster-api.sigs.k8s.io](https://release-1-2.cluster-api.sigs.k8s.io)


### PR DESCRIPTION
**What this PR does / why we need it**:
Document that the default documented version is now release-1.6 and provide backlink to release-1.5

**Which issue(s) this PR fixes**:
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/9094

/area release