### PR TITLE
🌱 Add namespaces to the list of resource handled by the in-memory API server

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/api/const.go
+++ b/test/infrastructure/inmemory/pkg/server/api/const.go
@@ -142,6 +142,25 @@ var (
 				},
 				StorageVersionHash: "",
 			},
+			{
+				Name:         "namespaces",
+				SingularName: "namespace",
+				Namespaced:   false,
+				Kind:         "Namespace",
+				Verbs: []string{
+					"create",
+					"delete",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+				ShortNames: []string{
+					"ns",
+				},
+				StorageVersionHash: "",
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
... because the service account reconciler in CAPV needs it! 😉 

/area provider/infrastructure-in-memory
