### PR TITLE
🌱 [release-1.6] Set linkchecker base branch to release-1.6

### DIFF
--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -20,4 +20,4 @@ jobs:
         use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json
         check-modified-files-only: 'yes'
-        base-branch: main
+        base-branch: release-1.6


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets linkchecker base branch to release-1.6 

/area ci