### PR TITLE
🐛 Skip checking `clusterConfiguration.dns` fields when KCP checking MachineNeedRollout 

### DIFF
--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -189,10 +189,15 @@ func matchClusterConfiguration(kcp *controlplanev1.KubeadmControlPlane, machine 
 	if machineClusterConfig == nil {
 		machineClusterConfig = &bootstrapv1.ClusterConfiguration{}
 	}
-	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration
+
+	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.DeepCopy()
 	if kcpLocalClusterConfiguration == nil {
 		kcpLocalClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
 	}
+
+	// Skip checking DNS fields because we can update the configuration of the working cluster in place.
+	kcpLocalClusterConfiguration.DNS = bootstrapv1.DNS{}
+	machineClusterConfig.DNS = bootstrapv1.DNS{}
 
 	// Compare and return.
 	return reflect.DeepEqual(machineClusterConfig, kcpLocalClusterConfiguration)

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -190,14 +190,13 @@ func matchClusterConfiguration(kcp *controlplanev1.KubeadmControlPlane, machine 
 		machineClusterConfig = &bootstrapv1.ClusterConfiguration{}
 	}
 
-	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.DeepCopy()
+	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration
 	if kcpLocalClusterConfiguration == nil {
 		kcpLocalClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
 	}
 
 	// Skip checking DNS fields because we can update the configuration of the working cluster in place.
-	kcpLocalClusterConfiguration.DNS = bootstrapv1.DNS{}
-	machineClusterConfig.DNS = bootstrapv1.DNS{}
+	machineClusterConfig.DNS = kcpLocalClusterConfiguration.DNS
 
 	// Compare and return.
 	return reflect.DeepEqual(machineClusterConfig, kcpLocalClusterConfiguration)

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -104,6 +104,31 @@ func TestMatchClusterConfiguration(t *testing.T) {
 		}
 		g.Expect(matchClusterConfiguration(kcp, m)).To(BeTrue())
 	})
+	t.Run("Return true although the DNS fields are different", func(t *testing.T) {
+		g := NewWithT(t)
+		kcp := &controlplanev1.KubeadmControlPlane{
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+						DNS: bootstrapv1.DNS{
+							ImageMeta: bootstrapv1.ImageMeta{
+								ImageTag:        "v1.10.1",
+								ImageRepository: "gcr.io/capi-test",
+							},
+						},
+					},
+				},
+			},
+		}
+		m := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					controlplanev1.KubeadmClusterConfigurationAnnotation: "{\"dns\":{\"imageRepository\":\"gcr.io/capi-test\",\"imageTag\":\"v1.9.3\"}}",
+				},
+			},
+		}
+		g.Expect(matchClusterConfiguration(kcp, m)).To(BeTrue())
+	})
 }
 
 func TestGetAdjustedKcpConfig(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

KCP uses the following method to update the coredns version, this does not require rolling updates of control plane nodes, and we can optimize it.

https://github.com/kubernetes-sigs/cluster-api/blob/9d36ddcbf8381574a86cebeacdcdfc85bafa71e9/controlplane/kubeadm/internal/controllers/controller.go#L466-L469


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/9832

**Test**:

1. Create CAPI Cluster with dns config.
```
kc get kcp -n default hw-sks-test-no-gpu-controlplane -ojson | jq '.spec.kubeadmConfigSpec.clusterConfiguration.dns'
{
  "imageRepository": "registry.smtx.io/kubesmart/coredns",
  "imageTag": "v1.10.1"
}
```

2. Then update the dns config.
```
kc get kcp -n default hw-sks-test-no-gpu-controlplane -ojson | jq '.spec.kubeadmConfigSpec.clusterConfiguration.dns'

{
  "imageRepository": "registry.smtx.io/kubesmart/coredns",
  "imageTag": "v1.11.0"
}
```
3. KCP is ready and CP Machine no need rolling update.
```
kc get kcp -n default hw-sks-test-no-gpu-controlplane
NAME                              CLUSTER              INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE   VERSION
hw-sks-test-no-gpu-controlplane   hw-sks-test-no-gpu   true          true                   3          3       3         0             17h   v1.25.15

kc get machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks-test-no-gpu,cluster.x-k8s.io/control-plane=
NAME                                    CLUSTER              NODENAME                                PROVIDERID                                   PHASE     AGE   VERSION
hw-sks-test-no-gpu-controlplane-2gmhm   hw-sks-test-no-gpu   hw-sks-test-no-gpu-controlplane-nw86c   elf://d29afee9-03ab-440c-a294-64afd5b67adf   Running   17h   v1.25.15
hw-sks-test-no-gpu-controlplane-f4x7n   hw-sks-test-no-gpu   hw-sks-test-no-gpu-controlplane-h2k4j   elf://c663ea39-865d-473b-8a30-56b4dc22a032   Running   17h   v1.25.15
hw-sks-test-no-gpu-controlplane-mzph8   hw-sks-test-no-gpu   hw-sks-test-no-gpu-controlplane-pztmt   elf://0f0ef45c-7b95-4b68-8a58-06b9235a1ae7   Running   17h   v1.25.15
```
4.  Workload cluster DNS config has been updated.
 
```
kc get deploy coredns -n kube-system -ojson | jq '.spec.template.spec.containers[].image'
"registry.smtx.io/kubesmart/coredns/coredns:v1.11.0"

kc get cm kubeadm-config -n kube-system -oyaml | yq '.data.ClusterConfiguration'  | yq '.dns'
imageRepository: registry.smtx.io/kubesmart/coredns
imageTag: v1.11.0
```

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area provider/control-plane-kubeadm