### PR TITLE
🌱 Fix TestPatchNode flake

### DIFF
--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -913,12 +913,12 @@ func TestPatchNode(t *testing.T) {
 			ms := tc.ms.DeepCopy()
 			md := tc.md.DeepCopy()
 
-			g.Expect(env.Create(ctx, oldNode)).To(Succeed())
-			g.Expect(env.Create(ctx, machine)).To(Succeed())
-			g.Expect(env.Create(ctx, ms)).To(Succeed())
-			g.Expect(env.Create(ctx, md)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, oldNode)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, ms)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, md)).To(Succeed())
 			t.Cleanup(func() {
-				_ = env.Cleanup(ctx, oldNode, machine, ms, md)
+				_ = env.CleanupAndWait(ctx, oldNode, machine, ms, md)
 			})
 
 			err := r.patchNode(ctx, env, oldNode, tc.newLabels, tc.newAnnotations, tc.machine)


### PR DESCRIPTION
**What this PR does / why we need it**:
Tentative fix for a flake that is happening  in https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-main ,  PatchNode tests: https://storage.googleapis.com/k8s-triage/index.html?job=.*-cluster-api-.*&xjob=.*-provider-.*#a6212fb6267562bbccbf

Area example:
/area ci