### PR TITLE
🌱 Bump Go to 1.22.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  go: "1.21"
+  go: "1.22"
   build-tags:
     - tools
     - e2e

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.21.5
+GO_VERSION ?= 1.22.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/Tiltfile
+++ b/Tiltfile
@@ -184,9 +184,9 @@ def load_provider_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.21.5 as tilt-helper
+FROM golang:1.22.0 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.22
 # Support live reloading with Tilt
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/tilt-dev/rerun-process-wrapper/master/start.sh && \
@@ -195,7 +195,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.21.5 as tilt
+FROM golang:1.22.0 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
+++ b/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
@@ -5,7 +5,7 @@ maintainers of providers and consumers of our Go API.
 
 ## Go version
 
-- The Go version used by Cluster API is Go 1.21.x
+- The Go version used by Cluster API is Go 1.22.x
 
 ## Dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api
 
-go 1.21
+go 1.22
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -38,7 +38,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.21
+  minimum_go_version=go1.22
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/cluster-api/hack/tools
 
-go 1.21
+go 1.22
+
+toolchain go1.22.0
 
 replace sigs.k8s.io/cluster-api => ../../
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.21"
+    GO_VERSION = "1.22"
 
 # Standard Netlify redirects
 [[redirects]]

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api/test
 
-go 1.21
+go 1.22
 
 replace sigs.k8s.io/cluster-api => ../
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump Go to 1.22.0.
Upstream Kubernetes bumped last week: https://github.com/kubernetes/kubernetes/commit/ddb0b8da9dbcd3d507001c5cf8a01708816f3cd5

/area dependency