### PR TITLE
:book: docs: add links to capg book

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -33,7 +33,7 @@ updated info about which API version they are supporting.
 - [CoxEdge](https://github.com/coxedge/cluster-api-provider-coxedge)
 - [DigitalOcean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean)
 - [Equinix Metal (formerly Packet)](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
-- [Google Cloud Platform (GCP)](https://github.com/kubernetes-sigs/cluster-api-provider-gcp)
+- [Google Cloud Platform (GCP)](https://cluster-api-gcp.sigs.k8s.io/)
 - [Hetzner](https://github.com/syself/cluster-api-provider-hetzner)
 - [IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud)
 - [KubeKey](https://github.com/kubesphere/kubekey)

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1716,7 +1716,7 @@ kind delete cluster
 [clusterctl get kubeconfig]: ../clusterctl/commands/get-kubeconfig.md
 [clusterctl]: ../clusterctl/overview.md
 [Docker]: https://www.docker.com/
-[GCP provider]: https://github.com/kubernetes-sigs/cluster-api-provider-gcp
+[GCP provider]: https://cluster-api-gcp.sigs.k8s.io/
 [Helm]: https://helm.sh/docs/intro/install/
 [Hetzner provider]: https://github.com/syself/cluster-api-provider-hetzner
 [IBM Cloud provider]: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud


### PR DESCRIPTION
**What this PR does / why we need it**:

The CAPG docs are now available as a book at https://cluster-api-gcp.sigs.k8s.io/. This PR updates links in the CAPI book to point to the new CAPG book.

**Which issue(s) this PR fixes**:
Fixes #

/area documentation