### PR TITLE
🌱 Bump Kubernetes in tests to v1.30.0 and claim support for v1.30

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -85,6 +85,7 @@ These diagrams show the relationships between components in a Cluster API releas
 | Kubernetes v1.27  | ✓ >= v1.4.2          | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.28  |                      | ✓ >= v1.5.1       | ✓                 | ✓                 |
 | Kubernetes v1.29  |                      |                   | ✓ >= v1.6.1       | ✓                 |
+| Kubernetes v1.30  |                      |                   |                   | ✓ >= v1.7.1       |
 
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
@@ -105,6 +106,7 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 | Kubernetes v1.27 + kubeadm/v1beta3 | ✓ >= v1.4.2          | ✓                  | ✓                  | ✓                  |
 | Kubernetes v1.28 + kubeadm/v1beta3 |                      | ✓ >= v1.5.1        | ✓                  | ✓                  |
 | Kubernetes v1.29 + kubeadm/v1beta3 |                      |                    | ✓ >= v1.6.1        | ✓                  |
+| Kubernetes v1.30 + kubeadm/v1beta3 |                      |                    |                    | ✓ >= v1.7.1        |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
@@ -121,6 +123,7 @@ The Kubeadm Bootstrap Provider generates kubeadm configuration using the API ver
 | Kubernetes v1.27 + etcd/v3 | ✓ >= v1.4.2          | ✓                 | ✓                 | ✓                 |
 | Kubernetes v1.28 + etcd/v3 |                      | ✓ >= v1.5.1       | ✓                 | ✓                 |
 | Kubernetes v1.29 + etcd/v3 |                      |                   | ✓ >= v1.6.1       | ✓                 |
+| Kubernetes v1.30 + etcd/v3 |                      |                   |                   | ✓ >= v1.7.1       |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
@@ -141,18 +144,6 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 **1.29**:
 * In-tree cloud providers are now switched off by default. Please use DisableCloudProviders and DisableKubeletCloudCredentialProvider feature flags if you still need this functionality. (https://github.com/kubernetes/kubernetes/pull/117503)
-
-**1.28**:
-* No specific notes
-
-**1.27**:
-* No specific notes
-
-**1.26**:
-* No specific notes
-
-**1.25**:
-* No specific notes
 
 **1.24**:
 * Kubeadm Bootstrap Provider:

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -34,12 +34,18 @@ capi:buildDockerImages () {
   fi
 }
 
-# k8s::prepareKindestImagesVariables defaults the environment variables KUBERNETES_VERSION,
+# k8s::prepareKindestImagesVariables defaults the environment variables KUBERNETES_VERSION_MANAGEMENT, KUBERNETES_VERSION,
 # KUBERNETES_VERSION_UPGRADE_TO, KUBERNETES_VERSION_UPGRADE_FROM and KUBERNETES_VERSION_LATEST_CI
 # depending on what is set in GINKGO_FOCUS.
 # Note: We do this to ensure that the kindest/node image gets built if it does
 # not already exist, e.g. for pre-releases, but only if necessary.
 k8s::prepareKindestImagesVariables() {
+  # Always default KUBERNETES_VERSION_MANAGEMENT because we always create a management cluster out of it.
+  if [[ -z "${KUBERNETES_VERSION_MANAGEMENT:-}" ]]; then
+    KUBERNETES_VERSION_MANAGEMENT=$(grep KUBERNETES_VERSION_MANAGEMENT: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+    echo "Defaulting KUBERNETES_VERSION_MANAGEMENT to ${KUBERNETES_VERSION_MANAGEMENT} to trigger image build (because env var is not set)"
+  fi
+
   if [[ ${GINKGO_FOCUS:-} == *"K8s-Install-ci-latest"* ]]; then
     # If the test focuses on [K8s-Install-ci-latest], only default KUBERNETES_VERSION_LATEST_CI
     # to the value in the e2e config and only if it is not set.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -314,12 +314,12 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.29.2"
-  KUBERNETES_VERSION: "v1.30.0-rc.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.30.0"
+  KUBERNETES_VERSION: "v1.30.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.29.2"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.30.0-rc.1"
-  KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.30"
-  ETCD_VERSION_UPGRADE_TO: "3.5.10-0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.30.0"
+  KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.31"
+  ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "dual"

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.30.0-rc.1
+  version: v1.30.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -77,7 +77,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.30.0-rc.1
+      version: v1.30.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.30.0-rc.1
+  version: v1.30.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -87,7 +87,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.30.0-rc.1
+      version: v1.30.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.30.0-rc.1
+  version: v1.30.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -76,7 +76,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.30.0-rc.1
+      version: v1.30.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.30.0-rc.1
+  version: v1.30.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.30.0-rc.1
+      version: v1.30.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Requirements:

- [ ] k8s v1.30 GA release

Steps:

* >  Modify CAPD to use the new Kubernetes release after it is GA:
* >  Update book:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of #10026

/area testing

/hold due to waiting for v1.30 GA

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->