### PR TITLE
🌱 clusterctl: Add 0 default to worker-machine-count help

### DIFF
--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -116,8 +116,9 @@ func init() {
 		"The Kubernetes version to use for the workload cluster. If unspecified, the value from OS environment variables or the $XDG_CONFIG_HOME/cluster-api/clusterctl.yaml config file will be used.")
 	generateClusterClusterCmd.Flags().Int64Var(&gc.controlPlaneMachineCount, "control-plane-machine-count", 1,
 		"The number of control plane machines for the workload cluster.")
+	// Remove default from hard coded text if the default is ever changed from 0 since cobra would then add it
 	generateClusterClusterCmd.Flags().Int64Var(&gc.workerMachineCount, "worker-machine-count", 0,
-		"The number of worker machines for the workload cluster.")
+		"The number of worker machines for the workload cluster. (default 0)")
 
 	// flags for the repository source
 	generateClusterClusterCmd.Flags().StringVarP(&gc.infrastructureProvider, "infrastructure", "i", "",


### PR DESCRIPTION
**What this PR does / why we need it**:

Cobra nicely adds the default value for arguments, except in the case where the default is 0 or empty. This causes the help output for `clusterctl generate cluster` `--worker-machine-count` to not include its default of 0, unlike `--control-plane-machine-count` that has a default of 1.

This change explicitly adds the default value to the help text for `--worker-machine-count` to make it easier to discover what to expect when running the command without this argument.

Help text after this change:

```txt
--worker-machine-count int           The number of worker machines for the workload cluster. (default 0)
```

**Which issue(s) this PR fixes**:
Fixes #10173

/area clusterctl