### PR TITLE
WIP:  Implement controller paused condition for core CAPI resources

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -50,6 +50,9 @@ const (
 
 	// AnnotationPausedReason (Severity=Info) documents a CAPI object that is paused due to the paused annotation being present.
 	AnnotationPausedReason = "PausedAnnotationSet"
+
+	// MachineDeploymentPausedReason (Severity=Info) documents a CAPI object that is paused due to the machine deployment being paused.
+	MachineDeploymentPausedReason = "MachineDeploymentPaused"
 )
 
 const (

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -24,9 +24,6 @@ const (
 	ReadyCondition ConditionType = "Ready"
 
 	// PausedCondition defines the Paused condition type that summarizes the operational state of a Cluster API object.
-
-	// TODO: I've noticed we have controller specific conditions. I'm not sure if
-	// I want to have a shared condition, or many controller specific conditions. 🤔
 	PausedCondition ConditionType = "Paused"
 )
 

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -22,6 +22,12 @@ package v1beta1
 const (
 	// ReadyCondition defines the Ready condition type that summarizes the operational state of a Cluster API object.
 	ReadyCondition ConditionType = "Ready"
+
+	// PausedCondition defines the Paused condition type that summarizes the operational state of a Cluster API object.
+
+	// TODO: I've noticed we have controller specific conditions. I'm not sure if
+	// I want to have a shared condition, or many controller specific conditions. 🤔
+	PausedCondition ConditionType = "Paused"
 )
 
 // Common ConditionReason used by Cluster API objects.
@@ -38,6 +44,12 @@ const (
 
 	// IncorrectExternalRefReason (Severity=Error) documents a CAPI object with an incorrect external object reference.
 	IncorrectExternalRefReason = "IncorrectExternalRef"
+
+	// ClusterPausedReason (Severity=Info) documents a CAPI object that is paused due to the cluster being paused (.Spec.Paused).
+	ClusterPausedReason = "ClusterPaused"
+
+	// AnnotationPausedReason (Severity=Info) documents a CAPI object that is paused due to the paused annotation being present.
+	AnnotationPausedReason = "PausedAnnotationSet"
 )
 
 const (

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2378,7 +2378,6 @@ func TestReconcilePausedCondition(t *testing.T) {
 		// The condition is set to true
 		return conditions.IsTrue(kcp, clusterv1.PausedCondition)
 	}, timeout).Should(BeTrue())
-
 }
 
 // test utils.

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -114,7 +114,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Machine{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachines),
@@ -122,7 +122,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
 					predicates.Any(ctrl.LoggerFrom(ctx),
-						predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
+						predicates.ClusterCreateUpdateEvent(ctrl.LoggerFrom(ctx)),
 						predicates.ClusterControlPlaneInitialized(ctrl.LoggerFrom(ctx)),
 					),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
@@ -181,12 +181,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			m.Spec.ClusterName, m.Name, m.Namespace)
 	}
 
-	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(cluster, m) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
-	}
-
 	// Initialize the patch helper
 	patchHelper, err := patch.NewHelper(m, r.Client)
 	if err != nil {
@@ -206,6 +200,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
+
+	// Return early and set the paused condition to True if the object or Cluster
+	// is paused.
+	if annotations.IsPaused(cluster, m) {
+		log.Info("Reconciliation is paused for this object")
+
+		newPausedCondition := &clusterv1.Condition{
+			Type:     clusterv1.PausedCondition,
+			Status:   corev1.ConditionTrue,
+			Severity: clusterv1.ConditionSeverityInfo,
+		}
+
+		if cluster.Spec.Paused {
+			newPausedCondition.Reason = clusterv1.ClusterPausedReason
+		} else {
+			newPausedCondition.Reason = clusterv1.AnnotationPausedReason
+		}
+
+		conditions.Set(m, newPausedCondition)
+		return ctrl.Result{}, nil
+	}
+
+	conditions.MarkFalseWithNegativePolarity(m, clusterv1.PausedCondition)
 
 	// Reconcile labels.
 	if m.Labels == nil {
@@ -273,6 +290,7 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 			clusterv1.ReadyCondition,
 			clusterv1.BootstrapReadyCondition,
 			clusterv1.InfrastructureReadyCondition,
+			clusterv1.PausedCondition,
 			clusterv1.DrainingSucceededCondition,
 			clusterv1.MachineHealthCheckSucceededCondition,
 			clusterv1.MachineOwnerRemediatedCondition,

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -2643,8 +2643,7 @@ func TestPauseConditionReconcile(t *testing.T) {
 	g.Expect(unstructured.SetNestedField(infraMachine.Object, true, "status", "ready")).To(Succeed())
 	g.Expect(env.Status().Patch(ctx, infraMachine, infraMachinePatch)).To(Succeed())
 
-	// The cluster starts paused, so the machine machine should have a Paused:
-	// true condition
+	// Cluster starts paused, so the machine should have a Paused: true condition
 	g.Eventually(func() bool {
 		if err := env.Get(ctx, key, machine); err != nil {
 			return false

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -87,14 +87,14 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.MachineSetToDeployments),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
-					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
+					predicates.ClusterCreateUpdateEvent(ctrl.LoggerFrom(ctx)),
 				),
 			),
 		).Complete(r)
@@ -130,12 +130,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(cluster, deployment) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
-	}
-
 	// Initialize the patch helper
 	patchHelper, err := patch.NewHelper(deployment, r.Client)
 	if err != nil {
@@ -153,6 +147,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
+
+	// Return early and set the paused condition to True if the object or Cluster
+	// is paused.
+	if annotations.IsPaused(cluster, deployment) {
+		log.Info("Reconciliation is paused for this object")
+
+		newPausedCondition := &clusterv1.Condition{
+			Type:     clusterv1.PausedCondition,
+			Status:   corev1.ConditionTrue,
+			Severity: clusterv1.ConditionSeverityInfo,
+		}
+
+		if cluster.Spec.Paused {
+			newPausedCondition.Reason = clusterv1.ClusterPausedReason
+		} else {
+			newPausedCondition.Reason = clusterv1.AnnotationPausedReason
+		}
+
+		conditions.Set(deployment, newPausedCondition)
+		return ctrl.Result{}, nil
+	}
+
+	conditions.MarkFalseWithNegativePolarity(deployment, clusterv1.PausedCondition)
 
 	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
 	// is enabled
@@ -261,6 +278,15 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	}
 
 	if md.Spec.Paused {
+		log.Info("This machine deployment is paused. Sync and status updates will still be reconciled")
+		newPausedCondition := &clusterv1.Condition{
+			Type:     clusterv1.PausedCondition,
+			Status:   corev1.ConditionTrue,
+			Severity: clusterv1.ConditionSeverityInfo,
+			Reason:   clusterv1.MachineDeploymentPausedReason,
+		}
+
+		conditions.Set(md, newPausedCondition)
 		return r.sync(ctx, md, msList)
 	}
 

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -64,6 +64,17 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		}
 	}()
 
