### PR TITLE
[release-1.6] :seedling: test: add dynamic finalizer assertions for e2e framework

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -187,7 +187,12 @@ var _ = Describe("When following the Cluster API quick-start check finalizers re
 			InfrastructureProvider: pointer.String("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName)
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName,
+					framework.CoreFinalizersAssertion,
+					framework.KubeadmControlPlaneFinalizersAssertion,
+					framework.ExpFinalizersAssertion,
+					framework.DockerInfraFinalizersAssertion,
+				)
 			},
 		}
 	})
@@ -205,7 +210,12 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass c
 			InfrastructureProvider: pointer.String("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName)
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName,
+					framework.CoreFinalizersAssertion,
+					framework.KubeadmControlPlaneFinalizersAssertion,
+					framework.ExpFinalizersAssertion,
+					framework.DockerInfraFinalizersAssertion,
+				)
 			},
 		}
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/9970

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/9969

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area testing