### PR TITLE
🌱Changelog entry to include cert-manager to v1.14.2

### DIFF
--- a/CHANGELOG/v1.5.6.md
+++ b/CHANGELOG/v1.5.6.md
@@ -14,11 +14,11 @@
 - ClusterCacheTracker: Fix ClusterCacheTracker memory leak (#10065)
 
 ## :seedling: Others
-- clusterctl: Bump cert-manager to v1.14.1 (#10121)
+- clusterctl: Bump cert-manager to v1.14.2 (#10121) (#10128)
 - Community meeting: Promote chrischdi to Cluster API maintainer (#10090)
 - Dependency: Bump Go to 1.21.5 (#10153)
 
-:book: Additionally, there has been 1 contribution to our documentation and book. (#10117) 
+:book: Additionally, there has been 1 contribution to our documentation and book. (#10117)
 
 
 _Thanks to all our contributors!_ 😊

--- a/CHANGELOG/v1.6.2.md
+++ b/CHANGELOG/v1.6.2.md
@@ -20,7 +20,7 @@
 - Machine: Watch external objects for machine before deleting (#10177)
 
 ## :seedling: Others
-- clusterctl: Bump cert-manager to v1.14.1 (#10120)
+- clusterctl: Bump cert-manager to v1.14.2 (#10120) (#10127)
 - clusterctl: Clarify rules for adding new clusterctl default providers (#10109)
 - Community meeting: Promote chrischdi to Cluster API maintainer (#10089)
 - Dependency: Bump controller runtime v0.16.5 (#10163)
@@ -28,7 +28,7 @@
 - e2e: Use manager in test extension (#10106)
 - Testing: Print conformance image used in kubetest (#10081)
 
-:book: Additionally, there have been 4 contributions to our documentation and book. (#10024, #10047, #10105, #10116) 
+:book: Additionally, there have been 4 contributions to our documentation and book. (#10024, #10047, #10105, #10116)
 
 
 _Thanks to all our contributors!_ 😊


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Updates the changelog to include cert-manager to v1.14.2 for v1.6.2 and v1.5.6

/area release