### PR TITLE
✨  Make sure IPAddressClaim has a cluster name label.

### DIFF
--- a/exp/ipam/internal/webhooks/ipaddressclaim_test.go
+++ b/exp/ipam/internal/webhooks/ipaddressclaim_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 )
 
@@ -48,8 +49,12 @@ func TestIPAddressClaimValidateCreate(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name:      "should accept a valid claim",
-			claim:     getClaim(func(addr *ipamv1.IPAddressClaim) {}),
+			name: "should accept a valid claim",
+			claim: getClaim(func(addr *ipamv1.IPAddressClaim) {
+				addr.GetObjectMeta().SetLabels(map[string]string{
+					clusterv1.ClusterNameLabel: "test-cluster",
+				})
+			}),
 			expectErr: false,
 		},
 		{
@@ -57,6 +62,11 @@ func TestIPAddressClaimValidateCreate(t *testing.T) {
 			claim: getClaim(func(addr *ipamv1.IPAddressClaim) {
 				addr.Spec.PoolRef.APIGroup = nil
 			}),
+			expectErr: true,
+		},
+		{
+			name:      "should reject an IPAddressClaim that doesn't have a cluster name label",
+			claim:     getClaim(func(addr *ipamv1.IPAddressClaim) {}),
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The `clusterctl move` fails because the IPAddressClaim is not paused so the controller in the target cluster will create IPAddress resouces.

To pause the IPAddressClaim, we need to set the cluster label name.

This PR adds validation to the webhook of IPAddressClaim to ensure the cluster name label is always set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/9478
/area ipam