### PR TITLE
🌱 Bump kind to v0.22.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,7 @@
 envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
-kubernetes_version = "v1.29.0"
+kubernetes_version = "v1.29.2"
 
 load("ext://uibutton", "cmd_button", "location", "text_input")
 

--- a/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
+++ b/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
@@ -10,6 +10,7 @@ maintainers of providers and consumers of our Go API.
 ## Dependencies
 
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
+- sigs.k8s.io/kind: v0.20.x => v0.22.x
 
 
 ## Changes by Kind

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -8,7 +8,7 @@ workflow that offers easy deployments and rapid iterative builds.
 ## Prerequisites
 
 1. [Docker](https://docs.docker.com/install/): v19.03 or newer
-2. [kind](https://kind.sigs.k8s.io): v0.20.0 or newer
+2. [kind](https://kind.sigs.k8s.io): v0.22.0 or newer
 3. [Tilt](https://docs.tilt.dev/install.html): v0.30.8 or newer
 4. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
 5. [envsubst](https://github.com/drone/envsubst): provided via `make envsubst`
@@ -337,7 +337,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: "default"
-  KUBERNETES_VERSION: "v1.29.0"
+  KUBERNETES_VERSION: "v1.29.2"
   CONTROL_PLANE_MACHINE_COUNT: "1"
   WORKER_MACHINE_COUNT: "3"
 # Note: kustomize substitutions expects the values to be strings. This can be achieved by wrapping the values in quotation marks.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -56,7 +56,7 @@ a target [management cluster] on the selected [infrastructure provider].
 
    [kind] is not designed for production use.
 
-   **Minimum [kind] supported version**: v0.20.0
+   **Minimum [kind] supported version**: v0.22.0
 
    **Help with common issues can be found in the [Troubleshooting Guide](./troubleshooting.md).**
 
@@ -1305,7 +1305,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.29.0 \
+  --kubernetes-version v1.29.2 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1348,7 +1348,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.29.0 \
+  --kubernetes-version v1.29.2 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1402,7 +1402,7 @@ and see an output similar to this:
 
 ```bash
 NAME              PHASE         AGE   VERSION
-capi-quickstart   Provisioned   8s    v1.29.0
+capi-quickstart   Provisioned   8s    v1.29.2
 ```
 
 To verify the first control plane is up:
@@ -1415,7 +1415,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.29.0
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.29.2
 ```
 
 <aside class="note warning">
@@ -1670,12 +1670,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE    VERSION
-capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.29.0
-capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.29.0
-capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.29.0
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.29.0
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.29.0
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.29.0
+capi-quickstart-vs89t-gmbld                   Ready    control-plane   5m33s  v1.29.2
+capi-quickstart-vs89t-kf9l5                   Ready    control-plane   6m20s  v1.29.2
+capi-quickstart-vs89t-t8cfn                   Ready    control-plane   7m10s  v1.29.2
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          6m5s   v1.29.2
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          6m9s   v1.29.2
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          6m9s   v1.29.2
 ```
 
 {{#/tab }}

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -30,7 +30,7 @@ goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 
 # Note: When updating the MINIMUM_KIND_VERSION new shas MUST be added in `preBuiltMappings` at `test/infrastructure/kind/mapper.go`
-MINIMUM_KIND_VERSION=v0.20.0
+MINIMUM_KIND_VERSION=v0.22.0
 
 
 # Ensure the kind tool exists and is a viable version, or installs it

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -283,8 +283,8 @@ var _ = Describe("When testing clusterctl upgrades (v1.6=>current)", func() {
 			InitWithBinary:            fmt.Sprintf(clusterctlDownloadURL, stableRelease),
 			InitWithProvidersContract: "v1beta1",
 			//  Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
-			InitWithKubernetesVersion: "v1.29.0",
-			WorkloadKubernetesVersion: "v1.29.0",
+			InitWithKubernetesVersion: "v1.29.2",
+			WorkloadKubernetesVersion: "v1.29.2",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "",
 		}
@@ -307,8 +307,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.6=>cur
 			InitWithBinary:            fmt.Sprintf(clusterctlDownloadURL, stableRelease),
 			InitWithProvidersContract: "v1beta1",
 			// Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
-			InitWithKubernetesVersion: "v1.29.0",
-			WorkloadKubernetesVersion: "v1.29.0",
+			InitWithKubernetesVersion: "v1.29.2",
+			WorkloadKubernetesVersion: "v1.29.2",
 			MgmtFlavor:                "topology",
 			WorkloadFlavor:            "topology",
 		}

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -314,10 +314,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.29.0"
-  KUBERNETES_VERSION: "v1.29.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.29.2"
+  KUBERNETES_VERSION: "v1.29.2"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.28.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.29.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.29.2"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.30"
   ETCD_VERSION_UPGRADE_TO: "3.5.10-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.11.1"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570"
+	DefaultNodeImageVersion = "v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/go.mod
+++ b/test/go.mod
@@ -33,7 +33,7 @@ require (
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.17.2
-	sigs.k8s.io/kind v0.20.0
+	sigs.k8s.io/kind v0.22.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -507,8 +507,8 @@ sigs.k8s.io/controller-runtime v0.17.2 h1:FwHwD1CTUemg0pW2otk7/U5/i5m2ymzvOXdbeG
 sigs.k8s.io/controller-runtime v0.17.2/go.mod h1:+MngTvIQQQhfXtwfdGw/UOQ/aIaqsYywfCINOtwMO/s=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kind v0.20.0 h1:f0sc3v9mQbGnjBUaqSFST1dwIuiikKVGgoTwpoP33a8=
-sigs.k8s.io/kind v0.20.0/go.mod h1:aBlbxg08cauDgZ612shr017/rZwqd7AS563FvpWKPVs=
+sigs.k8s.io/kind v0.22.0 h1:z/+yr/azoOfzsfooqRsPw1wjJlqT/ukXP0ShkHwNlsI=
+sigs.k8s.io/kind v0.22.0/go.mod h1:aBlbxg08cauDgZ612shr017/rZwqd7AS563FvpWKPVs=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.29.0
+  version: v1.29.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.29.0
+      version: v1.29.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.29.0
+  version: v1.29.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.29.0
+      version: v1.29.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.29.0
+  version: v1.29.2
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.29.0
+      version: v1.29.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.29.0
+  version: v1.29.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.29.0
+      version: v1.29.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -79,6 +79,99 @@ type Mapping struct {
 var preBuiltMappings = []Mapping{
 
 	// TODO: Add pre-built images for newer Kind versions on top
+	// Pre-built images for Kind v1.22.
+	{
+		KubernetesVersion: semver.MustParse("1.29.2"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.29.1"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.29.1@sha256:0c06baa545c3bb3fbd4828eb49b8b805f6788e18ce67bff34706ffa91866558b",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.28.7"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.28.6"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.28.6@sha256:e9e59d321795595d0eed0de48ef9fbda50388dc8bd4a9b23fb9bd869f370ec7e",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.27.11"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.27.10"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.27.10@sha256:e6b2f72f22a4de7b957cd5541e519a8bef3bae7261dd30c6df34cd9bdd3f8476",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.26.14"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.26.13"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.26.13@sha256:8cb4239d64ff897e0c21ad19fe1d68c3422d4f3c1c1a734b7ab9ccc76c549605",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.25.16"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.25.16@sha256:e8b50f8e06b44bb65a93678a65a26248fae585b3d3c2a669e5ca6c90c69dc519",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.24.17"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.23.17"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3",
+	},
+
+	// Pre-built images for Kind v1.21.
+	{
+		KubernetesVersion: semver.MustParse("1.29.1"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.28.6"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.28.6@sha256:b7e1cf6b2b729f604133c667a6be8aab6f4dde5bb042c1891ae248d9154f665b",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.27.10"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.27.10@sha256:3700c811144e24a6c6181065265f69b9bf0b437c45741017182d7c82b908918f",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.26.13"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.26.13@sha256:15ae92d507b7d4aec6e8920d358fc63d3b980493db191d7327541fbaaed1f789",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.25.16"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.25.16@sha256:9d0a62b55d4fe1e262953be8d406689b947668626a357b5f9d0cfbddbebbc727",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.24.17"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.24.17@sha256:ea292d57ec5dd0e2f3f5a2d77efa246ac883c051ff80e887109fabefbd3125c7",
+	},
+	{
+		KubernetesVersion: semver.MustParse("1.23.17"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.23.17@sha256:fbb92ac580fce498473762419df27fa8664dbaa1c5a361b5957e123b4035bdcf",
+	},
 
 	// Pre-built images for Kind v1.20.
 	{

--- a/test/infrastructure/kind/mapper_test.go
+++ b/test/infrastructure/kind/mapper_test.go
@@ -50,6 +50,14 @@ func TestGetMapping(t *testing.T) {
 		},
 		{
 			name:       "Exact match for Kubernetes version, kind Mode0_20",
+			k8sVersion: semver.MustParse("1.29.1"),
+			expectedMapping: Mapping{
+				Mode:  Mode0_20,
+				Image: "kindest/node:v1.29.1@sha256:0c06baa545c3bb3fbd4828eb49b8b805f6788e18ce67bff34706ffa91866558b",
+			},
+		},
+		{
+			name:       "Exact match for Kubernetes version, kind Mode0_20",
 			k8sVersion: semver.MustParse("1.27.3"),
 			expectedMapping: Mapping{
 				Mode:  Mode0_20,
@@ -69,7 +77,7 @@ func TestGetMapping(t *testing.T) {
 			k8sVersion: semver.MustParse("1.23.17"),
 			expectedMapping: Mapping{
 				Mode:  Mode0_20,
-				Image: "kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb",
+				Image: "kindest/node:v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3",
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
TBD if to keep this one or push https://github.com/kubernetes-sigs/cluster-api/pull/10094 towards the end line

for now, just validating the fix for 1.30 / https://github.com/kubernetes-sigs/cluster-api/issues/10142

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/10142

/area dependency
