### PR TITLE
🌱 test/framework add WatchDaemonSetLogsByLabelSelector method

### DIFF
--- a/test/framework/daemonset_helpers.go
+++ b/test/framework/daemonset_helpers.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	toolscache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/internal/util/kubeadm"
@@ -59,4 +61,40 @@ func WaitForKubeProxyUpgrade(ctx context.Context, input WaitForKubeProxyUpgradeI
 		}
 		return false, nil
 	}, intervals...).Should(BeTrue())
+}
+
+// WatchDaemonSetLogsByLabelSelectorInput is the input for WatchDaemonSetLogsByLabelSelector.
+type WatchDaemonSetLogsByLabelSelectorInput struct {
+	GetLister GetLister
+	Cache     toolscache.Cache
+	ClientSet *kubernetes.Clientset
+	Labels    map[string]string
+	LogPath   string
+}
+
+// WatchDaemonSetLogsByLabelSelector streams logs for all containers for all pods belonging to a daemonset on the basis of label. Each container's logs are streamed
+// in a separate goroutine so they can all be streamed concurrently. This only causes a test failure if there are errors
+// retrieving the daemonset, its pods, or setting up a log file. If there is an error with the log streaming itself,
+// that does not cause the test to fail.
+func WatchDaemonSetLogsByLabelSelector(ctx context.Context, input WatchDaemonSetLogsByLabelSelectorInput) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for WatchDaemonSetLogsByLabelSelector")
+	Expect(input.Cache).NotTo(BeNil(), "input.Cache is required for WatchDaemonSetLogsByLabelSelector")
+	Expect(input.ClientSet).NotTo(BeNil(), "input.ClientSet is required for WatchDaemonSetLogsByLabelSelector")
+	Expect(input.Labels).NotTo(BeNil(), "input.Selector is required for WatchDaemonSetLogsByLabelSelector")
+
+	daemonSetList := &appsv1.DaemonSetList{}
+	Eventually(func() error {
+		return input.GetLister.List(ctx, daemonSetList, client.MatchingLabels(input.Labels))
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to get DaemonSets for labels")
+
+	for _, daemonSet := range daemonSetList.Items {
+		watchPodLogs(ctx, watchPodLogsInput{
+			Cache:                input.Cache,
+			ClientSet:            input.ClientSet,
+			Namespace:            daemonSet.Namespace,
+			ManagingResourceName: daemonSet.Name,
+			LabelSelector:        daemonSet.Spec.Selector,
+			LogPath:              input.LogPath,
+		})
+	}
 }

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -127,12 +127,12 @@ func WatchDeploymentLogsByLabelSelector(ctx context.Context, input WatchDeployme
 
 	for _, deployment := range deploymentList.Items {
 		watchPodLogs(ctx, watchPodLogsInput{
-			Cache:          input.Cache,
-			ClientSet:      input.ClientSet,
-			Namespace:      deployment.Namespace,
-			DeploymentName: deployment.Name,
-			LabelSelector:  deployment.Spec.Selector,
-			LogPath:        input.LogPath,
+			Cache:                input.Cache,
+			ClientSet:            input.ClientSet,
+			Namespace:            deployment.Namespace,
+			ManagingResourceName: deployment.Name,
+			LabelSelector:        deployment.Spec.Selector,
+			LogPath:              input.LogPath,
 		})
 	}
 }
@@ -163,23 +163,23 @@ func WatchDeploymentLogsByName(ctx context.Context, input WatchDeploymentLogsByN
 	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to get deployment %s", klog.KObj(input.Deployment))
 
 	watchPodLogs(ctx, watchPodLogsInput{
-		Cache:          input.Cache,
-		ClientSet:      input.ClientSet,
-		Namespace:      deployment.Namespace,
-		DeploymentName: deployment.Name,
-		LabelSelector:  deployment.Spec.Selector,
-		LogPath:        input.LogPath,
+		Cache:                input.Cache,
+		ClientSet:            input.ClientSet,
+		Namespace:            deployment.Namespace,
+		ManagingResourceName: deployment.Name,
+		LabelSelector:        deployment.Spec.Selector,
+		LogPath:              input.LogPath,
 	})
 }
 
 // watchPodLogsInput is the input for watchPodLogs.
 type watchPodLogsInput struct {
-	Cache          toolscache.Cache
-	ClientSet      *kubernetes.Clientset
-	Namespace      string
-	DeploymentName string
-	LabelSelector  *metav1.LabelSelector
-	LogPath        string
+	Cache                toolscache.Cache
+	ClientSet            *kubernetes.Clientset
+	Namespace            string
+	ManagingResourceName string
+	LabelSelector        *metav1.LabelSelector
+	LogPath              string
 }
 
 // watchPodLogs streams logs for all containers for all pods belonging to a deployment with the given label. Each container's logs are streamed
@@ -251,16 +251,16 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 	}
 
 	for _, container := range pod.Spec.Containers {
-		log.Logf("Creating log watcher for controller %s, pod %s, container %s", klog.KRef(eh.input.Namespace, eh.input.DeploymentName), pod.Name, container.Name)
+		log.Logf("Creating log watcher for controller %s, pod %s, container %s", klog.KRef(eh.input.Namespace, eh.input.ManagingResourceName), pod.Name, container.Name)
 
 		// Create log metadata file.
-		logMetadataFile := filepath.Clean(path.Join(eh.input.LogPath, eh.input.DeploymentName, pod.Name, container.Name+"-log-metadata.json"))
+		logMetadataFile := filepath.Clean(path.Join(eh.input.LogPath, eh.input.ManagingResourceName, pod.Name, container.Name+"-log-metadata.json"))
 		Expect(os.MkdirAll(filepath.Dir(logMetadataFile), 0750)).To(Succeed())
 
 		metadata := logMetadata{
-			Job:       eh.input.Namespace + "/" + eh.input.DeploymentName,
+			Job:       eh.input.Namespace + "/" + eh.input.ManagingResourceName,
 			Namespace: eh.input.Namespace,
-			App:       eh.input.DeploymentName,
+			App:       eh.input.ManagingResourceName,
 			Pod:       pod.Name,
 			Container: container.Name,
 			NodeName:  pod.Spec.NodeName,
@@ -274,7 +274,7 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 		go func(pod *corev1.Pod, container corev1.Container) {
 			defer GinkgoRecover()
 
-			logFile := filepath.Clean(path.Join(eh.input.LogPath, eh.input.DeploymentName, pod.Name, container.Name+".log"))
+			logFile := filepath.Clean(path.Join(eh.input.LogPath, eh.input.ManagingResourceName, pod.Name, container.Name+".log"))
 			Expect(os.MkdirAll(filepath.Dir(logFile), 0750)).To(Succeed())
 
 			f, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Implements `WatchDaemonSetLogsByLabelSelector` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9983

/area test-framework