### PR TITLE
🌱 [release-1.5] e2e: Rename scale test to drop [Scale] tag

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("When scale testing using in-memory provider [Scale]", func() {
+var _ = Describe("When testing the machinery for scale testing using in-memory provider", func() {
 	scaleSpec(ctx, func() scaleSpecInput {
 		return scaleSpecInput{
 			E2EConfig:                e2eConfig,


### PR DESCRIPTION
Manual cherry-pick of #9968

Renames only the existing test to match the tests on the other branches (where we removed the test)