### PR TITLE
📖 book: fix cosign command to set COSIGN_EXPERIMENTAL

### DIFF
--- a/docs/book/src/tasks/verify-container-images.md
+++ b/docs/book/src/tasks/verify-container-images.md
@@ -16,7 +16,7 @@ Each [release](https://github.com/kubernetes-sigs/cluster-api/releases) of the C
 All of the four images are hosted by [registry.k8s.io](https://registry.k8s.io). In order to verify the authenticity of the images, you can use `cosign verify` command with the appropriate image name and version: 
 
 ```bash
-$ cosign verify registry.k8s.io/cluster-api/cluster-api-controller:v1.5.0 --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com --certificate-oidc-issuer https://accounts.google.com | jq .
+$ COSIGN_EXPERIMENTAL=1 cosign verify registry.k8s.io/cluster-api/cluster-api-controller:v1.5.0 --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com --certificate-oidc-issuer https://accounts.google.com | jq .
 ```
 ```text
 Verification for registry.k8s.io/cluster-api/cluster-api-controller:v1.5.0 --


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Without `COSIGN_EXPERIMENTAL=1` we get the following error:

```
Error: exactly one of: key reference (--key), certificate (--cert) or hardware token (--sk) must be provided
main.go:62: error during command execution: exactly one of: key reference (--key), certificate (--cert) or hardware token (--sk) must be provided
```

I did use cosign `v1.13.6`.

/cherry-pick release-1.7

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation