### PR TITLE
:bug: remove --enable-hostpath-provisioner flag

### DIFF
--- a/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
@@ -78,9 +78,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns: {}
       etcd: {}
       networking: {}

--- a/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-second-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-second-cluster.yaml
@@ -79,9 +79,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns: {}
       etcd: {}
       networking: {}

--- a/cmd/clusterctl/client/cluster/assets/topology-test/my-cluster-class.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/my-cluster-class.yaml
@@ -50,8 +50,6 @@ spec:
           namespace: default
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             certSANs: [ localhost, 127.0.0.1 ]
         initConfiguration:

--- a/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
@@ -90,8 +90,6 @@ spec:
           namespace: default
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             certSANs: [ localhost, 127.0.0.1 ]
         initConfiguration:

--- a/docs/book/src/clusterctl/commands/alpha-topology-plan.md
+++ b/docs/book/src/clusterctl/commands/alpha-topology-plan.md
@@ -135,8 +135,6 @@ spec:
         nodeDrainTimeout: 1s
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             certSANs: [ localhost, 127.0.0.1 ]
         initConfiguration:

--- a/docs/book/src/tasks/bootstrap/kubeadm-bootstrap/index.md
+++ b/docs/book/src/tasks/bootstrap/kubeadm-bootstrap/index.md
@@ -43,10 +43,6 @@ metadata:
 spec:
   initConfiguration:
     nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
-  clusterConfiguration:
-    controllerManager:
-      extraArgs:
-        enable-hostpath-provisioner: "true"
 ---
 kind: DockerMachine
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -118,10 +114,6 @@ spec:
   initConfiguration:
     nodeRegistration:
       nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
-  clusterConfiguration:
-    controllerManager:
-      extraArgs:
-        enable-hostpath-provisioner: "true"
 ```
 
 Additional control plane nodes:

--- a/docs/book/src/tasks/bootstrap/kubeadm-bootstrap/kubelet-config.md
+++ b/docs/book/src/tasks/bootstrap/kubeadm-bootstrap/kubelet-config.md
@@ -2,9 +2,16 @@
 
 CAPBK has several ways to configure kubelet.
 
-- [Pass `KubeletConfiguration` file via `KubeadmConfigSpec.files`](#pass-kubeletconfiguration-file-via-kubeadmconfigspecfiles)
-- [Set kubelet flags via `KubeadmConfigSpec.kubeletExtraArgs`](#set-kubelet-flags-via-kubeadmconfigspeckubeletextraargs)
-- [`kubeletconfiguration` patch target](#use-the-kubeletconfiguration-patch-target)
+- [Kubelet Configuration](#kubelet-configuration)
+  - [Pass `KubeletConfiguration` file via `KubeadmConfigSpec.files`](#pass-kubeletconfiguration-file-via-kubeadmconfigspecfiles)
+    - [KubeadmControlPlaneTemplate](#kubeadmcontrolplanetemplate)
+    - [KubeadmConfigTemplate](#kubeadmconfigtemplate)
+  - [Set kubelet flags via `KubeadmConfigSpec.kubeletExtraArgs`](#set-kubelet-flags-via-kubeadmconfigspeckubeletextraargs)
+    - [KubeadmControlPlaneTemplate](#kubeadmcontrolplanetemplate-1)
+    - [KubeadmConfigTemplate](#kubeadmconfigtemplate-1)
+  - [Use kubeadm's `kubeletconfiguration` patch target](#use-kubeadms-kubeletconfiguration-patch-target)
+    - [KubeadmControlPlaneTemplate](#kubeadmcontrolplanetemplate-2)
+    - [KubeadmConfigTemplate](#kubeadmconfigtemplate-2)
 
 ## Pass `KubeletConfiguration` file via `KubeadmConfigSpec.files`
 
@@ -86,10 +93,6 @@ spec:
             streamingConnectionIdleTimeout: 0s
             syncFrequency: 0s
             volumeStatsAggPeriod: 0s
-        clusterConfiguration:
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
@@ -203,10 +206,6 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
-        clusterConfiguration:
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
@@ -290,10 +289,6 @@ spec:
                 "nodefs.available": "10%",
               },
             }
-        clusterConfiguration:
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -2575,7 +2575,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 								"clusterConfiguration": map[string]interface{}{
 									"controllerManager": map[string]interface{}{
 										"extraArgs": map[string]interface{}{
-											"enable-hostpath-provisioner": "true",
+											"v": "4",
 										},
 									},
 								},
@@ -2588,7 +2588,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 								"clusterConfiguration": map[string]interface{}{
 									"controllerManager": map[string]interface{}{
 										"extraArgs": map[string]interface{}{
-											"enable-hostpath-provisioner": "true",
+											"v": "4",
 										},
 									},
 								},
@@ -2597,7 +2597,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 					},
 				},
 				reconcileStep{
-					name: "Drop enable-hostpath-provisioner",
+					name: "Drop v",
 					desired: object{
 						spec: nil,
 					},
@@ -2725,7 +2725,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 								"clusterConfiguration": map[string]interface{}{
 									"controllerManager": map[string]interface{}{
 										"extraArgs": map[string]interface{}{
-											"enable-hostpath-provisioner": "true",
+											"v": "4",
 										},
 									},
 								},
@@ -2738,7 +2738,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 								"clusterConfiguration": map[string]interface{}{
 									"controllerManager": map[string]interface{}{
 										"extraArgs": map[string]interface{}{
-											"enable-hostpath-provisioner": "true",
+											"v": "4",
 										},
 									},
 								},
@@ -2778,7 +2778,7 @@ func TestReconcileReferencedObjectSequences(t *testing.T) {
 								"clusterConfiguration": map[string]interface{}{
 									"controllerManager": map[string]interface{}{
 										"extraArgs": map[string]interface{}{
-											// Reconcile to drop enable-hostpath-provisioner,
+											// Reconcile to drop v field,
 											// while preserving user-defined enable-garbage-collector field.
 											"enable-garbage-collector": "true",
 										},

--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-kcp.yaml
@@ -79,8 +79,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
@@ -40,8 +40,6 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane-0"
 spec:
   clusterConfiguration:
-    controllerManager:
-      extraArgs: {enable-hostpath-provisioner: 'true'}
     apiServer:
       certSANs: [localhost, 127.0.0.1]
   initConfiguration:

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -53,8 +53,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -105,8 +105,6 @@ spec:
         nodeDrainTimeout: 1s
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -527,7 +527,6 @@ spec:
           # extraArgs must be non-empty for control plane components to enable patches from ClusterClass to work.
           controllerManager:
             extraArgs:
-              enable-hostpath-provisioner: 'true'
               v: "0"
           scheduler:
             extraArgs:

--- a/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
@@ -60,8 +60,6 @@ spec:
     name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -61,8 +61,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.0/bases/cluster-with-kcp.yaml
@@ -79,8 +79,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/v1.5/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.5/bases/cluster-with-kcp.yaml
@@ -79,8 +79,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/v1.5/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.5/clusterclass-quick-start.yaml
@@ -386,8 +386,6 @@ spec:
         nodeDrainTimeout: 1s
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, host.docker.internal, "::", "::1", "127.0.0.1", "0.0.0.0"]

--- a/test/e2e/data/infrastructure-docker/v1.6/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.6/bases/cluster-with-kcp.yaml
@@ -79,8 +79,6 @@ spec:
       name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     clusterConfiguration:
-      controllerManager:
-        extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
         # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
         certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/e2e/data/infrastructure-docker/v1.6/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.6/clusterclass-quick-start.yaml
@@ -527,7 +527,6 @@ spec:
           # extraArgs must be non-empty for control plane components to enable patches from ClusterClass to work.
           controllerManager:
             extraArgs:
-              enable-hostpath-provisioner: 'true'
               v: "0"
           scheduler:
             extraArgs:

--- a/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
+++ b/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
@@ -74,9 +74,6 @@ spec:
               - 127.0.0.1
               - 0.0.0.0
               - host.docker.internal
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -49,9 +49,6 @@ spec:
         - localhost
         - 127.0.0.1
         - 0.0.0.0
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -51,9 +51,6 @@ spec:
         - 0.0.0.0
         - "::"
         - "::1"
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
     initConfiguration:
       localAPIEndpoint:
         advertiseAddress: '::'

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -52,10 +52,6 @@ metadata:
   name: controlplane-0-config
   namespace: default
 spec:
-  clusterConfiguration:
-    controllerManager:
-      extraArgs:
-        enable-hostpath-provisioner: "true"
   initConfiguration:
     nodeRegistration:
       kubeletExtraArgs:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -49,9 +49,6 @@ spec:
         - localhost
         - 127.0.0.1
         - 0.0.0.0
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -240,8 +240,6 @@ spec:
     spec:
       kubeadmConfigSpec:
         clusterConfiguration:
-          controllerManager:
-            extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]

--- a/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
+++ b/test/infrastructure/inmemory/templates/clusterclass-in-memory-quick-start.yaml
@@ -74,9 +74,6 @@ spec:
               - 127.0.0.1
               - 0.0.0.0
               - host.docker.internal
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
         initConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

See https://github.com/kubernetes/kubernetes/issues/123804

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
See https://github.com/kubernetes/kubernetes/issues/123804#issuecomment-1985360589
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->