### PR TITLE
🐛 Reverting ginkgo.show-node-events to ginkgo.progress

### DIFF
--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -1,7 +1,10 @@
 ginkgo.focus: \[Conformance\]
 ginkgo.skip: \[Serial\]
 disable-log-dump: true
-ginkgo.show-node-events: true
+# ginkgo.progress flag is deprecated but its still used in
+# k8s versions <= v1.26, we have to keep it as long as we
+# support these versions.
+ginkgo.progress: true
 ginkgo.slow-spec-threshold: 120s
 ginkgo.flake-attempts: 3
 ginkgo.trace: true

--- a/test/e2e/data/kubetest/dualstack.yaml
+++ b/test/e2e/data/kubetest/dualstack.yaml
@@ -1,7 +1,10 @@
 ginkgo.focus: \[Feature\:IPv6DualStack\]
 ginkgo.skip: \[Feature\:SCTPConnectivity\]
 disable-log-dump: true
-ginkgo.show-node-events: true
+# ginkgo.progress flag is deprecated but its still used when
+# we run kubetest on K8s versions <= v1.26, we have to keep it
+# as long as we support these versions.
+ginkgo.progress: true
 ginkgo.slow-spec-threshold: 120s
 ginkgo.flake-attempts: 3
 ginkgo.trace: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Reverting ginkgo.show-node-events to ginkgo.progress, because older versions of the kubetest images we use (depends on k8s version) have a too old ginkgo version. Tests are failing because of it: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-upgrade-1-24-1-25-main/1762531387493060608
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->