### PR TITLE
🐛 Delete out of date machines with unhealthy control plane component conditions when rolling out KCP

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -238,6 +238,13 @@ func (c *ControlPlane) IsEtcdManaged() bool {
 	return c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration == nil || c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External == nil
 }
 
+// UnhealthyMachinesWithNonMHCUnhealthyCondition returns all unhealthy control plane machines that
+// does not have a Kubernetes node or have any control plane component condition set to False.
+// It is different from the UnhealthyMachines func which checks MachineHealthCheck conditions.
+func (c *ControlPlane) UnhealthyMachinesWithNonMHCUnhealthyCondition(machines collections.Machines) collections.Machines {
+	return machines.Filter(collections.HasUnhealthyControlPlaneComponentCondition(c.IsEtcdManaged()))
+}
+
 // UnhealthyMachines returns the list of control plane machines marked as unhealthy by MHC.
 func (c *ControlPlane) UnhealthyMachines() collections.Machines {
 	return c.Machines.Filter(collections.HasUnhealthyCondition)
@@ -313,10 +320,4 @@ func (c *ControlPlane) GetWorkloadCluster(ctx context.Context) (WorkloadCluster,
 func (c *ControlPlane) InjectTestManagementCluster(managementCluster ManagementCluster) {
 	c.managementCluster = managementCluster
 	c.workloadCluster = nil
-}
-
-// ControlPlaneMachinesWithUnhealthyCondition returns all unhealthy control plane machines. Unlike the UnhealthyMachines function,
-// it checks if all health conditions on the control plane machines are true, not just marked by MHC.
-func (c *ControlPlane) ControlPlaneMachinesWithUnhealthyCondition(machines collections.Machines) collections.Machines {
-	return machines.Filter(collections.HasUnhealthyControlPlaneMachineCondition(c.IsEtcdManaged()))
 }

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -314,3 +314,9 @@ func (c *ControlPlane) InjectTestManagementCluster(managementCluster ManagementC
 	c.managementCluster = managementCluster
 	c.workloadCluster = nil
 }
+
+// ControlPlaneMachinesWithUnhealthyCondition Returns unhealthy control plane machines. Unlike the UnhealthyMachines function,
+// it checks if all health conditions on the control plane machines are true, not just marked by MHC.
+func (c *ControlPlane) ControlPlaneMachinesWithUnhealthyCondition(machines collections.Machines) collections.Machines {
+	return machines.Filter(collections.HasUnhealthyControlPlaneMachineCondition(c.IsEtcdManaged()))
+}

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -315,7 +315,7 @@ func (c *ControlPlane) InjectTestManagementCluster(managementCluster ManagementC
 	c.workloadCluster = nil
 }
 
-// ControlPlaneMachinesWithUnhealthyCondition Returns unhealthy control plane machines. Unlike the UnhealthyMachines function,
+// ControlPlaneMachinesWithUnhealthyCondition returns all unhealthy control plane machines. Unlike the UnhealthyMachines function,
 // it checks if all health conditions on the control plane machines are true, not just marked by MHC.
 func (c *ControlPlane) ControlPlaneMachinesWithUnhealthyCondition(machines collections.Machines) collections.Machines {
 	return machines.Filter(collections.HasUnhealthyControlPlaneMachineCondition(c.IsEtcdManaged()))

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -246,24 +246,24 @@ func (c *ControlPlane) UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneCo
 	return machines.Filter(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(c.IsEtcdManaged()))
 }
 
-// UnhealthyMachinesByHealthCheck returns the list of control plane machines marked as unhealthy by Machine Health Check.
-func (c *ControlPlane) UnhealthyMachinesByHealthCheck() collections.Machines {
+// UnhealthyMachinesByMachineHealthCheck returns the list of control plane machines marked as unhealthy by Machine Health Check.
+func (c *ControlPlane) UnhealthyMachinesByMachineHealthCheck() collections.Machines {
 	return c.Machines.Filter(collections.HasUnhealthyCondition)
 }
 
-// HealthyMachinesByHealthCheck returns the list of control plane machines not marked as unhealthy by Machine Health Check.
-func (c *ControlPlane) HealthyMachinesByHealthCheck() collections.Machines {
+// HealthyMachinesByMachineHealthCheck returns the list of control plane machines not marked as unhealthy by Machine Health Check.
+func (c *ControlPlane) HealthyMachinesByMachineHealthCheck() collections.Machines {
 	return c.Machines.Filter(collections.Not(collections.HasUnhealthyCondition))
 }
 
-// HasUnhealthyMachineByHealthCheck returns true if any machine in the control plane is marked as unhealthy by Machine Health Check.
-func (c *ControlPlane) HasUnhealthyMachineByHealthCheck() bool {
-	return len(c.UnhealthyMachinesByHealthCheck()) > 0
+// HasUnhealthyMachineByMachineHealthCheck returns true if any machine in the control plane is marked as unhealthy by Machine Health Check.
+func (c *ControlPlane) HasUnhealthyMachineByMachineHealthCheck() bool {
+	return len(c.UnhealthyMachinesByMachineHealthCheck()) > 0
 }
 
 // HasHealthyMachineStillProvisioning returns true if any healthy machine in the control plane is still in the process of being provisioned.
 func (c *ControlPlane) HasHealthyMachineStillProvisioning() bool {
-	return len(c.HealthyMachinesByHealthCheck().Filter(collections.Not(collections.HasNode()))) > 0
+	return len(c.HealthyMachinesByMachineHealthCheck().Filter(collections.Not(collections.HasNode()))) > 0
 }
 
 // PatchMachines patches all the machines conditions.

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -238,12 +238,11 @@ func (c *ControlPlane) IsEtcdManaged() bool {
 	return c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration == nil || c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External == nil
 }
 
-// UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents returns all unhealthy control plane machines that
-// do not have a Kubernetes node, or have unhealthy control plane components.
-//
+// UnhealthyMachinesWithUnhealthyControlPlaneComponents returns all unhealthy control plane machines that
+// have unhealthy control plane components.
 // It differs from UnhealthyMachinesByHealthCheck which checks `MachineHealthCheck` conditions.
-func (c *ControlPlane) UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(machines collections.Machines) collections.Machines {
-	return machines.Filter(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(c.IsEtcdManaged()))
+func (c *ControlPlane) UnhealthyMachinesWithUnhealthyControlPlaneComponents(machines collections.Machines) collections.Machines {
+	return machines.Filter(collections.HasUnhealthyControlPlaneComponents(c.IsEtcdManaged()))
 }
 
 // UnhealthyMachinesByMachineHealthCheck returns the list of control plane machines marked as unhealthy by Machine Health Check.

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -238,11 +238,11 @@ func (c *ControlPlane) IsEtcdManaged() bool {
 	return c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration == nil || c.KCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External == nil
 }
 
-// UnhealthyControlPlaneOrNodeMissingMachines returns all unhealthy control plane machines that
+// UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents returns all unhealthy control plane machines that
 // do not have a Kubernetes node, or have unhealthy control plane components.
 //
 // It differs from UnhealthyMachinesByHealthCheck which checks `MachineHealthCheck` conditions.
-func (c *ControlPlane) UnhealthyControlPlaneOrNodeMissingMachines(machines collections.Machines) collections.Machines {
+func (c *ControlPlane) UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(machines collections.Machines) collections.Machines {
 	return machines.Filter(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(c.IsEtcdManaged()))
 }
 

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -88,7 +88,7 @@ func TestHasUnhealthyMachine(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		g.Expect(c.HasUnhealthyMachine()).To(BeTrue())
+		g.Expect(c.HasUnhealthyMachineByHealthCheck()).To(BeTrue())
 	})
 
 	t.Run("No unhealthy machine to be remediated by KCP", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestHasUnhealthyMachine(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		g.Expect(c.HasUnhealthyMachine()).To(BeFalse())
+		g.Expect(c.HasUnhealthyMachineByHealthCheck()).To(BeFalse())
 	})
 }
 

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -88,7 +88,7 @@ func TestHasUnhealthyMachine(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		g.Expect(c.HasUnhealthyMachineByHealthCheck()).To(BeTrue())
+		g.Expect(c.HasUnhealthyMachineByMachineHealthCheck()).To(BeTrue())
 	})
 
 	t.Run("No unhealthy machine to be remediated by KCP", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestHasUnhealthyMachine(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		g.Expect(c.HasUnhealthyMachineByHealthCheck()).To(BeFalse())
+		g.Expect(c.HasUnhealthyMachineByMachineHealthCheck()).To(BeFalse())
 	})
 }
 

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -48,7 +48,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	// Cleanup pending remediation actions not completed for any reasons (e.g. number of current replicas is less or equal to 1)
 	// if the underlying machine is now back to healthy / not deleting.
 	errList := []error{}
-	healthyMachines := controlPlane.HealthyMachinesByHealthCheck()
+	healthyMachines := controlPlane.HealthyMachinesByMachineHealthCheck()
 	for _, m := range healthyMachines {
 		if conditions.IsTrue(m, clusterv1.MachineHealthCheckSucceededCondition) &&
 			conditions.IsFalse(m, clusterv1.MachineOwnerRemediatedCondition) &&
@@ -74,7 +74,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 
 	// Gets all machines that have `MachineHealthCheckSucceeded=False` (indicating a problem was detected on the machine)
 	// and `MachineOwnerRemediated` present, indicating that this controller is responsible for performing remediation.
-	unhealthyMachines := controlPlane.UnhealthyMachinesByHealthCheck()
+	unhealthyMachines := controlPlane.UnhealthyMachinesByMachineHealthCheck()
 
 	// If there are no unhealthy machines, return so KCP can proceed with other operations (ctrl.Result nil).
 	if len(unhealthyMachines) == 0 {
@@ -192,7 +192,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 
 		// If the machine that is about to be deleted is the etcd leader, move it to the newest member available.
 		if controlPlane.IsEtcdManaged() {
-			etcdLeaderCandidate := controlPlane.HealthyMachinesByHealthCheck().Newest()
+			etcdLeaderCandidate := controlPlane.HealthyMachinesByMachineHealthCheck().Newest()
 			if etcdLeaderCandidate == nil {
 				log.Info("A control plane machine needs remediation, but there is no healthy machine to forward etcd leadership to")
 				conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationFailedReason, clusterv1.ConditionSeverityWarning,

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -48,7 +48,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	// Cleanup pending remediation actions not completed for any reasons (e.g. number of current replicas is less or equal to 1)
 	// if the underlying machine is now back to healthy / not deleting.
 	errList := []error{}
-	healthyMachines := controlPlane.HealthyMachines()
+	healthyMachines := controlPlane.HealthyMachinesByHealthCheck()
 	for _, m := range healthyMachines {
 		if conditions.IsTrue(m, clusterv1.MachineHealthCheckSucceededCondition) &&
 			conditions.IsFalse(m, clusterv1.MachineOwnerRemediatedCondition) &&
@@ -74,7 +74,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 
 	// Gets all machines that have `MachineHealthCheckSucceeded=False` (indicating a problem was detected on the machine)
 	// and `MachineOwnerRemediated` present, indicating that this controller is responsible for performing remediation.
-	unhealthyMachines := controlPlane.UnhealthyMachines()
+	unhealthyMachines := controlPlane.UnhealthyMachinesByHealthCheck()
 
 	// If there are no unhealthy machines, return so KCP can proceed with other operations (ctrl.Result nil).
 	if len(unhealthyMachines) == 0 {
@@ -192,7 +192,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 
 		// If the machine that is about to be deleted is the etcd leader, move it to the newest member available.
 		if controlPlane.IsEtcdManaged() {
-			etcdLeaderCandidate := controlPlane.HealthyMachines().Newest()
+			etcdLeaderCandidate := controlPlane.HealthyMachinesByHealthCheck().Newest()
 			if etcdLeaderCandidate == nil {
 				log.Info("A control plane machine needs remediation, but there is no healthy machine to forward etcd leadership to")
 				conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationFailedReason, clusterv1.ConditionSeverityWarning,

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -1885,8 +1885,6 @@ func withUnhealthyEtcdMember() machineOption {
 
 func withUnhealthyAPIServerPod() machineOption {
 	return func(machine *clusterv1.Machine) {
-		newConditions := machine.Status.Conditions.DeepCopy()
-		machine.Status.Conditions = newConditions
 		conditions.MarkFalse(machine, controlplanev1.MachineAPIServerPodHealthyCondition, controlplanev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, "")
 	}
 }

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -1877,6 +1877,8 @@ func withHealthyEtcdMember() machineOption {
 
 func withUnhealthyEtcdMember() machineOption {
 	return func(machine *clusterv1.Machine) {
+		newConditions := machine.Status.Conditions.DeepCopy()
+		machine.Status.Conditions = newConditions
 		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "")
 	}
 }

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -1883,6 +1883,14 @@ func withUnhealthyEtcdMember() machineOption {
 	}
 }
 
+func withUnhealthyAPIServerPod() machineOption {
+	return func(machine *clusterv1.Machine) {
+		newConditions := machine.Status.Conditions.DeepCopy()
+		machine.Status.Conditions = newConditions
+		conditions.MarkFalse(machine, controlplanev1.MachineAPIServerPodHealthyCondition, controlplanev1.ControlPlaneComponentsUnhealthyReason, clusterv1.ConditionSeverityError, "")
+	}
+}
+
 func withNodeRef(ref string) machineOption {
 	return func(machine *clusterv1.Machine) {
 		machine.Status.NodeRef = &corev1.ObjectReference{

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -1877,8 +1877,6 @@ func withHealthyEtcdMember() machineOption {
 
 func withUnhealthyEtcdMember() machineOption {
 	return func(machine *clusterv1.Machine) {
-		newConditions := machine.Status.Conditions.DeepCopy()
-		machine.Status.Conditions = newConditions
 		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "")
 	}
 }

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -230,8 +230,8 @@ func selectMachineForScaleDown(ctx context.Context, controlPlane *internal.Contr
 		machines = controlPlane.MachineWithDeleteAnnotation(outdatedMachines)
 	case controlPlane.MachineWithDeleteAnnotation(machines).Len() > 0:
 		machines = controlPlane.MachineWithDeleteAnnotation(machines)
-	case controlPlane.ControlPlaneMachinesWithUnhealthyCondition(outdatedMachines).Len() > 0:
-		machines = controlPlane.ControlPlaneMachinesWithUnhealthyCondition(outdatedMachines)
+	case controlPlane.UnhealthyMachinesWithNonMHCUnhealthyCondition(outdatedMachines).Len() > 0:
+		machines = controlPlane.UnhealthyMachinesWithNonMHCUnhealthyCondition(outdatedMachines)
 	case outdatedMachines.Len() > 0:
 		machines = outdatedMachines
 	}

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -230,6 +230,8 @@ func selectMachineForScaleDown(ctx context.Context, controlPlane *internal.Contr
 		machines = controlPlane.MachineWithDeleteAnnotation(outdatedMachines)
 	case controlPlane.MachineWithDeleteAnnotation(machines).Len() > 0:
 		machines = controlPlane.MachineWithDeleteAnnotation(machines)
+	case controlPlane.ControlPlaneMachinesWithUnhealthyCondition(outdatedMachines).Len() > 0:
+		machines = controlPlane.ControlPlaneMachinesWithUnhealthyCondition(outdatedMachines)
 	case outdatedMachines.Len() > 0:
 		machines = outdatedMachines
 	}

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -230,8 +230,8 @@ func selectMachineForScaleDown(ctx context.Context, controlPlane *internal.Contr
 		machines = controlPlane.MachineWithDeleteAnnotation(outdatedMachines)
 	case controlPlane.MachineWithDeleteAnnotation(machines).Len() > 0:
 		machines = controlPlane.MachineWithDeleteAnnotation(machines)
-	case controlPlane.UnhealthyControlPlaneOrNodeMissingMachines(outdatedMachines).Len() > 0:
-		machines = controlPlane.UnhealthyControlPlaneOrNodeMissingMachines(outdatedMachines)
+	case controlPlane.UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(outdatedMachines).Len() > 0:
+		machines = controlPlane.UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(outdatedMachines)
 	case outdatedMachines.Len() > 0:
 		machines = outdatedMachines
 	}

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -230,8 +230,8 @@ func selectMachineForScaleDown(ctx context.Context, controlPlane *internal.Contr
 		machines = controlPlane.MachineWithDeleteAnnotation(outdatedMachines)
 	case controlPlane.MachineWithDeleteAnnotation(machines).Len() > 0:
 		machines = controlPlane.MachineWithDeleteAnnotation(machines)
-	case controlPlane.UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(outdatedMachines).Len() > 0:
-		machines = controlPlane.UnhealthyMachinesWithMissingNodeOrUnhealthyControlPlaneComponents(outdatedMachines)
+	case controlPlane.UnhealthyMachinesWithUnhealthyControlPlaneComponents(outdatedMachines).Len() > 0:
+		machines = controlPlane.UnhealthyMachinesWithUnhealthyControlPlaneComponents(outdatedMachines)
 	case outdatedMachines.Len() > 0:
 		machines = outdatedMachines
 	}

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -230,8 +230,8 @@ func selectMachineForScaleDown(ctx context.Context, controlPlane *internal.Contr
 		machines = controlPlane.MachineWithDeleteAnnotation(outdatedMachines)
 	case controlPlane.MachineWithDeleteAnnotation(machines).Len() > 0:
 		machines = controlPlane.MachineWithDeleteAnnotation(machines)
-	case controlPlane.UnhealthyMachinesWithNonMHCUnhealthyCondition(outdatedMachines).Len() > 0:
-		machines = controlPlane.UnhealthyMachinesWithNonMHCUnhealthyCondition(outdatedMachines)
+	case controlPlane.UnhealthyControlPlaneOrNodeMissingMachines(outdatedMachines).Len() > 0:
+		machines = controlPlane.UnhealthyControlPlaneOrNodeMissingMachines(outdatedMachines)
 	case outdatedMachines.Len() > 0:
 		machines = outdatedMachines
 	}

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -368,15 +368,16 @@ func TestSelectMachineForScaleDown(t *testing.T) {
 		Spec: controlplanev1.KubeadmControlPlaneSpec{},
 	}
 	startDate := time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC)
-
-	m1 := machine("machine-1", withFailureDomain("one"), withTimestamp(startDate.Add(time.Hour)))
-	m2 := machine("machine-2", withFailureDomain("one"), withTimestamp(startDate.Add(-3*time.Hour)))
-	m3 := machine("machine-3", withFailureDomain("one"), withTimestamp(startDate.Add(-4*time.Hour)))
-	m4 := machine("machine-4", withFailureDomain("two"), withTimestamp(startDate.Add(-time.Hour)))
-	m5 := machine("machine-5", withFailureDomain("two"), withTimestamp(startDate.Add(-2*time.Hour)))
-	m6 := machine("machine-6", withFailureDomain("two"), withTimestamp(startDate.Add(-7*time.Hour)))
-	m7 := machine("machine-7", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"))
-	m8 := machine("machine-8", withFailureDomain("two"), withTimestamp(startDate.Add(-6*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"))
+	m1 := machine("machine-1", withFailureDomain("one"), withTimestamp(startDate.Add(time.Hour)), machineOpt(withNodeRef("machine-1")))
+	m2 := machine("machine-2", withFailureDomain("one"), withTimestamp(startDate.Add(-3*time.Hour)), machineOpt(withNodeRef("machine-2")))
+	m3 := machine("machine-3", withFailureDomain("one"), withTimestamp(startDate.Add(-4*time.Hour)), machineOpt(withNodeRef("machine-3")))
+	m4 := machine("machine-4", withFailureDomain("two"), withTimestamp(startDate.Add(-time.Hour)), machineOpt(withNodeRef("machine-4")))
+	m5 := machine("machine-5", withFailureDomain("two"), withTimestamp(startDate.Add(-2*time.Hour)), machineOpt(withNodeRef("machine-5")))
+	m6 := machine("machine-6", withFailureDomain("two"), withTimestamp(startDate.Add(-7*time.Hour)), machineOpt(withNodeRef("machine-6")))
+	m7 := machine("machine-7", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)),
+		withAnnotation("cluster.x-k8s.io/delete-machine"), machineOpt(withNodeRef("machine-7")))
+	m8 := machine("machine-8", withFailureDomain("two"), withTimestamp(startDate.Add(-6*time.Hour)),
+		withAnnotation("cluster.x-k8s.io/delete-machine"), machineOpt(withNodeRef("machine-8")))
 	m9 := machine("machine-9", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)),
 		machineOpt(withNodeRef("machine-9")))
 	m10 := machine("machine-10", withFailureDomain("two"), withTimestamp(startDate.Add(-4*time.Hour)),

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -369,37 +369,24 @@ func TestSelectMachineForScaleDown(t *testing.T) {
 	}
 	startDate := time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC)
 
-	controlPlaneHealthyConditions := []clusterv1.Condition{
-		*conditions.TrueCondition(controlplanev1.MachineAPIServerPodHealthyCondition),
-		*conditions.TrueCondition(controlplanev1.MachineControllerManagerPodHealthyCondition),
-		*conditions.TrueCondition(controlplanev1.MachineSchedulerPodHealthyCondition),
-		*conditions.TrueCondition(controlplanev1.MachineEtcdPodHealthyCondition),
-		*conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyCondition),
-	}
-
-	m1 := machine("machine-1", withFailureDomain("one"), withTimestamp(startDate.Add(time.Hour)),
-		machineOpt(withNodeRef("machine-1")), withConditions(controlPlaneHealthyConditions))
-	m2 := machine("machine-2", withFailureDomain("one"), withTimestamp(startDate.Add(-3*time.Hour)),
-		machineOpt(withNodeRef("machine-2")), withConditions(controlPlaneHealthyConditions))
-	m3 := machine("machine-3", withFailureDomain("one"), withTimestamp(startDate.Add(-4*time.Hour)),
-		machineOpt(withNodeRef("machine-3")), withConditions(controlPlaneHealthyConditions))
-	m4 := machine("machine-4", withFailureDomain("two"), withTimestamp(startDate.Add(-time.Hour)),
-		machineOpt(withNodeRef("machine-4")), withConditions(controlPlaneHealthyConditions))
-	m5 := machine("machine-5", withFailureDomain("two"), withTimestamp(startDate.Add(-2*time.Hour)),
-		machineOpt(withNodeRef("machine-5")), withConditions(controlPlaneHealthyConditions))
-	m6 := machine("machine-6", withFailureDomain("two"), withTimestamp(startDate.Add(-7*time.Hour)),
-		machineOpt(withNodeRef("machine-6")), withConditions(controlPlaneHealthyConditions))
-	m7 := machine("machine-7", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"),
-		machineOpt(withNodeRef("machine-7")), withConditions(controlPlaneHealthyConditions))
-	m8 := machine("machine-8", withFailureDomain("two"), withTimestamp(startDate.Add(-6*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"),
-		machineOpt(withNodeRef("machine-8")), withConditions(controlPlaneHealthyConditions))
-	m9 := machine("machine-9", withFailureDomain("two"), withTimestamp(startDate.Add(-2*time.Hour)),
-		machineOpt(withNodeRef("machine-9")), withConditions(controlPlaneHealthyConditions), machineOpt(withUnhealthyEtcdMember()))
-	m10 := machine("machine-10", withFailureDomain("two"), withTimestamp(startDate.Add(-3*time.Hour)),
-		machineOpt(withNodeRef("machine-10")), withConditions(controlPlaneHealthyConditions), machineOpt(withUnhealthyEtcdMember()))
+	m1 := machine("machine-1", withFailureDomain("one"), withTimestamp(startDate.Add(time.Hour)))
+	m2 := machine("machine-2", withFailureDomain("one"), withTimestamp(startDate.Add(-3*time.Hour)))
+	m3 := machine("machine-3", withFailureDomain("one"), withTimestamp(startDate.Add(-4*time.Hour)))
+	m4 := machine("machine-4", withFailureDomain("two"), withTimestamp(startDate.Add(-time.Hour)))
+	m5 := machine("machine-5", withFailureDomain("two"), withTimestamp(startDate.Add(-2*time.Hour)))
+	m6 := machine("machine-6", withFailureDomain("two"), withTimestamp(startDate.Add(-7*time.Hour)))
+	m7 := machine("machine-7", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"))
+	m8 := machine("machine-8", withFailureDomain("two"), withTimestamp(startDate.Add(-6*time.Hour)), withAnnotation("cluster.x-k8s.io/delete-machine"))
+	m9 := machine("machine-9", withFailureDomain("two"), withTimestamp(startDate.Add(-5*time.Hour)),
+		machineOpt(withNodeRef("machine-9")))
+	m10 := machine("machine-10", withFailureDomain("two"), withTimestamp(startDate.Add(-4*time.Hour)),
+		machineOpt(withNodeRef("machine-10")), machineOpt(withUnhealthyAPIServerPod()))
+	m11 := machine("machine-11", withFailureDomain("two"), withTimestamp(startDate.Add(-3*time.Hour)),
+		machineOpt(withNodeRef("machine-11")), machineOpt(withUnhealthyEtcdMember()))
 
 	mc3 := collections.FromMachines(m1, m2, m3, m4, m5)
 	mc6 := collections.FromMachines(m6, m7, m8)
+	mc9 := collections.FromMachines(m9, m10, m11)
 	fd := clusterv1.FailureDomains{
 		"one": failureDomain(true),
 		"two": failureDomain(true),
@@ -409,6 +396,11 @@ func TestSelectMachineForScaleDown(t *testing.T) {
 		KCP:      &kcp,
 		Cluster:  &clusterv1.Cluster{Status: clusterv1.ClusterStatus{FailureDomains: fd}},
 		Machines: mc3,
+	}
+	needsUpgradeControlPlane1 := &internal.ControlPlane{
+		KCP:      &kcp,
+		Cluster:  &clusterv1.Cluster{Status: clusterv1.ClusterStatus{FailureDomains: fd}},
+		Machines: mc9,
 	}
 	upToDateControlPlane := &internal.ControlPlane{
 		KCP:     &kcp,
@@ -473,23 +465,23 @@ func TestSelectMachineForScaleDown(t *testing.T) {
 			expectedMachine:  clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-7"}},
 		},
 		{
-			name:             "when there is an up to date machine with delete annotation, while there are any outdated machines without annotatio that still exist, it returns oldest marked machine first",
+			name:             "when there is an up to date machine with delete annotation, while there are any outdated machines without annotation that still exist, it returns oldest marked machine first",
 			cp:               upToDateControlPlane,
 			outDatedMachines: collections.FromMachines(m5, m3, m8, m7, m6, m1, m2),
 			expectErr:        false,
 			expectedMachine:  clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-8"}},
 		},
 		{
-			name:             "when there are machines needing upgrade, it returns the unhealthy machine in the largest failure domain which needing upgrade",
-			cp:               upToDateControlPlane,
-			outDatedMachines: collections.FromMachines(m6, m9),
+			name:             "when there are machines needing upgrade, it returns the single unhealthy machine with MachineAPIServerPodHealthyCondition set to False",
+			cp:               needsUpgradeControlPlane1,
+			outDatedMachines: collections.FromMachines(m9, m10),
 			expectErr:        false,
-			expectedMachine:  clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-9"}},
+			expectedMachine:  clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-10"}},
 		},
 		{
-			name:             "when there are machines needing upgrade, it returns the oldest unhealthy machine in the largest failure domain which needing upgrade",
-			cp:               upToDateControlPlane,
-			outDatedMachines: collections.FromMachines(m6, m9, m10),
+			name:             "when there are machines needing upgrade, it returns the oldest unhealthy machine with MachineEtcdMemberHealthyCondition set to False",
+			cp:               needsUpgradeControlPlane1,
+			outDatedMachines: collections.FromMachines(m9, m10, m11),
 			expectErr:        false,
 			expectedMachine:  clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-10"}},
 		},
@@ -703,11 +695,5 @@ func withAnnotation(annotation string) machineOpt {
 func withTimestamp(t time.Time) machineOpt {
 	return func(m *clusterv1.Machine) {
 		m.CreationTimestamp = metav1.NewTime(t)
-	}
-}
-
-func withConditions(conditions clusterv1.Conditions) machineOpt {
-	return func(m *clusterv1.Machine) {
-		m.Status.Conditions = conditions
 	}
 }

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -401,9 +401,9 @@ spec:
   - See [Preflight checks](#preflight-checks) below.
 - Scale down operations removes the oldest machine in the failure domain that has the most control-plane machines on it.
 - Allow scaling down of KCP with the possibility of marking specific control plane machine(s) to be deleted with delete annotation key. The presence of the annotation will affect the rollout strategy in a way that, it implements the following prioritization logic in descending order, while selecting machines for scale down:
-  - outdatedMachines with the delete annotation
+  - outdated machines with the delete annotation
   - machines with the delete annotation
-  - outdatedMachines with unhealthy conditions
+  - outdated machines with unhealthy control plane component pods
   - outdated machines
   - all machines
 

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -403,6 +403,7 @@ spec:
 - Allow scaling down of KCP with the possibility of marking specific control plane machine(s) to be deleted with delete annotation key. The presence of the annotation will affect the rollout strategy in a way that, it implements the following prioritization logic in descending order, while selecting machines for scale down:
   - outdatedMachines with the delete annotation
   - machines with the delete annotation
+  - outdatedMachines with unhealthy conditions
   - outdated machines
   - all machines
 

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -403,7 +403,7 @@ spec:
 - Allow scaling down of KCP with the possibility of marking specific control plane machine(s) to be deleted with delete annotation key. The presence of the annotation will affect the rollout strategy in a way that, it implements the following prioritization logic in descending order, while selecting machines for scale down:
   - outdated machines with the delete annotation
   - machines with the delete annotation
-  - outdated machines with unhealthy control plane component pods or missing nodes
+  - outdated machines with unhealthy control plane component pods
   - outdated machines
   - all machines
 

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -403,7 +403,7 @@ spec:
 - Allow scaling down of KCP with the possibility of marking specific control plane machine(s) to be deleted with delete annotation key. The presence of the annotation will affect the rollout strategy in a way that, it implements the following prioritization logic in descending order, while selecting machines for scale down:
   - outdated machines with the delete annotation
   - machines with the delete annotation
-  - outdated machines with unhealthy control plane component pods
+  - outdated machines with unhealthy control plane component pods or missing nodes
   - outdated machines
   - all machines
 

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -277,8 +277,8 @@ func HasNode() Func {
 
 // HasUnhealthyControlPlaneMachineCondition returns a filter to find all unhealthy control plane machines,
 // unlike the HasUnhealthyCondition func, it checks whether all health conditions on the control plane machine are true,
-// including 'APIServerPodHealthy', 'ControllerManagerPodHealthy', 'SchedulerPodHealthy' and kubernetes node exist.
-// If etcd managed, additional checks for 'EtcdPodHealthy', 'EtcdMemberHealthy' conditions.
+// including 'APIServerPodHealthy', 'ControllerManagerPodHealthy', 'SchedulerPodHealthy' and Kubernetes node exist.
+// If etcd is managed, add additional checks for 'EtcdPodHealthy', 'EtcdMemberHealthy' conditions.
 func HasUnhealthyControlPlaneMachineCondition(isEtcdManaged bool) Func {
 	controlPlaneMachineHealthConditions := []clusterv1.ConditionType{
 		controlplanev1.MachineAPIServerPodHealthyCondition,
@@ -291,18 +291,15 @@ func HasUnhealthyControlPlaneMachineCondition(isEtcdManaged bool) Func {
 			controlplanev1.MachineEtcdMemberHealthyCondition,
 		)
 	}
-
 	return func(machine *clusterv1.Machine) bool {
 		if !HasNode()(machine) {
 			return true
 		}
-
 		for _, condition := range controlPlaneMachineHealthConditions {
 			if conditions.IsFalse(machine, condition) {
 				return true
 			}
 		}
-
 		return false
 	}
 }

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -159,7 +159,7 @@ func HasUnhealthyCondition(machine *clusterv1.Machine) bool {
 }
 
 // HasUnhealthyControlPlaneComponentCondition returns a filter to find all unhealthy control plane machines that
-// does not have a Kubernetes node or have any of the follwing control plane component conditions set to False:
+// does not have a Kubernetes node or have any of the following control plane component conditions set to False:
 // APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy(if using managed etcd).
 // It is different from the HasUnhealthyCondition func which checks MachineHealthCheck conditions.
 func HasUnhealthyControlPlaneComponentCondition(isEtcdManaged bool) Func {

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -158,11 +158,11 @@ func HasUnhealthyCondition(machine *clusterv1.Machine) bool {
 	return conditions.IsFalse(machine, clusterv1.MachineHealthCheckSucceededCondition) && conditions.IsFalse(machine, clusterv1.MachineOwnerRemediatedCondition)
 }
 
-// HasUnhealthyControlPlaneComponentCondition returns a filter to find all unhealthy control plane machines that
+// HasMissingNodeOrUnhealthyControlPlaneComponents returns a filter to find all unhealthy control plane machines that
 // does not have a Kubernetes node or have any of the following control plane component conditions set to False:
 // APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy(if using managed etcd).
 // It is different from the HasUnhealthyCondition func which checks MachineHealthCheck conditions.
-func HasUnhealthyControlPlaneComponentCondition(isEtcdManaged bool) Func {
+func HasMissingNodeOrUnhealthyControlPlaneComponents(isEtcdManaged bool) Func {
 	controlPlaneMachineHealthConditions := []clusterv1.ConditionType{
 		controlplanev1.MachineAPIServerPodHealthyCondition,
 		controlplanev1.MachineControllerManagerPodHealthyCondition,

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -175,6 +175,9 @@ func HasMissingNodeOrUnhealthyControlPlaneComponents(isEtcdManaged bool) Func {
 		)
 	}
 	return func(machine *clusterv1.Machine) bool {
+		if machine == nil {
+			return false
+		}
 		if !HasNode()(machine) {
 			return true
 		}

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -179,6 +179,9 @@ func HasUnhealthyControlPlaneComponentCondition(isEtcdManaged bool) Func {
 			return true
 		}
 		for _, condition := range controlPlaneMachineHealthConditions {
+			// Do not return true when the condition is not set or is set to Unknown because
+			// it means a transient state and can not be considered as unhealthy.
+			// preflightCheckCondition() can cover these two cases and skip the scaling up/down.
 			if conditions.IsFalse(machine, condition) {
 				return true
 			}

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -160,7 +160,7 @@ func HasUnhealthyCondition(machine *clusterv1.Machine) bool {
 
 // HasMissingNodeOrUnhealthyControlPlaneComponents returns a filter to find all unhealthy control plane machines that
 // does not have a Kubernetes node or have any of the following control plane component conditions set to False:
-// APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy(if using managed etcd).
+// APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy & EtcdMemberHealthy (if using managed etcd).
 // It is different from the HasUnhealthyCondition func which checks MachineHealthCheck conditions.
 func HasMissingNodeOrUnhealthyControlPlaneComponents(isEtcdManaged bool) Func {
 	controlPlaneMachineHealthConditions := []clusterv1.ConditionType{

--- a/util/collections/machine_filters_test.go
+++ b/util/collections/machine_filters_test.go
@@ -457,13 +457,13 @@ func TestHasNode(t *testing.T) {
 func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 	t.Run("nil machine returns false", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(nil)).To(BeFalse())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(false)(nil)).To(BeFalse())
 	})
 
-	t.Run("machine without node returns true", func(t *testing.T) {
+	t.Run("machine without node returns false", func(t *testing.T) {
 		g := NewWithT(t)
 		machine := &clusterv1.Machine{}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeTrue())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
 	})
 
 	t.Run("machine with all healthy controlPlane component conditions returns false when the Etcd is not managed", func(t *testing.T) {
@@ -477,7 +477,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.TrueCondition(controlplanev1.MachineControllerManagerPodHealthyCondition),
 			*conditions.TrueCondition(controlplanev1.MachineSchedulerPodHealthyCondition),
 		}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
 	})
 
 	t.Run("machine with unhealthy 'APIServerPodHealthy' condition returns true when the Etcd is not managed", func(t *testing.T) {
@@ -492,7 +492,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineAPIServerPodHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeTrue())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(false)(machine)).To(BeTrue())
 	})
 
 	t.Run("machine with unhealthy etcd component conditions returns false when Etcd is not managed", func(t *testing.T) {
@@ -510,7 +510,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
 	})
 
 	t.Run("machine with unhealthy etcd conditions returns true when Etcd is managed", func(t *testing.T) {
@@ -528,7 +528,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(true)(machine)).To(BeTrue())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(true)(machine)).To(BeTrue())
 	})
 
 	t.Run("machine with all healthy controlPlane and the Etcd component conditions returns false when Etcd is managed", func(t *testing.T) {
@@ -544,7 +544,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.TrueCondition(controlplanev1.MachineEtcdPodHealthyCondition),
 			*conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyCondition),
 		}
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(true)(machine)).To(BeFalse())
+		g.Expect(collections.HasUnhealthyControlPlaneComponents(true)(machine)).To(BeFalse())
 	})
 }
 

--- a/util/collections/machine_filters_test.go
+++ b/util/collections/machine_filters_test.go
@@ -455,9 +455,9 @@ func TestHasNode(t *testing.T) {
 }
 
 func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
-	t.Run("nil machine returns true", func(t *testing.T) {
+	t.Run("nil machine returns false", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(nil)).To(BeTrue())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(nil)).To(BeFalse())
 	})
 
 	t.Run("machine without node returns true", func(t *testing.T) {

--- a/util/collections/machine_filters_test.go
+++ b/util/collections/machine_filters_test.go
@@ -457,13 +457,13 @@ func TestHasNode(t *testing.T) {
 func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 	t.Run("nil machine returns true", func(t *testing.T) {
 		g := NewWithT(t)
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(false)(nil)).To(BeTrue())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(nil)).To(BeTrue())
 	})
 
 	t.Run("machine without node returns true", func(t *testing.T) {
 		g := NewWithT(t)
 		machine := &clusterv1.Machine{}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(false)(machine)).To(BeTrue())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeTrue())
 	})
 
 	t.Run("machine with all healthy controlPlane component conditions returns false when the Etcd is not managed", func(t *testing.T) {
@@ -477,7 +477,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.TrueCondition(controlplanev1.MachineControllerManagerPodHealthyCondition),
 			*conditions.TrueCondition(controlplanev1.MachineSchedulerPodHealthyCondition),
 		}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(false)(machine)).To(BeFalse())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
 	})
 
 	t.Run("machine with unhealthy 'APIServerPodHealthy' condition returns true when the Etcd is not managed", func(t *testing.T) {
@@ -492,7 +492,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineAPIServerPodHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(false)(machine)).To(BeTrue())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeTrue())
 	})
 
 	t.Run("machine with unhealthy etcd component conditions returns false when Etcd is not managed", func(t *testing.T) {
@@ -510,7 +510,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(false)(machine)).To(BeFalse())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(false)(machine)).To(BeFalse())
 	})
 
 	t.Run("machine with unhealthy etcd conditions returns true when Etcd is managed", func(t *testing.T) {
@@ -528,7 +528,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, "",
 				clusterv1.ConditionSeverityWarning, ""),
 		}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(true)(machine)).To(BeTrue())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(true)(machine)).To(BeTrue())
 	})
 
 	t.Run("machine with all healthy controlPlane and the Etcd component conditions returns false when Etcd is managed", func(t *testing.T) {
@@ -544,7 +544,7 @@ func TestHasUnhealthyControlPlaneComponentCondition(t *testing.T) {
 			*conditions.TrueCondition(controlplanev1.MachineEtcdPodHealthyCondition),
 			*conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyCondition),
 		}
-		g.Expect(collections.HasUnhealthyControlPlaneComponentCondition(true)(machine)).To(BeFalse())
+		g.Expect(collections.HasMissingNodeOrUnhealthyControlPlaneComponents(true)(machine)).To(BeFalse())
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Fix https://github.com/kubernetes-sigs/cluster-api/issues/10093

**Test**
1. Create 1 CP 1 Worker CAPI Cluster.
```
kubectl get cluster,kcp,machine -n default | grep hw-sks-test-unhealthy-cp
cluster.cluster.x-k8s.io/hw-sks-test-unhealthy-cp   Provisioned   8m2s   
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane   hw-sks-test-unhealthy-cp   true          true                   1          1       1         0             8m2s   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-9nbvm             hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-9nbvm   elf://f688b268-0f09-4e3b-bcfe-b8cda710ab6e   Running        7m58s   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp    hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running        8m1s    v1.25.15

```
2. Update KCP by adding space between two names in `KCP.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.tls-cipher-suites`.
```
kubectl get cluster,kcp,machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks-test-unhealthy-cp
NAME                                                PHASE         AGE   VERSION
cluster.cluster.x-k8s.io/hw-sks-test-unhealthy-cp   Provisioned   18m   

NAME                                                                                      CLUSTER                    INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE   VERSION
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane   hw-sks-test-unhealthy-cp   true          true                   2          2       1         0             18m   v1.25.15

NAME                                                                            CLUSTER                    NODENAME                                      PROVIDERID                                   PHASE     AGE     VERSION
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-9nbvm            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-9nbvm   elf://f688b268-0f09-4e3b-bcfe-b8cda710ab6e   Running   17m     v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-lwm6b            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-lwm6b   elf://ebacfd9a-fd18-488f-959a-35a4fe2275fe   Running   7m14s   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp   hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running   17m     v1.25.15
```
3. Then the new CP Node will become ready, but its APIServer can not start and the APIServerPodHealthy condition with False status is added on the CP Machine. And the KCP won't become ready forever.
```
kubectl get  machine hw-sks-test-unhealthy-cp-controlplane-lwm6b -n default -ojson | jq '.status.conditions'
[
  {
    "lastTransitionTime": "2024-02-26T10:20:01Z",
    "status": "True",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:41Z",
    "message": "CrashLoopBackOff",
    "reason": "PodFailed",
    "severity": "Error",
    "status": "False",
    "type": "APIServerPodHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:12:11Z",
    "status": "True",
    "type": "BootstrapReady"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:06Z",
    "status": "True",
    "type": "ControllerManagerPodHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:09Z",
    "status": "True",
    "type": "EtcdMemberHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:07Z",
    "status": "True",
    "type": "EtcdPodHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:20:01Z",
    "status": "True",
    "type": "InfrastructureReady"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:24Z",
    "status": "True",
    "type": "NodeHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:15:24Z",
    "status": "True",
    "type": "SchedulerPodHealthy"
  }
]

kubectl get -n default kcp hw-sks-test-unhealthy-cp-controlplane -ojson | jq '.status.conditions'
[
  {
    "lastTransitionTime": "2024-02-26T10:12:12Z",
    "message": "Rolling 1 replicas with outdated spec (1 replicas up to date)",
    "reason": "RollingUpdateInProgress",
    "severity": "Warning",
    "status": "False",
    "type": "Ready"
  },
  {
    "lastTransitionTime": "2024-02-26T10:03:01Z",
    "status": "True",
    "type": "Available"
  },
  {
    "lastTransitionTime": "2024-02-26T10:01:27Z",
    "status": "True",
    "type": "CertificatesAvailable"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:10Z",
    "message": "Following machines are reporting control plane errors: hw-sks-test-unhealthy-cp-controlplane-lwm6b",
    "reason": "ControlPlaneComponentsUnhealthy",
    "severity": "Error",
    "status": "False",
    "type": "ControlPlaneComponentsHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:14:10Z",
    "status": "True",
    "type": "EtcdClusterHealthy"
  },
  {
    "lastTransitionTime": "2024-02-26T10:01:48Z",
    "status": "True",
    "type": "MachinesCreated"
  },
  {
    "lastTransitionTime": "2024-02-26T10:26:33Z",
    "status": "True",
    "type": "MachinesReady"
  },
  {
    "lastTransitionTime": "2024-02-26T10:12:12Z",
    "message": "Rolling 1 replicas with outdated spec (1 replicas up to date)",
    "reason": "RollingUpdateInProgress",
    "severity": "Warning",
    "status": "False",
    "type": "MachinesSpecUpToDate"
  },
  {
    "lastTransitionTime": "2024-02-26T10:12:12Z",
    "message": "Scaling down control plane to 1 replicas (actual 2)",
    "reason": "ScalingDown",
    "severity": "Warning",
    "status": "False",
    "type": "Resized"
  }
]

```

4. Update KCP, delete the spaces previously added in the `KCP.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.tls-cipher-suites` and delete any one of suites configuration to ensure that the current configuration is different from the one originally created.
5. First delete the CP Machine that is abnormal and outdated.
```
kubectl get machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks-test-unhealthy-cp
NAME                                                                            CLUSTER                    NODENAME                                      PROVIDERID                                   PHASE      AGE   VERSION
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-9nbvm            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-9nbvm   elf://f688b268-0f09-4e3b-bcfe-b8cda710ab6e   Running    34m   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-lwm6b            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-lwm6b   elf://ebacfd9a-fd18-488f-959a-35a4fe2275fe   Deleting   24m   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp   hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running    34m   v1.25.15

```
6.  Then create a new CP Machine.
```
 kubectl get machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks-test-unhealthy-cp 
NAME                                                   CLUSTER                    NODENAME                                      PROVIDERID                                   PHASE     AGE    VERSION
hw-sks-test-unhealthy-cp-controlplane-9nbvm            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-9nbvm   elf://f688b268-0f09-4e3b-bcfe-b8cda710ab6e   Running   37m    v1.25.15
hw-sks-test-unhealthy-cp-controlplane-d8ffd            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-d8ffd   elf://955ce3f7-3fde-4119-a885-09fc3ccd4e6e   Running   2m9s   v1.25.15
hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp   hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running   37m    v1.25.15
```

7. Finally delete the machine that is in Ready state but outdated.

```
kubectl get machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks
-test-unhealthy-cp -w
NAME                                                   CLUSTER                    NODENAME                                      PROVIDERID                                   PHASE      AGE     VERSION
hw-sks-test-unhealthy-cp-controlplane-9nbvm            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-9nbvm   elf://f688b268-0f09-4e3b-bcfe-b8cda710ab6e   Deleting   40m     v1.25.15
hw-sks-test-unhealthy-cp-controlplane-d8ffd            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-d8ffd   elf://955ce3f7-3fde-4119-a885-09fc3ccd4e6e   Running    4m37s   v1.25.15
hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp   hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running    40m     v1.25.15

```

8. Cluster, KCP, Machines are Ready.
```
kubectl get cluster,kcp,machine -n default -l cluster.x-k8s.io/cluster-name=hw-sks-test-unhealthy-cp
NAME                                                PHASE         AGE   VERSION
cluster.cluster.x-k8s.io/hw-sks-test-unhealthy-cp   Provisioned   41m   

NAME                                                                                      CLUSTER                    INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE   VERSION
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane   hw-sks-test-unhealthy-cp   true          true                   1          1       1         0             41m   v1.25.15

NAME                                                                            CLUSTER                    NODENAME                                      PROVIDERID                                   PHASE     AGE     VERSION
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-controlplane-d8ffd            hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-controlplane-d8ffd   elf://955ce3f7-3fde-4119-a885-09fc3ccd4e6e   Running   6m18s   v1.25.15
machine.cluster.x-k8s.io/hw-sks-test-unhealthy-cp-node-5769b6799cxkxcg9-5jtzp   hw-sks-test-unhealthy-cp   hw-sks-test-unhealthy-cp-node-l7ml5           elf://3d3a4a5e-ec32-4b49-a30a-52b00f972282   Running   41m     v1.25.15

```
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area provider/control-plane-kubeadm