### PR TITLE
:sparkles: Docker: Add support to specify network name

### DIFF
--- a/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
@@ -48,6 +48,11 @@ type DockerClusterSpec struct {
 	// LoadBalancer allows defining configurations for the cluster load balancer.
 	// +optional
 	LoadBalancer DockerLoadBalancer `json:"loadBalancer,omitempty"`
+
+	// Network describes the name of the network to use for kind
+	// It will fallback to 'kind' if not specified
+	// +optional
+	Network string `json:"network,omitempty"`
 }
 
 // DockerLoadBalancer allows defining configurations for the cluster load balancer.

--- a/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
@@ -49,8 +49,8 @@ type DockerClusterSpec struct {
 	// +optional
 	LoadBalancer DockerLoadBalancer `json:"loadBalancer,omitempty"`
 
-	// Network describes the name of the network to use for kind
-	// It will fallback to 'kind' if not specified
+	// Network describes the name of the network to use in Docker
+	// The default value is 'kind'
 	// +optional
 	Network string `json:"network,omitempty"`
 }

--- a/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
@@ -62,7 +62,7 @@ type DockerMachineSpec struct {
 	// +optional
 	BootstrapTimeout *metav1.Duration `json:"bootstrapTimeout,omitempty"`
 
-	// Network describes the name of the network to use for kind
+	// Network describes the name of the network to use in Docker
 	// The default value is 'kind'
 	// +optional
 	Network string `json:"network,omitempty"`

--- a/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
@@ -61,6 +61,11 @@ type DockerMachineSpec struct {
 	// The default value is 3m.
 	// +optional
 	BootstrapTimeout *metav1.Duration `json:"bootstrapTimeout,omitempty"`
+
+	// Network describes the name of the network to use for kind
+	// The default value is 'kind'
+	// +optional
+	Network string `json:"network,omitempty"`
 }
 
 // Mount specifies a host volume to mount into a container.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -123,6 +123,9 @@ spec:
                       if not set, "v20210715-a6da3463" will be used instead.
                     type: string
                 type: object
+              network:
+                description: Network describes the name of the network to use for kind
+                type: string
             type: object
           status:
             description: DockerClusterStatus defines the observed state of DockerCluster.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -125,8 +125,8 @@ spec:
                 type: object
               network:
                 description: |-
-                  Network describes the name of the network to use for kind
-                  It will fallback to 'kind' if not specified
+                  Network describes the name of the network to use in Docker
+                  The default value is 'kind'
                 type: string
             type: object
           status:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -124,7 +124,9 @@ spec:
                     type: string
                 type: object
               network:
-                description: Network describes the name of the network to use for kind
+                description: |-
+                  Network describes the name of the network to use for kind
+                  It will fallback to 'kind' if not specified
                 type: string
             type: object
           status:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -152,6 +152,11 @@ spec:
                               if not set, "v20210715-a6da3463" will be used instead.
                             type: string
                         type: object
+                      network:
+                        description: |-
+                          Network describes the name of the network to use for kind
+                          It will fallback to 'kind' if not specified
+                        type: string
                     type: object
                 required:
                 - spec

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -154,8 +154,8 @@ spec:
                         type: object
                       network:
                         description: |-
-                          Network describes the name of the network to use for kind
-                          It will fallback to 'kind' if not specified
+                          Network describes the name of the network to use in Docker
+                          The default value is 'kind'
                         type: string
                     type: object
                 required:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -87,6 +87,11 @@ spec:
                           type: boolean
                       type: object
                     type: array
+                  network:
+                    description: |-
+                      Network describes the name of the network to use for kind
+                      It will fallback to 'kind' if not specified
+                    type: string
                   preLoadImages:
                     description: |-
                       PreLoadImages allows to pre-load images in a newly created machine. This can be used to

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -89,8 +89,8 @@ spec:
                     type: array
                   network:
                     description: |-
-                      Network describes the name of the network to use for kind
-                      It will fallback to 'kind' if not specified
+                      Network describes the name of the network to use in Docker
+                      The default value is 'kind'
                     type: string
                   preLoadImages:
                     description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
@@ -122,6 +122,11 @@ spec:
                                   type: boolean
                               type: object
                             type: array
+                          network:
+                            description: |-
+                              Network describes the name of the network to use for kind
+                              It will fallback to 'kind' if not specified
+                            type: string
                           preLoadImages:
                             description: |-
                               PreLoadImages allows to pre-load images in a newly created machine. This can be used to

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
@@ -124,8 +124,8 @@ spec:
                             type: array
                           network:
                             description: |-
-                              Network describes the name of the network to use for kind
-                              It will fallback to 'kind' if not specified
+                              Network describes the name of the network to use in Docker
+                              The default value is 'kind'
                             type: string
                           preLoadImages:
                             description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -115,6 +115,9 @@ spec:
                 description: ProviderID will be the container name in ProviderID format
                   (docker:////<containername>)
                 type: string
+              network:
+                description: Network describes the name of the network to use for kind
+                type: string
             type: object
           status:
             description: DockerMachineStatus defines the observed state of DockerMachine.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -104,6 +104,11 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              network:
+                description: |-
+                  Network describes the name of the network to use for kind
+                  The default value is 'kind'
+                type: string
               preLoadImages:
                 description: |-
                   PreLoadImages allows to pre-load images in a newly created machine. This can be used to
@@ -114,9 +119,6 @@ spec:
               providerID:
                 description: ProviderID will be the container name in ProviderID format
                   (docker:////<containername>)
-                type: string
-              network:
-                description: Network describes the name of the network to use for kind
                 type: string
             type: object
           status:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -106,7 +106,7 @@ spec:
                 type: array
               network:
                 description: |-
-                  Network describes the name of the network to use for kind
+                  Network describes the name of the network to use in Docker
                   The default value is 'kind'
                 type: string
               preLoadImages:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -132,6 +132,9 @@ spec:
                         description: ProviderID will be the container name in ProviderID
                           format (docker:////<containername>)
                         type: string
+                      network:
+                        description: Network describes the name of the network to use for kind
+                        type: string
                     type: object
                 required:
                 - spec

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -123,7 +123,7 @@ spec:
                         type: array
                       network:
                         description: |-
-                          Network describes the name of the network to use for kind
+                          Network describes the name of the network to use in Docker
                           The default value is 'kind'
                         type: string
                       preLoadImages:

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -121,6 +121,11 @@ spec:
                               type: boolean
                           type: object
                         type: array
+                      network:
+                        description: |-
+                          Network describes the name of the network to use for kind
+                          The default value is 'kind'
+                        type: string
                       preLoadImages:
                         description: |-
                           PreLoadImages allows to pre-load images in a newly created machine. This can be used to
@@ -131,9 +136,6 @@ spec:
                       providerID:
                         description: ProviderID will be the container name in ProviderID
                           format (docker:////<containername>)
-                        type: string
-                      network:
-                        description: Network describes the name of the network to use for kind
                         type: string
                     type: object
                 required:

--- a/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
@@ -45,8 +45,8 @@ type DockerMachinePoolMachineTemplate struct {
 	// +optional
 	ExtraMounts []infrav1.Mount `json:"extraMounts,omitempty"`
 
-	// Network describes the name of the network to use for kind
-	// It will fallback to 'kind' if not specified
+	// Network describes the name of the network to use in Docker
+	// The default value is 'kind'
 	// +optional
 	Network string `json:"network,omitempty"`
 }

--- a/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
@@ -44,6 +44,11 @@ type DockerMachinePoolMachineTemplate struct {
 	// These may be used to bind a hostPath
 	// +optional
 	ExtraMounts []infrav1.Mount `json:"extraMounts,omitempty"`
+
+	// Network describes the name of the network to use for kind
+	// It will fallback to 'kind' if not specified
+	// +optional
+	Network string `json:"network,omitempty"`
 }
 
 // DockerMachinePoolSpec defines the desired state of DockerMachinePool.

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
@@ -99,7 +99,7 @@ func createDockerContainer(ctx context.Context, name string, cluster *clusterv1.
 	}
 
 	log.Info("Creating container for machinePool", "name", name, "machinePool", machinePool.Name)
-	if err := externalMachine.Create(ctx, dockerMachinePool.Spec.Template.CustomImage, constants.WorkerNodeRoleValue, machinePool.Spec.Template.Spec.Version, labels, dockerMachinePool.Spec.Template.ExtraMounts); err != nil {
+	if err := externalMachine.Create(ctx, dockerMachinePool.Spec.Template.CustomImage, constants.WorkerNodeRoleValue, machinePool.Spec.Template.Spec.Version, labels, dockerMachinePool.Spec.Template.ExtraMounts, dockerMachinePool.Spec.Template.Network); err != nil {
 		return errors.Wrapf(err, "failed to create docker machine with name %s", name)
 	}
 	return nil

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -295,7 +295,7 @@ func (r *DockerMachineReconciler) reconcileNormal(ctx context.Context, cluster *
 	if !externalMachine.Exists() {
 		// NOTE: FailureDomains don't mean much in CAPD since it's all local, but we are setting a label on
 		// each container, so we can check placement.
-		if err := externalMachine.Create(ctx, dockerMachine.Spec.CustomImage, role, machine.Spec.Version, docker.FailureDomainLabel(machine.Spec.FailureDomain), dockerMachine.Spec.ExtraMounts); err != nil {
+		if err := externalMachine.Create(ctx, dockerMachine.Spec.CustomImage, role, machine.Spec.Version, docker.FailureDomainLabel(machine.Spec.FailureDomain), dockerMachine.Spec.ExtraMounts, dockerMachine.Spec.Network); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to create worker DockerMachine")
 		}
 	}

--- a/test/infrastructure/docker/internal/docker/loadbalancer.go
+++ b/test/infrastructure/docker/internal/docker/loadbalancer.go
@@ -33,7 +33,7 @@ import (
 )
 
 type lbCreator interface {
-	CreateExternalLoadBalancerNode(ctx context.Context, name, image, clusterName, listenAddress string, port int32, ipFamily clusterv1.ClusterIPFamily) (*types.Node, error)
+	CreateExternalLoadBalancerNode(ctx context.Context, name, image, clusterName, listenAddress string, port int32, ipFamily clusterv1.ClusterIPFamily, network string) (*types.Node, error)
 }
 
 // LoadBalancer manages the load balancer for a specific docker cluster.
@@ -45,6 +45,7 @@ type LoadBalancer struct {
 	lbCreator                lbCreator
 	backendControlPlanePort  string
 	frontendControlPlanePort string
+	network                  string
 }
 
 // NewLoadBalancer returns a new helper for managing a docker loadbalancer with a given name.
@@ -80,6 +81,7 @@ func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerClus
 		lbCreator:                &Manager{},
 		frontendControlPlanePort: strconv.Itoa(dockerCluster.Spec.ControlPlaneEndpoint.Port),
 		backendControlPlanePort:  "6443",
+		network:                  dockerCluster.Spec.Network,
 	}, nil
 }
 
@@ -129,6 +131,7 @@ func (s *LoadBalancer) Create(ctx context.Context) error {
 			listenAddr,
 			0,
 			s.ipFamily,
+			s.network,
 		)
 		if err != nil {
 			return errors.WithStack(err)

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -55,8 +55,8 @@ var (
 )
 
 type nodeCreator interface {
-	CreateControlPlaneNode(ctx context.Context, name, clusterName, listenAddress string, port int32, mounts []v1alpha4.Mount, portMappings []v1alpha4.PortMapping, labels map[string]string, ipFamily clusterv1.ClusterIPFamily, kindMapping kind.Mapping) (node *types.Node, err error)
-	CreateWorkerNode(ctx context.Context, name, clusterName string, mounts []v1alpha4.Mount, portMappings []v1alpha4.PortMapping, labels map[string]string, ipFamily clusterv1.ClusterIPFamily, kindMapping kind.Mapping) (node *types.Node, err error)
+	CreateControlPlaneNode(ctx context.Context, name, clusterName, listenAddress string, port int32, mounts []v1alpha4.Mount, portMappings []v1alpha4.PortMapping, labels map[string]string, ipFamily clusterv1.ClusterIPFamily, kindMapping kind.Mapping, network string) (node *types.Node, err error)
+	CreateWorkerNode(ctx context.Context, name, clusterName string, mounts []v1alpha4.Mount, portMappings []v1alpha4.PortMapping, labels map[string]string, ipFamily clusterv1.ClusterIPFamily, kindMapping kind.Mapping, network string) (node *types.Node, err error)
 }
 
 // Machine implement a service for managing the docker containers hosting a kubernetes nodes.
@@ -201,7 +201,7 @@ func (m *Machine) ContainerImage() string {
 }
 
 // Create creates a docker container hosting a Kubernetes node.
-func (m *Machine) Create(ctx context.Context, image string, role string, version *string, labels map[string]string, mounts []infrav1.Mount) error {
+func (m *Machine) Create(ctx context.Context, image string, role string, version *string, labels map[string]string, mounts []infrav1.Mount, network string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Create if not exists.
@@ -236,6 +236,7 @@ func (m *Machine) Create(ctx context.Context, image string, role string, version
 				labels,
 				m.ipFamily,
 				kindMapping,
+				network,
 			)
 			if err != nil {
 				return errors.WithStack(err)
@@ -251,6 +252,7 @@ func (m *Machine) Create(ctx context.Context, image string, role string, version
 				labels,
 				m.ipFamily,
 				kindMapping,
+				network,
 			)
 			if err != nil {
 				return errors.WithStack(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, the CAPD provisioner forces the use of the `kind` network in Docker. This breaks other use cases when deploying in Docker, but not using Kind (like K3D), as the controller will fail to create resources as it cannot find the network to bind to. 

This change allows the user to optionally specify a different network name to use for provisioning, which allows deploying under different platforms.

**Which issue(s) this PR fixes**:

/area provider/infrastructure-docker