### PR TITLE
:book: Document MachinePool feature flag promotion

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
+++ b/docs/book/src/developer/providers/migrations/v1.6-to-v1.7.md
@@ -28,3 +28,11 @@ maintainers of providers and consumers of our Go API.
 * Patch helper now return error with enough error context (https://github.com/kubernetes-sigs/cluster-api/pull/9946). It is recommended to remove redundant error context on call sites if applicable.
 
 ### Suggested changes for providers
+
+* [MachinePools are now enabled by default](https://github.com/kubernetes-sigs/cluster-api/pull/10141) and the feature flag is marked as `beta` instead of `alpha`. If you are re-defining feature flags in your codebase, these values will need to be updated accordingly. If not, the following error will result:
+
+    ```
+    panic: feature gate "MachinePool" with different spec already exists: {true false BETA}
+    ```
+
+    See [this change](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4897/files#diff-bd8758c39c0deb35ee6c5c387594f6575580918777fbf2926f5762c7c9fce755L104) for how to update the flag.


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

#10141 enabled the MachinePool feature flag by default, and this change will cause errors if providers do not update their code to reflect the change.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation
