### PR TITLE
🐛 e2e: fix kubetest to allow parallel execution on different clusters

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -256,6 +256,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 					ArtifactsDirectory: input.ArtifactFolder,
 					ConfigFilePath:     kubetestConfigFilePath,
 					GinkgoNodes:        int(clusterResources.ExpectedWorkerNodes()),
+					ClusterName:        clusterResources.Cluster.GetName(),
 				},
 			)
 			Expect(err).ToNot(HaveOccurred(), "Failed to run Kubernetes conformance")

--- a/test/e2e/k8s_conformance.go
+++ b/test/e2e/k8s_conformance.go
@@ -148,6 +148,7 @@ func K8SConformanceSpec(ctx context.Context, inputGetter func() K8SConformanceSp
 				ArtifactsDirectory: input.ArtifactFolder,
 				ConfigFilePath:     kubetestConfigFilePath,
 				GinkgoNodes:        ginkgoNodes,
+				ClusterName:        clusterResources.Cluster.GetName(),
 			},
 		)
 		Expect(err).ToNot(HaveOccurred(), "Failed to run Kubernetes conformance")

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -157,6 +157,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
+						ClusterName:        clusterName,
 					},
 				)).To(Succeed())
 			},
@@ -183,6 +184,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						ClusterProxy:       proxy.GetWorkloadCluster(ctx, namespace, clusterName),
 						ArtifactsDirectory: artifactFolder,
 						ConfigFilePath:     "./data/kubetest/dualstack.yaml",
+						ClusterName:        clusterName,
 					},
 				)).To(Succeed())
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md
    2. 

    3. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adjusts the kubetest.Run function to include the cluster name at the reportDir and at the report filename of ginkgo.

This should allow running kubetest.Run in parallel.

As of now one kubetest.Run would e.g. have overwritten the kubeconfig of the other as well as the junit reports, which may also have caused a race condition leading to the flaky dualstack tests (the only e2e prowjobs where we currently run kubetest in-parallel.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing