### PR TITLE
🐛 ssa: fix flaky test TestPatch/Test patch with Machine

### DIFF
--- a/internal/util/ssa/patch_test.go
+++ b/internal/util/ssa/patch_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -110,6 +111,11 @@ func TestPatch(t *testing.T) {
 				NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Second},
 				Bootstrap: clusterv1.Bootstrap{
 					DataSecretName: ptr.To("data-secret"),
+				},
+				InfrastructureRef: corev1.ObjectReference{
+					// The namespace needs to get set here. Otherwise the defaulting webhook always sets this field again
+					// which would lead to an resourceVersion bump at the 3rd step and to a flaky test.
+					Namespace: ns.Name,
 				},
 			},
 		}


### PR DESCRIPTION
During the test at the additional Patch calls the defaulting webhook did always set the .spec.infrastructureRef.namespace field.

This caused flaky behaviour because there was a chance for the resourceVersion to getting bumped with the only change being the timestamp in managedFields.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This flake was reproducible by either the following command:
```
go test -race -count 120 -failfast -shuffle on -timeout 30s -run '^TestPatch$' sigs.k8s.io/cluster-api/internal/util/ssa
```

Or by adding a `time.Sleep(time.Second)` at:

https://github.com/kubernetes-sigs/cluster-api/blob/ec92803b4708c2e40656adfaaa6b4d22942f8d3f/internal/util/ssa/patch_test.go#L157

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8478

Area example:
/area testing