### PR TITLE
📖 Rename "others..." tab with "Other providers..."

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1278,7 +1278,7 @@ For more information about prerequisites, credentials management, or permissions
 
 For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
-{{#tabs name:"tab-clusterctl-config-cluster" tabs:"Docker, vcluster, KubeVirt, others..."}}
+{{#tabs name:"tab-clusterctl-config-cluster" tabs:"Docker, vcluster, KubeVirt, Other providers..."}}
 {{#tab Docker}}
 
 <aside class="note warning">
@@ -1330,7 +1330,7 @@ clusterctl generate cluster capi-quickstart \
 ```
 
 {{#/tab }}
-{{#tab others...}}
+{{#tab Other providers...}}
 
 ```bash
 clusterctl generate cluster capi-quickstart \
@@ -1463,7 +1463,7 @@ For more information, see the [CAPZ book](https://capz.sigs.k8s.io/topics/addons
 
 Calico is used here as an example.
 
-{{#tabs name:"tab-deploy-cni" tabs:"Azure,vcluster,KubeVirt,others..."}}
+{{#tabs name:"tab-deploy-cni" tabs:"Azure,vcluster,KubeVirt,Other providers..."}}
 {{#tab Azure}}
 
 Install the official Calico Helm chart on the workload cluster:
@@ -1606,7 +1606,7 @@ kube-scheduler-capi-quickstart-control-plane-kjjbb            1/1     Running   
 </aside>
 
 {{#/tab }}
-{{#tab others...}}
+{{#tab Other providers...}}
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9953 
This PR renames the instances of "others..." tab to "Other providers..." in the quickstart guide.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->