### PR TITLE
🌱 Update jobs.md and make it version-independent

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -55,7 +55,6 @@ changes should be cherry-picked to all release series that will support the new 
 
 * [ ] Update book:
   * Update supported versions in `versions.md`
-  * Update job documentation in `jobs.md`
   * Prior art: #9161
 * [ ] Issues specific to the Kubernetes minor release:
   * Sometimes there are adjustments that we have to make in Cluster API to be able to support

--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -7,33 +7,37 @@ It also documents the cluster-api specific configuration in test-infra.
 
 > NOTE: To see which test jobs execute which tests or e2e tests, you can click on the links which lead to the respective test overviews in testgrid.
 
+The dashboards for the ProwJobs can be found here: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api
+
+More details about ProwJob configurations can be found here: [cluster-api-prowjob-gen.yaml](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/cluster-api-prowjob-gen.yaml)
+
 ### Presubmits
 
 Prow Presubmits:
 * mandatory for merge, always run:
-  * [pull-cluster-api-build-main] `./scripts/ci-build.sh`
-  * [pull-cluster-api-verify-main] `./scripts/ci-verify.sh`
+  * pull-cluster-api-build-main `./scripts/ci-build.sh`
+  * pull-cluster-api-verify-main `./scripts/ci-verify.sh`
 * mandatory for merge, run if go code changes:
-  * [pull-cluster-api-test-main] `./scripts/ci-test.sh`
-  * [pull-cluster-api-e2e-main] `./scripts/ci-e2e.sh`
+  * pull-cluster-api-test-main `./scripts/ci-test.sh`
+  * pull-cluster-api-e2e-blocking-main `./scripts/ci-e2e.sh`
     * GINKGO_FOCUS: `[PR-Blocking]`
 * optional for merge, run if go code changes:
-  * [pull-cluster-api-apidiff-main] `./scripts/ci-apidiff.sh`
+  * pull-cluster-api-apidiff-main `./scripts/ci-apidiff.sh`
 * mandatory for merge, run if manually triggered:
-  * [pull-cluster-api-test-mink8s-main] `./scripts/ci-test.sh`
-    * KUBEBUILDER_ENVTEST_KUBERNETES_VERSION: `1.24.2`
-  * [pull-cluster-api-e2e-mink8s-main] `./scripts/ci-e2e.sh`
-    * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]|[IPv6]`
-    * KUBERNETES_VERSION_MANAGEMENT: `stable-1.24`
-  * [pull-cluster-api-e2e-full-dualstack-and-ipv6-main] `./scripts/ci-e2e.sh`
+  * pull-cluster-api-test-mink8s-main `./scripts/ci-test.sh`
+  * pull-cluster-api-e2e-mink8s-main `./scripts/ci-e2e.sh`
+    * GINKGO_SKIP: `[Conformance]|[IPv6]`
+  * pull-cluster-api-e2e-dualstack-and-ipv6-main `./scripts/ci-e2e.sh`
     * DOCKER_IN_DOCKER_IPV6_ENABLED: `true`
-    * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]`
-  * [pull-cluster-api-e2e-full-main] `./scripts/ci-e2e.sh`
-    * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]|[IPv6]`
-  * [pull-cluster-api-e2e-workload-upgrade-1-29-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.29` TO: `ci/latest-1.30`
-    * GINKGO_FOCUS: `[K8s-Upgrade]`
-* optional for merge, run if manually triggered:
-  * [pull-cluster-api-e2e-scale-main-experimental] `./scripts/ci-e2e-scale.sh`
+    * GINKGO_SKIP: `[Conformance]`
+  * pull-cluster-api-e2e-main `./scripts/ci-e2e.sh`
+    * GINKGO_SKIP: `[Conformance]|[IPv6]`
+  * pull-cluster-api-e2e-upgrade-* `./scripts/ci-e2e.sh`
+    * GINKGO_FOCUS: `[Conformance] [K8s-Upgrade]`  
+  * pull-cluster-api-e2e-conformance-main `./scripts/ci-e2e.sh`
+    * GINKGO_FOCUS: `[Conformance] [K8s-Install]`
+  * pull-cluster-api-e2e-conformance-ci-latest-main `./scripts/ci-e2e.sh`
+    * GINKGO_FOCUS: `[Conformance] [K8s-Install-ci-latest]`
 
 GitHub Presubmit Workflows:
 * PR golangci-lint: golangci/golangci-lint-action
@@ -68,29 +72,21 @@ Prow Postsubmits:
 ### Periodics
 
 Prow Periodics:
