### PR TITLE
🌱  replace context.TODO() from clusterctl proxy.go

### DIFF
--- a/cmd/clusterctl/client/alpha/kubeadmcontrolplane.go
+++ b/cmd/clusterctl/client/alpha/kubeadmcontrolplane.go
@@ -32,7 +32,7 @@ import (
 // getKubeadmControlPlane retrieves the KubeadmControlPlane object corresponding to the name and namespace specified.
 func getKubeadmControlPlane(ctx context.Context, proxy cluster.Proxy, name, namespace string) (*controlplanev1.KubeadmControlPlane, error) {
 	kcpObj := &controlplanev1.KubeadmControlPlane{}
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func setRolloutAfterOnKCP(ctx context.Context, proxy cluster.Proxy, name, namesp
 
 // patchKubeadmControlPlane applies a patch to a KubeadmControlPlane.
 func patchKubeadmControlPlane(ctx context.Context, proxy cluster.Proxy, name, namespace string, patch client.Patch) error {
-	cFrom, err := proxy.NewClient()
+	cFrom, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/alpha/machinedeployment.go
+++ b/cmd/clusterctl/client/alpha/machinedeployment.go
@@ -38,7 +38,7 @@ import (
 // getMachineDeployment retrieves the MachineDeployment object corresponding to the name and namespace specified.
 func getMachineDeployment(ctx context.Context, proxy cluster.Proxy, name, namespace string) (*clusterv1.MachineDeployment, error) {
 	mdObj := &clusterv1.MachineDeployment{}
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func setRolloutAfterOnMachineDeployment(ctx context.Context, proxy cluster.Proxy
 
 // patchMachineDeployment applies a patch to a machinedeployment.
 func patchMachineDeployment(ctx context.Context, proxy cluster.Proxy, name, namespace string, patch client.Patch) error {
-	cFrom, err := proxy.NewClient()
+	cFrom, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func findMachineDeploymentRevision(toRevision int64, allMSs []*clusterv1.Machine
 // getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
 func getMachineSetsForDeployment(ctx context.Context, proxy cluster.Proxy, md *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
 	log := logf.Log
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/alpha/rollout_pauser_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser_test.go
@@ -153,7 +153,7 @@ func Test_ObjectPauser(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient()
+				cl, err := proxy.NewClient(context.TODO())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_pauser_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser_test.go
@@ -153,7 +153,7 @@ func Test_ObjectPauser(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient(context.TODO())
+				cl, err := proxy.NewClient(context.Background())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_restarter_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter_test.go
@@ -211,7 +211,7 @@ func Test_ObjectRestarter(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient()
+				cl, err := proxy.NewClient(context.TODO())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_restarter_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter_test.go
@@ -211,7 +211,7 @@ func Test_ObjectRestarter(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient(context.TODO())
+				cl, err := proxy.NewClient(context.Background())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_resumer_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer_test.go
@@ -156,7 +156,7 @@ func Test_ObjectResumer(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient()
+				cl, err := proxy.NewClient(context.TODO())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_resumer_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer_test.go
@@ -156,7 +156,7 @@ func Test_ObjectResumer(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, obj := range tt.fields.objs {
-				cl, err := proxy.NewClient(context.TODO())
+				cl, err := proxy.NewClient(context.Background())
 				g.Expect(err).ToNot(HaveOccurred())
 				key := client.ObjectKeyFromObject(obj)
 				switch obj.(type) {

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker.go
@@ -51,7 +51,7 @@ func (r *rollout) ObjectRollbacker(ctx context.Context, proxy cluster.Proxy, ref
 // rollbackMachineDeployment will rollback to a previous MachineSet revision used by this MachineDeployment.
 func rollbackMachineDeployment(ctx context.Context, proxy cluster.Proxy, md *clusterv1.MachineDeployment, toRevision int64) error {
 	log := logf.Log
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker_test.go
@@ -247,7 +247,7 @@ func Test_ObjectRollbacker(t *testing.T) {
 				return
 			}
 			g.Expect(err).ToNot(HaveOccurred())
-			cl, err := proxy.NewClient()
+			cl, err := proxy.NewClient(context.TODO())
 			g.Expect(err).ToNot(HaveOccurred())
 			key := client.ObjectKeyFromObject(deployment)
 			md := &clusterv1.MachineDeployment{}

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker_test.go
@@ -247,7 +247,7 @@ func Test_ObjectRollbacker(t *testing.T) {
 				return
 			}
 			g.Expect(err).ToNot(HaveOccurred())
-			cl, err := proxy.NewClient(context.TODO())
+			cl, err := proxy.NewClient(context.Background())
 			g.Expect(err).ToNot(HaveOccurred())
 			key := client.ObjectKeyFromObject(deployment)
 			md := &clusterv1.MachineDeployment{}

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -134,7 +134,7 @@ func (cm *certManagerClient) Images(ctx context.Context) ([]string, error) {
 func (cm *certManagerClient) certManagerNamespaceExists(ctx context.Context) (bool, error) {
 	ns := &corev1.Namespace{}
 	key := client.ObjectKey{Name: certManagerNamespace}
-	c, err := cm.proxy.NewClient()
+	c, err := cm.proxy.NewClient(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -284,7 +284,7 @@ func (cm *certManagerClient) migrateCRDs(ctx context.Context) error {
 		return err
 	}
 
-	c, err := cm.proxy.NewClient()
+	c, err := cm.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func getTestResourcesManifestObjs() ([]unstructured.Unstructured, error) {
 func (cm *certManagerClient) createObj(ctx context.Context, obj unstructured.Unstructured) error {
 	log := logf.Log
 
-	c, err := cm.proxy.NewClient()
+	c, err := cm.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -512,7 +512,7 @@ func (cm *certManagerClient) deleteObj(ctx context.Context, obj unstructured.Uns
 	log := logf.Log
 	log.V(5).Info("Deleting", logf.UnstructuredToValues(obj)...)
 
-	cl, err := cm.proxy.NewClient()
+	cl, err := cm.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -594,7 +594,7 @@ func Test_certManagerClient_deleteObjs(t *testing.T) {
 					}
 				}
 
-				cl, err := proxy.NewClient()
+				cl, err := proxy.NewClient(ctx)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				err = cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)

--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -92,7 +92,7 @@ func (p *providerComponents) Create(ctx context.Context, objs []unstructured.Uns
 
 func (p *providerComponents) createObj(ctx context.Context, obj unstructured.Unstructured) error {
 	log := logf.Log
-	c, err := p.proxy.NewClient()
+	c, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (p *providerComponents) Delete(ctx context.Context, options DeleteOptions) 
 	}
 
 	// Delete all the provider components.
-	cs, err := p.proxy.NewClient()
+	cs, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (p *providerComponents) DeleteWebhookNamespace(ctx context.Context) error {
 	log := logf.Log
 	log.V(5).Info("Deleting", "namespace", webhookNamespaceName)
 
-	c, err := p.proxy.NewClient()
+	c, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/components_test.go
+++ b/cmd/clusterctl/client/cluster/components_test.go
@@ -270,7 +270,7 @@ func Test_providerComponents_Delete(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cs, err := proxy.NewClient()
+			cs, err := proxy.NewClient(context.TODO())
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, want := range tt.wantDiff {
@@ -322,7 +322,7 @@ func Test_providerComponents_DeleteCoreProviderWebhookNamespace(t *testing.T) {
 		}
 
 		proxy := test.NewFakeProxy().WithObjs(initObjs...)
-		proxyClient, _ := proxy.NewClient()
+		proxyClient, _ := proxy.NewClient(context.TODO())
 		var nsList corev1.NamespaceList
 
 		// assert length before deleting
@@ -457,7 +457,7 @@ func Test_providerComponents_Create(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cs, err := proxy.NewClient()
+			cs, err := proxy.NewClient(context.TODO())
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, item := range tt.want {

--- a/cmd/clusterctl/client/cluster/components_test.go
+++ b/cmd/clusterctl/client/cluster/components_test.go
@@ -270,7 +270,7 @@ func Test_providerComponents_Delete(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cs, err := proxy.NewClient(context.TODO())
+			cs, err := proxy.NewClient(context.Background())
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, want := range tt.wantDiff {
@@ -322,7 +322,7 @@ func Test_providerComponents_DeleteCoreProviderWebhookNamespace(t *testing.T) {
 		}
 
 		proxy := test.NewFakeProxy().WithObjs(initObjs...)
-		proxyClient, _ := proxy.NewClient(context.TODO())
+		proxyClient, _ := proxy.NewClient(context.Background())
 		var nsList corev1.NamespaceList
 
 		// assert length before deleting
@@ -457,7 +457,7 @@ func Test_providerComponents_Create(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 
-			cs, err := proxy.NewClient(context.TODO())
+			cs, err := proxy.NewClient(context.Background())
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, item := range tt.want {

--- a/cmd/clusterctl/client/cluster/crd_migration_test.go
+++ b/cmd/clusterctl/client/cluster/crd_migration_test.go
@@ -264,7 +264,7 @@ func Test_CRDMigrator(t *testing.T) {
 				objs = append(objs, &tt.CRs[i])
 			}
 
-			c, err := test.NewFakeProxy().WithObjs(objs...).NewClient(context.TODO())
+			c, err := test.NewFakeProxy().WithObjs(objs...).NewClient(context.Background())
 			g.Expect(err).ToNot(HaveOccurred())
 			countingClient := newUpgradeCountingClient(c)
 

--- a/cmd/clusterctl/client/cluster/crd_migration_test.go
+++ b/cmd/clusterctl/client/cluster/crd_migration_test.go
@@ -264,7 +264,7 @@ func Test_CRDMigrator(t *testing.T) {
 				objs = append(objs, &tt.CRs[i])
 			}
 
-			c, err := test.NewFakeProxy().WithObjs(objs...).NewClient()
+			c, err := test.NewFakeProxy().WithObjs(objs...).NewClient(context.TODO())
 			g.Expect(err).ToNot(HaveOccurred())
 			countingClient := newUpgradeCountingClient(c)
 

--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -151,7 +151,7 @@ func waitManagerDeploymentsReady(ctx context.Context, opts InstallOptions, insta
 
 func waitDeploymentReady(ctx context.Context, deployment unstructured.Unstructured, timeout time.Duration, proxy Proxy) error {
 	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, timeout, false, func(ctx context.Context) (bool, error) {
-		c, err := proxy.NewClient()
+		c, err := proxy.NewClient(ctx)
 		if err != nil {
 			return false, err
 		}

--- a/cmd/clusterctl/client/cluster/inventory.go
+++ b/cmd/clusterctl/client/cluster/inventory.go
@@ -153,7 +153,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions(ctx context.Context) e
 	// NB. NewClient has an internal retry loop that should mitigate temporary connection glitch; here we are
 	// trying to detect persistent connection problems (>10s) before entering in longer retry loops while executing
 	// clusterctl operations.
-	_, err := p.proxy.NewClient()
+	_, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions(ctx context.Context) e
 		if apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind() == o.GroupVersionKind().GroupKind() {
 			crdKey := client.ObjectKeyFromObject(&o)
 			if err := p.pollImmediateWaiter(ctx, waitInventoryCRDInterval, waitInventoryCRDTimeout, func(ctx context.Context) (bool, error) {
-				c, err := p.proxy.NewClient()
+				c, err := p.proxy.NewClient(ctx)
 				if err != nil {
 					return false, err
 				}
@@ -226,7 +226,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions(ctx context.Context) e
 
 // checkInventoryCRDs checks if the inventory CRDs are installed in the cluster.
 func checkInventoryCRDs(ctx context.Context, proxy Proxy) (bool, error) {
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -248,7 +248,7 @@ func checkInventoryCRDs(ctx context.Context, proxy Proxy) (bool, error) {
 }
 
 func (p *inventoryClient) createObj(ctx context.Context, o unstructured.Unstructured) error {
-	c, err := p.proxy.NewClient()
+	c, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func (p *inventoryClient) Create(ctx context.Context, m clusterctlv1.Provider) e
 	// Create the Kubernetes object.
 	createInventoryObjectBackoff := newWriteBackoff()
 	return retryWithExponentialBackoff(ctx, createInventoryObjectBackoff, func(ctx context.Context) error {
-		cl, err := p.proxy.NewClient()
+		cl, err := p.proxy.NewClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -321,7 +321,7 @@ func (p *inventoryClient) List(ctx context.Context) (*clusterctlv1.ProviderList,
 
 // listProviders retrieves the list of provider inventory objects.
 func listProviders(ctx context.Context, proxy Proxy, providerList *clusterctlv1.ProviderList) error {
-	cl, err := proxy.NewClient()
+	cl, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func (p *inventoryClient) CheckCAPIContract(ctx context.Context, options ...Chec
 		o.Apply(opt)
 	}
 
-	c, err := p.proxy.NewClient()
+	c, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -280,7 +280,7 @@ func (o *objectMover) checkProvisioningCompleted(ctx context.Context, graph *obj
 
 // getClusterObj retrieves the clusterObj corresponding to a node with type Cluster.
 func getClusterObj(ctx context.Context, proxy Proxy, cluster *node, clusterObj *clusterv1.Cluster) error {
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func getClusterObj(ctx context.Context, proxy Proxy, cluster *node, clusterObj *
 
 // getMachineObj retrieves the machineObj corresponding to a node with type Machine.
 func getMachineObj(ctx context.Context, proxy Proxy, machine *node, machineObj *clusterv1.Machine) error {
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -617,7 +617,7 @@ func waitReadyForMove(ctx context.Context, proxy Proxy, nodes []*node, dryRun bo
 
 	log := logf.Log
 
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error creating client")
 	}
@@ -672,7 +672,7 @@ func waitReadyForMove(ctx context.Context, proxy Proxy, nodes []*node, dryRun bo
 
 // patchCluster applies a patch to a node referring to a Cluster object.
 func patchCluster(ctx context.Context, proxy Proxy, n *node, patch client.Patch, mutators ...ResourceMutatorFunc) error {
-	cFrom, err := proxy.NewClient()
+	cFrom, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -707,7 +707,7 @@ func patchCluster(ctx context.Context, proxy Proxy, n *node, patch client.Patch,
 }
 
 func pauseClusterClass(ctx context.Context, proxy Proxy, n *node, pause bool, mutators ...ResourceMutatorFunc) error {
-	cFrom, err := proxy.NewClient()
+	cFrom, err := proxy.NewClient(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error creating client")
 	}
@@ -802,7 +802,7 @@ func (o *objectMover) ensureNamespaces(ctx context.Context, graph *objectGraph, 
 func (o *objectMover) ensureNamespace(ctx context.Context, toProxy Proxy, namespace string) error {
 	log := logf.Log
 
-	cs, err := toProxy.NewClient()
+	cs, err := toProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -940,7 +940,7 @@ func (o *objectMover) createTargetObject(ctx context.Context, nodeToCreate *node
 		return nil
 	}
 
-	cFrom, err := o.fromProxy.NewClient()
+	cFrom, err := o.fromProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -975,7 +975,7 @@ func (o *objectMover) createTargetObject(ctx context.Context, nodeToCreate *node
 	}
 
 	// Creates the targetObj into the target management cluster.
-	cTo, err := toProxy.NewClient()
+	cTo, err := toProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -1037,7 +1037,7 @@ func (o *objectMover) backupTargetObject(ctx context.Context, nodeToCreate *node
 	log := logf.Log
 	log.V(1).Info("Saving", nodeToCreate.identity.Kind, nodeToCreate.identity.Name, "Namespace", nodeToCreate.identity.Namespace)
 
-	cFrom, err := o.fromProxy.NewClient()
+	cFrom, err := o.fromProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -1089,7 +1089,7 @@ func (o *objectMover) restoreTargetObject(ctx context.Context, nodeToCreate *nod
 	log.V(1).Info("Restoring", nodeToCreate.identity.Kind, nodeToCreate.identity.Name, "Namespace", nodeToCreate.identity.Namespace)
 
 	// Creates the targetObj into the target management cluster.
-	cTo, err := toProxy.NewClient()
+	cTo, err := toProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -1206,7 +1206,7 @@ func (o *objectMover) deleteSourceObject(ctx context.Context, nodeToDelete *node
 		return nil
 	}
 
-	cFrom, err := o.fromProxy.NewClient()
+	cFrom, err := o.fromProxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -866,7 +866,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Check objects are in new restored cluster
-				csTo, err := toProxy.NewClient()
+				csTo, err := toProxy.NewClient(ctx)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				key := client.ObjectKey{
@@ -894,7 +894,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 
 				// Check objects are in new restored cluster
-				csAfter, err := toProxy.NewClient()
+				csAfter, err := toProxy.NewClient(ctx)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				keyAfter := client.ObjectKey{
@@ -959,7 +959,7 @@ func Test_objectMover_toDirectory(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// check that the objects are stored in the temporary directory but not deleted from the source cluster
-			csFrom, err := graph.proxy.NewClient()
+			csFrom, err := graph.proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			missingFiles := []string{}
@@ -1120,7 +1120,7 @@ func Test_objectMover_fromDirectory(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// Check objects are in new restored cluster
-			csTo, err := toProxy.NewClient()
+			csTo, err := toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, node := range graph.uidToNode {
@@ -1211,10 +1211,10 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// check that the objects are kept in the source cluster and are not created in the target cluster
-			csFrom, err := graph.proxy.NewClient()
+			csFrom, err := graph.proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			csTo, err := toProxy.NewClient()
+			csTo, err := toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 			for _, node := range graph.uidToNode {
 				key := client.ObjectKey{
@@ -1285,10 +1285,10 @@ func Test_objectMover_move(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// check that the objects are removed from the source cluster and are created in the target cluster
-			csFrom, err := graph.proxy.NewClient()
+			csFrom, err := graph.proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			csTo, err := toProxy.NewClient()
+			csTo, err := toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, node := range graph.uidToNode {
@@ -1397,10 +1397,10 @@ func Test_objectMover_move_with_Mutator(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			// check that the objects are removed from the source cluster and are created in the target cluster
-			csFrom, err := graph.proxy.NewClient()
+			csFrom, err := graph.proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			csTo, err := toProxy.NewClient()
+			csTo, err := toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			for _, node := range graph.uidToNode {
@@ -1813,7 +1813,7 @@ func Test_objectMoverService_ensureNamespace(t *testing.T) {
 
 			// Check that the namespaces either existed or were created in the
 			// target.
-			csTo, err := tt.args.toProxy.NewClient()
+			csTo, err := tt.args.toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			ns := &corev1.Namespace{}
@@ -1920,7 +1920,7 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 
 			// Check that the namespaces either existed or were created in the
 			// target.
-			csTo, err := tt.args.toProxy.NewClient()
+			csTo, err := tt.args.toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			namespaces := &corev1.NamespaceList{}
@@ -2170,7 +2170,7 @@ func Test_createTargetObject(t *testing.T) {
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 
-			toClient, err := tt.args.toProxy.NewClient()
+			toClient, err := tt.args.toProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			tt.want(g, toClient)
@@ -2313,7 +2313,7 @@ func Test_deleteSourceObject(t *testing.T) {
 			err := mover.deleteSourceObject(ctx, tt.args.node)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			fromClient, err := tt.args.fromProxy.NewClient()
+			fromClient, err := tt.args.fromProxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			tt.want(g, fromClient)
@@ -2360,7 +2360,7 @@ func TestWaitReadyForMove(t *testing.T) {
 			graph := getObjectGraphWithObjs(objs)
 
 			if tt.moveBlocked {
-				c, err := graph.proxy.NewClient()
+				c, err := graph.proxy.NewClient(ctx)
 				g.Expect(err).NotTo(HaveOccurred())
 
 				cluster := &clusterv1.Cluster{}

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -405,7 +405,7 @@ func getKindAPIString(typeMeta metav1.TypeMeta) string {
 }
 
 func getCRDList(ctx context.Context, proxy Proxy, crdList *apiextensionsv1.CustomResourceDefinitionList) error {
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -484,7 +484,7 @@ func (o *objectGraph) Discovery(ctx context.Context, namespace string) error {
 }
 
 func getObjList(ctx context.Context, proxy Proxy, typeMeta metav1.TypeMeta, selectors []client.ListOption, objList *unstructured.UnstructuredList) error {
-	c, err := proxy.NewClient()
+	c, err := proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -84,7 +84,7 @@ func (t *templateClient) GetFromConfigMap(ctx context.Context, configMapNamespac
 		return nil, errors.New("invalid GetFromConfigMap operation: missing configMapName value")
 	}
 
-	c, err := t.proxy.NewClient()
+	c, err := t.proxy.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -377,7 +377,7 @@ func (u *providerUpgrader) doUpgrade(ctx context.Context, upgradePlan *UpgradePl
 			return err
 		}
 
-		c, err := u.proxy.NewClient()
+		c, err := u.proxy.NewClient(ctx)
 		if err != nil {
 			return err
 		}
@@ -454,7 +454,7 @@ func (u *providerUpgrader) scaleDownProvider(ctx context.Context, provider clust
 	log := logf.Log
 	log.Info("Scaling down", "Provider", provider.Name, "Version", provider.Version, "Namespace", provider.Namespace)
 
-	cs, err := u.proxy.NewClient()
+	cs, err := u.proxy.NewClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/workload_cluster.go
+++ b/cmd/clusterctl/client/cluster/workload_cluster.go
@@ -44,7 +44,7 @@ func newWorkloadCluster(proxy Proxy) *workloadCluster {
 }
 
 func (p *workloadCluster) GetKubeconfig(ctx context.Context, workloadClusterName string, namespace string) (string, error) {
-	cs, err := p.proxy.NewClient()
+	cs, err := p.proxy.NewClient(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -99,7 +99,7 @@ func fetchMissingClusterClassTemplates(ctx context.Context, clusterClassClient r
 	// Check if the cluster is initialized
 	clusterInitialized := false
 	var err error
-	if err := clusterClient.Proxy().CheckClusterAvailable(); err == nil {
+	if err := clusterClient.Proxy().CheckClusterAvailable(ctx); err == nil {
 		clusterInitialized, err = clusterClient.ProviderInventory().CheckCAPIInstalled(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check if the cluster is initialized")
@@ -107,7 +107,7 @@ func fetchMissingClusterClassTemplates(ctx context.Context, clusterClassClient r
 	}
 	var c client.Client
 	if clusterInitialized {
-		c, err = clusterClient.Proxy().NewClient()
+		c, err = clusterClient.Proxy().NewClient(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/clusterctl/client/clusterclass_test.go
+++ b/cmd/clusterctl/client/clusterclass_test.go
@@ -72,7 +72,7 @@ func TestClusterClassExists(t *testing.T) {
 
 			config := newFakeConfig(ctx)
 			client := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config).WithObjs(tt.objs...)
-			c, _ := client.Proxy().NewClient()
+			c, _ := client.Proxy().NewClient(ctx)
 
 			actual, err := clusterClassExists(ctx, c, tt.clusterClass, metav1.NamespaceDefault)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -225,7 +225,7 @@ func (c *clusterctlClient) GetClusterTemplate(ctx context.Context, options GetCl
 
 	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
-		if err := clusterClient.Proxy().CheckClusterAvailable(); err != nil {
+		if err := clusterClient.Proxy().CheckClusterAvailable(ctx); err != nil {
 			return nil, errors.Wrap(err, "management cluster not available. Cannot auto-discover target namespace. Please specify a target namespace")
 		}
 		currentNamespace, err := clusterClient.Proxy().CurrentNamespace()
@@ -277,7 +277,7 @@ func (c *clusterctlClient) getTemplateFromRepository(ctx context.Context, cluste
 	provider := source.InfrastructureProvider
 	ensureCustomResourceDefinitions := false
 	if provider == "" {
-		if err := cluster.Proxy().CheckClusterAvailable(); err != nil {
+		if err := cluster.Proxy().CheckClusterAvailable(ctx); err != nil {
 			return nil, errors.Wrap(err, "management cluster not available. Cannot auto-discover default infrastructure provider. Please specify an infrastructure provider")
 		}
 		// ensure the custom resource definitions required by clusterctl are in place
@@ -305,7 +305,7 @@ func (c *clusterctlClient) getTemplateFromRepository(ctx context.Context, cluste
 
 	// If the version of the infrastructure provider to get templates from is empty, try to detect it.
 	if version == "" {
-		if err := cluster.Proxy().CheckClusterAvailable(); err != nil {
+		if err := cluster.Proxy().CheckClusterAvailable(ctx); err != nil {
 			return nil, errors.Wrapf(err, "management cluster not available. Cannot auto-discover version for the provider %q automatically. Please specify a version", name)
 		}
 		// ensure the custom resource definitions required by clusterctl are in place (if not already done)

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -181,7 +181,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			proxy := tt.fields.client.clusters[input].Proxy()
 			gotProviders := &clusterctlv1.ProviderList{}
 
-			c, err := proxy.NewClient()
+			c, err := proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(c.List(ctx, gotProviders)).To(Succeed())
 

--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -82,7 +82,7 @@ func (c *clusterctlClient) DescribeCluster(ctx context.Context, options Describe
 	}
 
 	// Fetch the Cluster client.
-	client, err := cluster.Proxy().NewClient()
+	client, err := cluster.Proxy().NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -841,7 +841,7 @@ func Test_Discovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			client, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient(context.TODO())
+			client, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient(context.Background())
 			g.Expect(client).ToNot(BeNil())
 			g.Expect(err).ToNot(HaveOccurred())
 

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -841,7 +841,7 @@ func Test_Discovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			client, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient()
+			client, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient(context.TODO())
 			g.Expect(client).ToNot(BeNil())
 			g.Expect(err).ToNot(HaveOccurred())
 

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -296,7 +296,7 @@ func Test_clusterctlClient_ApplyUpgrade(t *testing.T) {
 			proxy := tt.fields.client.clusters[input].Proxy()
 			gotProviders := &clusterctlv1.ProviderList{}
 
-			c, err := proxy.NewClient()
+			c, err := proxy.NewClient(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(c.List(ctx, gotProviders)).To(Succeed())

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -79,7 +79,7 @@ func (f *FakeProxy) GetConfig() (*rest.Config, error) {
 	return nil, nil
 }
 
-func (f *FakeProxy) NewClient() (client.Client, error) {
+func (f *FakeProxy) NewClient(_ context.Context) (client.Client, error) {
 	if f.cs != nil {
 		return f.cs, nil
 	}
@@ -87,7 +87,7 @@ func (f *FakeProxy) NewClient() (client.Client, error) {
 	return f.cs, nil
 }
 
-func (f *FakeProxy) CheckClusterAvailable() error {
+func (f *FakeProxy) CheckClusterAvailable(_ context.Context) error {
 	// default to considering the cluster as available unless explicitly set to be
 	// unavailable.
 	if f.available == nil || *f.available {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR:
- Replaces the `context.TODO()` with the underlying context in the function 
- adjust tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9442

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->