### PR TITLE
🌱 Add MachinePools to handler and topology test

### DIFF
--- a/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
@@ -31,6 +31,11 @@ spec:
     controlPlane:
       metadata: {}
       replicas: 1
+    workers:
+      machinePools:
+      - class: "default-worker"
+        name: "mp-0"
+        replicas: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerCluster

--- a/cmd/clusterctl/client/cluster/assets/topology-test/mock-CRDs.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/mock-CRDs.yaml
@@ -34,6 +34,22 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
     cluster.x-k8s.io/provider: infrastructure-docker
     cluster.x-k8s.io/v1beta1: v1beta1
   name: dockermachinetemplates.infrastructure.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachinepooltemplates.infrastructure.cluster.x-k8s.io

--- a/cmd/clusterctl/client/cluster/assets/topology-test/modified-CP-dockermachinepooltemplate.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/modified-CP-dockermachinepooltemplate.yaml
@@ -1,0 +1,14 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachinePoolTemplate
+metadata:
+  name: "docker-worker-machinepooltemplate"
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        docker-machinepool-template: test-template-worker
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"

--- a/cmd/clusterctl/client/cluster/assets/topology-test/my-cluster-class.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/my-cluster-class.yaml
@@ -22,6 +22,22 @@ spec:
       kind: DockerClusterTemplate
       name: my-cluster
       namespace: default
+  workers:
+    machinePools:
+    - class: "default-worker"
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-worker-bootstraptemplate
+            namespace: default
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachinePoolTemplate
+            name: docker-worker-machinepooltemplate
+            namespace: default
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
@@ -69,3 +85,26 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachinePoolTemplate
+metadata:
+  name: "docker-worker-machinepooltemplate"
+  namespace: default
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "docker-worker-bootstraptemplate"
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.

--- a/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
@@ -62,6 +62,31 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
             name: docker-worker-machinetemplate
+    machinePools:
+    - class: "default-worker"
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachinePoolTemplate
+            name: docker-worker-machinepooltemplate
+    - class: "default-worker-2"
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachinePoolTemplate
+            name: docker-worker-machinepooltemplate
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
@@ -123,6 +148,17 @@ spec:
       preLoadImages: 
       - gcr.io/kakaraparthy-devel/kindest/kindnetd:0.5.4
 ---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachinePoolTemplate
+metadata:
+  name: "docker-worker-machinepooltemplate"
+  namespace: default
+spec:
+  template:
+    spec:
+      preLoadImages: 
+      - gcr.io/kakaraparthy-devel/kindest/kindnetd:0.5.4
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -162,4 +198,11 @@ spec:
         replicas: 1
       - class: "default-worker"
         name: "md-1"
+        replicas: 1
+      machinePools:
+      - class: "default-worker"
+        name: "mp-0"
+        replicas: 1
+      - class: "default-worker"
+        name: "mp-1"
         replicas: 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds MachinePools to the unit tests in `handler_test.go` and `topology_test.go`. This is a follow-up task to enabling MachinePools in ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #10028

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterclass