### PR TITLE
📖 Update InfraCluster provider contract to account for the paused condition

### DIFF
--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -58,6 +58,7 @@ repo or add an item to the agenda in the [Cluster API community meeting](https:/
 | [Externally managed infrastructure]                                  | No        |                                                                     |
 | [Multi tenancy]                                                      | No        | Mandatory for clusterctl CLI support                                |
 | [Clusterctl support]                                                 | No        | Mandatory for clusterctl CLI support                                |
+| [InfraCluster: pausing]                                              | No        |                                                                     |
 
 Note:
 - `All resources` refers to all the provider's resources "core" Cluster API interacts with;
@@ -335,6 +336,12 @@ the implication of this choice which are described both in the document above an
 
 </aside>
 
+### InfraCluster: pausing
+
+Providers SHOULD implement the pause behaviour for every object with a reconciliation loop. This is done by checking if `spec.paused` is set on the Cluster object and by checking for the `cluster.x-k8s.io/paused` annotation on the InfraCluster object.
+
+If implementing the pause behavior, providers SHOULD surface the paused status of an object using the Paused condition: `Status.Conditions[Paused]`.
+
 ### InfraCluster: terminal failures
 
 Each InfraCluster SHOULD report when Cluster's enter in a state that cannot be recovered (terminal failure) by
@@ -525,3 +532,4 @@ is implemented in InfraCluster controllers:
 [clusterctl provider contract]: clusterctl.md
 [implementation best practices]: ../best-practices.md
 [infrastructure Provider Security Guidance]: ../security-guidelines.md
+[InfraCluster: pausing]: #infracluster-pausing


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This change updates the infra cluster provider contract to account for a new paused
condition.


Relates #10130

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area documentation