### PR TITLE
🌱 Improve weekly PR update generation script and documentation

### DIFF
--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -337,16 +337,26 @@ The goal of this task to make the book for the current release available under e
 
 #### Generate weekly PR updates to post in Slack
 The goal of this task is to keep the CAPI community updated on recent PRs that have been merged. This is done by using the weekly update tool in `hack/tools/release/weekly/main.go`. Here is how to use it:
-1. Checkout the latest commit on the release branch, e.g. `release-1.6`, or the main branch if the release branch doesn't yet exist (e.g. beta release).
-2. Build the release weekly update tools binary.
+1. Build the release weekly update tools binary.
    ```bash
    make release-weekly-update-tool
    ```
-3. Generate the weekly update with the following command:
+2. Generate the weekly update with the following command for desired branches:
    ```bash
-   ./bin/weekly --from YYYY-MM-DD --to YYYY-MM-DD --milestone v1.x
+   ./bin/weekly --since <YYYY-MM-DD> --until <YYYY-MM-DD> --branch <branch_name>
    ```
-4. Paste the output into a new Slack message in the [`#cluster-api`](https://kubernetes.slack.com/archives/C8TSNPY4T) channel. Currently, we post separate messages in a thread for `main` and the two most recent release branches (e.g. `release-1.5` and `release-1.4`).
+   **Note:** the `GITHUB_TOKEN` environment variable can be set to prevent/reduce GitHub rate limiting issues.
+3. Paste the output into a new Slack message in the [`#cluster-api`](https://kubernetes.slack.com/archives/C8TSNPY4T) channel. Currently, we post separate messages in a thread for the branch `main` - which corresponds to the active milestone - as well as the two most recent release branches (e.g. `release-1.6` and `release-1.5`).
+
+   Example commands to run for the weekly update during ongoing development towards release 1.7:
+   ```bash
+   # Main branch changes, which correspond to actively worked on release 1.7
+   ./bin/weekly --since 2024-01-22 --until 2024-01-28 --branch main
+
+   # Previous 2 release branches
+   ./bin/weekly --since 2024-01-22 --until 2024-01-28 --branch release-1.6
+   ./bin/weekly --since 2024-01-22 --until 2024-01-28 --branch release-1.5
+   ```
 
 #### Create PR for release notes
 1. Checkout the `main` branch.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -10,10 +10,12 @@ require (
 	cloud.google.com/go/storage v1.37.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/google/go-cmp v0.6.0
+	github.com/google/go-github v17.0.0+incompatible
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/valyala/fastjson v1.6.4
+	golang.org/x/oauth2 v0.16.0
 	google.golang.org/api v0.162.0
 	k8s.io/api v0.29.1
 	k8s.io/apiextensions-apiserver v0.29.1
@@ -102,7 +104,6 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
@@ -120,7 +121,6 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.16.0 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -146,6 +146,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -255,8 +257,8 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
@@ -377,7 +379,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=

--- a/hack/tools/release/weekly/main.go
+++ b/hack/tools/release/weekly/main.go
@@ -21,13 +21,17 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
 
 	release "sigs.k8s.io/cluster-api/hack/tools/release/internal"
 )
@@ -50,47 +54,62 @@ var (
 		release.Unknown,
 	}
 
-	from = flag.String("from", "", "Include commits starting from and including this date. Accepts format: YYYY-MM-DD")
-	to   = flag.String("to", "", "Include commits up to and including this date. Accepts format: YYYY-MM-DD")
+	since  string
+	until  string
+	branch string
 
-	milestone = flag.String("milestone", "v1.4", "Milestone. Accepts format: v1.4")
+	timeLayout = "2006-01-02"
+	repo       = "cluster-api"
+	owner      = "kubernetes-sigs"
 
 	tagRegex = regexp.MustCompile(`^\[release-[\w-\.]*\]`)
 )
 
 func main() {
+	flag.StringVar(&since, "since", "", "Include commits starting from and including this date. Accepts format: YYYY-MM-DD")
+	flag.StringVar(&until, "until", "", "Include commits up to and including this date. Accepts format: YYYY-MM-DD")
+	flag.StringVar(&branch, "branch", "release-1.6", "Release branch. Accepts formats: main, release-1.6")
 	flag.Parse()
 	os.Exit(run())
 }
 
-// Since git doesn't include the last day in rev-list we want to increase 1 day to include it in the interval.
-func increaseDateByOneDay(date string) (string, error) {
-	layout := "2006-01-02"
-	datetime, err := time.Parse(layout, date)
-	if err != nil {
-		return "", err
-	}
-	datetime = datetime.Add(time.Hour * 24)
-	return datetime.Format(layout), nil
-}
-
 func run() int {
-	var commitRange string
-	var cmd *exec.Cmd
-
-	if *from == "" && *to == "" {
-		fmt.Println("--from and --to are required together or both unset")
+	if since == "" && until == "" {
+		fmt.Println("--since and --until are required together or both unset")
 		return 1
 	}
 
-	commitRange = fmt.Sprintf("%s to %s", *from, *to)
-	lastDay, err := increaseDateByOneDay(*to)
+	ghToken := os.Getenv("GITHUB_TOKEN")
+	client := createGitHubClient(ghToken)
+
+	branchValid, err := isValidBranch(branch, owner, repo, client)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("Unable to verify if branch '%s' is valid: %s\n", branch, err.Error())
 		return 1
 	}
 
-	cmd = exec.Command("git", "rev-list", "HEAD", "--since=\""+*from+" 00:00:01\"", "--until=\""+lastDay+" 23:59:59\"", "--merges", "--pretty=format:%B") //nolint:gosec
+	if !branchValid {
+		fmt.Printf("Invalid branch '%s': branch does not exist. Example of valid branches: main, release-1.5.\n", branch)
+		return 1
+	}
+
+	sinceTime, err := parseTime(since)
+	if err != nil {
+		fmt.Printf("Unable to parse time for 'since' parameter: %s\n", since)
+		return 1
+	}
+
+	untilTime, err := parseTime(until)
+	if err != nil {
+		fmt.Printf("Unable to parse time for 'until' parameter: %s\n", until)
+		return 1
+	}
+
+	pullRequests, err := getMergedPullRequests(client, owner, repo, branch, sinceTime, untilTime)
+	if err != nil {
+		fmt.Println("Unable to get merged pull requests:", err.Error())
+		return 1
+	}
 
 	merges := map[string][]string{
 		release.Features:      {},
@@ -100,93 +119,53 @@ func run() int {
 		release.Other:         {},
 		release.Unknown:       {},
 	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Println("Error")
-		fmt.Println(err)
-		fmt.Println(string(out))
-		return 1
-	}
 
-	commits := []*commit{}
-	outLines := strings.Split(string(out), "\n")
-	for _, line := range outLines {
-		line = strings.TrimSpace(line)
-		last := len(commits) - 1
+	for _, pr := range pullRequests {
+		prTitle := trimTitle(pr.GetTitle())
+		var key, prNumber string
 		switch {
-		case strings.HasPrefix(line, "commit"):
-			commits = append(commits, &commit{})
-		case strings.HasPrefix(line, "Merge"):
-			commits[last].merge = line
-			continue
-		case line == "":
-		default:
-			commits[last].body = line
-		}
-	}
-
-	for _, c := range commits {
-		body := trimTitle(c.body)
-		var key, prNumber, fork string
-		switch {
-		case strings.HasPrefix(body, ":sparkles:"), strings.HasPrefix(body, "✨"):
+		case strings.HasPrefix(prTitle, ":sparkles:"), strings.HasPrefix(prTitle, "✨"):
 			key = release.Features
-			body = strings.TrimPrefix(body, ":sparkles:")
-			body = strings.TrimPrefix(body, "✨")
-		case strings.HasPrefix(body, ":bug:"), strings.HasPrefix(body, "🐛"):
+			prTitle = strings.TrimPrefix(prTitle, ":sparkles:")
+			prTitle = strings.TrimPrefix(prTitle, "✨")
+		case strings.HasPrefix(prTitle, ":bug:"), strings.HasPrefix(prTitle, "🐛"):
 			key = release.Bugs
-			body = strings.TrimPrefix(body, ":bug:")
-			body = strings.TrimPrefix(body, "🐛")
-		case strings.HasPrefix(body, ":book:"), strings.HasPrefix(body, "📖"):
+			prTitle = strings.TrimPrefix(prTitle, ":bug:")
+			prTitle = strings.TrimPrefix(prTitle, "🐛")
+		case strings.HasPrefix(prTitle, ":book:"), strings.HasPrefix(prTitle, "📖"):
 			key = release.Documentation
-			body = strings.TrimPrefix(body, ":book:")
-			body = strings.TrimPrefix(body, "📖")
-			if strings.Contains(body, "CAEP") || strings.Contains(body, "proposal") {
+			prTitle = strings.TrimPrefix(prTitle, ":book:")
+			prTitle = strings.TrimPrefix(prTitle, "📖")
+			if strings.Contains(prTitle, "CAEP") || strings.Contains(prTitle, "proposal") {
 				key = release.Proposals
 			}
-		case strings.HasPrefix(body, ":seedling:"), strings.HasPrefix(body, "🌱"):
+		case strings.HasPrefix(prTitle, ":seedling:"), strings.HasPrefix(prTitle, "🌱"):
 			key = release.Other
-			body = strings.TrimPrefix(body, ":seedling:")
-			body = strings.TrimPrefix(body, "🌱")
-		case strings.HasPrefix(body, ":warning:"), strings.HasPrefix(body, "⚠️"):
+			prTitle = strings.TrimPrefix(prTitle, ":seedling:")
+			prTitle = strings.TrimPrefix(prTitle, "🌱")
+		case strings.HasPrefix(prTitle, ":warning:"), strings.HasPrefix(prTitle, "⚠️"):
 			key = release.Warning
-			body = strings.TrimPrefix(body, ":warning:")
-			body = strings.TrimPrefix(body, "⚠️")
+			prTitle = strings.TrimPrefix(prTitle, ":warning:")
+			prTitle = strings.TrimPrefix(prTitle, "⚠️")
 		default:
 			key = release.Unknown
 		}
 
-		body = strings.TrimSpace(body)
-		if body == "" {
+		prTitle = strings.TrimSpace(prTitle)
+		if prTitle == "" {
 			continue
 		}
-		body = fmt.Sprintf("\t - %s", body)
-		_, _ = fmt.Sscanf(c.merge, "Merge pull request %s from %s", &prNumber, &fork)
+		prTitle = fmt.Sprintf("\t - %s", prTitle)
 		if key == release.Documentation {
 			merges[key] = append(merges[key], prNumber)
 			continue
 		}
-		merges[key] = append(merges[key], formatMerge(body, prNumber))
+		merges[key] = append(merges[key], formatMerge(prTitle, strconv.Itoa(pr.GetNumber())))
 	}
 
-	// fetch the current branch
-	out, err = exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
-	if err != nil {
-		fmt.Println("Error")
-		fmt.Println(err)
-		fmt.Println(string(out))
-		return 1
-	}
-
-	branch := strings.TrimSpace(string(out))
-	if branch == "" {
-		fmt.Println("Error: failed to get current branch!!!")
-		return 1
-	}
-
-	// TODO Turn this into a link (requires knowing the project name + organization)
+	// TODO Turn this into a link (requires knowing the project name + organization).
 	fmt.Println("Weekly update :rotating_light:")
-	fmt.Printf("Changes from %v a total of %d new commits were merged into %s.\n\n", commitRange, len(commits), branch)
+	fmt.Printf("From %s to %s a total of %d changes merged into %s.\n\n", sinceTime.Format(timeLayout), untilTime.Format(timeLayout), len(pullRequests), branch)
 
 	for _, key := range outputOrder {
 		mergeslice := merges[key]
@@ -209,9 +188,9 @@ func run() int {
 	}
 
 	fmt.Println("All merged PRs can be viewed in GitHub:")
-	fmt.Println("https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+closed%3A" + *from + ".." + lastDay + "+is%3Amerged+milestone%3A" + *milestone + "+\n")
+	fmt.Println("https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+closed%3A" + sinceTime.Format(timeLayout) + ".." + untilTime.Format(timeLayout) + "+is%3Amerged+base%3A" + branch + "+\n")
 
-	fmt.Println("_Thanks to all our contributors!_ 😊")
+	fmt.Println("*Thanks to all our contributors!* 😊")
 	fmt.Println("/Your friendly comms release team")
 
 	return 0
@@ -224,14 +203,93 @@ func trimTitle(title string) string {
 	return strings.TrimSpace(title)
 }
 
-type commit struct {
-	merge string
-	body  string
-}
-
 func formatMerge(line, prNumber string) string {
 	if prNumber == "" {
 		return line
 	}
-	return fmt.Sprintf("%s (%s)", line, prNumber)
+	return fmt.Sprintf("%s (#%s)", line, prNumber)
+}
+
+// Parse the time from string to time.Time format.
+func parseTime(date string) (time.Time, error) {
+	datetime, err := time.Parse(timeLayout, date)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return datetime, nil
+}
+
+func getMergedPullRequests(client *github.Client, owner string, repo string, branch string, since time.Time, until time.Time) ([]*github.PullRequest, error) {
+	var allPullRequests []*github.PullRequest
+
+	listOptions := &github.ListOptions{PerPage: 100}
+
+	for {
+		pullRequests, resp, err := client.PullRequests.List(context.Background(), owner, repo, &github.PullRequestListOptions{
+			State:       "closed",
+			Sort:        "updated",
+			Direction:   "desc",
+			ListOptions: *listOptions,
+			Base:        branch,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		// Include PRs until EOD.
+		until = until.Add(time.Hour * 24)
+		for _, pr := range pullRequests {
+			// Our query returned PRs sorted by most recently _updated_.
+			// The moment we get a PR that is updated before our `since` timestamp,
+			// we have seen all _merged_ PRs since `since`.
+			if pr.UpdatedAt.Before(since) {
+				return allPullRequests, nil
+			}
+
+			if pr.MergedAt != nil && pr.MergedAt.After(since) && pr.MergedAt.Before(until) {
+				allPullRequests = append(allPullRequests, pr)
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		listOptions.Page = resp.NextPage
+	}
+
+	return allPullRequests, nil
+}
+
+// Checks if the branch exists.
+func isValidBranch(branchName string, owner string, repo string, client *github.Client) (bool, error) {
+	branches, _, err := client.Repositories.ListBranches(context.Background(), owner, repo, nil)
+	if err != nil {
+		return false, err
+	}
+	for _, branch := range branches {
+		if branchName == branch.GetName() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// If the token is empty, we create a GitHub client without authentication
+// Using a token enables more api requests until we run into rate limitation
+// This is not necessary, but a nice to have when extending this script and going beyond
+// normal usage.
+func createGitHubClient(ghToken string) *github.Client {
+	if ghToken != "" {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: ghToken},
+		)
+
+		tc := oauth2.NewClient(context.Background(), ts)
+
+		return github.NewClient(tc)
+	}
+
+	return github.NewClient(nil)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the usage of the weekly PR update generation script is a bit confusing because it requires checking out the right branches as well as providing the right milestones for these branches. This PR attempts to address this issue by clarifying the documentation and updating the script to only use the branch parameter for the whole flow.

This PR updates the `Generate weekly PR updates to post in Slack` flow:
- the script has been updated 
   - it now pulls from github instead of needing a local correct checkout and right branch
   - the time range was previously off by a day, this is now fixed
   - `--milestone` is now `--branch` and should no more cause confusion between the relationship of branch to milestone
   - a parameter check for `--branch` was added
- the documentation was updated
   - added a full example of commands to run during an ongoing release cycle
   - updated the usage to branch instead of milestone
  

**Which issue(s) this PR fixes** 
Fixes #10008

/area release