### PR TITLE
[release-1.7] 🌱 e2e: enable ability to test pre-releases of kubernetes

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -35,13 +35,11 @@ capi:buildDockerImages () {
 }
 
 # k8s::prepareKindestImagesVariables defaults the environment variables KUBERNETES_VERSION,
-# KUBERNETES_VERSION_UPGRADE_TO and KUBERNETES_VERSION_LATEST_CI depending on what
-# is set in GINKGO_FOCUS.
+# KUBERNETES_VERSION_UPGRADE_TO, KUBERNETES_VERSION_UPGRADE_FROM and KUBERNETES_VERSION_LATEST_CI
+# depending on what is set in GINKGO_FOCUS.
 # Note: We do this to ensure that the kindest/node image gets built if it does
 # not already exist, e.g. for pre-releases, but only if necessary.
 k8s::prepareKindestImagesVariables() {
-  # Always default KUBERNETES_VERSION to the value in the e2e config.
-
   if [[ ${GINKGO_FOCUS:-} == *"K8s-Install-ci-latest"* ]]; then
     # If the test focuses on [K8s-Install-ci-latest], only default KUBERNETES_VERSION_LATEST_CI
     # to the value in the e2e config and only if it is not set.
@@ -60,8 +58,8 @@ k8s::prepareKindestImagesVariables() {
   fi
 
   # Tests not focusing on [PR-Blocking], [K8s-Install] or [K8s-Install-ci-latest],
-  # also run upgrade tests so default KUBERNETES_VERSION_UPGRADE_TO to the value
-  # in the e2e config if it is not set.
+  # also run upgrade tests so default KUBERNETES_VERSION_UPGRADE_TO and KUBERNETES_VERSION_UPGRADE_FROM
+  # to the value in the e2e config if they are not set.
   if [[ ${GINKGO_FOCUS:-} != *"PR-Blocking"* ]] && [[ ${GINKGO_FOCUS:-} != *"K8s-Install"* ]]; then
     if [[ -z "${KUBERNETES_VERSION_UPGRADE_TO:-}" ]]; then
       KUBERNETES_VERSION_UPGRADE_TO=$(grep KUBERNETES_VERSION_UPGRADE_TO: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -54,6 +54,7 @@ export USE_EXISTING_CLUSTER=false
 # - KUBERNETES_VERSION_UPGRADE_TO
 # - KUBERNETES_VERSION_UPGRADE_FROM
 # - KUBERNETES_VERSION_LATEST_CI
+k8s::prepareKindestImagesVariables
 k8s::prepareKindestImages
 
 # pre-pull all the images that will be used in the e2e, thus making the actual test run

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -331,13 +331,13 @@ func patchDockerMachineTemplate(ctx context.Context, dockerMachineTemplate *infr
 
 	// if found
 	if err == nil {
-		semVer, err := version.ParseMajorMinorPatchTolerant(cpVersion)
+		semVer, err := semver.ParseTolerant(cpVersion)
 		if err != nil {
 			return errors.Wrap(err, "could not parse control plane version")
 		}
 		kindMapping := kind.GetMapping(semVer, "")
 
-		log.Info(fmt.Sprintf("Setting MachineDeployment custom image to %q", kindMapping.Image))
+		log.Info(fmt.Sprintf("Setting control plane custom image to %q", kindMapping.Image))
 		dockerMachineTemplate.Spec.Template.Spec.CustomImage = kindMapping.Image
 		// return early if we have successfully patched a control plane dockerMachineTemplate
 		return nil
@@ -357,7 +357,7 @@ func patchDockerMachineTemplate(ctx context.Context, dockerMachineTemplate *infr
 		return errors.Wrap(err, "could not set customImage to MachineDeployment DockerMachineTemplate")
 	}
 
-	semVer, err := version.ParseMajorMinorPatchTolerant(mdVersion)
+	semVer, err := semver.ParseTolerant(mdVersion)
 	if err != nil {
 		return errors.Wrap(err, "could not parse MachineDeployment version")
 	}

--- a/test/extension/handlers/topologymutation/handler_test.go
+++ b/test/extension/handlers/topologymutation/handler_test.go
@@ -427,6 +427,26 @@ func TestHandler_GeneratePatches(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "sets customImage for templates linked to ControlPlane for pre versions",
+			template: &infrav1.DockerMachineTemplate{},
+			variables: map[string]apiextensionsv1.JSON{
+				runtimehooksv1.BuiltinsName: {Raw: toJSON(runtimehooksv1.Builtins{
+					ControlPlane: &runtimehooksv1.ControlPlaneBuiltins{
+						Version: "v1.23.0-rc.0",
+					},
+				})},
+			},
+			expectedTemplate: &infrav1.DockerMachineTemplate{
+				Spec: infrav1.DockerMachineTemplateSpec{
+					Template: infrav1.DockerMachineTemplateResource{
+						Spec: infrav1.DockerMachineSpec{
+							CustomImage: "kindest/node:v1.23.0-rc.0",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(*testing.T) {

--- a/test/extension/handlers/topologymutation/handler_test.go
+++ b/test/extension/handlers/topologymutation/handler_test.go
@@ -324,6 +324,26 @@ func Test_patchDockerMachineTemplate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "sets customImage for templates linked to ControlPlane for pre versions",
+			template: &infrav1.DockerMachineTemplate{},
+			variables: map[string]apiextensionsv1.JSON{
+				runtimehooksv1.BuiltinsName: {Raw: toJSON(runtimehooksv1.Builtins{
+					ControlPlane: &runtimehooksv1.ControlPlaneBuiltins{
+						Version: "v1.23.0-rc.0",
+					},
+				})},
+			},
+			expectedTemplate: &infrav1.DockerMachineTemplate{
+				Spec: infrav1.DockerMachineTemplateSpec{
+					Template: infrav1.DockerMachineTemplateResource{
+						Spec: infrav1.DockerMachineSpec{
+							CustomImage: "kindest/node:v1.23.0-rc.0",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(*testing.T) {
@@ -424,26 +444,6 @@ func TestHandler_GeneratePatches(t *testing.T) {
 					responseItem("5", `[
 {"op":"add","path":"/spec/template/spec/joinConfiguration","value":{"discovery":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}}
 ]`),
-				},
-			},
-		},
-		{
-			name:     "sets customImage for templates linked to ControlPlane for pre versions",
-			template: &infrav1.DockerMachineTemplate{},
-			variables: map[string]apiextensionsv1.JSON{
-				runtimehooksv1.BuiltinsName: {Raw: toJSON(runtimehooksv1.Builtins{
-					ControlPlane: &runtimehooksv1.ControlPlaneBuiltins{
-						Version: "v1.23.0-rc.0",
-					},
-				})},
-			},
-			expectedTemplate: &infrav1.DockerMachineTemplate{
-				Spec: infrav1.DockerMachineTemplateSpec{
-					Template: infrav1.DockerMachineTemplateResource{
-						Spec: infrav1.DockerMachineSpec{
-							CustomImage: "kindest/node:v1.23.0-rc.0",
-						},
-					},
 				},
 			},
 		},

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -219,7 +219,7 @@ func parseKubetestConfig(kubetestConfigFile string) (kubetestConfig, error) {
 }
 
 func isUsingCIArtifactsVersion(k8sVersion string) bool {
-	return strings.Contains(k8sVersion, "-")
+	return strings.Contains(k8sVersion, "+")
 }
 
 func discoverClusterKubernetesVersion(proxy framework.ClusterProxy) (string, error) {

--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -376,8 +376,8 @@ func GetMapping(k8sVersion semver.Version, customImage string) Mapping {
 			continue
 		}
 
-		// If the mapping is for the same patch version, return it
-		if k8sVersion.Patch == m.KubernetesVersion.Patch {
+		// If the mapping is for the same patch version and no pre version is defined, return it
+		if k8sVersion.Patch == m.KubernetesVersion.Patch && len(k8sVersion.Pre) == 0 {
 			return Mapping{
 				KubernetesVersion: m.KubernetesVersion,
 				Mode:              m.Mode,


### PR DESCRIPTION
This is an manual cherry-pick of:

- #10412.

Supersedes:

- #10413

/area e2e-testing