### PR TITLE
:bug: Use keys/values structured log interface

### DIFF
--- a/exp/runtime/topologymutation/walker.go
+++ b/exp/runtime/topologymutation/walker.go
@@ -168,7 +168,7 @@ func WalkTemplates(ctx context.Context, decoder runtime.Decoder, req *runtimehoo
 			PatchType: options.patchFormat,
 			Patch:     patch,
 		})
-		requestItemLog.V(5).Info("Generated patch (uid: %q): %q\n", requestItem.UID, string(patch))
+		requestItemLog.V(5).Info("Generated patch", "uid", requestItem.UID, "patch", string(patch))
 	}
 
 	resp.Status = runtimehooksv1.ResponseStatusSuccess


### PR DESCRIPTION
Use keys/values structured log interface

Previously, the log message was malformed, e.g.

```
"Generated patch (uid: %q): %q\n" template="infrastructure.cluster.x-k8s.io/v1beta1/DockerClusterTemplate" holder="cluster.x-k8s.io/v1beta1/Cluster/default/docker-quick-start" cc9b55a6-2ac0-470a-9b0e-444e5a08b5de="]"
```

With this change, the log message is:

```
"Generated patch" template="infrastructure.cluster.x-k8s.io/v1beta1/DockerClusterTemplate" holder="cluster.x-k8s.io/v1beta1/Cluster/default/docker-quick-start" uid="cc9b55a6-2ac0-470a-9b0e-444e5a08b5de" patch="]"
```

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->