### PR TITLE
🌱 Print conformance image used in kubetest

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -174,7 +174,7 @@ func Run(ctx context.Context, input RunInput) error {
 	// Get our current working directory. Just for information, so we don't need
 	// to worry about errors at this point.
 	cwd, _ := os.Getwd()
-	ginkgoextensions.Byf("Running e2e test: dir=%s, command=%q", cwd, args)
+	ginkgoextensions.Byf("Running e2e test: dir=%s, command=%q, image=%q", cwd, args, input.ConformanceImage)
 
 	containerRuntime, err := container.NewDockerClient()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR helps to figure out via logs which version of the conformance tests were executed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->