### PR TITLE
🌱 Feature gate for old infra machine naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -243,6 +243,11 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: (clusterv1alpha3.*|clusterv1alpha4.*) is deprecated: This type will be removed in one of the next releases."
+  # Specific exclude rules for deprecated featuregates that are still part of the codebase. These
+  # should be removed as the referenced deprecated types are removed from the project.
+  - linters:
+    - staticcheck
+    text: "SA1019: feature.InfraMachineNameFromTemplate is deprecated: v1.7."
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false},InfraMachineNameFromTemplate=${INFRA_MACHINE_NAME_FROM_TEMPLATE:=false}"
           image: controller:latest
           name: manager
           env:

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false},InfraMachineNameFromTemplate=${INFRA_MACHINE_NAME_FROM_TEMPLATE:=false}"
           image: controller:latest
           name: manager
           env:

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/certs"
@@ -180,12 +181,16 @@ func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx conte
 		UID:        kcp.UID,
 	}
 
+	infraMachineName := machine.Name
+	if feature.Gates.Enabled(feature.InfraMachineNameFromTemplate) {
+		infraMachineName = names.SimpleNameGenerator.GenerateName(kcp.Spec.MachineTemplate.InfrastructureRef.Name + "-")
+	}
 	// Clone the infrastructure template
 	infraRef, err := external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 		Client:      r.Client,
 		TemplateRef: &kcp.Spec.MachineTemplate.InfrastructureRef,
 		Namespace:   kcp.Namespace,
-		Name:        machine.Name,
+		Name:        infraMachineName,
 		OwnerRef:    infraCloneOwner,
 		ClusterName: cluster.Name,
 		Labels:      internal.ControlPlaneMachineLabelsForCluster(kcp, cluster.Name),

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -61,6 +61,13 @@ const (
 	//
 	// alpha: v1.5
 	MachineSetPreflightChecks featuregate.Feature = "MachineSetPreflightChecks"
+
+	// InfraMachineNameFromTemplate is a feature gate for the now deprecated way of naming infra machines.
+	// With this feature gate enabled, infra machines will be named based on the infra machine template.
+	// The new behavior is that they get the same name as the machine.
+	//
+	// Deprecated: v1.7.
+	InfraMachineNameFromTemplate featuregate.Feature = "InfraMachineNameFromTemplate"
 )
 
 func init() {
@@ -77,4 +84,5 @@ var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	KubeadmBootstrapFormatIgnition: {Default: false, PreRelease: featuregate.Alpha},
 	RuntimeSDK:                     {Default: false, PreRelease: featuregate.Alpha},
 	MachineSetPreflightChecks:      {Default: false, PreRelease: featuregate.Alpha},
+	InfraMachineNameFromTemplate:   {Default: false, PreRelease: featuregate.Deprecated},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a breaking change to the way infra machines are named in v1.7.0. This commit adds a feature gate for getting the old behavior back. It defaults to disabled so the new behavior stays. It is also marked as deprecated so it can be removed in a future minor release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/10463 (temporary fix to give more time to adapt)

/area provider/control-plane-kubeadm
/area machineset