### PR TITLE
:seedling: Fix markdown format error in MachinePool API proposal

### DIFF
--- a/docs/proposals/20190919-machinepool-api.md
+++ b/docs/proposals/20190919-machinepool-api.md
@@ -1,18 +1,17 @@
 ---
 title: MachinePool API
 authors:
-- "@juan-lee"
-- "@CecileRobertMichon"
-  reviewers:
-- "@detiber"
-- "@justaugustus"
-- "@ncdc"
-- "@vincepri"
-  creation-date: 2019-09-19
-  last-updated: 2019-11-24
-  replaces:
-- [cluster-api-provider-azure Proposal](https://docs.google.com/document/d/1nbOqCIC0-ezdMXubZIV6EQrzD0QYPrpcdCBB4oSjWeQ/edit)
-  status: provisional
+  - "@juan-lee"
+  - "@CecileRobertMichon"
+reviewers:
+  - "@detiber"
+  - "@justaugustus"
+  - "@ncdc"
+  - "@vincepri"
+creation-date: 2019-09-19
+last-updated: 2019-11-24
+replaces: https://docs.google.com/document/d/1nbOqCIC0-ezdMXubZIV6EQrzD0QYPrpcdCBB4oSjWeQ
+status: provisional
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
github throw error `Error in user YAML: (<unknown>): did not find expected key while parsing a block mapping at line 1 column 1` when user visit this proposal

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->