### PR TITLE
📖 Set 1.4 EOL date and update coredns version table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,8 +166,9 @@ Cluster API maintains the most recent release/releases for all supported API and
 
 | Minor Release | API Version  | Supported Until                                     |
 |---------------|--------------|-----------------------------------------------------|
+| v1.6.x        | **v1beta1**  | when v1.8.0 will be released                        |
 | v1.5.x        | **v1beta1**  | when v1.7.0 will be released                        |
-| v1.4.x        | **v1beta1**  | when v1.6.0 will be released, tentatively Nov 2023  |
+| v1.4.x        | **v1beta1**  | EOL since 2023-12-05 - v1.6.0 release date          |
 | v1.3.x        | **v1beta1**  | EOL since 2023-07-25 - v1.5.0 release date          |
 | v1.2.x        | **v1beta1**  | EOL since 2023-03-28 - v1.4.0 release date          |
 | v1.1.x        | **v1beta1**  | EOL since 2022-07-18 - v1.2.0 release date (*)      |

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -138,14 +138,9 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 | CAPI Version         | Max CoreDNS Version for Upgrade |
 |----------------------|---------------------------------|
-| >= v1.2.7 (v1beta1)  | v1.10.0                         |
-| >= v1.2.11 (v1beta1) | v1.10.1                         |
-| v1.3 (v1beta1)       | v1.10.0                         |
-| >= v1.3.4 (v1beta1)  | v1.10.1                         |
-| v1.4 (v1beta1)       | v1.10.1                         |
-| >= v1.4.6 (v1beta1)  | v1.11.1                         |
 | v1.5 (v1beta1)       | v1.10.1                         |
 | >= v1.5.1 (v1beta1)  | v1.11.1                         |
+| v1.6 (v1beta1)       | v1.11.1                         |
 
 #### Kubernetes version specific notes
 


### PR DESCRIPTION
After 1.6.0 release, this is an extension to some of the task done via this PR https://github.com/kubernetes-sigs/cluster-api/pull/9119

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->