### PR TITLE
📖 Reflect a week of delay in the release-1.6/1.7 timelines

### DIFF
--- a/docs/release/releases/release-1.6.md
+++ b/docs/release/releases/release-1.6.md
@@ -16,13 +16,13 @@ The following table shows the preliminary dates for the `v1.6` release cycle.
 | *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 24th October 2023   | week 13  |
 | v1.6.0-beta.x released                               | Release Lead | Tuesday 31st October 2023   | week 14  |
 | KubeCon idle week                                    |      -       | 6th - 10th November 2023    | week 15  |
-| release-1.6 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 14th November 2023  | week 16  |
-| v1.6.0-rc.0 released                                 | Release Lead | Tuesday 14th November 2023  | week 16  |
-| release-1.6 jobs created                             | CI Manager   | Tuesday 14th November 2023  | week 16  |
-| v1.6.0-rc.x released                                 | Release Lead | Tuesday 21st November 2023  | week 17  |
-| **v1.6.0 released**                                  | Release Lead | Tuesday 28th November 2023  | week 18  |
-| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 28th November 2023  | week 18  |
-| Organize release retrospective                       | Release Lead | TBC                         | week 18  |
+| release-1.6 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 21st November 2023  | week 17  |
+| v1.6.0-rc.0 released                                 | Release Lead | Tuesday 21st November 2023  | week 17  |
+| release-1.6 jobs created                             | CI Manager   | Tuesday 21st November 2023  | week 17  |
+| v1.6.0-rc.x released                                 | Release Lead | Tuesday 28th November 2023  | week 18  |
+| **v1.6.0 released**                                  | Release Lead | Tuesday 5th December 2023   | week 19  |
+| *v1.4.x & v1.5.x released*                           | Release Lead | Tuesday 5th December 2023   | week 19  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 19  |
 
 After the `.0` release monthly patch release will be created.
 

--- a/docs/release/releases/release-1.7.md
+++ b/docs/release/releases/release-1.7.md
@@ -6,22 +6,22 @@ The following table shows the preliminary dates for the `v1.7` release cycle.
 
 | **What**                                             | **Who**      | **When**                    | **Week** |
 |------------------------------------------------------|--------------|-----------------------------|----------|
-| Start of Release Cycle                               | Release Lead | Monday 4th December 2023    | week 1   |
-| Schedule finalized                                   | Release Lead | Friday 8th December 2023    | week 1   |
-| Team finalized                                       | Release Lead | Friday 8th December 2023    | week 1   |
-| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 9th January 2024    | week 6   |
-| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 6th February 2024   | week 10  |
-| v1.7.0-beta.0 released                               | Release Lead | Tuesday 5th March 2024      | week 14  |
-| Communicate beta to providers                        | Comms Manager| Tuesday 5th March 2024      | week 14  |
-| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 5th March 2024      | week 14  |
-| v1.7.0-beta.x released                               | Release Lead | Tuesday 12th March 2024     | week 15  |
-| KubeCon idle week                                    |      -       | 19th - 22nd March 2024      | week 16  |
-| release-1.7 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 26th March 2024     | week 17  |
-| v1.7.0-rc.0 released                                 | Release Lead | Tuesday 26th March 2024     | week 17  |
-| release-1.7 jobs created                             | CI Manager   | Tuesday 26th March 2024     | week 17  |
-| v1.7.0-rc.x released                                 | Release Lead | Tuesday 2nd April 2024      | week 18  |
-| **v1.7.0 released**                                  | Release Lead | Tuesday 9th April 2024      | week 19  |
-| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 9th April 2024      | week 19  |
+| Start of Release Cycle                               | Release Lead | Monday 11th December 2023   | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 15th December 2023   | week 1   |
+| Team finalized                                       | Release Lead | Friday 15th December 2023   | week 1   |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 16th January 2024   | week 6   |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 13th February 2024  | week 10  |
+| v1.7.0-beta.0 released                               | Release Lead | Tuesday 12th March 2024     | week 14  |
+| Communicate beta to providers                        | Comms Manager| Tuesday 12th March 2024     | week 14  |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 12th March 2024     | week 14  |
+| KubeCon idle week                                    |      -       | 19th - 22nd March 2024      | week 15  |
+| v1.7.0-beta.x released                               | Release Lead | Tuesday 26th March 2024     | week 16  |
+| release-1.7 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 2nd April 2024      | week 17  |
+| v1.7.0-rc.0 released                                 | Release Lead | Tuesday 2nd April 2024      | week 17  |
+| release-1.7 jobs created                             | CI Manager   | Tuesday 2nd April 2024      | week 17  |
+| v1.7.0-rc.x released                                 | Release Lead | Tuesday 9th April 2024      | week 18  |
+| **v1.7.0 released**                                  | Release Lead | Tuesday 16th April 2024     | week 19  |
+| *v1.5.x & v1.6.x released*                           | Release Lead | Tuesday 16th April 2024     | week 19  |
 | Organize release retrospective                       | Release Lead | TBC                         | week 19  |
 
 After the `.0` release monthly patch release will be created.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This PR updates the release-1.6/1.7 timelines where it:

- moves dates a week at the end of the release-1.6 cycle timeline doc due to the delay of week in release candidate cutting
- moves preliminary dates for release-1.7 cycle timeline for a week consequently

/area release

