### PR TITLE
🌱 Stop relying on GVK being set on regular typed objects

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -416,7 +416,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 	if scope.Config.Spec.InitConfiguration == nil {
 		scope.Config.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "kubeadm.k8s.io/v1beta1",
+				APIVersion: "kubeadm.k8s.io/v1beta3",
 				Kind:       "InitConfiguration",
 			},
 		}
@@ -431,7 +431,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 	if scope.Config.Spec.ClusterConfiguration == nil {
 		scope.Config.Spec.ClusterConfiguration = &bootstrapv1.ClusterConfiguration{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "kubeadm.k8s.io/v1beta1",
+				APIVersion: "kubeadm.k8s.io/v1beta3",
 				Kind:       "ClusterConfiguration",
 			},
 		}

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -142,8 +142,8 @@ func TestKubeadmConfigReconciler_TestSecretOwnerReferenceReconciliation(t *testi
 
 	config := newKubeadmConfig(metav1.NamespaceDefault, "cfg")
 	config.SetOwnerReferences(util.EnsureOwnerRef(config.GetOwnerReferences(), metav1.OwnerReference{
-		APIVersion: machine.APIVersion,
-		Kind:       machine.Kind,
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Machine",
 		Name:       machine.Name,
 		UID:        machine.UID,
 	}))
@@ -207,8 +207,8 @@ func TestKubeadmConfigReconciler_TestSecretOwnerReferenceReconciliation(t *testi
 
 		actual.SetOwnerReferences([]metav1.OwnerReference{
 			{
-				APIVersion: machine.APIVersion,
-				Kind:       machine.Kind,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Machine",
 				Name:       machine.Name,
 				UID:        machine.UID,
 				Controller: ptr.To(true),

--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -181,8 +181,8 @@ func (s *semaphore) setMetadata(cluster *clusterv1.Cluster) {
 		},
 		OwnerReferences: []metav1.OwnerReference{
 			{
-				APIVersion: cluster.APIVersion,
-				Kind:       cluster.Kind,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Cluster",
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			},

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -119,8 +119,8 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 		}
 	}
 	c.OwnerReferences = removeOwnerRef(c.GetOwnerReferences(), metav1.OwnerReference{
-		APIVersion: clusterResourceSet.APIVersion,
-		Kind:       clusterResourceSet.Kind,
+		APIVersion: GroupVersion.String(),
+		Kind:       "ClusterResourceSet",
 		Name:       clusterResourceSet.Name,
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -200,8 +200,8 @@ func (r *ClusterResourceSetReconciler) reconcileDelete(ctx context.Context, clus
 
 		clusterResourceSetBinding.RemoveBinding(crs)
 		clusterResourceSetBinding.OwnerReferences = util.RemoveOwnerRef(clusterResourceSetBinding.GetOwnerReferences(), metav1.OwnerReference{
-			APIVersion: crs.APIVersion,
-			Kind:       crs.Kind,
+			APIVersion: addonsv1.GroupVersion.String(),
+			Kind:       "ClusterResourceSet",
 			Name:       crs.Name,
 		})
 
@@ -296,7 +296,7 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 	// Ensure that the owner references are set on the ClusterResourceSetBinding.
 	clusterResourceSetBinding.SetOwnerReferences(util.EnsureOwnerRef(clusterResourceSetBinding.GetOwnerReferences(), metav1.OwnerReference{
 		APIVersion: addonsv1.GroupVersion.String(),
-		Kind:       clusterResourceSet.Kind,
+		Kind:       "ClusterResourceSet",
 		Name:       clusterResourceSet.Name,
 		UID:        clusterResourceSet.UID,
 	}))

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -225,7 +225,7 @@ func (r *MachinePoolReconciler) reconcile(ctx context.Context, cluster *clusterv
 	// Ensure the MachinePool is owned by the Cluster it belongs to.
 	mp.SetOwnerReferences(util.EnsureOwnerRef(mp.GetOwnerReferences(), metav1.OwnerReference{
 		APIVersion: clusterv1.GroupVersion.String(),
-		Kind:       cluster.Kind,
+		Kind:       "Cluster",
 		Name:       cluster.Name,
 		UID:        cluster.UID,
 	}))

--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -189,8 +189,8 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 				ready++
 			}
 			nodeRefs = append(nodeRefs, corev1.ObjectReference{
-				Kind:       node.Kind,
-				APIVersion: node.APIVersion,
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Node",
 				Name:       node.Name,
 				UID:        node.UID,
 			})

--- a/internal/contract/references.go
+++ b/internal/contract/references.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Ref provide a helper struct for working with references in Unstructured objects.
@@ -88,7 +87,9 @@ func SetNestedRef(obj, refObj *unstructured.Unstructured, fields ...string) erro
 }
 
 // ObjToRef returns a reference to the given object.
-func ObjToRef(obj client.Object) *corev1.ObjectReference {
+// Note: This function only operates on Unstructured instead of client.Object
+// because it is only safe to assume for Unstructured that the GVK is set.
+func ObjToRef(obj *unstructured.Unstructured) *corev1.ObjectReference {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	return &corev1.ObjectReference{
 		Kind:       gvk.Kind,

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -185,7 +185,7 @@ func assertInfrastructureClusterTemplate(ctx context.Context, actualClusterClass
 	if err := env.Get(ctx, actualInfraClusterTemplateKey, actualInfraClusterTemplate); err != nil {
 		return err
 	}
-	if err := assertHasOwnerReference(actualInfraClusterTemplate, *ownerReferenceTo(actualClusterClass)); err != nil {
+	if err := assertHasOwnerReference(actualInfraClusterTemplate, *ownerReferenceTo(actualClusterClass, clusterv1.GroupVersion.WithKind("ClusterClass"))); err != nil {
 		return err
 	}
 
@@ -205,7 +205,7 @@ func assertControlPlaneTemplate(ctx context.Context, actualClusterClass *cluster
 	if err := env.Get(ctx, actualControlPlaneTemplateKey, actualControlPlaneTemplate); err != nil {
 		return err
 	}
-	if err := assertHasOwnerReference(actualControlPlaneTemplate, *ownerReferenceTo(actualClusterClass)); err != nil {
+	if err := assertHasOwnerReference(actualControlPlaneTemplate, *ownerReferenceTo(actualClusterClass, clusterv1.GroupVersion.WithKind("ClusterClass"))); err != nil {
 		return err
 	}
 
@@ -226,7 +226,7 @@ func assertControlPlaneTemplate(ctx context.Context, actualClusterClass *cluster
 		if err := env.Get(ctx, actualInfrastructureMachineTemplateKey, actualInfrastructureMachineTemplate); err != nil {
 			return err
 		}
-		if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, *ownerReferenceTo(actualClusterClass)); err != nil {
+		if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, *ownerReferenceTo(actualClusterClass, clusterv1.GroupVersion.WithKind("ClusterClass"))); err != nil {
 			return err
 		}
 
@@ -260,7 +260,7 @@ func assertMachineDeploymentClass(ctx context.Context, actualClusterClass *clust
 	if err := env.Get(ctx, actualInfrastructureMachineTemplateKey, actualInfrastructureMachineTemplate); err != nil {
 		return err
 	}
-	if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, *ownerReferenceTo(actualClusterClass)); err != nil {
+	if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, *ownerReferenceTo(actualClusterClass, clusterv1.GroupVersion.WithKind("ClusterClass"))); err != nil {
 		return err
 	}
 
@@ -280,7 +280,7 @@ func assertMachineDeploymentClass(ctx context.Context, actualClusterClass *clust
 	if err := env.Get(ctx, actualBootstrapTemplateKey, actualBootstrapTemplate); err != nil {
 		return err
 	}
-	if err := assertHasOwnerReference(actualBootstrapTemplate, *ownerReferenceTo(actualClusterClass)); err != nil {
+	if err := assertHasOwnerReference(actualBootstrapTemplate, *ownerReferenceTo(actualClusterClass, clusterv1.GroupVersion.WithKind("ClusterClass"))); err != nil {
 		return err
 	}
 

--- a/internal/controllers/clusterclass/suite_test.go
+++ b/internal/controllers/clusterclass/suite_test.go
@@ -90,12 +90,15 @@ func TestMain(m *testing.M) {
 	}))
 }
 
-func ownerReferenceTo(obj client.Object) *metav1.OwnerReference {
+// ownerReferenceTo converts an object to an OwnerReference.
+// Note: We pass in gvk explicitly as we can't rely on GVK being set on all objects
+// (only on Unstructured).
+func ownerReferenceTo(obj client.Object, gvk schema.GroupVersionKind) *metav1.OwnerReference {
 	return &metav1.OwnerReference{
-		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
 		Name:       obj.GetName(),
 		UID:        obj.GetUID(),
-		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 	}
 }
 

--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -87,8 +87,8 @@ func (r *Reconciler) reconcileNode(ctx context.Context, s *scope) (ctrl.Result, 
 	// Set the Machine NodeRef.
 	if machine.Status.NodeRef == nil {
 		machine.Status.NodeRef = &corev1.ObjectReference{
-			Kind:       node.Kind,
-			APIVersion: node.APIVersion,
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Node",
 			Name:       node.Name,
 			UID:        node.UID,
 		}

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -196,8 +196,8 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string, g *WithT) {
 
 	patchMachine = client.MergeFrom(m.DeepCopy())
 	m.Status.NodeRef = &corev1.ObjectReference{
-		APIVersion: node.APIVersion,
-		Kind:       node.Kind,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "Node",
 		Name:       node.Name,
 	}
 	g.Expect(env.Status().Patch(ctx, m, patchMachine)).To(Succeed())

--- a/internal/controllers/machineset/suite_test.go
+++ b/internal/controllers/machineset/suite_test.go
@@ -205,8 +205,8 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string, g *WithT) {
 
 	patchMachine = client.MergeFrom(m.DeepCopy())
 	m.Status.NodeRef = &corev1.ObjectReference{
-		APIVersion: node.APIVersion,
-		Kind:       node.Kind,
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "Node",
 		Name:       node.Name,
 	}
 	g.Expect(env.Status().Patch(ctx, m, patchMachine)).To(Succeed())

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -208,7 +208,7 @@ func computeControlPlaneInfrastructureMachineTemplate(_ context.Context, s *scop
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and updating the Cluster object
 		// with the reference to the ControlPlane object using this template.
-		ownerRef: ownerReferenceTo(s.Current.Cluster),
+		ownerRef: ownerReferenceTo(s.Current.Cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	})
 }
 
@@ -623,7 +623,7 @@ func computeMachineDeployment(ctx context.Context, s *scope.Scope, machineDeploy
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachineDeployment object
 		// with the reference to this template.
-		ownerRef: ownerReferenceTo(s.Current.Cluster),
+		ownerRef: ownerReferenceTo(s.Current.Cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	})
 	if err != nil {
 		return nil, err
@@ -651,7 +651,7 @@ func computeMachineDeployment(ctx context.Context, s *scope.Scope, machineDeploy
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachineDeployment object
 		// with the reference to this template.
-		ownerRef: ownerReferenceTo(s.Current.Cluster),
+		ownerRef: ownerReferenceTo(s.Current.Cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	})
 	if err != nil {
 		return nil, err
@@ -719,8 +719,8 @@ func computeMachineDeployment(ctx context.Context, s *scope.Scope, machineDeploy
 
 	desiredMachineDeploymentObj := &clusterv1.MachineDeployment{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       clusterv1.GroupVersion.WithKind("MachineDeployment").Kind,
 			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineDeployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -977,7 +977,7 @@ func computeMachinePool(_ context.Context, s *scope.Scope, machinePoolTopology c
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachinePool object
 		// with the reference to this template.
-		ownerRef: ownerReferenceTo(s.Current.Cluster),
+		ownerRef: ownerReferenceTo(s.Current.Cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compute bootstrap object for topology %q", machinePoolTopology.Name)
@@ -1005,7 +1005,7 @@ func computeMachinePool(_ context.Context, s *scope.Scope, machinePoolTopology c
 		// Note: we are adding an ownerRef to Cluster so the template will be automatically garbage collected
 		// in case of errors in between creating this template and creating/updating the MachinePool object
 		// with the reference to this template.
-		ownerRef: ownerReferenceTo(s.Current.Cluster),
+		ownerRef: ownerReferenceTo(s.Current.Cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compute infrastructure object for topology %q", machinePoolTopology.Name)
@@ -1068,8 +1068,8 @@ func computeMachinePool(_ context.Context, s *scope.Scope, machinePoolTopology c
 
 	desiredMachinePoolObj := &expv1.MachinePool{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       expv1.GroupVersion.WithKind("MachinePool").Kind,
 			APIVersion: expv1.GroupVersion.String(),
+			Kind:       "MachinePool",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1345,12 +1345,15 @@ func templateToTemplate(in templateToInput) (*unstructured.Unstructured, error) 
 	return template, nil
 }
 
-func ownerReferenceTo(obj client.Object) *metav1.OwnerReference {
+// ownerReferenceTo converts an object to an OwnerReference.
+// Note: We pass in gvk explicitly as we can't rely on GVK being set on all objects
+// (only on Unstructured).
+func ownerReferenceTo(obj client.Object, gvk schema.GroupVersionKind) *metav1.OwnerReference {
 	return &metav1.OwnerReference{
-		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
 		Name:       obj.GetName(),
 		UID:        obj.GetUID(),
-		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 	}
 }
 
@@ -1358,8 +1361,8 @@ func computeMachineHealthCheck(ctx context.Context, healthCheckTarget client.Obj
 	// Create a MachineHealthCheck with the spec given in the ClusterClass.
 	mhc := &clusterv1.MachineHealthCheck{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       clusterv1.GroupVersion.WithKind("MachineHealthCheck").Kind,
 			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineHealthCheck",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      healthCheckTarget.GetName(),

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -144,7 +144,7 @@ func TestComputeInfrastructureCluster(t *testing.T) {
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
 		scope := scope.New(clusterWithInfrastructureRef)
 		scope.Current.InfrastructureCluster = infrastructureClusterTemplate.DeepCopy()
-		scope.Current.InfrastructureCluster.SetOwnerReferences([]metav1.OwnerReference{*ownerReferenceTo(shim)})
+		scope.Current.InfrastructureCluster.SetOwnerReferences([]metav1.OwnerReference{*ownerReferenceTo(shim, corev1.SchemeGroupVersion.WithKind("Secret"))})
 		scope.Blueprint = blueprint
 
 		obj, err := computeInfrastructureCluster(ctx, scope)
@@ -623,7 +623,7 @@ func TestComputeControlPlane(t *testing.T) {
 				}).
 				Build(),
 		}
-		s.Current.ControlPlane.Object.SetOwnerReferences([]metav1.OwnerReference{*ownerReferenceTo(shim)})
+		s.Current.ControlPlane.Object.SetOwnerReferences([]metav1.OwnerReference{*ownerReferenceTo(shim, corev1.SchemeGroupVersion.WithKind("Secret"))})
 		s.Blueprint = blueprint
 
 		r := &Reconciler{}
@@ -2877,8 +2877,8 @@ func Test_computeMachineHealthCheck(t *testing.T) {
 	clusterName := "cluster1"
 	want := &clusterv1.MachineHealthCheck{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       clusterv1.GroupVersion.WithKind("MachineHealthCheck").Kind,
 			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineHealthCheck",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "md1",

--- a/internal/controllers/topology/cluster/patches/template.go
+++ b/internal/controllers/topology/cluster/patches/template.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -56,10 +57,12 @@ func newRequestItemBuilder(template *unstructured.Unstructured) *requestItemBuil
 }
 
 // WithHolder adds holder to the requestItemBuilder.
-func (t *requestItemBuilder) WithHolder(object client.Object, fieldPath string) *requestItemBuilder {
+// Note: We pass in gvk explicitly as we can't rely on GVK being set on all objects
+// (only on Unstructured).
+func (t *requestItemBuilder) WithHolder(object client.Object, gvk schema.GroupVersionKind, fieldPath string) *requestItemBuilder {
 	t.holder = runtimehooksv1.HolderReference{
-		APIVersion: object.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-		Kind:       object.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
 		Namespace:  object.GetNamespace(),
 		Name:       object.GetName(),
 		FieldPath:  fieldPath,

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -126,12 +126,12 @@ func (r *Reconciler) reconcileClusterShim(ctx context.Context, s *scope.Scope) e
 
 		// Add the shim as a temporary owner for the InfrastructureCluster.
 		ownerRefs := s.Desired.InfrastructureCluster.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(shim))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(shim, corev1.SchemeGroupVersion.WithKind("Secret")))
 		s.Desired.InfrastructureCluster.SetOwnerReferences(ownerRefs)
 
 		// Add the shim as a temporary owner for the ControlPlane.
 		ownerRefs = s.Desired.ControlPlane.Object.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(shim))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(shim, corev1.SchemeGroupVersion.WithKind("Secret")))
 		s.Desired.ControlPlane.Object.SetOwnerReferences(ownerRefs)
 	}
 
@@ -168,7 +168,7 @@ func clusterShim(c *clusterv1.Cluster) *corev1.Secret {
 			Name:      fmt.Sprintf("%s-shim", c.Name),
 			Namespace: c.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
-				*ownerReferenceTo(c),
+				*ownerReferenceTo(c, clusterv1.GroupVersion.WithKind("Cluster")),
 			},
 		},
 		Type: clusterv1.ClusterSecretType,

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -174,10 +174,10 @@ func TestReconcileShim(t *testing.T) {
 
 		// Add the shim as a temporary owner for the InfrastructureCluster and ControlPlane.
 		ownerRefs := s.Current.InfrastructureCluster.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim, corev1.SchemeGroupVersion.WithKind("Secret")))
 		s.Current.InfrastructureCluster.SetOwnerReferences(ownerRefs)
 		ownerRefs = s.Current.ControlPlane.Object.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim, corev1.SchemeGroupVersion.WithKind("Secret")))
 		s.Current.ControlPlane.Object.SetOwnerReferences(ownerRefs)
 
 		// Pre-create a shim
@@ -221,14 +221,14 @@ func TestReconcileShim(t *testing.T) {
 		ownerRefs := s.Current.InfrastructureCluster.GetOwnerReferences()
 		ownerRefs = append(
 			ownerRefs,
-			*ownerReferenceTo(cluster1Shim),
-			*ownerReferenceTo(cluster1))
+			*ownerReferenceTo(cluster1Shim, corev1.SchemeGroupVersion.WithKind("Secret")),
+			*ownerReferenceTo(cluster1, clusterv1.GroupVersion.WithKind("Cluster")))
 		s.Current.InfrastructureCluster.SetOwnerReferences(ownerRefs)
 		ownerRefs = s.Current.ControlPlane.Object.GetOwnerReferences()
 		ownerRefs = append(
 			ownerRefs,
-			*ownerReferenceTo(cluster1Shim),
-			*ownerReferenceTo(cluster1))
+			*ownerReferenceTo(cluster1Shim, corev1.SchemeGroupVersion.WithKind("Secret")),
+			*ownerReferenceTo(cluster1, clusterv1.GroupVersion.WithKind("Cluster")))
 		s.Current.ControlPlane.Object.SetOwnerReferences(ownerRefs)
 
 		// Pre-create a shim
@@ -269,10 +269,10 @@ func TestReconcileShim(t *testing.T) {
 
 		// Add the cluster as a final owner for the InfrastructureCluster and ControlPlane (reconciled).
 		ownerRefs := s.Current.InfrastructureCluster.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1, clusterv1.GroupVersion.WithKind("Cluster")))
 		s.Current.InfrastructureCluster.SetOwnerReferences(ownerRefs)
 		ownerRefs = s.Current.ControlPlane.Object.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1))
+		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1, clusterv1.GroupVersion.WithKind("Cluster")))
 		s.Current.ControlPlane.Object.SetOwnerReferences(ownerRefs)
 
 		// Run reconcileClusterShim using a nil client, so an error will be triggered if any operation is attempted

--- a/internal/test/builder/builders.go
+++ b/internal/test/builder/builders.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -1859,7 +1858,9 @@ func (m *MachineBuilder) Build() *clusterv1.Machine {
 }
 
 // objToRef returns a reference to the given object.
-func objToRef(obj client.Object) *corev1.ObjectReference {
+// Note: This function only operates on Unstructured instead of client.Object
+// because it is only safe to assume for Unstructured that the GVK is set.
+func objToRef(obj *unstructured.Unstructured) *corev1.ObjectReference {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	return &corev1.ObjectReference{
 		Kind:       gvk.Kind,

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
@@ -264,8 +264,8 @@ func computeDesiredDockerMachine(name string, cluster *clusterv1.Cluster, machin
 
 	// Note: Since the MachinePool controller has not created its owner Machine yet, we want to set the DockerMachinePool as the owner so it's not orphaned.
 	dockerMachine.SetOwnerReferences(util.EnsureOwnerRef(dockerMachine.OwnerReferences, metav1.OwnerReference{
-		APIVersion: dockerMachinePool.APIVersion,
-		Kind:       dockerMachinePool.Kind,
+		APIVersion: infraexpv1.GroupVersion.String(),
+		Kind:       "DockerMachinePool",
 		Name:       dockerMachinePool.Name,
 		UID:        dockerMachinePool.UID,
 	}))

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller_test.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller_test.go
@@ -75,10 +75,10 @@ func newCluster(clusterName string, dockerCluster *infrav1.DockerCluster) *clust
 	}
 	if dockerCluster != nil {
 		cluster.Spec.InfrastructureRef = &corev1.ObjectReference{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       "DockerCluster",
 			Name:       dockerCluster.Name,
 			Namespace:  dockerCluster.Namespace,
-			Kind:       dockerCluster.Kind,
-			APIVersion: dockerCluster.GroupVersionKind().GroupVersion().String(),
 		}
 	}
 	return cluster
@@ -111,10 +111,10 @@ func newMachine(clusterName, machineName string, dockerMachine *infrav1.DockerMa
 	}
 	if dockerMachine != nil {
 		machine.Spec.InfrastructureRef = corev1.ObjectReference{
+			APIVersion: infrav1.GroupVersion.String(),
+			Kind:       "DockerMachine",
 			Name:       dockerMachine.Name,
 			Namespace:  dockerMachine.Namespace,
-			Kind:       dockerMachine.Kind,
-			APIVersion: dockerMachine.GroupVersionKind().GroupVersion().String(),
 		}
 	}
 	return machine


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Today controller-runtime doesn't set the GVKs of objects in all cases.

The current state is:
* APIReader:
  * sets GVK on Unstructured objects
  * does not set GVK on regular typed objects
* Cached reader:
  * sets GVK on Unstructured objects
  * sets GVK on regular typed objects (if disableDeepCopy = false, which is default)
* fake client
  * sets GVK on Unstructured objects
  * sets GVK on regular typed objects
  * Note: This will probably be changed with CR v0.17 (https://github.com/kubernetes-sigs/controller-runtime/pull/2633)

Because of these inconsistencies (that cannot be easily changed upstream) and because it's hard to tell across entire call stacks where objects come from I would suggest to only rely on GVK being set on Unstructured objects. For Unstructured objects GVK has to be always set to be able to identify the object, for regular typed objects this is not the case.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->