### PR TITLE
🌱 Bump cert-manager to v1.14.1

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -29,7 +29,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.13.2"
+	CertManagerDefaultVersion = "v1.14.1"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -194,7 +194,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.13.2). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.14.1). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -81,7 +81,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.
@@ -179,8 +179,8 @@ To test another iteration, you'll need to follow the steps to build, push, updat
 
 **Let's chat about ...**
 
-We are currently hosting "Let's chat about ..." sessions where we are talking about topics relevant to 
-contributors and users of the Cluster API project. For more details and an up-to-date list of recordings of past sessions please 
+We are currently hosting "Let's chat about ..." sessions where we are talking about topics relevant to
+contributors and users of the Cluster API project. For more details and an up-to-date list of recordings of past sessions please
 see [Let's chat about ...](https://github.com/kubernetes-sigs/cluster-api/discussions/6106).
 
 * [Local CAPI development and debugging with Tilt (EMEA/Americas) - February 2022](https://www.youtube.com/watch?v=tEIRGmJahWs)

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -220,9 +220,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.13.2"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.13.2"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.13.2"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.14.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.14.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.14.1"
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -1,6 +1,6 @@
-# This is a file for CAPI end-to-end test configuration. 
+# This is a file for CAPI end-to-end test configuration.
 # The format of this file follows https://pkg.go.dev/sigs.k8s.io/cluster-api/test/framework/clusterctl#E2EConfig
-# 
+#
 # CI E2E test configuration scenario using locally build images and manifests for:
 # - cluster-api
 # - bootstrap kubeadm
@@ -23,11 +23,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/test-extension-{ARCH}:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.13.2
+- name: quay.io/jetstack/cert-manager-cainjector:v1.14.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.13.2
+- name: quay.io/jetstack/cert-manager-webhook:v1.14.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.13.2
+- name: quay.io/jetstack/cert-manager-controller:v1.14.1
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
**What this PR does / why we need it:**
Updates cert-manager to v1.14.1

**Which issue(s) this PR fixes:**
Fixes #10112

/area clusterctl