### PR TITLE
🐛 Fix defaulting logic in release notes tool

### DIFF
--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -154,7 +154,7 @@ func validateConfig(config *notesCmdConfig) error {
 // computeConfigDefaults calculates the value the non specified configuration fields
 // based on the set fields.
 func computeConfigDefaults(config *notesCmdConfig) error {
-	if config.fromRef != "" && config.branch != "" {
+	if config.fromRef != "" && config.branch != "" && config.toRef != "" {
 		return nil
 	}
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The bug created an out of range error when from and branch where set but toRef wasn't.


/area release