### PR TITLE
🌱 Move ykakarap to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,3 +17,4 @@ emeritus_approvers:
   - ncdc
   - roberthbailey
   - davidewatson
+  - ykakarap

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,7 +33,6 @@ aliases:
   - JoelSpeed
   - richardcase
   - stmcginnis
-  - ykakarap
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for controllers/topology
@@ -73,7 +72,6 @@ aliases:
   # -----------------------------------------------------------
 
   cluster-api-clusterctl-maintainers:
-  - ykakarap
   cluster-api-clusterctl-reviewers:
   - Jont828
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

First of all, @ykakarap thank you very much for all the work you did on Cluster API. It was always great working with you!!


This PR moves Yuvaraj to emeritus approver, given that he wasn't actively contributing for a while now and considering that we want to keep our OWNERS files reasonably up-to-date.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->