### PR TITLE
:bug: Checking cert's keypair for nil before accessing to avoid panics

### DIFF
--- a/util/secret/certificates.go
+++ b/util/secret/certificates.go
@@ -371,6 +371,10 @@ func (c *Certificate) AsSecret(clusterName client.ObjectKey, owner metav1.OwnerR
 // AsFiles converts the certificate to a slice of Files that may have 0, 1 or 2 Files.
 func (c *Certificate) AsFiles() []bootstrapv1.File {
 	out := make([]bootstrapv1.File, 0)
+	if c.KeyPair == nil {
+		return out
+	}
+
 	if len(c.KeyPair.Cert) > 0 {
 		out = append(out, bootstrapv1.File{
 			Path:        c.CertFile,

--- a/util/secret/certificates_test.go
+++ b/util/secret/certificates_test.go
@@ -45,3 +45,11 @@ func TestNewControlPlaneJoinCertsExternal(t *testing.T) {
 	certs := secret.NewControlPlaneJoinCerts(config)
 	g.Expect(certs.GetByPurpose(secret.EtcdCA).KeyFile).To(BeEmpty())
 }
+
+func TestNewControlPlaneJoinCertsAsFilesNotPanicsWhenEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	config := &bootstrapv1.ClusterConfiguration{}
+	certs := secret.NewControlPlaneJoinCerts(config)
+	g.Expect(certs.AsFiles()).To(BeEmpty())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In some circumstances `AsFiles()` can panic. The PR adds additional nil check for `c.KeyPair` to avoid it.
```
2024-02-02T09:15:35Z	INFO	Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference	{"controller": "k0scontrollerconfig", "controllerGroup": "bootstrap.cluster.x-k8s.io", "controllerKind": "K0sControllerConfig", "K0sControllerConfig": {"name":"bar-2-1","namespace":"default"}, "namespace": "default", "name": "bar-2-1", "reconcileID": "8a558d44-7dcf-406e-a7e0-e47c895189f6"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x16ca8fd]

goroutine 270 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x1a37520?, 0x2e3bb30?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
sigs.k8s.io/cluster-api/util/secret.(*Certificate).AsFiles(...)
	/go/pkg/mod/sigs.k8s.io/cluster-api@v1.5.3/util/secret/certificates.go:374
sigs.k8s.io/cluster-api/util/secret.Certificates.AsFiles({0xc00035ffb0, 0x4, 0xc0002839b0?})
	/go/pkg/mod/sigs.k8s.io/cluster-api@v1.5.3/util/secret/certificates.go:419 +0xbd
github.com/k0sproject/k0smotron/internal/controller/bootstrap.(*ControlPlaneController).getCerts(0xc000144300, {0x1f94308, 0xc00043cb40}, 0xc000775be0)
	/workspace/internal/controller/bootstrap/controlplane_bootstrap_controller.go:415 +0x1d0
github.com/k0sproject/k0smotron/internal/controller/bootstrap.(*ControlPlaneController).genControlPlaneJoinFiles(0xc000144300, {0x1f94308, 0xc00043cb40}, 0xc000775be0, 0x192b7c0?, {0xc000801fb0, 0x1, 0x1})
	/workspace/internal/controller/bootstrap/controlplane_bootstrap_controller.go:279 +0x19f
github.com/k0sproject/k0smotron/internal/controller/bootstrap.(*ControlPlaneController).Reconcile(0xc000144300, {0x1f94308, 0xc00043cb40}, {{{0xc0006097d0, 0x7}, {0xc0006097c6, 0x7}}})
	/workspace/internal/controller/bootstrap/controlplane_bootstrap_controller.go:180 +0xf7f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1f97e00?, {0x1f94308?, 0xc00043cb40?}, {{{0xc0006097d0?, 0xb?}, {0xc0006097c6?, 0x0?}}})
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002bedc0, {0x1f94340, 0xc0004afa40}, {0x1afb900?, 0xc0003a25c0?})
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


Fixes https://github.com/k0sproject/k0smotron/issues/438