### PR TITLE
🐛 CAPD: verify lb config after writing it

### DIFF
--- a/test/infrastructure/docker/internal/docker/types/node.go
+++ b/test/infrastructure/docker/internal/docker/types/node.go
@@ -120,6 +120,21 @@ func (n *Node) Delete(ctx context.Context) error {
 	return nil
 }
 
+// ReadFile reads a file from a running container.
+func (n *Node) ReadFile(ctx context.Context, dest string) ([]byte, error) {
+	command := n.Commander.Command("cp", dest, "/dev/stdout")
+	stdout := bytes.Buffer{}
+
+	command.SetStdout(&stdout)
+	// Also set stderr so it does not pollute stdout.
+	command.SetStderr(&bytes.Buffer{})
+
+	if err := command.Run(ctx); err != nil {
+		return nil, errors.Wrapf(err, "failed to read file %s", dest)
+	}
+	return stdout.Bytes(), nil
+}
+
 // WriteFile puts a file inside a running container.
 func (n *Node) WriteFile(ctx context.Context, dest, content string) error {
 	// create destination directory


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adds a check to ensure the written configuration for haproxy matches the one we just wrote.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of #10356

/area provider/infrastructure-docker