### PR TITLE
🌱 Fix ci-latest test to actually use ci latest

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -65,6 +65,15 @@ k8s::prepareKindestImages() {
     kind::prepareKindestImage "$resolveVersion"
   fi
 
+  # If the test focuses on [K8s-Install-ci-latest], default KUBERNETES_VERSION_LATEST_CI
+  # to the value in the e2e config if it is not set.
+  # Note: We do this because we want to specify KUBERNETES_VERSION_LATEST_CI *only* in the e2e config.
+  if [[ $GINKGO_FOCUS == *"K8s-Install-ci-latest"* ]]; then
+    if [[ -z "${KUBERNETES_VERSION_LATEST_CI:-}" ]]; then
+      KUBERNETES_VERSION_LATEST_CI=$(grep KUBERNETES_VERSION_LATEST_CI < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+      echo "Defaulting KUBERNETES_VERSION_LATEST_CI to ${KUBERNETES_VERSION_LATEST_CI} to trigger image build (because env var is not set)"
+    fi
+  fi
   if [ -n "${KUBERNETES_VERSION_LATEST_CI:-}" ]; then
     k8s::resolveVersion "KUBERNETES_VERSION_LATEST_CI" "$KUBERNETES_VERSION_LATEST_CI"
     export KUBERNETES_VERSION_LATEST_CI=$resolveVersion

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -37,6 +37,15 @@ export PATH="${REPO_ROOT}/hack/tools/bin:${PATH}"
 # Builds CAPI (and CAPD) images.
 capi:buildDockerImages
 
+# Configure e2e tests
+export GINKGO_NODES=3
+export GINKGO_NOCOLOR=true
+export GINKGO_ARGS="${GINKGO_ARGS:-""}"
+export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
+export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
+export SKIP_RESOURCE_CLEANUP=${SKIP_RESOURCE_CLEANUP:-"false"}
+export USE_EXISTING_CLUSTER=false
+
 # Prepare kindest/node images for all the required Kubernetes version; this implies
 # 1. Kubernetes version labels (e.g. latest) to the corresponding version numbers.
 # 2. Pre-pulling the corresponding kindest/node image if available; if not, building the image locally.
@@ -51,15 +60,6 @@ k8s::prepareKindestImages
 # less sensible to the network speed. This includes:
 # - cert-manager images
 kind:prepullAdditionalImages
-
-# Configure e2e tests
-export GINKGO_NODES=3
-export GINKGO_NOCOLOR=true
-export GINKGO_ARGS="${GINKGO_ARGS:-""}"
-export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
-export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
-export SKIP_RESOURCE_CLEANUP=${SKIP_RESOURCE_CLEANUP:-"false"}
-export USE_EXISTING_CLUSTER=false
 
 # Setup local output directory
 ARTIFACTS_LOCAL="${ARTIFACTS}/localhost"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->