### PR TITLE
:sparkles: Support e2e for WSL

### DIFF
--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -287,9 +287,9 @@ func (p *clusterProxy) GetWorkloadCluster(ctx context.Context, namespace, name s
 	// gets the kubeconfig from the cluster
 	config := p.getKubeconfig(ctx, namespace, name)
 
-	// if we are on mac and the cluster is a DockerCluster, it is required to fix the control plane address
+	// if we are on mac or Windows Subsystem for Linux (WSL), and the cluster is a DockerCluster, it is required to fix the control plane address
 	// by using localhost:load-balancer-host-port instead of the address used in the docker network.
-	if goruntime.GOOS == "darwin" && p.isDockerCluster(ctx, namespace, name) {
+	if (goruntime.GOOS == "darwin" || os.Getenv("WSL_DISTRO_NAME") != "") && p.isDockerCluster(ctx, namespace, name) {
 		p.fixConfig(ctx, name, config)
 	}
 

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -243,9 +243,9 @@ func dockeriseKubeconfig(kubetestConfigDir string, kubeConfigPath string) (strin
 	}
 	newPath := path.Join(kubetestConfigDir, "kubeconfig")
 
-	// On CAPD, if not running on Linux, we need to use Docker's proxy to connect back to the host
+	// On CAPD, if not running on Linux or the environment is Windows Subsystem for Linux (WSL), we need to use Docker's proxy to connect back to the host
 	// to the CAPD cluster. Moby on Linux doesn't use the host.docker.internal DNS name.
-	if runtime.GOOS != "linux" {
+	if runtime.GOOS != "linux" || os.Getenv("WSL_DISTRO_NAME") != "" {
 		for i := range kubeConfig.Clusters {
 			kubeConfig.Clusters[i].Server = strings.ReplaceAll(kubeConfig.Clusters[i].Server, "127.0.0.1", "host.docker.internal")
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
When running `e2e` with WSL, the API address from the Docker network could not be used to connect to the workload cluster, instead, we need to use `localhost:load-balancer-host-port`. `fixConfig` done the fix, but for now it only applies to `darwin`.

This PR add check to see if the current environment is WSL, based on the env variable `WSL_DISTRO_NAME`. If so, it will use load balancer host port to access the workload cluster.

After the fix, on WSL, the e2e will be supported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10103

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing