### PR TITLE
🌱 Added test for state_test.go

### DIFF
--- a/internal/controllers/topology/cluster/scope/state_test.go
+++ b/internal/controllers/topology/cluster/scope/state_test.go
@@ -121,6 +121,8 @@ func TestMPIsUpgrading(t *testing.T) {
 	g := NewWithT(t)
 	scheme := runtime.NewScheme()
 	g.Expect(expv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	tests := []struct {
 		name    string
@@ -154,10 +156,10 @@ func TestMPIsUpgrading(t *testing.T) {
 				Build(),
 			nodes: []*corev1.Node{
 				builder.Node("node1").
-					WithStatus(corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.3"}}).
+					WithStatus(corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.4"}}).
 					Build(),
 				builder.Node("node2").
-					WithStatus(corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.4"}}).
+					WithStatus(corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.3"}}).
 					Build(),
 			},
 			want:    true,
@@ -185,9 +187,9 @@ func TestMPIsUpgrading(t *testing.T) {
 				WithClusterName("cluster1").
 				WithVersion("v1.2.3").
 				Build(),
-			nodes: []*corev1.Node{},
-			want:     false,
-			wantErr:  false,
+			nodes:   []*corev1.Node{},
+			want:    false,
+			wantErr: false,
 		},
 	}
 
@@ -260,6 +262,7 @@ func TestMPUpgrading(t *testing.T) {
 	g := NewWithT(t)
 	scheme := runtime.NewScheme()
 	g.Expect(expv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	ctx := context.Background()
 

--- a/internal/test/builder/builders.go
+++ b/internal/test/builder/builders.go
@@ -1574,6 +1574,39 @@ func (m *MachinePoolBuilder) Build() *expv1.MachinePool {
 	return obj
 }
 
+// NodeBuilder holds the variables required to build a Node.
+type NodeBuilder struct {
+	name        string
+	status      corev1.NodeStatus
+}
+
+// Node returns a NodeBuilder.
+func Node(name string) *NodeBuilder {
+	return &NodeBuilder{
+		name:      name,
+	}
+}
+
+// WithStatus adds Status to the NodeBuilder
+func (n *NodeBuilder) WithStatus(status corev1.NodeStatus) *NodeBuilder {
+	n.status = status
+	return n
+}
+
+// Build produces a new Node from the information passed to the NodeBuilder
+func (n *NodeBuilder) Build() *corev1.Node {
+	obj := &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: clusterv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n.name,
+		},
+	}
+	return obj
+}
+
 // MachineDeploymentBuilder holds the variables and objects needed to build a generic MachineDeployment.
 type MachineDeploymentBuilder struct {
 	namespace              string

--- a/internal/test/builder/builders.go
+++ b/internal/test/builder/builders.go
@@ -1550,6 +1550,9 @@ func (m *MachinePoolBuilder) Build() *expv1.MachinePool {
 			Namespace: m.namespace,
 			Labels:    m.labels,
 		},
+		Status: expv1.MachinePoolStatus{
+			NodeRefs: m.status.NodeRefs,
+		},
 		Spec: expv1.MachinePoolSpec{
 			ClusterName:     m.clusterName,
 			Replicas:        m.replicas,
@@ -1576,14 +1579,15 @@ func (m *MachinePoolBuilder) Build() *expv1.MachinePool {
 
 // NodeBuilder holds the variables required to build a Node.
 type NodeBuilder struct {
-	name        string
-	status      corev1.NodeStatus
+	name   string
+	status corev1.NodeStatus
 }
 
 // Node returns a NodeBuilder.
 func Node(name string) *NodeBuilder {
+
 	return &NodeBuilder{
-		name:      name,
+		name: name,
 	}
 }
 
@@ -1601,7 +1605,7 @@ func (n *NodeBuilder) Build() *corev1.Node {
 			APIVersion: clusterv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      n.name,
+			Name: n.name,
 		},
 	}
 	return obj


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds tests for the new ClusterClass MachinePool implementation for the internal/controllers/topology/cluster/scope/state_test.go
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #5991

/area testing
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->