### PR TITLE
🐛 [release-1.6] fix(capd): remove hack for btrfs/zfs support

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -51,7 +51,6 @@ const (
 
 	btrfsStorage = "btrfs"
 	zfsStorage   = "zfs"
-	xfsStorage   = "xfs"
 )
 
 type dockerRuntime struct {
@@ -445,15 +444,6 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 	}
 	containerConfig.Env = envVars
 
-	// handle Docker on Btrfs or ZFS
-	// https://github.com/kubernetes-sigs/kind/issues/1416#issuecomment-606514724
-	if d.mountDevMapper(info) {
-		runConfig.Mounts = append(runConfig.Mounts, Mount{
-			Source: "/dev/mapper",
-			Target: "/dev/mapper",
-		})
-	}
-
 	configureVolumes(runConfig, &containerConfig, &hostConfig)
 	configurePortMappings(runConfig.PortMappings, &containerConfig, &hostConfig)
 
@@ -690,28 +680,6 @@ func (d *dockerRuntime) usernsRemap(info types.Info) bool {
 		}
 	}
 	return false
-}
-
-// mountDevMapper checks if the Docker storage driver is Btrfs or ZFS
-// or if the backing filesystem is Btrfs.
-func (d *dockerRuntime) mountDevMapper(info types.Info) bool {
-	storage := ""
-	storage = strings.ToLower(strings.TrimSpace(info.Driver))
-	if storage == btrfsStorage || storage == zfsStorage || storage == "devicemapper" {
-		return true
-	}
-
-	// check the backing file system
-	// docker info -f '{{json .DriverStatus  }}'
-	// [["Backing Filesystem","extfs"],["Supports d_type","true"],["Native Overlay Diff","true"]]
-	for _, item := range info.DriverStatus {
-		if item[0] == "Backing Filesystem" {
-			storage = strings.ToLower(item[1])
-			break
-		}
-	}
-
-	return storage == btrfsStorage || storage == zfsStorage || storage == xfsStorage
 }
 
 // rootless: use fuse-overlayfs by default


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/cluster-api/pull/8376#issuecomment-1921871963

Support for btrfs/zfs was upstreamed to kind in https://github.com/kubernetes-sigs/kind/pull/1464, removing the need for us to hack support in ourselves.

Helps https://github.com/kubernetes-sigs/cluster-api/issues/8317

chore: PR feedback

Removes the now-unused function mountDevMapper(...)

chore: fix ci lint

fix: restore missing storage consts

chore: fix bad rebase

mountDevMapper() is unused

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->