### PR TITLE
:seedling:Test commit for k8s main failures

### DIFF
--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -171,6 +171,10 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 			"crictl", "info",
 		),
 		execToPathFn(
+			"containerd-images.txt",
+			"crictl", "images",
+		),
+		execToPathFn(
 			"containerd.log",
 			"journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service",
 		),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Test PR to see crictl images in workload cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->