### PR TITLE
🌱 Bump kubebuilder-release-tools to v0.4.3

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - name: Verifier action
       id: verifier
-      uses: kubernetes-sigs/kubebuilder-release-tools@3c3411345eedc489d1022288aa844691e92a9c29 # tag=v0.4.2
+      uses: kubernetes-sigs/kubebuilder-release-tools@012269a88fa4c034a0acf1ba84c26b195c0dbab4 # tag=v0.4.3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
kubebuilder-release-tools [v0.4.3](https://github.com/kubernetes-sigs/kubebuilder-release-tools/releases/tag/v0.4.3
) is out, let's use it to be able to use 🚀 emoji in release PRs

/area release
