### PR TITLE
🌱 Allow using different resource group and listener name with the in memory server

### DIFF
--- a/test/infrastructure/inmemory/api/v1alpha1/inmemorycluster_types.go
+++ b/test/infrastructure/inmemory/api/v1alpha1/inmemorycluster_types.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	// ResourceGroupAnnotationName tracks the name of a resource group a InMemoryCluster cluster is linked to.
-	ResourceGroupAnnotationName = "inmemorycluster.infrastructure.cluster.x-k8s.io/resource-group"
+	// ListenerAnnotationName tracks the name of the listener a cluster is linked to.
+	// NOTE: the annotation must be added by the components that creates the listener only if using the HotRestart feature.
+	ListenerAnnotationName = "inmemorycluster.infrastructure.cluster.x-k8s.io/listener"
 
 	// ClusterFinalizer allows InMemoryClusterReconciler to clean up resources associated with InMemoryCluster before
 	// removing it from the API server.

--- a/test/infrastructure/inmemory/pkg/server/listener.go
+++ b/test/infrastructure/inmemory/pkg/server/listener.go
@@ -39,6 +39,8 @@ type WorkloadClusterListener struct {
 	host string
 	port int
 
+	resourceGroup string
+
 	scheme *runtime.Scheme
 
 	apiServers                  sets.Set[string]
@@ -63,6 +65,11 @@ func (s *WorkloadClusterListener) Host() string {
 // Port returns the port of a WorkloadClusterListener.
 func (s *WorkloadClusterListener) Port() int {
 	return s.port
+}
+
+// ResourceGroup returns the resource group that hosts in memory resources for a WorkloadClusterListener.
+func (s *WorkloadClusterListener) ResourceGroup() string {
+	return s.resourceGroup
 }
 
 // Address returns the address of a WorkloadClusterListener.


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR it is now possible to use different resource group and listener name with the in-memory server.
This will greatly simplify using the in-memory server in context where the control plane endpoint and the in-memory resources are managed separately or where the name of the cluster is not known in advance, e.g. E2E tests

Note: for convenience we will continue to use the same name for resource group and listener within the in-memory, but this is not required anymore for other consumers of the in-memory server

/area provider/infrastructure-in-memory