### PR TITLE
[WIP] [DON'T REVIEW] 🌱 Add e2e test to reproduce SSA apiVersion issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,10 +511,14 @@ generate-doctoc:
 	TRACE=$(TRACE) ./hack/generate-doctoc.sh
 
 .PHONY: generate-e2e-templates
-generate-e2e-templates: $(KUSTOMIZE) $(addprefix generate-e2e-templates-, v1.0 v1.5 v1.6 main) ## Generate cluster templates for all versions
+generate-e2e-templates: $(KUSTOMIZE) $(addprefix generate-e2e-templates-, v0.4 v1.0 v1.5 v1.6 main) ## Generate cluster templates for all versions
 
 DOCKER_TEMPLATES := test/e2e/data/infrastructure-docker
 INMEMORY_TEMPLATES := test/e2e/data/infrastructure-inmemory
+
+.PHONY: generate-e2e-templates-v0.4
+generate-e2e-templates-v0.4: $(KUSTOMIZE)
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v0.4/cluster-template --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v0.4/cluster-template.yaml
 
 .PHONY: generate-e2e-templates-v1.0
 generate-e2e-templates-v1.0: $(KUSTOMIZE)

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -34,6 +34,59 @@ var (
 	providerDockerPrefix  = "docker:v%s"
 )
 
+var _ = Describe("When testing clusterctl upgrades (v0.4=>v1.6=>current) [PR-Blocking]", func() {
+	// Get v0.4 latest stable release
+	version04 := "0.4"
+	stableRelease04, err := GetStableReleaseOfMinor(ctx, version04)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version04)
+
+	// Get v1.6 latest stable release
+	version16 := "1.6"
+	stableRelease16, err := GetStableReleaseOfMinor(ctx, version16)
+	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version16)
+
+	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
+		return ClusterctlUpgradeSpecInput{
+			E2EConfig:              e2eConfig,
+			ClusterctlConfigPath:   clusterctlConfigPath,
+			BootstrapClusterProxy:  bootstrapClusterProxy,
+			ArtifactFolder:         artifactFolder,
+			SkipCleanup:            skipCleanup,
+			InfrastructureProvider: ptr.To("docker"),
+			// ### Versions for the initial deployment of providers ###
+			InitWithBinary:                    fmt.Sprintf(clusterctlDownloadURL, stableRelease04),
+			InitWithCoreProvider:              fmt.Sprintf(providerCAPIPrefix, stableRelease04),
+			InitWithBootstrapProviders:        []string{fmt.Sprintf(providerKubeadmPrefix, stableRelease04)},
+			InitWithControlPlaneProviders:     []string{fmt.Sprintf(providerKubeadmPrefix, stableRelease04)},
+			InitWithInfrastructureProviders:   []string{fmt.Sprintf(providerDockerPrefix, stableRelease04)},
+			InitWithRuntimeExtensionProviders: []string{},
+			// ### Versions for the first upgrade of providers ### // FIXME: move upgrades to slice & add hook
+			UpgradeWithBinary:         fmt.Sprintf(clusterctlDownloadURL, stableRelease16),
+			CoreProvider:              fmt.Sprintf(providerCAPIPrefix, stableRelease16),
+			BootstrapProviders:        []string{fmt.Sprintf(providerKubeadmPrefix, stableRelease16)},
+			ControlPlaneProviders:     []string{fmt.Sprintf(providerKubeadmPrefix, stableRelease16)},
+			InfrastructureProviders:   []string{fmt.Sprintf(providerDockerPrefix, stableRelease16)},
+			RuntimeExtensionProviders: []string{},
+			// Run a final upgrade to latest
+			AdditionalUpgrade: true,
+
+			// Some notes about the version pinning: (FIXME)
+			// We have to pin the providers because with `InitWithProvidersContract` the test would
+			// use the latest version for the contract (which is v1.6.X for v1beta1).
+			// We have to set this to an empty array as clusterctl v1.0 doesn't support
+			// runtime extension providers. If we don't do this the test will automatically
+			// try to deploy the latest version of our test-extension from docker.yaml.
+
+			// NOTE: If this version is changed here the image and SHA must also be updated in all DockerMachineTemplates in `test/data/infrastructure-docker/v1.0/bases.
+			//  Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
+			InitWithKubernetesVersion: "v1.23.17",
+			WorkloadKubernetesVersion: "v1.23.17",
+			MgmtFlavor:                "topology",
+			WorkloadFlavor:            "",
+		}
+	})
+})
+
 var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 	// Get v1.0 latest stable release
 	version := "1.0"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -35,6 +35,15 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
+  - name: "{go://sigs.k8s.io/cluster-api@v0.4}" # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v0.4}/core-components.yaml"
+    type: "url"
+    contract: v1alpha4
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/v0.4/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.0}" # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.0}/core-components.yaml"
     type: "url"
@@ -73,6 +82,15 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
+  - name: "{go://sigs.k8s.io/cluster-api@v0.4}" # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v0.4}/bootstrap-components.yaml"
+    type: "url"
+    contract: v1alpha4
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/v0.4/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.0}" # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.0}/bootstrap-components.yaml"
     type: "url"
@@ -111,6 +129,15 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
+  - name: "{go://sigs.k8s.io/cluster-api@v0.4}" # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v0.4}/control-plane-components.yaml"
+    type: "url"
+    contract: v1alpha4
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/v0.4/metadata.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.0}" # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.0}/control-plane-components.yaml"
     type: "url"
@@ -149,6 +176,16 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
+  - name: "{go://sigs.k8s.io/cluster-api@v0.4}" # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v0.4}/infrastructure-components-development.yaml"
+    type: "url"
+    contract: v1alpha4
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+    files:
+    - sourcePath: "../data/shared/v0.4/metadata.yaml"
+    - sourcePath: "../data/infrastructure-docker/v0.4/cluster-template.yaml"
   - name: "{go://sigs.k8s.io/cluster-api@v1.0}" # supported release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/{go://sigs.k8s.io/cluster-api@v1.0}/infrastructure-components-development.yaml"
     type: "url"

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -1,0 +1,87 @@
+---
+# DockerCluster object referenced by the Cluster object
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerCluster
+metadata:
+  name: '${CLUSTER_NAME}'
+---
+# Cluster object with
+# - Reference to the KubeadmControlPlane object
+# - the label cni=${CLUSTER_NAME}-crs-0, so the cluster can be selected by the ClusterResourceSet.
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ['${DOCKER_SERVICE_CIDRS}']
+    pods:
+      cidrBlocks: ['${DOCKER_POD_CIDRS}']
+    serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: DockerCluster
+    name: '${CLUSTER_NAME}'
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    name: "${CLUSTER_NAME}-control-plane"
+---
+# DockerMachineTemplate object referenced by the KubeadmControlPlane object
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      # NOTE: If the Kubernetes version is changed in `clusterctl_upgrade_test.go` the image and SHA must be updated here.
+      customImage: "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
+      extraMounts:
+        - containerPath: "/var/run/docker.sock"
+          hostPath: "/var/run/docker.sock"
+---
+# KubeadmControlPlane referenced by the Cluster object with
+# - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  labels:
+    kcp-adoption.step2: ""
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: DockerMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      controllerManager:
+        extraArgs: {enable-hostpath-provisioner: 'true'}
+      apiServer:
+        # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
+        certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
+    initConfiguration:
+      nodeRegistration:
+        criSocket: unix:///var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: unix:///var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+          # This cluster is used in tests where the Kubernetes version is < 1.24
+          cgroup-driver: cgroupfs
+          eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+          fail-swap-on: "false"
+  version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/crs.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/crs.yaml
@@ -1,0 +1,24 @@
+---
+# ConfigMap object referenced by the ClusterResourceSet object and with
+# the CNI resource defined in the test config file
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+binaryData:
+---
+# ClusterResourceSet object with
+# a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
+apiVersion: addons.cluster.x-k8s.io/v1alpha4
+kind: ClusterResourceSet
+metadata:
+  name:  "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-0"
+      kind: ConfigMap

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
@@ -1,0 +1,57 @@
+---
+# DockerMachineTemplate referenced by the MachineDeployment and with
+# - extraMounts for the docker sock, thus allowing self-hosting test
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      # NOTE: If the Kubernetes version is changed in `clusterctl_upgrade_test.go` the image and SHA must be updated here.
+      customImage: "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
+      extraMounts:
+        - containerPath: "/var/run/docker.sock"
+          hostPath: "/var/run/docker.sock"
+---
+# KubeadmConfigTemplate referenced by the MachineDeployment
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: unix:///var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
+            # This cluster is used in tests where the Kubernetes version is < 1.24
+            cgroup-driver: cgroupfs
+            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+            fail-swap-on: "false"
+---
+# MachineDeployment object
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: DockerMachineTemplate

--- a/test/e2e/data/infrastructure-docker/v0.4/cluster-template/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/cluster-template/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+- ../bases/cluster-with-kcp.yaml
+- ../bases/md.yaml
+- ../bases/crs.yaml

--- a/test/e2e/data/shared/v0.4/metadata.yaml
+++ b/test/e2e/data/shared/v0.4/metadata.yaml
@@ -1,0 +1,12 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 0
+    minor: 4
+    contract: v1alpha4
+  - major: 0
+    minor: 3
+    contract: v1alpha3
+  - major: 0
+    minor: 2
+    contract: v1alpha2

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -61,7 +61,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [ClusterClass]", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -109,7 +109,7 @@ func InitWithBinary(_ context.Context, binary string, input InitInput) {
 }
 
 func calculateClusterCtlInitArgs(input InitInput) []string {
-	args := []string{"init", "--config", input.ClusterctlConfigPath, "--kubeconfig", input.KubeconfigPath}
+	args := []string{"init", "--config", input.ClusterctlConfigPath, "--kubeconfig", input.KubeconfigPath, "--wait-providers"} // FIXME: This should be contributed in any case. We also have to set --wait-providers for InitWithBinary not only for Init
 	if input.CoreProvider != "" {
 		args = append(args, "--core", input.CoreProvider)
 	}
@@ -163,37 +163,8 @@ func Upgrade(ctx context.Context, input UpgradeInput) {
 		input.ClusterctlConfigPath = outputPath
 	}
 
-	// Check if the user want a custom upgrade
-	isCustomUpgrade := input.CoreProvider != "" ||
-		len(input.BootstrapProviders) > 0 ||
-		len(input.ControlPlaneProviders) > 0 ||
-		len(input.InfrastructureProviders) > 0 ||
-		len(input.IPAMProviders) > 0 ||
-		len(input.RuntimeExtensionProviders) > 0 ||
-		len(input.AddonProviders) > 0
-
-	Expect((input.Contract != "" && !isCustomUpgrade) || (input.Contract == "" && isCustomUpgrade)).To(BeTrue(), `Invalid arguments. Either the input.Contract parameter or at least one of the following providers has to be set:
-		input.CoreProvider, input.BootstrapProviders, input.ControlPlaneProviders, input.InfrastructureProviders, input.IPAMProviders, input.RuntimeExtensionProviders, input.AddonProviders`)
-
-	if isCustomUpgrade {
-		log.Logf("clusterctl upgrade apply --core %s --bootstrap %s --control-plane %s --infrastructure %s --ipam %s --runtime-extension %s --addon %s --config %s --kubeconfig %s",
-			input.CoreProvider,
-			strings.Join(input.BootstrapProviders, ","),
-			strings.Join(input.ControlPlaneProviders, ","),
-			strings.Join(input.InfrastructureProviders, ","),
-			strings.Join(input.IPAMProviders, ","),
-			strings.Join(input.RuntimeExtensionProviders, ","),
-			strings.Join(input.AddonProviders, ","),
-			input.ClusterctlConfigPath,
-			input.KubeconfigPath,
-		)
-	} else {
-		log.Logf("clusterctl upgrade apply --contract %s --config %s --kubeconfig %s",
-			input.Contract,
-			input.ClusterctlConfigPath,
-			input.KubeconfigPath,
-		)
-	}
+	args := calculateClusterCtlUpgradeArgs(input)
+	log.Logf("clusterctl %s", strings.Join(args, " "))
 
 	upgradeOpt := clusterctlclient.ApplyUpgradeOptions{
 		Kubeconfig: clusterctlclient.Kubeconfig{
@@ -216,6 +187,79 @@ func Upgrade(ctx context.Context, input UpgradeInput) {
 
 	err := clusterctlClient.ApplyUpgrade(ctx, upgradeOpt)
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl upgrade")
+}
+
+// UpgradeWithBinary calls clusterctl upgrade apply with the list of providers defined in the local repository.
+func UpgradeWithBinary(ctx context.Context, binary string, input UpgradeInput) {
+	if len(input.ClusterctlVariables) > 0 {
+		outputPath := filepath.Join(filepath.Dir(input.ClusterctlConfigPath), fmt.Sprintf("clusterctl-upgrade-config-%s.yaml", input.ClusterName))
+		Expect(CopyAndAmendClusterctlConfig(ctx, CopyAndAmendClusterctlConfigInput{
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
+			OutputPath:           outputPath,
+			Variables:            input.ClusterctlVariables,
+		})).To(Succeed(), "Failed to CopyAndAmendClusterctlConfig")
+		input.ClusterctlConfigPath = outputPath
+	}
+
+	args := calculateClusterCtlUpgradeArgs(input)
+	log.Logf("clusterctl %s", strings.Join(args, " "))
+
+	cmd := exec.Command(binary, args...) //nolint:gosec // We don't care about command injection here.
+
+	out, err := cmd.CombinedOutput()
+	_ = os.WriteFile(filepath.Join(input.LogFolder, "clusterctl-upgrade.log"), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
+	var stdErr string
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stdErr = string(exitErr.Stderr)
+		}
+	}
+	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl upgrade:\nstdout:\n%s\nstderr:\n%s", string(out), stdErr)
+}
+
+func calculateClusterCtlUpgradeArgs(input UpgradeInput) []string {
+	args := []string{"upgrade", "apply", "--config", input.ClusterctlConfigPath, "--kubeconfig", input.KubeconfigPath, "--wait-providers"}
+
+	// Check if the user want a custom upgrade
+	isCustomUpgrade := input.CoreProvider != "" ||
+		len(input.BootstrapProviders) > 0 ||
+		len(input.ControlPlaneProviders) > 0 ||
+		len(input.InfrastructureProviders) > 0 ||
+		len(input.IPAMProviders) > 0 ||
+		len(input.RuntimeExtensionProviders) > 0 ||
+		len(input.AddonProviders) > 0
+
+	Expect((input.Contract != "" && !isCustomUpgrade) || (input.Contract == "" && isCustomUpgrade)).To(BeTrue(), `Invalid arguments. Either the input.Contract parameter or at least one of the following providers has to be set:
+		input.CoreProvider, input.BootstrapProviders, input.ControlPlaneProviders, input.InfrastructureProviders, input.IPAMProviders, input.RuntimeExtensionProviders, input.AddonProviders`)
+
+	if isCustomUpgrade {
+		if input.CoreProvider != "" {
+			args = append(args, "--core", input.CoreProvider)
+		}
+		if len(input.BootstrapProviders) > 0 {
+			args = append(args, "--bootstrap", strings.Join(input.BootstrapProviders, ","))
+		}
+		if len(input.ControlPlaneProviders) > 0 {
+			args = append(args, "--control-plane", strings.Join(input.ControlPlaneProviders, ","))
+		}
+		if len(input.InfrastructureProviders) > 0 {
+			args = append(args, "--infrastructure", strings.Join(input.InfrastructureProviders, ","))
+		}
+		if len(input.IPAMProviders) > 0 {
+			args = append(args, "--ipam", strings.Join(input.IPAMProviders, ","))
+		}
+		if len(input.RuntimeExtensionProviders) > 0 {
+			args = append(args, "--runtime-extension", strings.Join(input.RuntimeExtensionProviders, ","))
+		}
+		if len(input.AddonProviders) > 0 {
+			args = append(args, "--addon", strings.Join(input.AddonProviders, ","))
+		}
+	} else {
+		args = append(args, "--contract", input.Contract)
+	}
+
+	return args
 }
 
 // DeleteInput is the input for Delete.

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -144,6 +144,7 @@ type UpgradeManagementClusterAndWaitInput struct {
 	RuntimeExtensionProviders []string
 	AddonProviders            []string
 	LogFolder                 string
+	ClusterctlBinaryPath      string
 }
 
 // UpgradeManagementClusterAndWait upgrades provider a management cluster using clusterctl, and waits for the cluster to be ready.
@@ -165,7 +166,7 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 
 	Expect(os.MkdirAll(input.LogFolder, 0750)).To(Succeed(), "Invalid argument. input.LogFolder can't be created for UpgradeManagementClusterAndWait")
 
-	Upgrade(ctx, UpgradeInput{
+	upgradeInput := UpgradeInput{
 		ClusterctlConfigPath:      input.ClusterctlConfigPath,
 		ClusterctlVariables:       input.ClusterctlVariables,
 		ClusterName:               input.ClusterProxy.GetName(),
@@ -179,7 +180,13 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 		RuntimeExtensionProviders: input.RuntimeExtensionProviders,
 		AddonProviders:            input.AddonProviders,
 		LogFolder:                 input.LogFolder,
-	})
+	}
+
+	if input.ClusterctlBinaryPath != "" {
+		UpgradeWithBinary(ctx, input.ClusterctlBinaryPath, upgradeInput)
+	} else {
+		Upgrade(ctx, upgradeInput)
+	}
 
 	client := input.ClusterProxy.GetClient()
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds an clusterctl upgrade test to reproduce #10051.

The test does the following:
* install v0.4
* upgrade to v1.6
* upgrade to main
* test if SSA still works


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->