### PR TITLE
🌱 Add MP back to dualstack E2E test

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/drop-machinepools.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/drop-machinepools.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/topology/workers/machinePools

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary/kustomization.yaml
@@ -3,9 +3,4 @@ resources:
 - ../bases/crs.yaml
 
 patches:
-- path: ./drop-machinepools.yaml
-  target:
-    group: cluster.x-k8s.io
-    kind: Cluster
-    version: v1beta1
 - path: cluster.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/drop-machinepools.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/drop-machinepools.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/topology/workers/machinePools

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary/kustomization.yaml
@@ -3,9 +3,4 @@ resources:
 - ../bases/crs.yaml
 
 patches:
-- path: ./drop-machinepools.yaml
-  target:
-    group: cluster.x-k8s.io
-    kind: Cluster
-    version: v1beta1
 - path: cluster.yaml


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds MachinePools back to the dualstack E2E test and fixes the issue found in #9477 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #10028

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterclass
/area e2e-testing