### PR TITLE
🌱 hack/prowjob-gen skip creating empty files

### DIFF
--- a/hack/tools/prowjob-gen/generator.go
+++ b/hack/tools/prowjob-gen/generator.go
@@ -87,6 +87,11 @@ func (g *generator) generate() error {
 				return errors.Wrapf(err, "Generating prowjobs for template %s", tpl.Name)
 			}
 
+			if out.Len() == len(generatedFileHeader) {
+				klog.Infof("Skipping template %s for branch %s because the resulting file would have been empty", tpl.Name, branch)
+				continue
+			}
+
 			fileName, err := g.executeNameTemplate(branch, tpl.Name)
 			if err != nil {
 				return errors.Wrapf(err, "Generating name for template %s and branch %s", tpl.Name, branch)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adjusts prowjob-gen to not create files which would have been empty otherwise.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci