### PR TITLE
🌱 Make in memory API server more tolerant when starting

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/mux.go
+++ b/test/infrastructure/inmemory/pkg/server/mux.go
@@ -451,7 +451,7 @@ func (m *WorkloadClustersMux) AddAPIServer(wclName, podName string, caCert *x509
 
 	// Wait until the sever is working.
 	var pollErr error
-	err = wait.PollUntilContextTimeout(context.TODO(), 10*time.Millisecond, 1*time.Second, true, func(context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(context.TODO(), 250*time.Millisecond, 5*time.Second, true, func(context.Context) (done bool, err error) {
 		d := &net.Dialer{Timeout: 50 * time.Millisecond}
 		conn, err := tls.DialWithDialer(d, "tcp", wcl.HostPort(), &tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec // config is used to connect to our own port.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the in-memory API server wait slightly more before declaring an error on startup; this could help when starting many instances in parallel.

Area example:
/area provider/infrastructure-in-memory
