### PR TITLE
:book: Change release candidate to beta in beta release notes

### DIFF
--- a/CHANGELOG/v1.7.0-beta.0.md
+++ b/CHANGELOG/v1.7.0-beta.0.md
@@ -1,4 +1,4 @@
-🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
+🚨 This is a BETA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
 
 ## Highlights
 

--- a/CHANGELOG/v1.7.0-beta.1.md
+++ b/CHANGELOG/v1.7.0-beta.1.md
@@ -1,4 +1,4 @@
-🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
+🚨 This is a BETA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
 
 ## Highlights
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the release notes for v1.7.0-beta.0 and v1.7.0-beta.1. It called the release a RELEASE CANDIDATE instead of a BETA RELEASE.

/area release