### PR TITLE
🐛 clusterctl: move handlePlugins function call out of init to allow debugging tests

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -106,6 +106,8 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() {
+	handlePlugins()
+
 	if err := RootCmd.Execute(); err != nil {
 		if verbosity != nil && *verbosity >= 5 {
 			if err, ok := err.(stackTracer); ok {
@@ -146,8 +148,6 @@ func init() {
 	RootCmd.SetCompletionCommandGroupID(groupOther)
 
 	cobra.OnInitialize(initConfig, registerCompletionFuncForCommonFlags)
-
-	handlePlugins()
 }
 
 func initConfig() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR moves the call to `handlePlugins()` from `init()` to `Execute()`.

Calling `handlePlugins()` at the init function leads to not being able to debug tests using dlv, instead it exits with the following error message:

```
Error: flags cannot be placed before plugin name: -test.run
```

Reason for that is that the test execution will try to run a plugin because running tests provides args. At the end it always exits with an error and `os.Exit(1)` here:

https://github.com/kubernetes-sigs/cluster-api/blob/02b8789fd75b8065a5491065dbd4e7887644b09a/cmd/clusterctl/cmd/root.go#L221

Moving the call to `handlePlugins` from the init function to `Execute` leads to not running it when running tests.

Found this while trying to investigate the following test:

https://github.com/kubernetes-sigs/cluster-api/blob/02b8789fd75b8065a5491065dbd4e7887644b09a/cmd/clusterctl/cmd/config_repositories_test.go#L30

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterctl