### PR TITLE
[release-1.6] 🌱 Add DeepCopy method for E2EConfig

### DIFF
--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -245,6 +245,27 @@ type Files struct {
 	TargetName string `json:"targetName,omitempty"`
 }
 
+func (c *E2EConfig) DeepCopy() *E2EConfig {
+	if c == nil {
+		return nil
+	}
+	out := new(E2EConfig)
+	out.ManagementClusterName = c.ManagementClusterName
+	out.Images = make([]ContainerImage, len(c.Images))
+	copy(out.Images, c.Images)
+	out.Providers = make([]ProviderConfig, len(c.Providers))
+	copy(out.Providers, c.Providers)
+	out.Variables = make(map[string]string, len(c.Variables))
+	for key, val := range c.Variables {
+		out.Variables[key] = val
+	}
+	out.Intervals = make(map[string][]string, len(c.Intervals))
+	for key, val := range c.Intervals {
+		out.Intervals[key] = val
+	}
+	return out
+}
+
 // Defaults assigns default values to the object. More specifically:
 // - ManagementClusterName gets a default name if empty.
 // - Providers version gets type KustomizeSource if not otherwise specified.

--- a/test/framework/clusterctl/e2e_config_test.go
+++ b/test/framework/clusterctl/e2e_config_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterctl
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_E2EConfig_DeepCopy(t *testing.T) {
+	g := NewWithT(t)
+
+	config1 := E2EConfig{
+		ManagementClusterName: "config1-cluster-name",
+		Images: []ContainerImage{
+			{
+				Name: "config1-image",
+			},
+		},
+		Providers: []ProviderConfig{
+			{
+				Name: "config1-provider",
+			},
+		},
+		Variables: map[string]string{
+			"config1-variable": "config1-variable-value",
+		},
+		Intervals: map[string][]string{
+			"config1-interval": {"2m", "10s"},
+		},
+	}
+
+	config2 := config1.DeepCopy()
+
+	// Verify everything was copied from config1
+	g.Expect(config2.ManagementClusterName).To(Equal("config1-cluster-name"))
+	g.Expect(config2.Images).To(Equal([]ContainerImage{
+		{
+			Name: "config1-image",
+		},
+	}))
+	g.Expect(config2.Providers).To(Equal([]ProviderConfig{
+		{
+			Name: "config1-provider",
+		},
+	}))
+	g.Expect(config2.Variables).To(Equal(map[string]string{
+		"config1-variable": "config1-variable-value",
+	}))
+	g.Expect(config2.Intervals).To(Equal(map[string][]string{
+		"config1-interval": {"2m", "10s"},
+	}))
+
+	// Mutate config2
+	config2.ManagementClusterName = "config2-cluster-name"
+	config2.Images[0].Name = "config2-image"
+	config2.Providers[0].Name = "config2-provider"
+	config2.Variables["config2-variable"] = "config2-variable-value"
+	config2.Intervals["config2-interval"] = []string{"2m", "10s"}
+
+	// Validate config1 was not mutated
+	g.Expect(config1.ManagementClusterName).To(Equal("config1-cluster-name"))
+	g.Expect(config1.Images).To(Equal([]ContainerImage{
+		{
+			Name: "config1-image",
+		},
+	}))
+	g.Expect(config1.Providers).To(Equal([]ProviderConfig{
+		{
+			Name: "config1-provider",
+		},
+	}))
+	g.Expect(config1.Variables).To(Equal(map[string]string{
+		"config1-variable": "config1-variable-value",
+	}))
+	g.Expect(config1.Intervals).To(Equal(map[string][]string{
+		"config1-interval": {"2m", "10s"},
+	}))
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Manual cherry-pick of #9988

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->