### PR TITLE
🌱 MinReadySeconds for machinepools

### DIFF
--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1118,7 +1118,6 @@ spec:
                   be ready.
                   Defaults to 0 (machine instance will be considered available as soon as it
                   is ready)
-                  NOTE: No logic is implemented for this field and it currently has no behaviour.
                 format: int32
                 type: integer
               providerIDList:

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -49,7 +49,6 @@ type MachinePoolSpec struct {
 	// be ready.
 	// Defaults to 0 (machine instance will be considered available as soon as it
 	// is ready)
-	// NOTE: No logic is implemented for this field and it currently has no behaviour.
 	// +optional
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -45,6 +45,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			Spec: corev1.NodeSpec{
 				ProviderID: "aws://us-east-1/id-node-1",
 			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -52,6 +60,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "aws://us-west-2/id-node-2",
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
 			},
 		},
 		&corev1.Node{
@@ -61,6 +77,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			Spec: corev1.NodeSpec{
 				ProviderID: "gce://us-central1/gce-id-node-2",
 			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -68,6 +92,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure://westus2/id-node-4",
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
 			},
 		},
 		&corev1.Node{
@@ -77,6 +109,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure://westus2/id-nodepool1/0",
 			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -84,6 +124,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: "azure://westus2/id-nodepool2/0",
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
 			},
 		},
 	}
@@ -104,6 +152,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{
 					{Name: "node-1"},
 				},
+				available: 1,
+				ready:     1,
 			},
 		},
 		{
@@ -113,6 +163,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{
 					{Name: "node-2"},
 				},
+				available: 1,
+				ready:     1,
 			},
 		},
 		{
@@ -122,6 +174,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{
 					{Name: "gce-node-2"},
 				},
+				available: 1,
+				ready:     1,
 			},
 		},
 		{
@@ -131,6 +185,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{
 					{Name: "azure-node-4"},
 				},
+				available: 1,
+				ready:     1,
 			},
 		},
 		{
@@ -141,6 +197,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 					{Name: "node-1"},
 					{Name: "azure-node-4"},
 				},
+				available: 2,
+				ready:     2,
 			},
 		},
 		{
@@ -165,6 +223,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{
 					{Name: "azure-nodepool1-0"},
 				},
+				available: 1,
+				ready:     1,
 			},
 		},
 		{
@@ -175,6 +235,8 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 					{Name: "azure-nodepool1-0"},
 					{Name: "azure-nodepool2-0"},
 				},
+				available: 2,
+				ready:     2,
 			},
 		},
 		{
@@ -216,6 +278,9 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			}
 
 			g.Expect(result.references).To(HaveLen(len(test.expected.references)), "Expected NodeRef count to be %v, got %v", len(result.references), len(test.expected.references))
+
+			g.Expect(result.available).To(Equal(test.expected.available), "Expected available node count to be %v, got %v", test.expected.available, result.available)
+			g.Expect(result.ready).To(Equal(test.expected.ready), "Expected ready node count to be %v, got %v", test.expected.ready, result.ready)
 
 			for n := range test.expected.references {
 				g.Expect(result.references[n].Name).To(Equal(test.expected.references[n].Name), "Expected NodeRef's name to be %v, got %v", result.references[n].Name, test.expected.references[n].Name)

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -72,6 +72,14 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 		},
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-3",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "aws://us-west-2/id-node-3",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "gce-node-2",
 			},
 			Spec: corev1.NodeSpec{
@@ -165,6 +173,17 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				},
 				available: 1,
 				ready:     1,
+			},
+		},
+		{
+			name:           "valid provider id, valid aws node, nodeReady condition set to false",
+			providerIDList: []string{"aws://us-west-2/id-node-3"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "node-3"},
+				},
+				available: 0,
+				ready:     0,
 			},
 		},
 		{

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -1616,6 +1616,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 					},
 				},
 			},
+			MinReadySeconds: ptr.To[int32](0),
 		},
 		Status: expv1.MachinePoolStatus{},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Making MinReadySeconds work in machinepools

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8952 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machinepool