### PR TITLE
🌱 Determine release type from tag to also handle beta releases

### DIFF
--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -364,13 +364,8 @@ The goal of this task is to keep the CAPI community updated on recent PRs that h
 
    ```bash
    # RELEASE_TAG should be the new desired tag (note: at this point the tag does not yet exist).
+   # Can be also used for pre-releases. The warning banner for RC and beta releases will be determined automatically.
    RELEASE_TAG=v1.6.x make release-notes
-   ```
-
-   If this is a beta or RC release, add the --pre-release-version flag
-   ```bash
-   make release-notes-tool
-   ./bin/notes --release=${RELEASE_TAG} --pre-release-version > CHANGELOG/${RELEASE_TAG}.md
    ```
 
 1. This will generate a new release notes file at `CHANGELOG/<RELEASE_TAG>.md`. Finalize the release notes:

--- a/hack/tools/release/notes/print.go
+++ b/hack/tools/release/notes/print.go
@@ -41,7 +41,7 @@ var defaultOutputOrder = []string{
 // the right format for the release notes.
 type releaseNotesPrinter struct {
 	outputOrder            []string
-	isPreRelease           bool
+	releaseType            string
 	printKubernetesSupport bool
 	printDeprecation       bool
 	fromTag                string
@@ -75,8 +75,8 @@ func (p *releaseNotesPrinter) print(entries []notesEntry, commitsInRelease int, 
 		}
 	}
 
-	if p.isPreRelease {
-		fmt.Printf("🚨 This is a RELEASE CANDIDATE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/%s/issues/new).\n", p.repo)
+	if p.releaseType != "" {
+		fmt.Printf("🚨 This is a %s. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/%s/issues/new).\n", p.releaseType, p.repo)
 	}
 
 	if p.printKubernetesSupport {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the tool prints the same warning for both beta and rc releases.
This PR removes the parameter `--pre-release-version` and let the binary determine from the given tag what type of release it is.

Related to https://github.com/kubernetes-sigs/cluster-api/pull/10323

/area release