### PR TITLE
✨ KCP: Allow mutation of all fields that should be mutable

### DIFF
--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -159,12 +159,20 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
 	// add a * to indicate everything beneath is ok.
 	// For example, {"spec", "*"} will allow any path under "spec" to change.
 	allowedPaths := [][]string{
+		// metadata
 		{"metadata", "*"},
-		{spec, kubeadmConfigSpec, "useExperimentalRetryJoin"},
+		// spec.kubeadmConfigSpec.clusterConfiguration
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "extraArgs"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "extraArgs", "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "dataDir"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "peerCertSANs"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "serverCertSANs"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "external", "endpoints"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "external", "caFile"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "external", "certFile"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "external", "keyFile"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
@@ -174,16 +182,27 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
 		{spec, kubeadmConfigSpec, clusterConfiguration, controllerManager, "*"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler},
 		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler, "*"},
+		// spec.kubeadmConfigSpec.initConfiguration
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration},
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, patches, directory},
 		{spec, kubeadmConfigSpec, initConfiguration, patches},
 		{spec, kubeadmConfigSpec, initConfiguration, skipPhases},
+		{spec, kubeadmConfigSpec, initConfiguration, "bootstrapTokens"},
+		{spec, kubeadmConfigSpec, initConfiguration, "localAPIEndpoint"},
+		{spec, kubeadmConfigSpec, initConfiguration, "localAPIEndpoint", "*"},
+		// spec.kubeadmConfigSpec.joinConfiguration
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration},
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, joinConfiguration, patches, directory},
 		{spec, kubeadmConfigSpec, joinConfiguration, patches},
 		{spec, kubeadmConfigSpec, joinConfiguration, skipPhases},
+		{spec, kubeadmConfigSpec, joinConfiguration, "caCertPath"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "controlPlane"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "controlPlane", "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "discovery"},
+		{spec, kubeadmConfigSpec, joinConfiguration, "discovery", "*"},
+		// spec.kubeadmConfigSpec
 		{spec, kubeadmConfigSpec, preKubeadmCommands},
 		{spec, kubeadmConfigSpec, postKubeadmCommands},
 		{spec, kubeadmConfigSpec, files},
@@ -197,6 +216,8 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
 		{spec, kubeadmConfigSpec, diskSetup, "*"},
 		{spec, kubeadmConfigSpec, "format"},
 		{spec, kubeadmConfigSpec, "mounts"},
+		{spec, kubeadmConfigSpec, "useExperimentalRetryJoin"},
+		// spec.machineTemplate
 		{spec, "machineTemplate", "metadata"},
 		{spec, "machineTemplate", "metadata", "*"},
 		{spec, "machineTemplate", "infrastructureRef", "apiVersion"},
@@ -205,6 +226,7 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
 		{spec, "machineTemplate", "nodeDrainTimeout"},
 		{spec, "machineTemplate", "nodeVolumeDetachTimeout"},
 		{spec, "machineTemplate", "nodeDeletionTimeout"},
+		// spec
 		{spec, "replicas"},
 		{spec, "version"},
 		{spec, "remediationStrategy"},

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
@@ -380,17 +380,11 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	wrongReplicaCountForScaleIn := before.DeepCopy()
 	wrongReplicaCountForScaleIn.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntVal = int32(0)
 
-	invalidUpdateKubeadmConfigInit := before.DeepCopy()
-	invalidUpdateKubeadmConfigInit.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
-
 	validUpdateKubeadmConfigInit := before.DeepCopy()
 	validUpdateKubeadmConfigInit.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration = bootstrapv1.NodeRegistrationOptions{}
 
 	invalidUpdateKubeadmConfigCluster := before.DeepCopy()
 	invalidUpdateKubeadmConfigCluster.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
-
-	invalidUpdateKubeadmConfigJoin := before.DeepCopy()
-	invalidUpdateKubeadmConfigJoin.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 
 	validUpdateKubeadmConfigJoin := before.DeepCopy()
 	validUpdateKubeadmConfigJoin.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration = bootstrapv1.NodeRegistrationOptions{}
@@ -586,8 +580,6 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	localDataDir.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &bootstrapv1.LocalEtcd{
 		DataDir: "some local data dir",
 	}
-	modifyLocalDataDir := localDataDir.DeepCopy()
-	modifyLocalDataDir.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.DataDir = "a different local data dir"
 
 	localPeerCertSANs := before.DeepCopy()
 	localPeerCertSANs.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &bootstrapv1.LocalEtcd{
@@ -727,12 +719,6 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       validUpdate,
 		},
 		{
-			name:      "should return error when trying to mutate the kubeadmconfigspec initconfiguration",
-			expectErr: true,
-			before:    before,
-			kcp:       invalidUpdateKubeadmConfigInit,
-		},
-		{
 			name:      "should not return an error when trying to mutate the kubeadmconfigspec initconfiguration noderegistration",
 			expectErr: false,
 			before:    before,
@@ -743,12 +729,6 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: true,
 			before:    before,
 			kcp:       invalidUpdateKubeadmConfigCluster,
-		},
-		{
-			name:      "should return error when trying to mutate the kubeadmconfigspec joinconfiguration",
-			expectErr: true,
-			before:    before,
-			kcp:       invalidUpdateKubeadmConfigJoin,
 		},
 		{
 			name:      "should not return an error when trying to mutate the kubeadmconfigspec joinconfiguration noderegistration",
@@ -912,20 +892,20 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       featureGates,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's local etcd's configuration localDataDir field",
-			expectErr: true,
+			name:      "should succeed when making a change to the cluster config's local etcd's configuration localDataDir field",
+			expectErr: false,
 			before:    before,
 			kcp:       localDataDir,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's local etcd's configuration localPeerCertSANs field",
-			expectErr: true,
+			name:      "should succeed when making a change to the cluster config's local etcd's configuration localPeerCertSANs field",
+			expectErr: false,
 			before:    before,
 			kcp:       localPeerCertSANs,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's local etcd's configuration localServerCertSANs field",
-			expectErr: true,
+			name:      "should succeed when making a change to the cluster config's local etcd's configuration localServerCertSANs field",
+			expectErr: false,
 			before:    before,
 			kcp:       localServerCertSANs,
 		},
@@ -936,8 +916,8 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       localExtraArgs,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's external etcd's configuration",
-			expectErr: true,
+			name:      "should succeed when making a change to the cluster config's external etcd's configuration",
+			expectErr: false,
 			before:    before,
 			kcp:       externalEtcd,
 		},
@@ -946,12 +926,6 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: true,
 			before:    etcdLocalImageTag,
 			kcp:       unsetEtcd,
-		},
-		{
-			name:      "should fail when modifying a field that is not the local etcd image metadata",
-			expectErr: true,
-			before:    localDataDir,
-			kcp:       modifyLocalDataDir,
 		},
 		{
 			name:      "should fail if both local and external etcd are set",


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I went over the entire KCP struct and audited for fields that can be mutated.

The goal was to avoid further PRs to make more fields mutable only after someone hit a problem

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->