### PR TITLE
🐛 Fix documentation area comparison in release notes

### DIFF
--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -143,7 +143,7 @@ const (
 	missingAreaLabelPrefix   = "MISSING_AREA"
 	areaLabelPrefix          = "area/"
 	multipleAreaLabelsPrefix = "MULTIPLE_AREAS["
-	documentationAreaLabel   = "documentation"
+	documentationAreaLabel   = "Documentation"
 )
 
 type githubPullRequest struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since now all areas are capitalized by default, when looking for the docs area label we need to use a capitalized constant.

/area release

cc @kubernetes-sigs/cluster-api-release-team 