### PR TITLE
🐛 SSA: recover gvk after scheme.Convert

### DIFF
--- a/internal/util/ssa/patch_test.go
+++ b/internal/util/ssa/patch_test.go
@@ -125,6 +125,8 @@ func TestPatch(t *testing.T) {
 		// 1. Create the object
 		createObject := initialObject.DeepCopy()
 		g.Expect(Patch(ctx, env.GetClient(), fieldManager, createObject)).To(Succeed())
+		// Verify that gvk is still set
+		g.Expect(createObject.GroupVersionKind()).To(Equal(initialObject.GroupVersionKind()))
 		// Note: We have to patch the status here to explicitly set these two status fields.
 		// If we don't do it the Machine defaulting webhook will try to set the two fields to false.
 		// For an unknown reason this will happen with the 2nd update call (3.) below and not before.
@@ -154,6 +156,8 @@ func TestPatch(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		// Update the object
 		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
+		// Verify that gvk is still set
+		g.Expect(modifiedObject.GroupVersionKind()).To(Equal(initialObject.GroupVersionKind()))
 		// Verify that request was not cached (as it changed the object)
 		g.Expect(ssaCache.Has(requestIdentifier)).To(BeFalse())
 
@@ -173,5 +177,7 @@ func TestPatch(t *testing.T) {
 		g.Expect(Patch(ctx, env.GetClient(), fieldManager, modifiedObject, WithCachingProxy{Cache: ssaCache, Original: originalObject})).To(Succeed())
 		// Verify that request was cached (as it did not change the object)
 		g.Expect(ssaCache.Has(requestIdentifier)).To(BeTrue())
+		// Verify that gvk is still set
+		g.Expect(modifiedObject.GroupVersionKind()).To(Equal(initialObject.GroupVersionKind()))
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:


Ensures that the SSA library recovers the gvk of the objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10405

/area util