### PR TITLE
📖 capd: fix quickstart to also enable the machine pool feature gate

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -530,14 +530,17 @@ The Docker provider is not designed for production use and is intended for devel
 
 </aside>
 
-The Docker provider requires the `ClusterTopology` feature to deploy ClusterClass-based clusters. We are
-only supporting ClusterClass-based cluster-templates in this quickstart as ClusterClass makes it possible to
+The Docker provider requires the `ClusterTopology` and `MachinePool` features to deploy ClusterClass-based clusters.
+We are only supporting ClusterClass-based cluster-templates in this quickstart as ClusterClass makes it possible to
 adapt configuration based on Kubernetes version. This is required to install Kubernetes clusters < v1.24 and
 for the upgrade from v1.23 to v1.24 as we have to use different cgroupDrivers depending on Kubernetes version.
 
 ```bash
 # Enable the experimental Cluster topology feature.
 export CLUSTER_TOPOLOGY=true
+
+# Enable the experimental Machine Pool feature
+export EXP_MACHINE_POOL=true
 
 # Initialize the management cluster
 clusterctl init --infrastructure docker


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The manifests of the topology flavor for CAPD also include a MachinePool.
This flavor is used in quick-start which is why it should also note enabling the Machine Pool related feature gate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area docs