### PR TITLE
Set previous release tag version for RELEASE CANDIDATE/BETA RELEASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1000,6 +1000,10 @@ RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 ifneq (,$(findstring -,$(RELEASE_TAG)))
     PRE_RELEASE=true
 endif
+## Check if previous tag is provided, if not set empty
+ifeq (,$(findstring -,$(PREVIOUS_VERSION_TAG)))
+    PREVIOUS_VERSION_TAG=""
+endif
 # the previous release tag, e.g., v0.3.9, excluding pre-release tags
 PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
 ## set by Prow, ref name of the base branch, e.g., main
@@ -1166,7 +1170,7 @@ release-notes-tool:
 
 .PHONY: release-notes
 release-notes: release-notes-tool
-	./bin/notes --release $(RELEASE_TAG) > CHANGELOG/$(RELEASE_TAG).md
+	./bin/notes --release $(RELEASE_TAG) --previous-release-version $(PREVIOUS_VERSION_TAG) > CHANGELOG/$(RELEASE_TAG).md
 
 .PHONY: test-release-notes-tool
 test-release-notes-tool:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

- Add Previous release tag version for RELEASE CANDIDATE/BETA RELEASE

For RELEASE CANDIDATE/BETA RELEASE
```bash
$ RELEASE_TAG=v1.7.0-rc.1 PREVIOUS_VERSION_TAG=tags/v1.7.0-rc.0 make release-notes

go build -C hack/tools -o /Users/ckumar14/go/src/github.com/sigs.k8s.io/cluster-api/bin/notes -tags tools sigs.k8s.io/cluster-api/hack/tools/release/notes
./bin/notes --release v1.7.0-rc.1 --previous-release-version tags/v1.7.0-rc.0 > CHANGELOG/v1.7.0-rc.1.md
2024/04/14 10:46:08 Computing diff between v1.7.0-rc.0 and heads/release-1.7
2024/04/14 10:46:08 Calling endpoint repos/kubernetes-sigs/cluster-api/compare/v1.7.0-rc.0...release-1.7?per_page=250&page=1&
2024/04/14 10:46:09 Total of 1 pages and 31 elements read
2024/04/14 10:46:09 Reading ref heads/release-1.7 for upper limit
.....
```

For Release TAG
```bash
$ RELEASE_TAG=v1.7.0 make release-notes

go build -C hack/tools -o /Users/ckumar14/go/src/github.com/sigs.k8s.io/cluster-api/bin/notes -tags tools sigs.k8s.io/cluster-api/hack/tools/release/notes
./bin/notes --release v1.7.0 --previous-release-version "" > CHANGELOG/v1.7.0.md
2024/04/14 10:56:07 Computing diff between tags/v1.6.0 and heads/release-1.7
2024/04/14 10:56:07 Calling endpoint repos/kubernetes-sigs/cluster-api/compare/v1.6.0...release-1.7?per_page=250&page=1&
2024/04/14 10:56:09 Calling endpoint repos/kubernetes-sigs/cluster-api/compare/v1.6.0...release-1.7?per_page=250&page=2&
.....
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10396 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->