### PR TITLE
:bug: Change MachineHealthCheck.spec.unhealthyConditions to optional

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -252,6 +252,8 @@ type MachineHealthCheckClass struct {
 	// UnhealthyConditions contains a list of the conditions that determine
 	// whether a node is considered unhealthy. The conditions are combined in a
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+	//
+	// +optional
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
 	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -47,8 +47,8 @@ type MachineHealthCheckSpec struct {
 	// whether a node is considered unhealthy.  The conditions are combined in a
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
-	// +kubebuilder:validation:MinItems=1
-	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions"`
+	// +optional
+	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
 	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
 	// "selector" are not healthy.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -2277,7 +2277,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheckSpec(ref common.
 						},
 					},
 				},
-				Required: []string{"clusterName", "selector", "unhealthyConditions"},
+				Required: []string{"clusterName", "selector"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -767,7 +767,6 @@ spec:
                   - timeout
                   - type
                   type: object
-                minItems: 1
                 type: array
               unhealthyRange:
                 description: |-
@@ -781,7 +780,6 @@ spec:
             required:
             - clusterName
             - selector
-            - unhealthyConditions
             type: object
           status:
             description: Most recently observed status of MachineHealthCheck resource

--- a/docs/book/src/user/concepts.md
+++ b/docs/book/src/user/concepts.md
@@ -69,9 +69,9 @@ A MachineSet works similarly to a core Kubernetes [ReplicaSet](https://kubernete
 
 ### MachineHealthCheck
 
-A MachineHealthCheck defines the conditions when a Node should be considered unhealthy.
+A MachineHealthCheck defines the conditions when a Node should be considered missing or unhealthy.
 
-If the Node matches these unhealthy conditions for a given user-configured time, the MachineHealthCheck initiates remediation of the Node. Remediation of Nodes is performed by deleting the corresponding Machine.
+If the Node matches these unhealthy conditions for a given user-configured time, the MachineHealthCheck initiates remediation of the Node. Remediation of Nodes is performed by replacing the corresponding Machine.
 
 MachineHealthChecks will only remediate Nodes if they are owned by a MachineSet. This ensures that the Kubernetes cluster does not lose capacity, since the MachineSet will create a new Machine to replace the failed Machine.
 

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -1092,7 +1092,6 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		)
 		defer cleanup1()
 
-		//machines = append(machines)
 		targetMachines := make([]string, len(machines))
 		for i, m := range machines {
 			targetMachines[i] = m.Name

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -1071,6 +1071,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 	})
 
 	t.Run("when a Machine's Node has gone away without conditions", func(t *testing.T) {
+		// FIXME: Resolve flaky/failing test
 		t.Skip("skipping until made stable")
 		g := NewWithT(t)
 		cluster := createCluster(g, ns.Name)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -290,10 +290,19 @@ func TestHealthCheckTargets(t *testing.T) {
 	// Target for when the Node has been seen, but has now gone
 	// using MHC without unhealthyConditions
 	nodeGoneAwayEmptyConditions := healthCheckTarget{
-		Cluster:     cluster,
-		MHC:         testMHCEmptyConditions,
-		Machine:     testMachine.DeepCopy(),
-		Node:        &corev1.Node{},
+		Cluster: cluster,
+		MHC:     testMHCEmptyConditions,
+		Machine: testMachine.DeepCopy(),
+		Node: &corev1.Node{
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		},
 		nodeMissing: true,
 	}
 

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -296,7 +296,7 @@ func TestHealthCheckTargets(t *testing.T) {
 		Node: &corev1.Node{
 			Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
-					corev1.NodeCondition{
+					{
 						Type:   corev1.NodeReady,
 						Status: corev1.ConditionFalse,
 					},

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -446,6 +446,13 @@ func TestHealthCheckTargets(t *testing.T) {
 			expectedNeedsRemediationCondition: []clusterv1.Condition{machineAnnotationRemediationCondition},
 			expectedNextCheckTimes:            []time.Duration{},
 		},
+		{
+			desc:                              "health check without conditions",
+			targets:                           []healthCheckTarget{},
+			expectedHealthy:                   []healthCheckTarget{},
+			expectedNeedsRemediationCondition: []clusterv1.Condition{},
+			expectedNextCheckTimes:            []time.Duration{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1759,7 +1759,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "Accept a cluster that has MHC enabled for machine deployment but is missing MHC definition unhealthyConditions in cluster topology and ClusterClass",
+			name: "Reject a cluster that has MHC enabled for machine deployment but is missing MHC definition in cluster topology and ClusterClass",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().
@@ -1785,7 +1785,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			name: "Reject a cluster that has MHC override defined for machine deployment but is missing unhealthy conditions",
+			name: "Accept a cluster that has MHC override defined for machine deployment and does not set unhealthy conditions",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1668,7 +1668,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			name: "Accept a cluster that MHC override defined for control plane and does not set unhealthy conditions",
+			name: "Accept a cluster that has MHC override defined for control plane and does not set unhealthy conditions",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1759,7 +1759,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "Reject a cluster that has MHC enabled for machine deployment but is missing MHC definition in cluster topology and ClusterClass",
+			name: "Do not reject a cluster that has MHC enabled for machine deployment but is missing MHC definition unhealthyConditions in cluster topology and ClusterClass",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().
@@ -1810,7 +1810,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 				).
 				Build(),
 			classReconciled: true,
-			wantErr:         true,
+			wantErr:         false,
 		},
 		{
 			name: "Accept a cluster that has MHC enabled for machine deployment with machine deployment MHC defined in ClusterClass",

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1668,7 +1668,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			name: "Reject a cluster that MHC override defined for control plane but is missing unhealthy conditions",
+			name: "Accept a cluster that MHC override defined for control plane and does not set unhealthy conditions",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().
@@ -1683,9 +1683,10 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 						Build()).
 				Build(),
 			class: builder.ClusterClass(metav1.NamespaceDefault, "clusterclass").
+				WithControlPlaneInfrastructureMachineTemplate(&unstructured.Unstructured{}).
 				Build(),
 			classReconciled: true,
-			wantErr:         true,
+			wantErr:         false,
 		},
 		{
 			name: "Reject a cluster that MHC override defined for control plane but is set when control plane is missing machineInfrastructure",

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1759,7 +1759,7 @@ func TestClusterTopologyValidationWithClient(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "Do not reject a cluster that has MHC enabled for machine deployment but is missing MHC definition unhealthyConditions in cluster topology and ClusterClass",
+			name: "Accept a cluster that has MHC enabled for machine deployment but is missing MHC definition unhealthyConditions in cluster topology and ClusterClass",
 			cluster: builder.Cluster(metav1.NamespaceDefault, "cluster1").
 				WithTopology(
 					builder.ClusterTopology().

--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -403,7 +403,7 @@ func validateMachineHealthCheckClasses(clusterClass *clusterv1.ClusterClass) fie
 		}
 	}
 
-	// Ensure MachineDeployment MachineHealthChecks define UnhealthyConditions.
+	// Validate MachineDeployment MachineHealthChecks.
 	for i, md := range clusterClass.Spec.Workers.MachineDeployments {
 		if md.MachineHealthCheck == nil {
 			continue

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -910,7 +910,7 @@ func TestClusterClassValidation(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "create fail if ControlPlane MachineHealthCheck does not define UnhealthyConditions",
+			name: "create does not fail if ControlPlane MachineHealthCheck does not define UnhealthyConditions",
 			in: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithInfrastructureClusterTemplate(
 					builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()).
@@ -924,7 +924,7 @@ func TestClusterClassValidation(t *testing.T) {
 					NodeStartupTimeout: &metav1.Duration{
 						Duration: time.Duration(6000000000000)}}).
 				Build(),
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			name: "create pass if MachineDeployment MachineHealthCheck is valid",
@@ -983,7 +983,7 @@ func TestClusterClassValidation(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "create fail if MachineDeployment MachineHealthCheck does not define UnhealthyConditions",
+			name: "create does not fail if MachineDeployment MachineHealthCheck does not define UnhealthyConditions",
 			in: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithInfrastructureClusterTemplate(
 					builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()).
@@ -1001,7 +1001,7 @@ func TestClusterClassValidation(t *testing.T) {
 								Duration: time.Duration(6000000000000)}}).
 						Build()).
 				Build(),
-			expectErr: true,
+			expectErr: false,
 		},
 
 		/*

--- a/internal/webhooks/machinehealthcheck.go
+++ b/internal/webhooks/machinehealthcheck.go
@@ -165,7 +165,7 @@ func (webhook *MachineHealthCheck) validate(oldMHC, newMHC *clusterv1.MachineHea
 	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("MachineHealthCheck").GroupKind(), newMHC.Name, allErrs)
 }
 
-// ValidateCommonFields validates UnhealthyConditions NodeStartupTimeout, MaxUnhealthy, and RemediationTemplate of the MHC.
+// ValidateCommonFields validates NodeStartupTimeout, MaxUnhealthy, and RemediationTemplate of the MHC.
 // These are the fields in common with other types which define MachineHealthChecks such as MachineHealthCheckClass and MachineHealthCheckTopology.
 func (webhook *MachineHealthCheck) validateCommonFields(m *clusterv1.MachineHealthCheck, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList

--- a/internal/webhooks/machinehealthcheck.go
+++ b/internal/webhooks/machinehealthcheck.go
@@ -197,12 +197,5 @@ func (webhook *MachineHealthCheck) validateCommonFields(m *clusterv1.MachineHeal
 		)
 	}
 
-	if len(m.Spec.UnhealthyConditions) == 0 {
-		allErrs = append(allErrs, field.Forbidden(
-			fldPath.Child("unhealthyConditions"),
-			"must have at least one entry",
-		))
-	}
-
 	return allErrs
 }

--- a/internal/webhooks/machinehealthcheck_test.go
+++ b/internal/webhooks/machinehealthcheck_test.go
@@ -186,13 +186,13 @@ func TestMachineHealthCheckClusterNameImmutable(t *testing.T) {
 
 func TestMachineHealthCheckUnhealthyConditions(t *testing.T) {
 	tests := []struct {
-		name               string
-		unhealthConditions []clusterv1.UnhealthyCondition
-		expectErr          bool
+		name                string
+		unhealthyConditions []clusterv1.UnhealthyCondition
+		expectErr           bool
 	}{
 		{
 			name: "pass with correctly defined unhealthyConditions",
-			unhealthConditions: []clusterv1.UnhealthyCondition{
+			unhealthyConditions: []clusterv1.UnhealthyCondition{
 				{
 					Type:   corev1.NodeReady,
 					Status: corev1.ConditionFalse,
@@ -201,14 +201,14 @@ func TestMachineHealthCheckUnhealthyConditions(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:               "do not fail if the UnhealthCondition array is nil",
-			unhealthConditions: nil,
-			expectErr:          false,
+			name:                "do not fail if the UnhealthyCondition array is nil",
+			unhealthyConditions: nil,
+			expectErr:           false,
 		},
 		{
-			name:               "do not fail if the UnhealthCondition array is empty",
-			unhealthConditions: []clusterv1.UnhealthyCondition{},
-			expectErr:          false,
+			name:                "do not fail if the UnhealthyCondition array is nil",
+			unhealthyConditions: []clusterv1.UnhealthyCondition{},
+			expectErr:           false,
 		},
 	}
 
@@ -222,7 +222,7 @@ func TestMachineHealthCheckUnhealthyConditions(t *testing.T) {
 							"test": "test",
 						},
 					},
-					UnhealthyConditions: tt.unhealthConditions,
+					UnhealthyConditions: tt.unhealthyConditions,
 				},
 			}
 			webhook := &MachineHealthCheck{}

--- a/internal/webhooks/machinehealthcheck_test.go
+++ b/internal/webhooks/machinehealthcheck_test.go
@@ -201,14 +201,14 @@ func TestMachineHealthCheckUnhealthyConditions(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:               "fail if the UnhealthCondition array is nil",
+			name:               "do not fail if the UnhealthCondition array is nil",
 			unhealthConditions: nil,
-			expectErr:          true,
+			expectErr:          false,
 		},
 		{
-			name:               "fail if the UnhealthCondition array is empty",
+			name:               "do not fail if the UnhealthCondition array is empty",
 			unhealthConditions: []clusterv1.UnhealthyCondition{},
-			expectErr:          true,
+			expectErr:          false,
 		},
 	}
 

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -20,10 +20,7 @@ spec:
         name: quick-start-control-plane
     machineHealthCheck:
       maxUnhealthy: 100%
-      unhealthyConditions:
-      - type: e2e.remediation.condition
-        status: "False"
-        timeout: 20s
+      # We are intentionally not setting the 'unhealthyConditions' here to test that the field is optional.
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -50,10 +47,7 @@ spec:
             name: quick-start-default-worker-machinetemplate
       machineHealthCheck:
         maxUnhealthy: 100%
-        unhealthyConditions:
-        - type: e2e.remediation.condition
-          status: "False"
-          timeout: 20s
+        # We are intentionally not setting the 'unhealthyConditions' here to test that the field is optional.
     machinePools:
     - class: default-worker
       template:

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -20,7 +20,10 @@ spec:
         name: quick-start-control-plane
     machineHealthCheck:
       maxUnhealthy: 100%
-      # We are intentionally not setting the 'unhealthyConditions' here to test that the field is optional.
+      unhealthyConditions:
+        - type: e2e.remediation.condition
+          status: "False"
+          timeout: 20s
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/framework/machinehealthcheck_helpers.go
+++ b/test/framework/machinehealthcheck_helpers.go
@@ -56,7 +56,6 @@ func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input
 	Expect(machineHealthChecks).NotTo(BeEmpty())
 
 	for _, mhc := range machineHealthChecks {
-
 		fmt.Fprintln(GinkgoWriter, "Ensuring there is at least 1 Machine that MachineHealthCheck is matching")
 		machines := GetMachinesByMachineHealthCheck(ctx, GetMachinesByMachineHealthCheckInput{
 			Lister:             mgmtClient,

--- a/test/framework/machinehealthcheck_helpers.go
+++ b/test/framework/machinehealthcheck_helpers.go
@@ -56,7 +56,6 @@ func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input
 	Expect(machineHealthChecks).NotTo(BeEmpty())
 
 	for _, mhc := range machineHealthChecks {
-		Expect(mhc.Spec.UnhealthyConditions).NotTo(BeEmpty())
 
 		fmt.Fprintln(GinkgoWriter, "Ensuring there is at least 1 Machine that MachineHealthCheck is matching")
 		machines := GetMachinesByMachineHealthCheck(ctx, GetMachinesByMachineHealthCheckInput{
@@ -67,18 +66,20 @@ func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input
 
 		Expect(machines).NotTo(BeEmpty())
 
-		fmt.Fprintln(GinkgoWriter, "Patching MachineHealthCheck unhealthy condition to one of the nodes")
-		unhealthyNodeCondition := corev1.NodeCondition{
-			Type:               mhc.Spec.UnhealthyConditions[0].Type,
-			Status:             mhc.Spec.UnhealthyConditions[0].Status,
-			LastTransitionTime: metav1.Time{Time: time.Now()},
+		if len(mhc.Spec.UnhealthyConditions) > 0 {
+			fmt.Fprintln(GinkgoWriter, "Patching MachineHealthCheck unhealthy condition to one of the nodes")
+			unhealthyNodeCondition := corev1.NodeCondition{
+				Type:               mhc.Spec.UnhealthyConditions[0].Type,
+				Status:             mhc.Spec.UnhealthyConditions[0].Status,
+				LastTransitionTime: metav1.Time{Time: time.Now()},
+			}
+			PatchNodeCondition(ctx, PatchNodeConditionInput{
+				ClusterProxy:  input.ClusterProxy,
+				Cluster:       input.Cluster,
+				NodeCondition: unhealthyNodeCondition,
+				Machine:       machines[0],
+			})
 		}
-		PatchNodeCondition(ctx, PatchNodeConditionInput{
-			ClusterProxy:  input.ClusterProxy,
-			Cluster:       input.Cluster,
-			NodeCondition: unhealthyNodeCondition,
-			Machine:       machines[0],
-		})
 
 		fmt.Fprintln(GinkgoWriter, "Waiting for remediation")
 		WaitForMachineHealthCheckToRemediateUnhealthyNodeCondition(ctx, WaitForMachineHealthCheckToRemediateUnhealthyNodeConditionInput{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md


    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The MHC API doesn't allow creating a health check for a missing node only,
it requires you to create fake conditions.

This PR, make the `spec.unhealthyConditions` to allow creating MHC for missing nodes.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9762

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area machinehealthcheck 