### PR TITLE
📖 Fix function link reference and heading level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@
 - [Proposal process (CAEP)](#proposal-process-caep)
 - [Triaging E2E test failures](#triaging-e2e-test-failures)
 - [Reviewing a Patch](#reviewing-a-patch)
-- [Reviews](#reviews)
+  - [Reviews](#reviews)
   - [Approvals](#approvals)
 - [Features and bugs](#features-and-bugs)
 - [Experiments](#experiments)
@@ -314,7 +314,7 @@ In case you want to run E2E test locally, please refer to the [Testing](https://
 
 ## Reviewing a Patch
 
-## Reviews
+### Reviews
 
 > Parts of the following content have been adapted from https://google.github.io/eng-practices/review.
 

--- a/docs/book/src/developer/e2e.md
+++ b/docs/book/src/developer/e2e.md
@@ -164,7 +164,7 @@ The following recommendations should be followed to write portable E2E tests:
 
 - Create different [E2E config file], one for each target infrastructure provider,
   providing different sets of env variables and timeout intervals.
-- Use the [InitManagementCluster method] for setting up the management cluster.
+- Use the [InitManagementClusterAndWatchControllerLogs method] for setting up the management cluster.
 - Use the [ClusterTemplate method] and the [Apply method]
   for creating objects in the cluster using `cluster-templates.yaml` files instead
   of hard coding object creation.


### PR DESCRIPTION
**What this PR does / why we need it**:

- change `InitManagementCluster` to `InitManagementClusterAndWatchControllerLogs`; otherwise it won't point to the correct reference link. ([current doc](https://cluster-api.sigs.k8s.io/developer/e2e#writing-portable-e2e-tests))
- change the heading level according to the context; otherwise, it might confuse users. ([current layout](https://cluster-api.sigs.k8s.io/contributing#contributing-guidelines))

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area documentation