### PR TITLE
🐛 Fix Community meeting area formatting in release notes

### DIFF
--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -96,7 +96,7 @@ var (
 		"machinehealthcheck":                "MachineHealthCheck",
 		"clusterctl":                        "clusterctl", // Preserve lowercase
 		"util":                              "util",       // Preserve lowercase
-		"Community-meeting":                 "Community meeting",
+		"community-meeting":                 "Community meeting",
 	}
 
 	releaseBackportMarker = regexp.MustCompile(`(?m)^\[release-\d\.\d\]\s*`)


### PR DESCRIPTION
**What this PR does / why we need it**:
Tons of stupid mistakes from my side lately. Hopefully we can get https://github.com/kubernetes-sigs/cluster-api/pull/9617 merged soon to avoid these :) 

/area release