### PR TITLE
🌱 Small improvements to tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -366,7 +366,7 @@ def enable_provider(name, debug):
         k8s_yaml(p.get("context") + "/" + resource)
         additional_objs = additional_objs + decode_yaml_stream(read_file(p.get("context") + "/" + resource))
 
-    if p.get("kustomize_config", True):
+    if p.get("apply_provider_yaml", True):
         yaml = read_file("./.tiltbuild/yaml/{}.provider.yaml".format(name))
         k8s_yaml(yaml, allow_duplicates = True)
         objs = decode_yaml_stream(yaml)

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -429,7 +429,13 @@ COPY --from=tilt-helper /usr/bin/docker /usr/bin/docker
 COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 ```
 
-**kustomize_config** (Bool, default=true): Whether or not running kustomize on the ./config folder of the provider.
+**kustomize_folder** (String, default=config/default): The folder where the kustomize file for a provider
+are defined; the path is relative to the provider root folder.
+
+**kustomize_options** (String, default="""): Options to be applied when running kustomize for genereating
+yaml manifest for a provider. e.g. `"kustomize_options": "--load-restrictor=LoadRestrictionsNone"`
+
+**apply_provider_yaml** (Bool, default=true): Whether or not apply the provider yaml.
 Set to `false` if your provider does not have a ./config folder or you do not want it to be applied in the cluster.
 
 **go_main** (String, default="main.go"): The go main file if not located at the root of the folder

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -430,12 +430,12 @@ COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 ```
 
 **kustomize_folder** (String, default=config/default): The folder where the kustomize file for a provider
-are defined; the path is relative to the provider root folder.
+is defined; the path is relative to the provider root folder.
 
-**kustomize_options** (String, default="""): Options to be applied when running kustomize for genereating
-yaml manifest for a provider. e.g. `"kustomize_options": "--load-restrictor=LoadRestrictionsNone"`
+**kustomize_options** ([]String, default=[]): Options to be applied when running kustomize for generating the
+yaml manifest for a provider. e.g. `"kustomize_options": [ "--load-restrictor=LoadRestrictionsNone" ]`
 
-**apply_provider_yaml** (Bool, default=true): Whether or not apply the provider yaml.
+**apply_provider_yaml** (Bool, default=true): Whether to apply the provider yaml.
 Set to `false` if your provider does not have a ./config folder or you do not want it to be applied in the cluster.
 
 **go_main** (String, default="main.go"): The go main file if not located at the root of the folder

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/kustomize/api/types"
@@ -346,9 +345,9 @@ func tiltResources(ctx context.Context, ts *tiltSettings) error {
 			return errors.Errorf("failed to obtain config for the provider %s, please add the providers path to the provider_repos list in tilt-settings.yaml/json file", providerName)
 		}
 		if ptr.Deref(config.ApplyProviderYaml, true) {
-			kustomize_folder := path.Join(*config.Context, ptr.Deref(config.KustomizeFolder, "config/default"))
-			kustomize_options := ptr.Deref(config.KustomizeOptions, "")
-			tasks[providerName] = workloadTask(providerName, "provider", "manager", "manager", ts, kustomize_folder, kustomize_options, getProviderObj(config.Version))
+			kustomizeFolder := path.Join(*config.Context, ptr.Deref(config.KustomizeFolder, "config/default"))
+			kustomizeOptions := ptr.Deref(config.KustomizeOptions, "")
+			tasks[providerName] = workloadTask(providerName, "provider", "manager", "manager", ts, kustomizeFolder, kustomizeOptions, getProviderObj(config.Version))
 		}
 	}
 
@@ -693,7 +692,7 @@ func workloadTask(name, workloadType, binaryName, containerName string, ts *tilt
 		if options != "" {
 			args = []string{"build", options, path}
 		}
-		kustomizeCmd := exec.CommandContext(ctx, kustomizePath, args...)
+		kustomizeCmd := exec.CommandContext(ctx, kustomizePath, args...) //nolint: gosec
 		var stdout1, stderr1 bytes.Buffer
 		kustomizeCmd.Dir = rootPath
 		kustomizeCmd.Stdout = &stdout1
@@ -847,7 +846,7 @@ func prepareWorkload(name, prefix, binaryName, containerName string, objs []unst
 			container.Command = cmd
 			container.Args = args
 			deployment.Spec.Template.Spec.Containers[j] = container
-			deployment.Spec.Replicas = pointer.Int32(1)
+			deployment.Spec.Replicas = ptr.To[int32](1)
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Small improvement to tilt
- rename "kustomize_config" to a more explicit "apply_provider_yaml"
- add support for defining a "kustomize_folder" (defaults config/default)
- add support for defining "kustomize_options", e.g. `"kustomize_options": "--load-restrictor=LoadRestrictionsNone"`
- automatically scale down deployments to 1 + remove resource limits/requests when activating the debugger


/area devtools