+	conditionsRemediationAllowedNotPaused := clusterv1.Conditions{
+		{
+			Type:   clusterv1.RemediationAllowedCondition,
+			Status: corev1.ConditionTrue,
+		},
+		{
+			Type:   clusterv1.PausedCondition,
+			Status: corev1.ConditionFalse,
+		},
+	}
+
 	t.Run("it should ensure the correct cluster-name label when no existing labels exist", func(t *testing.T) {
 		g := NewWithT(t)
 		cluster := createCluster(g, ns.Name)
@@ -235,12 +246,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -288,12 +294,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -336,12 +337,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -393,12 +389,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -451,12 +442,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -509,12 +495,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -575,6 +556,10 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 					Severity: clusterv1.ConditionSeverityWarning,
 					Reason:   clusterv1.TooManyUnhealthyReason,
 					Message:  "Remediation is not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy (total: 3, unhealthy: 2, maxUnhealthy: 40%)",
+				},
+				{
+					Type:   clusterv1.PausedCondition,
+					Status: corev1.ConditionFalse,
 				},
 			},
 		}))
@@ -666,12 +651,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 	})
 
@@ -732,6 +712,10 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 					Severity: clusterv1.ConditionSeverityWarning,
 					Reason:   clusterv1.TooManyUnhealthyReason,
 					Message:  "Remediation is not allowed, the number of not started or unhealthy machines does not fall within the range (total: 3, unhealthy: 2, unhealthyRange: [3-5])",
+				},
+				{
+					Type:   clusterv1.PausedCondition,
+					Status: corev1.ConditionFalse,
 				},
 			},
 		}))
@@ -830,12 +814,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -929,12 +908,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1025,12 +999,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 2,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1116,6 +1085,10 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 					Type:   clusterv1.RemediationAllowedCondition,
 					Status: corev1.ConditionTrue,
 				},
+				{
+					Type:   clusterv1.PausedCondition,
+					Status: corev1.ConditionFalse,
+				},
 			},
 		}))
 
@@ -1195,12 +1168,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 1,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Transition the node to unhealthy.
@@ -1231,6 +1199,10 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 				{
 					Type:   clusterv1.RemediationAllowedCondition,
 					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   clusterv1.PausedCondition,
+					Status: corev1.ConditionFalse,
 				},
 			},
 		}))
@@ -1462,12 +1434,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			CurrentHealthy:     1,
 			ObservedGeneration: 1,
 			Targets:            targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:         conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Pause the machine
@@ -1502,12 +1469,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 0,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1614,12 +1576,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 1,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Transition the node to unhealthy.
@@ -1647,12 +1604,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 0,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1762,12 +1714,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 1,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Transition the node to unhealthy.
@@ -1795,12 +1742,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 0,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1846,12 +1788,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			RemediationsAllowed: 1,
 			ObservedGeneration:  1,
 			Targets:             targetMachines,
-			Conditions: clusterv1.Conditions{
-				{
-					Type:   clusterv1.RemediationAllowedCondition,
-					Status: corev1.ConditionTrue,
-				},
-			},
+			Conditions:          conditionsRemediationAllowedNotPaused,
 		}))
 
 		// Calculate how many Machines have health check succeeded = false.
@@ -1890,6 +1827,78 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return obj
 		}, timeout, 100*time.Millisecond).Should(BeNil())
+	})
+
+	t.Run("When the machine health check is paused, the condition is set to true", func(t *testing.T) {
+		g := NewWithT(t)
+		cluster := createCluster(g, ns.Name)
+
+		mhc := newMachineHealthCheck(cluster.Namespace, cluster.Name)
+		g.Expect(env.Create(ctx, mhc)).To(Succeed())
+		defer func(do ...client.Object) {
+			g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
+		}(cluster, mhc)
+
+		// Healthy nodes and machines.
+		_, machines, cleanup := createMachinesWithNodes(g, cluster,
+			count(1),
+			firstMachineAsControlPlane(),
+			createNodeRefForMachine(true),
+			nodeStatus(corev1.ConditionTrue),
+			machineLabels(mhc.Spec.Selector.MatchLabels),
+		)
+		defer cleanup()
+		targetMachines := make([]string, len(machines))
+		for i, m := range machines {
+			targetMachines[i] = m.Name
+		}
+		sort.Strings(targetMachines)
+
+		// Make sure the status matches.
+		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
+			err := env.Get(ctx, util.ObjectKey(mhc), mhc)
+			if err != nil {
+				return nil
+			}
+			return &mhc.Status
+		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			ObservedGeneration:  1,
+			RemediationsAllowed: 1,
+			Targets:             targetMachines,
+			Conditions:          conditionsRemediationAllowedNotPaused,
+		}))
+
+		// Transition the machine health check to paused.
+		g.Expect(env.Get(ctx, util.ObjectKey(cluster), cluster)).To(Succeed())
+		cluster.Spec.Paused = true
+		g.Expect(env.Update(ctx, cluster)).To(Succeed())
+
+		// Make sure the status matches.
+		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
+			err := env.Get(ctx, util.ObjectKey(mhc), mhc)
+			if err != nil {
+				return nil
+			}
+			return &mhc.Status
+		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 1,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   clusterv1.PausedCondition,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		}))
 	})
 }
 

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -111,14 +111,14 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.MachineToMachineSets),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(ctrl.LoggerFrom(ctx),
-					predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
+					predicates.ClusterCreateUpdateEvent(ctrl.LoggerFrom(ctx)),
 					predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
 				),
 			),
@@ -159,12 +159,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(cluster, machineSet) {
-		log.Info("Reconciliation is paused for this object")
-		return ctrl.Result{}, nil
-	}
-
 	// Initialize the patch helper
 	patchHelper, err := patch.NewHelper(machineSet, r.Client)
 	if err != nil {
@@ -177,6 +171,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
+
+	// Return early and set the paused condition to True if the object or Cluster
+	// is paused.
+	if annotations.IsPaused(cluster, machineSet) {
+		log.Info("Reconciliation is paused for this object")
+
+		newPausedCondition := &clusterv1.Condition{
+			Type:     clusterv1.PausedCondition,
+			Status:   corev1.ConditionTrue,
+			Severity: clusterv1.ConditionSeverityInfo,
+		}
+
+		if cluster.Spec.Paused {
+			newPausedCondition.Reason = clusterv1.ClusterPausedReason
+		} else {
+			newPausedCondition.Reason = clusterv1.AnnotationPausedReason
+		}
+
+		conditions.Set(machineSet, newPausedCondition)
+		return ctrl.Result{}, nil
+	}
+
+	conditions.MarkFalseWithNegativePolarity(machineSet, clusterv1.PausedCondition)
 
 	// Ignore deleted MachineSets, this can happen when foregroundDeletion
 	// is enabled
@@ -214,6 +231,7 @@ func patchMachineSet(ctx context.Context, patchHelper *patch.Helper, machineSet 
 			clusterv1.MachinesCreatedCondition,
 			clusterv1.ResizedCondition,
 			clusterv1.MachinesReadyCondition,
+			clusterv1.PausedCondition,
 		}},
 	)
 	return patchHelper.Patch(ctx, machineSet, options...)

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -168,6 +168,8 @@ func ClusterUnpaused(logger logr.Logger) predicate.Funcs {
 	return Any(log, ClusterCreateNotPaused(log), ClusterUpdateUnpaused(log))
 }
 
+// ClusterCreateUpdateEvent returns a predicate that returns true on any cluster creation event, or any update event where the cluster is paused or unpaused. This is to allow updating of paused conditions on CAPI objects.
+// TODO: Look and see if there's a better way to do this. I'm pretty sure there is.
 func ClusterCreateUpdateEvent(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -203,7 +205,8 @@ func ClusterCreateUpdateEvent(logger logr.Logger) predicate.Funcs {
 				return false
 			}
 			log = log.WithValues("Cluster", klog.KObj(c))
-
+			log.V(4).Info(`Cluster created, allowing further processing regardless of
+			.spec.paused to update conditions`)
 			return true
 		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR Adds the Paused condition, and tests to all of the core CAPI resources. 

Fixes #10130

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area area/provider/core 