### PR TITLE
✨ clusterctl: Add public function to create new CRD migrator

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -289,7 +289,7 @@ func (cm *certManagerClient) migrateCRDs(ctx context.Context) error {
 		return err
 	}
 
-	return newCRDMigrator(c).Run(ctx, objs)
+	return NewCRDMigrator(c).Run(ctx, objs)
 }
 
 func (cm *certManagerClient) deleteObjs(ctx context.Context, objs []unstructured.Unstructured) error {

--- a/cmd/clusterctl/client/cluster/crd_migration.go
+++ b/cmd/clusterctl/client/cluster/crd_migration.go
@@ -35,6 +35,11 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
+// CRDMigrator interface defines methods for migrating CRs to the storage version of new CRDs.
+type CRDMigrator interface {
+	Run(ctx context.Context, objs []unstructured.Unstructured) error
+}
+
 // crdMigrator migrates CRs to the storage version of new CRDs.
 // This is necessary when the new CRD drops a version which
 // was previously used as a storage version.
@@ -42,8 +47,8 @@ type crdMigrator struct {
 	Client client.Client
 }
 
-// newCRDMigrator creates a new CRD migrator.
-func newCRDMigrator(client client.Client) *crdMigrator {
+// NewCRDMigrator creates a new CRD migrator.
+func NewCRDMigrator(client client.Client) CRDMigrator {
 	return &crdMigrator{
 		Client: client,
 	}

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -382,7 +382,7 @@ func (u *providerUpgrader) doUpgrade(ctx context.Context, upgradePlan *UpgradePl
 			return err
 		}
 
-		if err := newCRDMigrator(c).Run(ctx, components.Objs()); err != nil {
+		if err := NewCRDMigrator(c).Run(ctx, components.Objs()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Add public function to create new CRD migrator, we would like to reuse the code in CAPI Operator helm chart hook to help migrate CRDs if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->