### PR TITLE
🌱 test/framework: expose CopyAndAmendClusterctlConfig function

### DIFF
--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -155,11 +155,11 @@ type UpgradeInput struct {
 func Upgrade(ctx context.Context, input UpgradeInput) {
 	if len(input.ClusterctlVariables) > 0 {
 		outputPath := filepath.Join(filepath.Dir(input.ClusterctlConfigPath), fmt.Sprintf("clusterctl-upgrade-config-%s.yaml", input.ClusterName))
-		copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
+		Expect(CopyAndAmendClusterctlConfig(ctx, CopyAndAmendClusterctlConfigInput{
 			ClusterctlConfigPath: input.ClusterctlConfigPath,
 			OutputPath:           outputPath,
 			Variables:            input.ClusterctlVariables,
-		})
+		})).To(Succeed(), "Failed to CopyAndAmendClusterctlConfig")
 		input.ClusterctlConfigPath = outputPath
 	}
 
@@ -288,11 +288,11 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 
 	if len(input.ClusterctlVariables) > 0 {
 		outputPath := filepath.Join(filepath.Dir(input.ClusterctlConfigPath), fmt.Sprintf("clusterctl-upgrade-config-%s.yaml", input.ClusterName))
-		copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
+		Expect(CopyAndAmendClusterctlConfig(ctx, CopyAndAmendClusterctlConfigInput{
 			ClusterctlConfigPath: input.ClusterctlConfigPath,
 			OutputPath:           outputPath,
 			Variables:            input.ClusterctlVariables,
-		})
+		})).To(Succeed(), "Failed to CopyAndAmendClusterctlConfig")
 		input.ClusterctlConfigPath = outputPath
 	}
 

--- a/test/framework/clusterctl/repository.go
+++ b/test/framework/clusterctl/repository.go
@@ -141,7 +141,7 @@ func CreateRepository(ctx context.Context, input CreateRepositoryInput) string {
 	for key := range input.E2EConfig.Variables {
 		clusterctlConfigFile.Values[key] = input.E2EConfig.GetVariable(key)
 	}
-	clusterctlConfigFile.write()
+	Expect(clusterctlConfigFile.write()).To(Succeed(), "Failed to write clusterctlConfigFile")
 
 	// creates a clusterctl config file to be used for working with such repository with only the providers supported in clusterctl < v1.3
 	clusterctlConfigFileV1_2 := &clusterctlConfig{
@@ -154,26 +154,28 @@ func CreateRepository(ctx context.Context, input CreateRepositoryInput) string {
 	for key := range input.E2EConfig.Variables {
 		clusterctlConfigFileV1_2.Values[key] = input.E2EConfig.GetVariable(key)
 	}
-	clusterctlConfigFileV1_2.write()
+	Expect(clusterctlConfigFileV1_2.write()).To(Succeed(), "Failed to write v1.2 clusterctlConfigFile")
 
 	return clusterctlConfigFile.Path
 }
 
-// copyAndAmendClusterctlConfigInput is the input for copyAndAmendClusterctlConfig.
-type copyAndAmendClusterctlConfigInput struct {
+// CopyAndAmendClusterctlConfigInput is the input for copyAndAmendClusterctlConfig.
+type CopyAndAmendClusterctlConfigInput struct {
 	ClusterctlConfigPath string
 	OutputPath           string
 	Variables            map[string]string
 }
 
-// copyAndAmendClusterctlConfig copies the clusterctl-config from ClusterctlConfigPath to
+// CopyAndAmendClusterctlConfig copies the clusterctl-config from ClusterctlConfigPath to
 // OutputPath and adds the given Variables.
-func copyAndAmendClusterctlConfig(_ context.Context, input copyAndAmendClusterctlConfigInput) {
+func CopyAndAmendClusterctlConfig(_ context.Context, input CopyAndAmendClusterctlConfigInput) error {
 	// Read clusterctl config from ClusterctlConfigPath.
 	clusterctlConfigFile := &clusterctlConfig{
 		Path: input.ClusterctlConfigPath,
 	}
-	clusterctlConfigFile.read()
+	if err := clusterctlConfigFile.read(); err != nil {
+		return err
+	}
 
 	// Overwrite variables.
 	if clusterctlConfigFile.Values == nil {
@@ -185,7 +187,7 @@ func copyAndAmendClusterctlConfig(_ context.Context, input copyAndAmendClusterct
 
 	// Write clusterctl config to OutputPath.
 	clusterctlConfigFile.Path = input.OutputPath
-	clusterctlConfigFile.write()
+	return clusterctlConfigFile.write()
 }
 
 // AdjustConfigPathForBinary adjusts the clusterctlConfigPath in case the clusterctl version v1.3.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In CAPV we made a copy of the `copyAndAmendClusterctlConfig` function because it was very useful in tests.

In CAPV we use it to dynamically set a variable for different tests.

This PR makes the function `CopyAndAmendClusterctlConfig` and struct `CopyAndAmendClusterctlConfigInput` public so providers could make use of the function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing