### PR TITLE
🌱 test: adjust capd dockerfile so the binary exposes the package in the built binraries path variable

### DIFF
--- a/hack/docker-image-verify.sh
+++ b/hack/docker-image-verify.sh
@@ -51,7 +51,7 @@ for arch in ${ALL_ARCH}; do
   TESTIMAGE "${REGISTRY}/cluster-api-controller-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api$"
   TESTIMAGE "${REGISTRY}/kubeadm-bootstrap-controller-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/bootstrap/kubeadm$"
   TESTIMAGE "${REGISTRY}/kubeadm-control-plane-controller-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/controlplane/kubeadm$"
-  TESTIMAGE "${REGISTRY}/capd-manager-${arch}:${TAG}" "${arch}" "command-line-arguments$"
+  TESTIMAGE "${REGISTRY}/capd-manager-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/test/infrastructure/docker$"
   TESTIMAGE "${REGISTRY}/capim-manager-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/test/infrastructure/inmemory$"
   TESTIMAGE "${REGISTRY}/test-extension-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/test/extension$"
   TESTIMAGE "${REGISTRY}/clusterctl-${arch}:${TAG}" "${arch}" "sigs.k8s.io/cluster-api/cmd/clusterctl$" "clusterctl"

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -63,7 +63,7 @@ ARG ARCH
 # Build the CAPD manager using the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager main.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager .
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Follow up for https://github.com/kubernetes-sigs/cluster-api/pull/9932#discussion_r1461535941

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci