### PR TITLE
🐛 test: wait for topology to get rolled out before continuing with scaling checks

### DIFF
--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -582,7 +582,7 @@ func ScaleAndWaitMachineDeploymentTopology(ctx context.Context, input ScaleAndWa
 			return -1, errors.New("Machine count does not match existing nodes count")
 		}
 		return nodeRefCount, nil
-	}, input.WaitForMachineDeployments...).Should(Equal(int(*md.Spec.Replicas)), "Timed out waiting for Machine Deployment %s to have %d replicas", klog.KObj(&md), *md.Spec.Replicas)
+	}, input.WaitForMachineDeployments...).Should(Equal(int(input.Replicas)), "Timed out waiting for Machine Deployment %s to have %d replicas", klog.KObj(&md), input.Replicas)
 }
 
 type AssertMachineDeploymentReplicasInput struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixes a race condition in the test function `ScaleAndWaitMachineDeploymentTopology`, when:

* The Cluster object gets patched:
  * https://github.com/kubernetes-sigs/cluster-api/blob/3711210d42714669208d57f625c9151c04e3fd14/test/framework/machinedeployment_helpers.go#L536
* And the Machinedeployment gets retrieced
  * https://github.com/kubernetes-sigs/cluster-api/blob/3711210d42714669208d57f625c9151c04e3fd14/test/framework/machinedeployment_helpers.go#L542

It could be the case that the topology controller did not yet update the MachineDeployment with the new number of replicas. But we use `.spec.replicas` from the machinedeployment.

This fixes the race condition by using the replicas from the provided input instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area testing