### PR TITLE
:bug: Fix wrong branch name display for weekly update script

### DIFF
--- a/hack/tools/release/weekly/main.go
+++ b/hack/tools/release/weekly/main.go
@@ -169,9 +169,24 @@ func run() int {
 		merges[key] = append(merges[key], formatMerge(body, prNumber))
 	}
 
+	// fetch the current branch
+	out, err = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		fmt.Println("Error")
+		fmt.Println(err)
+		fmt.Println(string(out))
+		return 1
+	}
+
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		fmt.Println("Error: failed to get current branch!!!")
+		return 1
+	}
+
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Println("Weekly update :rotating_light:")
-	fmt.Printf("Changes from %v a total of %d new commits were merged into main.\n\n", commitRange, len(commits))
+	fmt.Printf("Changes from %v a total of %d new commits were merged into %s.\n\n", commitRange, len(commits), branch)
 
 	for _, key := range outputOrder {
 		mergeslice := merges[key]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fix the branch name display issue after running the command `make release-weekly-update-tool` from branch other than `main`.

Example: Output of command after bug fix!!
```bash
$:: github.com/sigs.k8s.io/cluster-api ‹release-1.6*› » ./bin/weekly --from 2023-12-11 --to 2023-12-17 --milestone v1.7
Weekly update :rotating_light:
Changes from 2023-12-11 to 2023-12-17 a total of 7 new commits where merged into release-1.6.

- 1 :sparkles: New Features
         - KCP: Allow mutation of all fields that should be mutable (#9885)

- 4 :bug: Bug Fixes
         - capd: fix ignition to also set the kube-proxy configuration to skip setting sysctls (#9895)
         - Improve log k/v pairs and a improve/drop a few log lines (#9880)
         - ipam: fix webhooks using mixed api versions (#9863)
         - clusterctl: validate no objects exist from CRDs before deleting them (#9834)

- 2 Other changes :seedling:

All merged PRs can be viewed in GitHub:
https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+closed%3A2023-12-11..2023-12-18+is%3Amerged+milestone%3Av1.7+

_Thanks to all our contributors!_ 😊
/Your friendly comms release team

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:

-->

/area release