### PR TITLE
🐛 capd: fix ignition to also set the kube-proxy configuration to skip setting sysctls

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/ignition.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-ignition/ignition.yaml
@@ -12,6 +12,8 @@ spec:
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
           fail-swap-on: "false"
+          cgroup-root: "/kubelet"
+          runtime-cgroups: "/system.slice/containerd.service"
     joinConfiguration:
       nodeRegistration:
         # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
@@ -19,6 +21,8 @@ spec:
         kubeletExtraArgs:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
           fail-swap-on: "false"
+          cgroup-root: "/kubelet"
+          runtime-cgroups: "/system.slice/containerd.service"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -45,3 +49,5 @@ spec:
           kubeletExtraArgs:
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
             fail-swap-on: "false"
+            cgroup-root: "/kubelet"
+            runtime-cgroups: "/system.slice/containerd.service"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

While developing for k8s v1.29 support (#9872 and #9890) ignition tests started to fail because kube-proxy was not able to start due to the following error:

```
❯ k logs -n kube-system kube-proxy-brfk2
I1218 12:12:16.663929       1 server_others.go:72] "Using iptables proxy"
I1218 12:12:16.670800       1 server.go:1050] "Successfully retrieved node IP(s)" IPs=["172.18.0.5"]
I1218 12:12:16.671585       1 conntrack.go:118] "Set sysctl" entry="net/netfilter/nf_conntrack_max" value=196608
E1218 12:12:16.671607       1 server.go:556] "Error running ProxyServer" err="open /proc/sys/net/netfilter/nf_conntrack_max: permission denied"
E1218 12:12:16.671633       1 run.go:74] "command failed" err="open /proc/sys/net/netfilter/nf_conntrack_max: permission denied"
```

It turns out that we are adding custom kube-proxy configuration when using cloud-init in capd already for a long time. This did not happen for ignition.
With k8s v1.29, kube-proxy seems to have changed its behaviour so it wanted to set the sysctls when `maxPerCore` was set to `nil`.

This fixes the issue by adding the configuration similar to what we do for cloud-init in CAPD.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


/area provider/infrastructure-docker