### PR TITLE
:seedling: Fix grammar in release script

### DIFF
--- a/hack/tools/release/weekly/main.go
+++ b/hack/tools/release/weekly/main.go
@@ -171,7 +171,7 @@ func run() int {
 
 	// TODO Turn this into a link (requires knowing the project name + organization)
 	fmt.Println("Weekly update :rotating_light:")
-	fmt.Printf("Changes from %v a total of %d new commits where merged into main.\n\n", commitRange, len(commits))
+	fmt.Printf("Changes from %v a total of %d new commits were merged into main.\n\n", commitRange, len(commits))
 
 	for _, key := range outputOrder {
 		mergeslice := merges[key]


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR fixes a small grammar mistake in the release script.

Area example:
/area release