### PR TITLE
🌱 clusterctl: always run crd migration if possible to reduce conversion webhook usage

### DIFF
--- a/cmd/clusterctl/client/cluster/crd_migration_test.go
+++ b/cmd/clusterctl/client/cluster/crd_migration_test.go
@@ -69,7 +69,7 @@ func Test_CRDMigrator(t *testing.T) {
 			wantIsMigrated: false,
 		},
 		{
-			name: "No-op if new CRD supports same versions",
+			name: "No-op if new CRD uses the same storage version",
 			currentCRD: &apiextensionsv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -90,7 +90,7 @@ func Test_CRDMigrator(t *testing.T) {
 			wantIsMigrated: false,
 		},
 		{
-			name: "No-op if new CRD adds a new versions",
+			name: "No-op if new CRD adds a new versions and stored versions is only the old storage version",
 			currentCRD: &apiextensionsv1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -104,30 +104,8 @@ func Test_CRDMigrator(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-						{Name: "v1beta1", Storage: true, Served: true}, // v1beta1 is being added
-						{Name: "v1alpha1", Served: true},               // v1alpha1 still exists
-					},
-				},
-			},
-			wantIsMigrated: false,
-		},
-		{
-			name: "No-op if new CRD adds a new versions and unserves the old",
-			currentCRD: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-						{Name: "v1alpha1", Storage: true, Served: true},
-					},
-				},
-				Status: apiextensionsv1.CustomResourceDefinitionStatus{StoredVersions: []string{"v1alpha1"}},
-			},
-			newCRD: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-						{Name: "v1beta1", Storage: true, Served: true}, // v1beta1 is being added
-						{Name: "v1alpha1", Served: false},              // v1alpha1 still exists but is not served anymore
+						{Name: "v1beta1", Storage: true, Served: false}, // v1beta1 is being added
+						{Name: "v1alpha1", Served: true},                // v1alpha1 still exists
 					},
 				},
 			},
@@ -155,7 +133,7 @@ func Test_CRDMigrator(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Migrate CRs if their storage version is removed from the CRD",
+			name: "Migrate CRs if there are stored versions is not only the current storage version",
 			CRs: []unstructured.Unstructured{
 				{
 					Object: map[string]interface{}{
@@ -209,67 +187,6 @@ func Test_CRDMigrator(t *testing.T) {
 						{Name: "v1", Storage: true, Served: true}, // v1 is being added
 						{Name: "v1beta1", Served: true},           // v1beta1 still there
 						// v1alpha1 is being dropped
-					},
-				},
-			},
-			wantStoredVersions: []string{"v1beta1"}, // v1alpha1 should be dropped from current CRD's stored versions
-			wantIsMigrated:     true,
-		},
-		{
-			name: "Migrate the CR if their storage version is no longer served by the CRD",
-			CRs: []unstructured.Unstructured{
-				{
-					Object: map[string]interface{}{
-						"apiVersion": "foo/v1beta1",
-						"kind":       "Foo",
-						"metadata": map[string]interface{}{
-							"name":      "cr1",
-							"namespace": metav1.NamespaceDefault,
-						},
-					},
-				},
-				{
-					Object: map[string]interface{}{
-						"apiVersion": "foo/v1beta1",
-						"kind":       "Foo",
-						"metadata": map[string]interface{}{
-							"name":      "cr2",
-							"namespace": metav1.NamespaceDefault,
-						},
-					},
-				},
-				{
-					Object: map[string]interface{}{
-						"apiVersion": "foo/v1beta1",
-						"kind":       "Foo",
-						"metadata": map[string]interface{}{
-							"name":      "cr3",
-							"namespace": metav1.NamespaceDefault,
-						},
-					},
-				},
-			},
-			currentCRD: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-					Group: "foo",
-					Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Foo", ListKind: "FooList"},
-					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-						{Name: "v1beta1", Storage: true, Served: true},
-						{Name: "v1alpha1", Served: true},
-					},
-				},
-				Status: apiextensionsv1.CustomResourceDefinitionStatus{StoredVersions: []string{"v1beta1", "v1alpha1"}},
-			},
-			newCRD: &apiextensionsv1.CustomResourceDefinition{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-					Group: "foo",
-					Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Foo", ListKind: "FooList"},
-					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
-						{Name: "v1", Storage: true, Served: true}, // v1 is being added
-						{Name: "v1beta1", Served: true},           // v1beta1 still there (required for future migration)
-						{Name: "v1alpha1", Served: false},         // v1alpha1 is no longer being served
 					},
 				},
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

If objects are still stored in the old version, every time an object is requested
the kube-apiserver will call the conversion webhook. Instead of lots of conversion
webhook calls we once do the migration if possible.

Also increases the timeout used for the migrations: Before running CRD migration
clusterctl usually upgrades cert-manager which may lead to updating Certificates and
rolling out new certificates to our controllers. There is a chance that this can take
up to 90s in which conversion, validating or mutatingwebhooks may be unavailable.
Because the migration gets run more aggresively during upgrades this also increases
the relevant timeouts.

---

This also fixes to not run the CRD version migration, if the stored version is equal to the storageVersion (which would result in running migration, but being a no-op because of no conversion happening).

This could e.g. be the case when upgrading from v0.4 to v1.6 or v1.7: What would happen with the old code:
* old CRD is deployed, having `storageVersion=v1alpha4` and `storedVersions = [v1alpha4]`
* `clusterctl upgrade apply`
  * CRD migration starts
    * v1alpha4 is not served anymore so it runs migration
    * migration is no-op, because storageVersion is still v1alpha4
  * CRD's get patched/updated
  * CRD's would have `storedVersions = [v1alpha4, v1beta1] (as soon as the first object got applied`

It is totally fine that v1alpha4 is not served anymore with the new CRD, important is that it is still in the versions of the new CRD, so kube-apiserver is still able to run the conversion webhook. The next upgrade would cover removing the `valpha4` from storedVersions, because the migration would be done.

We have a safeguard to not run in the error case above the changed code:

https://github.com/kubernetes-sigs/cluster-api/blob/03889674070653b0183f878ef2822646fa461905/cmd/clusterctl/client/cluster/crd_migration.go#L114

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterctl