### PR TITLE
[release-1.4] 🐛 clusterresourceset: requeue after 1 minute if ErrClusterLocked got hit

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -151,7 +151,7 @@ func (r *ClusterResourceSetReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// the current cluster because of concurrent access.
 			if errors.Is(err, remote.ErrClusterLocked) {
 				log.V(5).Info("Requeuing because another worker has the lock on the ClusterCacheTracker")
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: time.Minute}, nil
 			}
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9777

/assign sbueringer