-* [periodic-cluster-api-test-main] `./scripts/ci-test.sh`
-* [periodic-cluster-api-test-mink8s-main] `./scripts/ci-test.sh`
-  * KUBEBUILDER_ENVTEST_KUBERNETES_VERSION: `1.24.2`
-* [periodic-cluster-api-e2e-main] `./scripts/ci-e2e.sh`
-  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]|[IPv6]`
-* [periodic-cluster-api-e2e-mink8s-main] `./scripts/ci-e2e.sh`
-  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]|[IPv6]`
-  * KUBERNETES_VERSION_MANAGEMENT: `stable-1.24`
-* [periodic-cluster-api-e2e-dualstack-and-ipv6-main] `./scripts/ci-e2e.sh`
+* periodic-cluster-api-test-main `./scripts/ci-test.sh`
+* periodic-cluster-api-test-mink8s-main `./scripts/ci-test.sh`
+* periodic-cluster-api-e2e-main `./scripts/ci-e2e.sh`
+  * GINKGO_SKIP: `[Conformance]|[IPv6]`
+* periodic-cluster-api-e2e-mink8s-main `./scripts/ci-e2e.sh`
+  * GINKGO_SKIP: `[Conformance]|[IPv6]`
+* periodic-cluster-api-e2e-dualstack-and-ipv6-main `./scripts/ci-e2e.sh`
   * DOCKER_IN_DOCKER_IPV6_ENABLED: `true`
-  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main] `./scripts/ci-e2e.sh` FROM: `stable-1.24` TO: `stable-1.25`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-main] `./scripts/ci-e2e.sh` FROM: `stable-1.25` TO: `stable-1.26`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-main] `./scripts/ci-e2e.sh` FROM: `stable-1.26` TO: `stable-1.27`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main] `./scripts/ci-e2e.sh` FROM: `stable-1.27` TO: `stable-1.28`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-28-1-29-main] `./scripts/ci-e2e.sh` FROM: `stable-1.28` TO: `stable-1.29`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-29-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.29` TO: `ci/latest-1.30`
-  * GINKGO_FOCUS: `[K8s-Upgrade]`
+  * GINKGO_SKIP: `[Conformance]`
+* periodic-cluster-api-e2e-upgrade-* `./scripts/ci-e2e.sh`
+  * GINKGO_FOCUS: `[Conformance] [K8s-Upgrade]`
+* periodic-cluster-api-e2e-conformance-main `./scripts/ci-e2e.sh`
+  * GINKGO_FOCUS: `[Conformance] [K8s-Install]`
+* periodic-cluster-api-e2e-conformance-ci-latest-main `./scripts/ci-e2e.sh`
+  * GINKGO_FOCUS: `[Conformance] [K8s-Install-ci-latest]`
 * [cluster-api-push-images-nightly] Google Cloud Build: `make release-staging-nightly`
 
 ## Test-infra configuration
@@ -116,28 +112,5 @@ Prow Periodics:
 
 
 <!-- links -->
-[pull-cluster-api-build-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-build-main
-[pull-cluster-api-apidiff-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-apidiff-main
-[pull-cluster-api-verify-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-verify-main
-[pull-cluster-api-test-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-test-main
-[pull-cluster-api-test-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-test-mink8s-main
-[pull-cluster-api-e2e-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-mink8s-main
-[pull-cluster-api-e2e-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main
-[pull-cluster-api-e2e-informing-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-informing-main
-[pull-cluster-api-e2e-full-dualstack-and-ipv6-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-full-dualstack-and-ipv6-main
-[pull-cluster-api-e2e-full-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-full-main
-[pull-cluster-api-e2e-workload-upgrade-1-29-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-1-29-latest
-[pull-cluster-api-e2e-scale-main-experimental]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-scale-main-experimental
-[periodic-cluster-api-test-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-main
-[periodic-cluster-api-test-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-mink8s-main
-[periodic-cluster-api-e2e-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main
-[periodic-cluster-api-e2e-mink8s-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-mink8s-main
-[periodic-cluster-api-e2e-dualstack-and-ipv6-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-dualstack-and-ipv6-main
-[periodic-cluster-api-e2e-workload-upgrade-1-24-1-25-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-24-1-25
-[periodic-cluster-api-e2e-workload-upgrade-1-25-1-26-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-25-1-26
-[periodic-cluster-api-e2e-workload-upgrade-1-26-1-27-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-26-1-27
-[periodic-cluster-api-e2e-workload-upgrade-1-27-1-28-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-27-1-28
-[periodic-cluster-api-e2e-workload-upgrade-1-28-1-29-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-28-1-29
-[periodic-cluster-api-e2e-workload-upgrade-1-29-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-29-latest
 [cluster-api-push-images-nightly]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#cluster-api-push-images-nightly
 [post-cluster-api-push-images]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-cluster-api-push-images


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Updated the jobs.md and got rid of some toil. Not very useful to try to keep this doc 100% up-to-date with links etc. if we can just link to the source of truth instead.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10062

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->