### PR TITLE
[release-1.5] 🐛 test: fix kubetest to allow parallel execution on different clusters

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -243,6 +243,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 					ArtifactsDirectory: input.ArtifactFolder,
 					ConfigFilePath:     kubetestConfigFilePath,
 					GinkgoNodes:        int(clusterResources.ExpectedWorkerNodes()),
+					ClusterName:        clusterResources.Cluster.GetName(),
 				},
 			)
 			Expect(err).ToNot(HaveOccurred(), "Failed to run Kubernetes conformance")

--- a/test/e2e/k8s_conformance.go
+++ b/test/e2e/k8s_conformance.go
@@ -127,6 +127,7 @@ func K8SConformanceSpec(ctx context.Context, inputGetter func() K8SConformanceSp
 				ArtifactsDirectory: input.ArtifactFolder,
 				ConfigFilePath:     kubetestConfigFilePath,
 				GinkgoNodes:        int(workerMachineCount),
+				ClusterName:        clusterResources.Cluster.GetName(),
 			},
 		)
 		Expect(err).ToNot(HaveOccurred(), "Failed to run Kubernetes conformance")

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -146,6 +146,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
 						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
 						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
+						ClusterName:      clusterName,
 					},
 				)).To(Succeed())
 			},
@@ -175,6 +176,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 						// Pin the conformance image to workaround https://github.com/kubernetes-sigs/cluster-api/issues/9240 .
 						// This should get dropped again when bumping to a version post v1.28.0 in `test/e2e/config/docker.yaml`.
 						ConformanceImage: "gcr.io/k8s-staging-ci-images/conformance:v1.29.0-alpha.0.190_18290bfdc8fbe1",
+						ClusterName:      clusterName,
 					},
 				)).To(Succeed())
 			},

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
@@ -72,6 +73,8 @@ type RunInput struct {
 	// KubeTestRepoListPath is optional file for specifying custom image repositories
 	// https://github.com/kubernetes/kubernetes/blob/master/test/images/README.md#testing-the-new-image
 	KubeTestRepoListPath string
+	// ClusterName is the name of the cluster to run the test at
+	ClusterName string
 }
 
 // Run executes kube-test given an artifact directory, and sets settings
@@ -81,6 +84,12 @@ func Run(ctx context.Context, input RunInput) error {
 	if input.ClusterProxy == nil {
 		return errors.New("ClusterProxy must be provided")
 	}
+	// If input.ClusterName is not set use a random string to allow parallel execution
+	// of kubetest on different clusters.
+	if input.ClusterName == "" {
+		input.ClusterName = rand.String(10)
+	}
+
 	if input.GinkgoNodes == 0 {
 		input.GinkgoNodes = DefaultGinkgoNodes
 	}
@@ -102,7 +111,7 @@ func Run(ctx context.Context, input RunInput) error {
 		input.KubernetesVersion = discoveredVersion
 	}
 	input.ArtifactsDirectory = framework.ResolveArtifactsDirectory(input.ArtifactsDirectory)
-	reportDir := path.Join(input.ArtifactsDirectory, "kubetest")
+	reportDir := path.Join(input.ArtifactsDirectory, "kubetest", input.ClusterName)
 	outputDir := path.Join(reportDir, "e2e-output")
 	kubetestConfigDir := path.Join(reportDir, "config")
 	if err := os.MkdirAll(outputDir, 0o750); err != nil {
@@ -132,7 +141,7 @@ func Run(ctx context.Context, input RunInput) error {
 		"report-dir":           "/output",
 		"e2e-output-dir":       "/output/e2e-output",
 		"dump-logs-on-failure": "false",
-		"report-prefix":        "kubetest.",
+		"report-prefix":        fmt.Sprintf("kubetest.%s.", input.ClusterName),
 		"num-nodes":            strconv.FormatInt(int64(input.NumberOfNodes), 10),
 	}
 	ginkgoArgs := buildArgs(ginkgoVars, "-")


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/10424


/area e2e-testing