### PR TITLE
🌱 Add BootstrapFailedMachineError error

### DIFF
--- a/errors/consts.go
+++ b/errors/consts.go
@@ -31,6 +31,14 @@ const (
 	// Example: the ProviderSpec specifies an instance type that doesn't exist,.
 	InvalidConfigurationMachineError MachineStatusError = "InvalidConfiguration"
 
+	// BootstrapFailedMachineError indicates that the machine has been created, but
+	// the bootstrap process failed (e.g., Cloud init failed),
+	// This is not a transient error, but
+	// indicates a state that must be fixed before progress can be made.
+	//
+	// Example: the ControlPlaneEndpoint is wrong.
+	BootstrapFailedMachineError MachineStatusError = "BootstrapFailed"
+
 	// UnsupportedChangeMachineError indicates that the MachineSpec has been updated in a way that
 	// is not supported for reconciliation on this cluster. The spec may be
 	// completely valid from a configuration standpoint, but the controller

--- a/errors/machines.go
+++ b/errors/machines.go
@@ -45,6 +45,14 @@ func InvalidMachineConfiguration(msg string, args ...interface{}) *MachineError 
 	}
 }
 
+// BootstrapFailed creates a new error when a bootstrap failed for Machine.
+func BootstrapFailed(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  BootstrapFailedMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
 // CreateMachine creates a new error for when creating a Machine.
 func CreateMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In some infra providers, we need more configuration to provision a cluster.
For example, cloud-init config and control plane endpoint.

Since there are no validations for those configs, the Bootstrap (cloud-init) may fail due to misconfiguration, and we need to figure out why.

Having a new machine error  reason will give clear idea what's happening to users

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area machine