### PR TITLE
✨ v1.29: Prepare quickstart, capd and tests for the new release including kind bump

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,7 @@
 envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
-kubernetes_version = "v1.28.0"
+kubernetes_version = "v1.29.0"
 
 load("ext://uibutton", "cmd_button", "location", "text_input")
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -337,7 +337,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: "default"
-  KUBERNETES_VERSION: "v1.28.0"
+  KUBERNETES_VERSION: "v1.29.0"
   CONTROL_PLANE_MACHINE_COUNT: "1"
   WORKER_MACHINE_COUNT: "3"
 # Note: kustomize substitutions expects the values to be strings. This can be achieved by wrapping the values in quotation marks.

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -133,6 +133,9 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 #### Kubernetes version specific notes
 
+**1.29**:
+* In-tree cloud providers are now switched off by default. Please use DisableCloudProviders and DisableKubeletCloudCredentialProvider feature flags if you still need this functionality. (https://github.com/kubernetes/kubernetes/pull/117503)
+
 **1.28**:
 * No specific notes
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1288,7 +1288,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.28.0 \
+  --kubernetes-version v1.29.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1331,7 +1331,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.28.0 \
+  --kubernetes-version v1.29.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1385,7 +1385,7 @@ and see an output similar to this:
 
 ```bash
 NAME              PHASE         AGE   VERSION
-capi-quickstart   Provisioned   8s    v1.28.0
+capi-quickstart   Provisioned   8s    v1.29.0
 ```
 
 To verify the first control plane is up:
@@ -1398,7 +1398,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.28.0
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.29.0
 ```
 
 <aside class="note warning">
@@ -1618,12 +1618,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE    VERSION
-capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.28.0
-capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.28.0
-capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.28.0
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.28.0
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.28.0
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.28.0
+capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.29.0
+capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.29.0
+capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.29.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.29.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.29.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.29.0
 ```
 
 {{#/tab }}

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -129,7 +129,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.5=>cur
 })
 
 var _ = Describe("When testing clusterctl upgrades (v1.6=>current)", func() {
-	// Get v1.5 latest stable release
+	// Get v1.6 latest stable release
 	version := "1.6"
 	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version)
@@ -144,7 +144,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.6=>current)", func() {
 			InitWithBinary:            fmt.Sprintf(clusterctlDownloadURL, stableRelease),
 			InitWithProvidersContract: "v1beta1",
 			//  Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
-			InitWithKubernetesVersion: "v1.28.0",
+			InitWithKubernetesVersion: "v1.29.0",
 			WorkloadKubernetesVersion: "v1.28.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
@@ -153,7 +153,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.6=>current)", func() {
 })
 
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.6=>current) [ClusterClass]", func() {
-	// Get v1.5 latest stable release
+	// Get v1.6 latest stable release
 	version := "1.6"
 	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version)
@@ -168,7 +168,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.6=>cur
 			InitWithBinary:            fmt.Sprintf(clusterctlDownloadURL, stableRelease),
 			InitWithProvidersContract: "v1beta1",
 			// Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
-			InitWithKubernetesVersion: "v1.28.0",
+			InitWithKubernetesVersion: "v1.29.0",
 			WorkloadKubernetesVersion: "v1.28.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -237,14 +237,12 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.28.0"
-  # TODO when bumping this version: also remove the pinning of the conformanceImage at the [ipv6] tests in
-  # `test/e2e/quick_start_test.go`.
-  KUBERNETES_VERSION: "v1.28.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.28.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.29.0"
+  KUBERNETES_VERSION: "v1.29.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.28.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.29.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.10-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "dual"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -143,9 +143,6 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
-						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
-						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
-						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
 					},
 				)).To(Succeed())
 			},
@@ -172,9 +169,6 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
-						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
-						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
-						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
 					},
 				)).To(Succeed())
 			},

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
+	DefaultNodeImageVersion = "v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.28.0
+  version: v1.29.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.28.0
+      version: v1.29.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.28.0
+  version: v1.29.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.28.0
+      version: v1.29.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.28.0
+  version: v1.29.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.28.0
+      version: v1.29.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.28.0
+  version: v1.29.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.28.0
+      version: v1.29.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -82,6 +82,11 @@ var preBuiltMappings = []Mapping{
 
 	// Pre-built images for Kind v1.20.
 	{
+		KubernetesVersion: semver.MustParse("1.29.0"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570",
+	},
+	{
 		KubernetesVersion: semver.MustParse("1.28.0"),
 		Mode:              Mode0_20,
 		Image:             "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Modify quickstart and CAPD to use the new Kubernetes release:

* Bump the Kubernetes version in:
  * `test/*`: search for occurrences of the previous Kubernetes version
  * `Tiltfile`
* Ensure the latest available kind version is used (including the latest images for this kind release)
  * Add new images in the [kind mapper.go](https://github.com/kubernetes-sigs/cluster-api/blob/48ae58e51f9723ab7b9635d0e05ee54c4843707a/test/infrastructure/kind/mapper.go#L79).
    * See the [kind releases page](https://github.com/kubernetes-sigs/kind/releases) for the list of released images.
  * Set new default image for the [test framework](https://github.com/kubernetes-sigs/cluster-api/blob/48ae58e51f9723ab7b9635d0e05ee54c4843707a/test/framework/bootstrap/kind_provider.go#L40)
* Verify the quickstart manually
* Bump `InitWithKubernetesVersion` and `WorkloadKubernetesVersion` in `clusterctl_upgrade_test.go`
  * Note: Only bump for Cluster API versions that will support the new Kubernetes release.
* Prior art: [✨ v1.28: Prepare quickstart, capd and tests for the new release including kind bump #9160](https://github.com/kubernetes-sigs/cluster-api/pull/9160)

TODO's:

- [x] Wait for dependend PR to merge
  - #9799
- [x] Rebase after above got merged
- [x] Wait for kindest/node image to be released for v1.29.0
- [x] Fix open `TODO(chrischdi)`'s to set proper SHA's to the new image
- [x] verify the quickstart manually

Follow-up

- [ ] manually cherry-pick this PR after merge to release-1.6
  - prior art: #9225

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #9578

/area testing