### PR TITLE
🌱 Promote chrischdi to Cluster API maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -19,6 +19,7 @@ aliases:
 
   # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-maintainers:
+  - chrischdi
   - enxebre
   - fabriziopandini
   - killianmuldoon
@@ -27,7 +28,6 @@ aliases:
 
   # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
-  - chrischdi
   - jackfrancis
   - JoelSpeed
   - richardcase


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds @chrischdi (that's me 😂 ) to cluster-api-maintainers.

I'm now working with the community and am contributing to the CAPI project for a good amount of time and also a reviewer for quite some time. I especially did work on ClusterClass features and on keeping the CI stable, deflaking issues, doing reviews, ... and want to continue with that in future.

I don't think we have the data quality to filter down for those specific areas so I'll just list all CAPI contributions:

* PRs: https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+is%3Aclosed+author%3Achrischdi+sort%3Aupdated-desc
* Reviews: https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+sort%3Aupdated-desc+assignee%3Achrischdi+is%3Aclosed
* Issues: https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aissue+author%3Achrischdi+sort%3Aupdated-desc
* test-infra (cluster-api) PRs: https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+author%3Achrischdi+is%3Aclosed+cluster-api+sort%3Aupdated-desc

/hold for consensus and community meeting

/cc @sbueringer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area community-meeting