### PR TITLE
📖 Refining 'cluster init --help' command documentation

### DIFF
--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -56,11 +56,12 @@ var initCmd = &cobra.Command{
 		The management cluster must be an existing Kubernetes cluster, make sure
 		to have enough privileges to install the desired components.
 
-		Use 'clusterctl config repositories' to get a list of available providers; if necessary, edit
-		$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml file to add new provider or to customize existing ones.
+		Use 'clusterctl config repositories' to get a list of available providers and their configuration; if
+		necessary, edit $XDG_CONFIG_HOME/cluster-api/clusterctl.yaml file to add new provider or to customize existing ones.
 
 		Some providers require environment variables to be set before running clusterctl init.
-		Refer to the provider documentation, or use 'clusterctl config provider [name]' to get a list of required variables.
+		Refer to the provider documentation, or use 'clusterctl generate provider --infrastructure [name] --describe'
+		to get a list of required variables.
 
 		See https://cluster-api.sigs.k8s.io for more details.`),
 


### PR DESCRIPTION
…r repository info and configurations

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Refining the "clusterctl init --help" command documentation. As `clusterctl config provider` is modified to used `clusterctl config repositories` updated the document for the same.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9374 

/area documentation
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->