### PR TITLE
🌱 Add MachinePools to autoscaler e2e test

### DIFF
--- a/exp/internal/webhooks/machinepool_test.go
+++ b/exp/internal/webhooks/machinepool_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/webhooks/util"
 )
 
-var ctx = admission.NewContextWithRequest(ctrl.SetupSignalHandler(), admission.Request{})
+var ctx = ctrl.SetupSignalHandler()
 
 func TestMachinePoolDefault(t *testing.T) {
 	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
@@ -58,6 +58,7 @@ func TestMachinePoolDefault(t *testing.T) {
 		},
 	}
 	webhook := &MachinePool{}
+	ctx = admission.NewContextWithRequest(ctx, admission.Request{})
 	t.Run("for MachinePool", util.CustomDefaultValidateTest(ctx, mp, webhook))
 	g.Expect(webhook.Default(ctx, mp)).To(Succeed())
 

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -27,15 +27,16 @@ import (
 var _ = Describe("When using the autoscaler with Cluster API using ClusterClass [ClusterClass]", func() {
 	AutoscalerSpec(ctx, func() AutoscalerSpecInput {
 		return AutoscalerSpecInput{
-			E2EConfig:                         e2eConfig,
-			ClusterctlConfigPath:              clusterctlConfigPath,
-			BootstrapClusterProxy:             bootstrapClusterProxy,
-			ArtifactFolder:                    artifactFolder,
-			SkipCleanup:                       skipCleanup,
-			InfrastructureProvider:            ptr.To("docker"),
-			InfrastructureMachineTemplateKind: "dockermachinetemplates",
-			Flavor:                            ptr.To("topology-autoscaler"),
-			AutoscalerVersion:                 "v1.29.0",
+			E2EConfig:                             e2eConfig,
+			ClusterctlConfigPath:                  clusterctlConfigPath,
+			BootstrapClusterProxy:                 bootstrapClusterProxy,
+			ArtifactFolder:                        artifactFolder,
+			SkipCleanup:                           skipCleanup,
+			InfrastructureProvider:                ptr.To("docker"),
+			InfrastructureMachineTemplateKind:     "dockermachinetemplates",
+			InfrastructureMachinePoolTemplateKind: "dockermachinepooltemplates",
+			Flavor:                                ptr.To("topology-autoscaler"),
+			AutoscalerVersion:                     "v1.29.0",
 		}
 	})
 })

--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -35,6 +35,7 @@ var _ = Describe("When using the autoscaler with Cluster API using ClusterClass 
 			InfrastructureProvider:                ptr.To("docker"),
 			InfrastructureMachineTemplateKind:     "dockermachinetemplates",
 			InfrastructureMachinePoolTemplateKind: "dockermachinepooltemplates",
+			InfrastructureMachinePoolKind:         "dockermachinepools",
 			Flavor:                                ptr.To("topology-autoscaler"),
 			AutoscalerVersion:                     "v1.29.0",
 		}

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-autoscaler/cluster-autoscaler.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-autoscaler/cluster-autoscaler.yaml
@@ -29,6 +29,12 @@ spec:
             annotations:
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
               cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "2"
+      machinePools:
+        - class: "default-worker"
+          name: "mp-0"
+          nodeDeletionTimeout: "30s"
+          failureDomains:
+          - fd4
     variables:
       - name: etcdImageTag
         value: ""


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds MachinePools to the autoscaler e2e tests. This is a follow-up task to enabling MachinePools in ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #10028 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterclass