### PR TITLE
📖 Update docs for beta ClusterResourceSet

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}"
           image: controller:latest
           name: manager
           env:

--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -263,7 +263,6 @@ via [Create the local repository](http://localhost:3000/clusterctl/developers.ht
 ```yaml
 kustomize_substitutions:
   CLUSTER_TOPOLOGY: "true"
-  EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_RUNTIME_SDK: "true"
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -108,7 +108,6 @@ provider's yaml. These substitutions are also used when deploying cluster templa
 ```yaml
 kustomize_substitutions:
   CLUSTER_TOPOLOGY: "true"
-  EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_RUNTIME_SDK: "true"
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"

--- a/docs/book/src/tasks/experimental-features/cluster-resource-set.md
+++ b/docs/book/src/tasks/experimental-features/cluster-resource-set.md
@@ -1,10 +1,12 @@
-# Experimental Feature: ClusterResourceSet (alpha)
+# Experimental Feature: ClusterResourceSet (beta)
 
 The `ClusterResourceSet` feature is introduced to provide a way to automatically apply a set of resources (such as CNI/CSI) defined by users to matching newly-created/existing clusters.
 
 **Feature gate name**: `ClusterResourceSet`
 
 **Variable name to enable/disable the feature gate**: `EXP_CLUSTER_RESOURCE_SET`
+
+The `ClusterResourceSet` feature is enabled by default, but can be disabled by setting the `EXP_CLUSTER_RESOURCE_SET` environment variable to `false`.
 
 More details on `ClusterResourceSet` and an example to test it can be found at:
 [ClusterResourceSet CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20200220-cluster-resource-set.md)

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -8,7 +8,7 @@ temporary location for features which will be moved to their permanent locations
 Users can enable/disable features by setting OS environment variables before running `clusterctl init`, e.g.:
 
 ```yaml
-export EXP_CLUSTER_RESOURCE_SET=true
+export EXP_SOME_FEATURE_NAME=true
 
 clusterctl init --infrastructure vsphere
 ```
@@ -16,7 +16,7 @@ clusterctl init --infrastructure vsphere
 As an alternative to environment variables, it is also possible to set variables in the clusterctl config file located at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`, e.g.:
 ```yaml
 # Values for environment variable substitution
-EXP_CLUSTER_RESOURCE_SET: "true"
+EXP_SOME_FEATURE_NAME: "true"
 ```
 In case a variable is defined in both the config file and as an OS environment variable, the environment variable takes precedence.
 For more information on how to set variables for clusterctl, see [clusterctl Configuration File](../../clusterctl/configuration.md)
@@ -30,7 +30,6 @@ As an example, Cluster API Provider Azure (CAPZ) has support for MachinePool thr
 One way is to set experimental variables on the clusterctl config file. For CAPI, these configs are under ./test/e2e/config/... such as `docker.yaml`:
 ```yaml
 variables:
-  EXP_CLUSTER_RESOURCE_SET: "true"
   CLUSTER_TOPOLOGY: "true"
   EXP_RUNTIME_SDK: "true"
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: "true"
@@ -44,7 +43,6 @@ On development environments started with `Tilt`, features can be enabled by sett
 
 ```yaml
 kustomize_substitutions:
-  EXP_CLUSTER_RESOURCE_SET: 'true'
   CLUSTER_TOPOLOGY: 'true'
   EXP_RUNTIME_SDK: 'true'
   EXP_MACHINE_SET_PREFLIGHT_CHECKS: 'true'

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -743,7 +743,6 @@ project][Proxmox getting started guide].
 
 Please follow the Cluster API Provider for [Cloud Director Getting Started Guide](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/README.md)
 
-EXP_CLUSTER_RESOURCE_SET: "true"
 ```bash
 # Initialize the management cluster
 clusterctl init --infrastructure vcd

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -332,7 +332,6 @@ variables:
   AUTOSCALER_WORKLOAD: "./data/autoscaler/autoscaler-to-workload-workload.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
   # Enabling the feature flags by setting the env variables.
-  EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
   EXP_MACHINE_POOL: "true"
   CLUSTER_TOPOLOGY: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the documentation (and two manifests) to reflect the status of the ClusterResourceSet experimental feature as Beta and `true` by default.

When creating a PR to promote the MachinePools experimental feature to Beta / `true`, it seemed there was similar cleanup that should be done to CRS.

**Which issue(s) this PR fixes**:
N/A, but see also #10141

/area documentation
