### PR TITLE
:seedling: Update glossary.md: Fix typo in level of heading.

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -87,7 +87,7 @@ Cluster API Provider Kubevirt
 ### CAPO
 Cluster API Provider OpenStack
 
-## CAPOSC
+### CAPOSC
 Cluster API Provider Outscale
 
 ### CAPOCI


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix typo in heading of "Cluster API Provider Outscale"

/area documentation
