### PR TITLE
🐛 Add tests and update provider_issues.go

### DIFF
--- a/hack/tools/release/internal/update_providers/README.md
+++ b/hack/tools/release/internal/update_providers/README.md
@@ -15,14 +15,14 @@
   export PROVIDER_ISSUES_DRY_RUN="true"
   ```
 
-- Export `RELEASE_TAG` environment variable to the CAPI release version e.g. `1.6.0`. The suffix `-beta.0` is appended by the utility.  
+- Export `RELEASE_TAG` environment variable to the CAPI release version e.g. `v1.7.0-beta.0`. 
   Example:
 
   ```sh
-  export RELEASE_TAG="1.6.0"
+  export RELEASE_TAG="v1.7.0-beta.0"
   ```
 
-- Export `RELEASE_DATE` to the targeted CAPI release version date. Fetch the target date from latest [release file](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases).
+- Export `RELEASE_DATE` to the targeted CAPI release version date. Fetch the target date from latest [release file](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases). The `RELEASE_DATE` should be in the format `YYYY-MM-DD`.
   Example:
 
   ```sh

--- a/hack/tools/release/internal/update_providers/provider_issues_test.go
+++ b/hack/tools/release/internal/update_providers/provider_issues_test.go
@@ -1,0 +1,115 @@
+//go:build tools
+// +build tools
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_GetReleaseDetails(t *testing.T) {
+	tests := []struct {
+		name        string
+		releaseTag  string
+		releaseDate string
+		want        releaseDetails
+		expectErr   bool
+		err         string
+	}{
+		{
+			name:        "Correct RELEASE_TAG and RELEASE_DATE are set",
+			releaseTag:  "v1.7.0-beta.0",
+			releaseDate: "2024-04-16",
+			want: releaseDetails{
+				ReleaseDate:      "Tuesday, 16th April 2024",
+				ReleaseTag:       "v1.7.0",
+				BetaTag:          "v1.7.0-beta.0",
+				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-beta.0",
+			},
+			expectErr: false,
+		},
+		{
+			name:        "RELEASE_TAG is not in the format ^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$",
+			releaseTag:  "v1.7.0.1",
+			releaseDate: "2024-04-16",
+			expectErr:   true,
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+		},
+		{
+			name:        "RELEASE_TAG does not have prefix 'v' in its semver",
+			releaseTag:  "1.7.0-beta.0",
+			releaseDate: "2024-04-16",
+			expectErr:   true,
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+		},
+		{
+			name:        "RELEASE_TAG contains invalid Major.Minor.Patch SemVer",
+			releaseTag:  "v1.x.0-beta.0",
+			releaseDate: "2024-04-16",
+			expectErr:   true,
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+		},
+		{
+			name:        "invalid yyyy-dd-mm RELEASE_DATE entered",
+			releaseTag:  "v1.7.0-beta.0",
+			releaseDate: "2024-16-4",
+			expectErr:   true,
+			err:         "unable to parse the date",
+		},
+		{
+			name:        "invalid yyyy/dd/mm RELEASE_DATE entered",
+			releaseTag:  "v1.7.0-beta.0",
+			releaseDate: "2024/16/4",
+			expectErr:   true,
+			err:         "unable to parse the date",
+		},
+		{
+			name:        "invalid yyyy/mm/dd RELEASE_DATE entered",
+			releaseTag:  "v1.7.0-beta.0",
+			releaseDate: "2024/4/16",
+			expectErr:   true,
+			err:         "unable to parse the date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			_ = os.Setenv("RELEASE_TAG", tt.releaseTag)
+			_ = os.Setenv("RELEASE_DATE", tt.releaseDate)
+
+			got, err := getReleaseDetails()
+			if tt.expectErr {
+				g.Expect(err.Error()).To(Equal(tt.err))
+			} else {
+				g.Expect(got.ReleaseDate).To(Equal(tt.want.ReleaseDate))
+				g.Expect(got.ReleaseTag).To(Equal(tt.want.ReleaseTag))
+				g.Expect(got.BetaTag).To(Equal(tt.want.BetaTag))
+				g.Expect(got.ReleaseLink).To(Equal(tt.want.ReleaseLink))
+			}
+			_ = os.Unsetenv("RELEASE_TAG")
+			_ = os.Unsetenv("RELEASE_DATE")
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
- This PR helps streamlines the documentation team's effort while updating providers for a new beta release.
	- We export `RELEASE_TAG` before running `make promote-images` as part of release process. I noticed that the same `RELEASE_TAG` cannot be used before running `make release-provider-issues-tool`.
  -  `release-provider-issues-tool` expected users to `export RELEASE_TAG` as `1.7.0` whereas the release team initially sets `RELEASE_TAG` to `v1.7.0-beta.0` during the release workflow. 
  - Since this tool (`release-provider-issues-tool`) is only expected to run once every release, i.e., at the time of releasing a beta version, it is important that we streamline the `RELEASE_TAG` to one format to avoid any user errors.
- I have also added supporting test cases to validate core URLs derived from `RELEASE_TAG` and `RELEASE_DATE`.
- This PR also fixes url to CAPI v1.7.0 release timeline.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->