### PR TITLE
🌱 release notes: also detect alpha releases as pre releases

### DIFF
--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -39,6 +39,7 @@ Use these as the base of your release notes.
 */
 
 const (
+	alphaRelease     = "ALPHA RELEASE"
 	betaRelease      = "BETA RELEASE"
 	releaseCandidate = "RELEASE CANDIDATE"
 )
@@ -146,6 +147,8 @@ func releaseTypeFromNewTag(newTagConfig string) string {
 		return releaseCandidate
 	case "beta":
 		return betaRelease
+	case "alpha":
+		return alphaRelease
 	}
 	return ""
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* While we don't do it / plan for it today. It's entirely possible that we want to cut alpha releases in CAPI at some point
* This tool is also used in (at least) CAPV / controller-runtime. Also relatively realistic that we have alpha releases there

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->