### PR TITLE
🌱 Fixing kubetest warnings for deprecations

### DIFF
--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -1,9 +1,9 @@
 ginkgo.focus: \[Conformance\]
 ginkgo.skip: \[Serial\]
 disable-log-dump: true
-ginkgo.progress: true
-ginkgo.slowSpecThreshold: 120.0
-ginkgo.flakeAttempts: 3
+ginkgo.show-node-events: true
+ginkgo.slow-spec-threshold: 120s
+ginkgo.flake-attempts: 3
 ginkgo.trace: true
 ginkgo.v: true
 # Use 5m instead of the default 10m to fail faster

--- a/test/e2e/data/kubetest/dualstack.yaml
+++ b/test/e2e/data/kubetest/dualstack.yaml
@@ -1,9 +1,9 @@
 ginkgo.focus: \[Feature\:IPv6DualStack\]
 ginkgo.skip: \[Feature\:SCTPConnectivity\]
 disable-log-dump: true
-ginkgo.progress: true
-ginkgo.slowSpecThreshold: 120.0
-ginkgo.flakeAttempts: 3
+ginkgo.show-node-events: true
+ginkgo.slow-spec-threshold: 120s
+ginkgo.flake-attempts: 3
 ginkgo.trace: true
 ginkgo.v: true
 ginkgo.no-color: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10171

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing