### PR TITLE
🐛 kubetest: also gather junit reports in case of errors observed from ginkgo

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
@@ -204,7 +205,10 @@ func Run(ctx context.Context, input RunInput) error {
 		RestartPolicy: dockercontainer.RestartPolicyDisabled,
 	}, ginkgo.GinkgoWriter)
 	if err != nil {
-		return errors.Wrap(err, "Unable to run conformance tests")
+		return kerrors.NewAggregate([]error{
+			errors.Wrap(err, "Unable to run conformance tests"),
+			framework.GatherJUnitReports(reportDir, input.ArtifactsDirectory),
+		})
 	}
 	return framework.GatherJUnitReports(reportDir, input.ArtifactsDirectory)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Ensures to always bubble-up junit reports to prow so there are visible when the ginkgo failed.

Follow-up from: https://github.com/kubernetes-sigs/cluster-api/issues/5123#issuecomment-2072101355

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing