### PR TITLE
🌱 test/e2e: bump WorkloadKubernetesVersion for v1.6 clusterctl upgrade test

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -145,7 +145,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.6=>current)", func() {
 			InitWithProvidersContract: "v1beta1",
 			//  Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
 			InitWithKubernetesVersion: "v1.29.0",
-			WorkloadKubernetesVersion: "v1.28.0",
+			WorkloadKubernetesVersion: "v1.29.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 		}
@@ -169,7 +169,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.6=>cur
 			InitWithProvidersContract: "v1beta1",
 			// Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
 			InitWithKubernetesVersion: "v1.29.0",
-			WorkloadKubernetesVersion: "v1.28.0",
+			WorkloadKubernetesVersion: "v1.29.0",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Part of #9578

Bumps the k8s version used because the test now uses CAPI v1.6.1 which supports v1.29.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci