### PR TITLE
🐛 Re-introduce exclude capi-webhook-system to fix test flake

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -184,7 +184,14 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 	client := input.ClusterProxy.GetClient()
 
 	log.Logf("Waiting for provider controllers to be running")
-	controllersDeployments := framework.GetControllerDeployments(ctx, framework.GetControllerDeploymentsInput{Lister: client})
+	controllersDeployments := framework.GetControllerDeployments(ctx, framework.GetControllerDeploymentsInput{
+		Lister: client,
+		// This namespace has been dropped in v0.4.x.
+		// We have to exclude this namespace here as after an upgrade from v0.3x there won't
+		// be a controller in this namespace anymore and if we wait for it to come up the test would fail.
+		// Note: We can drop this as soon as we don't have a test upgrading from v0.3.x anymore.
+		ExcludeNamespaces: []string{"capi-webhook-system"},
+	})
 	Expect(controllersDeployments).ToNot(BeEmpty(), "The list of controller deployments should not be empty")
 	for _, deployment := range controllersDeployments {
 		framework.WaitForDeploymentsAvailable(ctx, framework.WaitForDeploymentsAvailableInput{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Introducing the new test upgrading from v0.3.x lead to some flakes in CI.

This PR will fix the flakes. The new tests are entirely stable on release-1.6, because on release-1.6 we still exclude this namespace (it was only missing on main)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->