### PR TITLE
🌱 webhooks: use the alias for ClusterCacheTrackerReader instead of the internal reference

### DIFF
--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -26,7 +26,7 @@ import (
 // Cluster implements a validating and defaulting webhook for Cluster.
 type Cluster struct {
 	Client                    client.Reader
-	ClusterCacheTrackerReader webhooks.ClusterCacheTrackerReader
+	ClusterCacheTrackerReader ClusterCacheTrackerReader
 }
 
 // ClusterCacheTrackerReader is a read-only ClusterCacheTracker useful to gather information


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Uses the alias instead of the internal Interface when defining the Cluster struct.

Follow-up for #10063

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterclass