### PR TITLE
📖 Update CAPI support and guarantees for v1.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,7 @@ Cluster API maintains the most recent release/releases for all supported API and
 
 | Minor Release | API Version  | Supported Until                                     |
 |---------------|--------------|-----------------------------------------------------|
+| v1.7.x        | **v1beta1**  | when v1.9.0 will be released                        |
 | v1.6.x        | **v1beta1**  | when v1.8.0 will be released                        |
 | v1.5.x        | **v1beta1**  | when v1.7.0 will be released                        |
 | v1.4.x        | **v1beta1**  | EOL since 2023-12-05 - v1.6.0 release date          |

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -72,61 +72,50 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | v1.3 (v1beta1) (EOL) | v1.4 (v1beta1)    | v1.5 (v1beta1)    | v1.6 (v1beta1)    |
+|                   | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)    | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
 |-------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.18  | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.19  | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.20  | ✓                    |                   |                   |                   |
-| Kubernetes v1.21  | ✓                    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.22  | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.23* | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.24  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.25  | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21  | ✓ (only workload)    |                   |                   |                   |
+| Kubernetes v1.22  | ✓ (only workload)    | ✓ (only workload) |                   |                   |
+| Kubernetes v1.23* | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
+| Kubernetes v1.24  | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.25  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
 | Kubernetes v1.26  | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.27  |                      | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.28  |                      |                   | ✓                 | ✓                 |
+| Kubernetes v1.27  | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.28  |                      | ✓                 | ✓                 | ✓                 |
 
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
 	 Previous Kubernetes **minor** versions are not affected.
 
-\** When using CAPI v1.2 or v1.3 with the CLUSTER_TOPOLOGY experimental feature on, the Kubernetes Version for the management cluster must be >= 1.22.0.
-
 The Core Provider also talks to API server of every Workload Cluster. Therefore, the Workload Cluster's Kubernetes version must also be compatible.
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    | v1.3 (v1beta1) (EOL) | v1.4 (v1beta1)     | v1.5 (v1beta1)     | v1.6 (v1beta1)     |
+|                                    | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)     | v1.6 (v1beta1)     | v1.7 (v1beta1)     |
 |------------------------------------|----------------------|--------------------|--------------------|--------------------|
-| Kubernetes v1.18 + kubeadm/v1beta2 | ✓ (only workload)    |                    |                    |                    |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓ (only workload)    |                    |                    |                    |
-| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                    |                    |                    |                    |
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                    | ✓  (only workload) |                    |                    |
-| Kubernetes v1.22 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) |                    |
-| Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓  (only workload) | ✓  (only workload) |
-| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓  (only workload) |
-| Kubernetes v1.25 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
+| Kubernetes v1.21 + kubeadm/v1beta2 | ✓  (only workload)   |                    |                    |                    |
+| Kubernetes v1.22 + kubeadm/v1beta3 | ✓  (only workload)   | ✓  (only workload) |                    |                    |
+| Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) |                    |
+| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓  (only workload) | ✓  (only workload) |
+| Kubernetes v1.25 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓  (only workload) |
 | Kubernetes v1.26 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
-| Kubernetes v1.27 + kubeadm/v1beta3 |                      | ✓                  | ✓                  | ✓                  |
-| Kubernetes v1.28 + kubeadm/v1beta3 |                      |                    | ✓                  | ✓                  |
+| Kubernetes v1.27 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
+| Kubernetes v1.28 + kubeadm/v1beta3 |                      | ✓                  | ✓                  | ✓                  |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | v1.3 (v1beta1) (EOL) | v1.4 (v1beta1)    | v1.5 (v1beta1)    | v1.6 (v1beta1)    |
+|                            | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)    | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
 |----------------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.18 + etcd/v3 | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.19 + etcd/v3 | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.20 + etcd/v3 | ✓                    |                   |                   |                   |
-| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.22 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.23 + etcd/v3 | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.25 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21 + etcd/v3 | ✓ (only workload)    |                   |                   |                   |
+| Kubernetes v1.22 + etcd/v3 | ✓ (only workload)    | ✓ (only workload) |                   |                   |
+| Kubernetes v1.23 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
+| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.25 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
 | Kubernetes v1.26 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.27 + etcd/v3 |                      | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.28 + etcd/v3 |                      |                   | ✓                 | ✓                 |
+| Kubernetes v1.27 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.28 + etcd/v3 |                      | ✓                 | ✓                 | ✓                 |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 


### PR DESCRIPTION
This PR updates the supported versions for the next release cycle (1.7).
Task: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#update-supported-versions

@kubernetes-sigs/cluster-api-release-team

/area documentation