### PR TITLE
🐛 ci: fix unset GINKGO_FOCUS variable

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -68,7 +68,7 @@ k8s::prepareKindestImages() {
   # If the test focuses on [K8s-Install-ci-latest], default KUBERNETES_VERSION_LATEST_CI
   # to the value in the e2e config if it is not set.
   # Note: We do this because we want to specify KUBERNETES_VERSION_LATEST_CI *only* in the e2e config.
-  if [[ $GINKGO_FOCUS == *"K8s-Install-ci-latest"* ]]; then
+  if [[ ${GINKGO_FOCUS:-} == *"K8s-Install-ci-latest"* ]]; then
     if [[ -z "${KUBERNETES_VERSION_LATEST_CI:-}" ]]; then
       KUBERNETES_VERSION_LATEST_CI=$(grep KUBERNETES_VERSION_LATEST_CI < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
       echo "Defaulting KUBERNETES_VERSION_LATEST_CI to ${KUBERNETES_VERSION_LATEST_CI} to trigger image build (because env var is not set)"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixes the error:

```
/home/prow/go/src/sigs.k8s.io/cluster-api/scripts/ci-e2e-lib.sh: line 71: GINKGO_FOCUS: unbound variable
```

introduced in #10080 .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing
