### PR TITLE
📖 Update reference to clusterctl config file

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -708,7 +708,8 @@ clusterctl init --infrastructure outscale
 
 {{#tab Proxmox}}
 
-First, we need to add the IPAM provider to your clusterctl config file `~/.cluster-api/clusterctl.yaml`:
+First, we need to add the IPAM provider to your [clusterctl config file](../clusterctl/configuration.md) (`$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`):
+
 ```yaml
 providers:
   - name: in-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

The ProxMox initialization steps mention adding the IPAM provider to the config file. This is the first mention of the config file in the doc, with very little context as to what it is or how to work with it.

This updates the text to also provide a link to the clusterctl config documentation to make it easier to find out more about what is being asked. It also updates the path given to the current XDG-based path instead of the older `$HOME/.cluster-api` directory path.

/area documentation