### PR TITLE
📖 decouple the support new kubernetes version process from kind releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -22,10 +22,10 @@ This section contains tasks to update our book, e2e testing and CI to use and te
 as well as changes to Cluster API that we might have to make to support the new Kubernetes version. All of these
 changes should be cherry-picked to all release series that will support the new Kubernetes version.
 
-* [ ] Modify CAPD to use a release candidate of the upcoming Kubernetes release:
-  * Bump the Kubernetes version in `test/*`.
+* [ ] Continuously modify CAPD to use early versions of the upcoming Kubernetes release (betas and rcs):
+  * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
   * Prior art: TODO (previously #9160)
-* [ ] Modify CAPD to use the new Kubernetes release:
+* [ ] Modify CAPD to use the new Kubernetes release after it is GA:
   * Bump the Kubernetes version in `test/*`.
   * Prior art: TODO (previously #9160)
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
@@ -57,6 +57,11 @@ changes should be cherry-picked to all release series that will support the new 
     a new Kubernetes minor version. Please add these issues here when they are identified.
 
 ### Bump quickstart and kind image references in CAPD
+
+Prerequisites:
+
+* The target Kubernetes version is GA
+* There is a new [kind version with/or a new set of kind images](https://github.com/kubernetes-sigs/kind/releases) for the target Kubernetes version
 
 * [ ] Bump quickstart and kind image references in CAPD:
   * Bump the Kubernetes version in:
@@ -96,5 +101,3 @@ run the Cluster API controllers on the new Kubernetes version.
   * Prior art: #7118
 
 After release of CAPI v1.X.x (that supports Kubernetes v1.Y):
-
-* [ ] Bump WorkloadKubernetesVersion for test When testing clusterctl upgrades using ClusterClass (v1.X=>current) [ClusterClass]

--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -12,6 +12,7 @@ This issue is tracking the tasks that should be implemented **after** the Kubern
 ## Tasks
 
 Prerequisites:
+
 * [ ] Decide which Cluster API release series will support the new Kubernetes version
   * If feasible we usually cherry-pick the changes back to the latest release series.
 
@@ -21,20 +22,12 @@ This section contains tasks to update our book, e2e testing and CI to use and te
 as well as changes to Cluster API that we might have to make to support the new Kubernetes version. All of these
 changes should be cherry-picked to all release series that will support the new Kubernetes version.
 
-* [ ] Modify quickstart and CAPD to use the new Kubernetes release:
-  * Bump the Kubernetes version in:
-    * `test/*`: search for occurrences of the previous Kubernetes version
-    * `Tiltfile`
-  * Ensure the latest available kind version is used (including the latest images for this kind release)
-    * Add new images in the [kind mapper.go](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/infrastructure/kind/mapper.go#L79).
-      * See the [kind releases page](https://github.com/kubernetes-sigs/kind/releases) for the list of released images.
-    * Set new default image for the [test framework](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/framework/bootstrap/kind_provider.go#L40)
-    * If code changes are required for CAPD to incorporate the new Kind version, update [kind latestMode](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/infrastructure/kind/mapper.go#L66)
-    * Prior art: #10094
-  * Verify the quickstart manually
-  * Bump `InitWithKubernetesVersion` and `WorkloadKubernetesVersion` in `clusterctl_upgrade_test.go`
-    * Note: Only bump for Cluster API versions that will support the new Kubernetes release.
-  * Prior art: #9160
+* [ ] Modify CAPD to use a release candidate of the upcoming Kubernetes release:
+  * Bump the Kubernetes version in `test/*`.
+  * Prior art: TODO (previously #9160)
+* [ ] Modify CAPD to use the new Kubernetes release:
+  * Bump the Kubernetes version in `test/*`.
+  * Prior art: TODO (previously #9160)
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
 
   * At the `.versions`  section in the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/):
@@ -58,9 +51,24 @@ changes should be cherry-picked to all release series that will support the new 
 * [ ] Update book:
   * Update supported versions in `versions.md`
   * Prior art: #9161
+
 * [ ] Issues specific to the Kubernetes minor release:
   * Sometimes there are adjustments that we have to make in Cluster API to be able to support
     a new Kubernetes minor version. Please add these issues here when they are identified.
+
+### Bump quickstart and kind image references in CAPD
+
+* [ ] Bump quickstart and kind image references in CAPD:
+  * Bump the Kubernetes version in:
+    * `docs/*`
+    * `Tiltfile`
+  * Bump kind image references in CAPD (and also kind if necessary, including the latest images for this kind release)
+    * Add new images in the [kind mapper.go](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/infrastructure/kind/mapper.go#L79).
+      * See the [kind releases page](https://github.com/kubernetes-sigs/kind/releases) for the list of released images.
+    * Set new default image for the [test framework](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/framework/bootstrap/kind_provider.go#L40)
+    * If code changes are required for CAPD to incorporate the new Kind version, update [kind latestMode](https://github.com/kubernetes-sigs/cluster-api/blob/0f47a19e038ee6b0d3b1e7675a62cdaf84face8c/test/infrastructure/kind/mapper.go#L66)
+  * Verify the quickstart manually
+  * Prior art: TODO (previously #9160 and #10094)
 
 ### Using new Kubernetes dependencies
 
@@ -86,3 +94,7 @@ run the Cluster API controllers on the new Kubernetes version.
   * Prior art: #7193
 * [ ] Bump conversion-gen via `CONVERSION_GEN_VER` in `Makefile`
   * Prior art: #7118
+
+After release of CAPI v1.X.x (that supports Kubernetes v1.Y):
+
+* [ ] Bump WorkloadKubernetesVersion for test When testing clusterctl upgrades using ClusterClass (v1.X=>current) [ClusterClass]

--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -21,10 +21,10 @@ changes should be cherry-picked to all release series that will support the new 
 
 * [ ] Continuously modify CAPD to use early versions of the upcoming Kubernetes release (betas and rcs):
   * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
-  * Prior art: TODO (previously #9160)
+  * Prior art: #10384
 * [ ] Modify CAPD to use the new Kubernetes release after it is GA:
   * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
-  * Prior art: #10384
+  * Prior art: #10454
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
 
   * At the `.versions`  section in the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/):
@@ -45,9 +45,11 @@ changes should be cherry-picked to all release series that will support the new 
     TEST_INFRA_DIR=../../k8s.io/test-infra make generate-test-infra-prowjobs
     ```
 
+  * Prior art: #32456
+
 * [ ] Update book:
   * Update supported versions in `versions.md`
-  * Prior art: #9161
+  * Prior art: #10454
 
 * [ ] Issues specific to the Kubernetes minor release:
   * Sometimes there are adjustments that we have to make in Cluster API to be able to support
@@ -82,17 +84,17 @@ run the Cluster API controllers on the new Kubernetes version.
 * [ ] Ensure there is a new controller-runtime minor release which uses the new Kubernetes Go dependencies.
 * [ ] Update our Prow jobs for the `main` branch to use the correct `kubekins-e2e` image via the configuration file and by running `make generate-test-infra-prowjobs`.
   * It is recommended to have one PR for presubmit and one for periodic jobs to reduce the risk of breaking the periodic jobs.
-  * Prior art: presubmit jobs: https://github.com/kubernetes/test-infra/pull/27311
-  * Prior art: periodic jobs: https://github.com/kubernetes/test-infra/pull/27326
+  * Prior art: https://github.com/kubernetes/test-infra/pull/32380
 * [ ] Bump the Go version in Cluster API: (if Kubernetes is using a new Go minor version)
   * Search for the currently used Go version across the repository and update it
   * We have to at least modify it in: `hack/ensure-go.sh`, `.golangci.yml`, `cloudbuild*.yaml`, `go.mod`, `Makefile`, `netlify.toml`, `Tiltfile`
-  * Prior art: #7135
+  * Prior art: #10452
 * [ ] Bump controller-runtime
 * [ ] Bump controller-tools
 * [ ] Bump the Kubernetes version used in integration tests via `KUBEBUILDER_ENVTEST_KUBERNETES_VERSION` in `Makefile`
   * **Note**: This PR should be cherry-picked as well. It is part of this section as it depends on kubebuilder/controller-runtime
     releases and is not strictly necessary for [Supporting managing and running on the new Kubernetes version](#supporting-managing-and-running-on-the-new-kubernetes-version).
+  * Prior art to release envtest binaries: https://github.com/kubernetes-sigs/kubebuilder/pull/3864
   * Prior art: #7193
 * [ ] Bump conversion-gen via `CONVERSION_GEN_VER` in `Makefile`
   * Prior art: #7118

--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -26,7 +26,7 @@ changes should be cherry-picked to all release series that will support the new 
   * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
   * Prior art: TODO (previously #9160)
 * [ ] Modify CAPD to use the new Kubernetes release after it is GA:
-  * Bump the Kubernetes version in `test/*`.
+  * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
   * Prior art: TODO (previously #9160)
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
 

--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -11,10 +11,7 @@ This issue is tracking the tasks that should be implemented **after** the Kubern
 
 ## Tasks
 
-Prerequisites:
-
-* [ ] Decide which Cluster API release series will support the new Kubernetes version
-  * If feasible we usually cherry-pick the changes back to the latest release series.
+**Note:** If feasible we usually cherry-pick the changes back to the latest release series.
 
 ### Supporting managing and running on the new Kubernetes version
 
@@ -27,7 +24,7 @@ changes should be cherry-picked to all release series that will support the new 
   * Prior art: TODO (previously #9160)
 * [ ] Modify CAPD to use the new Kubernetes release after it is GA:
   * Bump the Kubernetes version in `test/*` except for `test/infrastructure/kind/*`.
-  * Prior art: TODO (previously #9160)
+  * Prior art: #10384
 * [ ] Ensure the jobs are adjusted to provide test coverage according to our [support policy](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions):
 
   * At the `.versions`  section in the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR changes the github template we normally use to track the kubernetes bump.

The change targets to decouple the process of

* Supporting managing and running on the new Kubernetes version

and

* waiting for a new kind release / publishing new kindest/node images after a kubernetes release

because the new kind release and/or images get published some time after the final kubernetes minor release.
The changes of:

- #10412

Allow us to test a released kubernetes version although there are no kindest/node images yet, by building the `kindest/node` images like we already do for other e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation