### PR TITLE
:sparkles: Add release notes expander functionality

### DIFF
--- a/hack/tools/release/notes/list.go
+++ b/hack/tools/release/notes/list.go
@@ -54,9 +54,18 @@ func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string) *gi
 // between fromRef and toRef, discarding any PR not seeing in the commits list.
 // This ensures we don't include any PR merged in the same date range that
 // doesn't belong to our git timeline.
-func (l *githubFromToPRLister) listPRs() ([]pr, error) {
-	log.Printf("Computing diff between %s and %s", l.fromRef, l.toRef)
-	diff, err := l.client.getDiffAllCommits(l.fromRef.value, l.toRef.value)
+func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
+	var (
+		diff *githubDiff
+		err  error
+	)
+	if previousReleaseRef.value != "" {
+		log.Printf("Computing diff between %s and %s", previousReleaseRef.value, l.toRef)
+		diff, err = l.client.getDiffAllCommits(previousReleaseRef.value, l.toRef.value)
+	} else {
+		log.Printf("Computing diff between %s and %s", l.fromRef, l.toRef)
+		diff, err = l.client.getDiffAllCommits(l.fromRef.value, l.toRef.value)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/hack/tools/release/notes/process.go
+++ b/hack/tools/release/notes/process.go
@@ -117,10 +117,16 @@ func (g prEntriesProcessor) process(prs []pr) []notesEntry {
 	return entries
 }
 
-func (d dependenciesProcessor) generateDependencies() (string, error) {
+func (d dependenciesProcessor) generateDependencies(previousRelease ref) (string, error) {
 	repoURL := fmt.Sprintf("https://github.com/%s", d.repo)
+
+	fromTag := d.fromTag
+	if previousRelease.value != "" {
+		fromTag = previousRelease.value
+	}
+
 	deps, err := notes.NewDependencies().ChangesForURL(
-		repoURL, d.fromTag, d.toTag,
+		repoURL, fromTag, d.toTag,
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Add expander in generated release notes

```bash
./bin/notes --release v1.6.0 --pre-release-version true > CHANGELOG/v1.6.0.md


$ cat CHANGELOG/v1.6.0.md 
🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
## 👌 Kubernetes version support

- Management Cluster: v1.**X**.x -> v1.**X**.x
- Workload Cluster: v1.**X**.x -> v1.**X**.x

[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)

## Highlights

* REPLACE ME

## Deprecation Warning

REPLACE ME: A couple sentences describing the deprecation, including links to docs.

* [GitHub issue #REPLACE ME](REPLACE ME)

## Changes since v1.5.0
## :chart_with_upwards_trend: Overview
- 417 new commits merged
- 6 breaking changes :warning:
- 16 feature additions ✨
- 46 bugs fixed 🐛

## :memo: Proposals
- Community meeting: Add proposal for karpenter integration feature group (#9571)

<details>
<summary>More details about the release</summary>

## :warning: Breaking Changes
- API: Remove v1alpha3 API Version (#8997)
- API: Stop serving v1alpha4 API Versions (#8996)
- clusterctl: Improve Context handling in clusterctl (#8939)
- Dependency: Bump to controller-runtime v0.16 (#8999)
- MULTIPLE_AREAS[Metrics/Logging]: Implement secure diagnostics (metrics, pprof, log level changes) (#9264)
- util: : Remove go-vcs dependency from releaselink tool (#9288)

## :sparkles: New Features
- Testing: V1.29: Prepare quickstart, capd and tests for the new release including kind bump (#9890)
.....

## :bug: Bug Fixes

- util: Fix AddAnnotations for unstructured.Unstructured (#9164)
.....

## :seedling: Others
- API: Add ClusterClass column to Cluster CRD (#9120)
....

:book: Additionally, there have been 65 contributions to our documentation and book. (#10024, #10047, #8260, #8500, #8678, #8819, #8988, #9001, #9013, #9014, #9024, #9029, #9080, #9081, #9087, #9112, #9119, #9141, #9146, #9150, #9161, #9173, #9208, #9209, #9213, #9214, #9232, #9270, #9286, #9291, #9305, #9328, #9364, #9386, #9403, #9415, #9429, #9433, #9463, #9487, #9488, #9490, #9511, #9513, #9514, #9527, #9550, #9559, #9565, #9572, #9577, #9590, #9593, #9613, #9635, #9654, #9706, #9815, #9816, #9824, #9830, #9878, #9902, #9951, #9979) 


</details>
<br/>

_Thanks to all our contributors!_ 😊

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9319 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release