### PR TITLE
📖 Drop v1.4 column, set v1.5 to EOL in versions.md

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -74,19 +74,17 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)    | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
-|-------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.21  | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.22  | ✓ (only workload)    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.23* | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.24  | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.25  | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.26  | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.27  | ✓ >= v1.4.2          | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.28  |                      | ✓ >= v1.5.1       | ✓                 | ✓                 |
-| Kubernetes v1.29  |                      |                   | ✓ >= v1.6.1       | ✓                 |
-| Kubernetes v1.30  |                      |                   |                   | ✓ >= v1.7.1       |
-
+|                   | v1.5 (v1beta1) (EOL) | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
+|-------------------|----------------------|-------------------|-------------------|
+| Kubernetes v1.22  | ✓ (only workload)    |                   |                   |
+| Kubernetes v1.23* | ✓ (only workload)    | ✓ (only workload) |                   |
+| Kubernetes v1.24  | ✓                    | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.25  | ✓                    | ✓                 | ✓ (only workload) |
+| Kubernetes v1.26  | ✓                    | ✓                 | ✓                 |
+| Kubernetes v1.27  | ✓                    | ✓                 | ✓                 |
+| Kubernetes v1.28  | ✓ >= v1.5.1          | ✓                 | ✓                 |
+| Kubernetes v1.29  |                      | ✓ >= v1.6.1       | ✓                 |
+| Kubernetes v1.30  |                      |                   | ✓ >= v1.7.1       |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
 	 Previous Kubernetes **minor** versions are not affected.
@@ -95,35 +93,33 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)     | v1.6 (v1beta1)     | v1.7 (v1beta1)     |
-|------------------------------------|----------------------|--------------------|--------------------|--------------------|
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓  (only workload)   |                    |                    |                    |
-| Kubernetes v1.22 + kubeadm/v1beta3 | ✓  (only workload)   | ✓  (only workload) |                    |                    |
-| Kubernetes v1.23 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) |                    |
-| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓  (only workload) | ✓  (only workload) |
-| Kubernetes v1.25 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓  (only workload) |
-| Kubernetes v1.26 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  | ✓                  |
-| Kubernetes v1.27 + kubeadm/v1beta3 | ✓ >= v1.4.2          | ✓                  | ✓                  | ✓                  |
-| Kubernetes v1.28 + kubeadm/v1beta3 |                      | ✓ >= v1.5.1        | ✓                  | ✓                  |
-| Kubernetes v1.29 + kubeadm/v1beta3 |                      |                    | ✓ >= v1.6.1        | ✓                  |
-| Kubernetes v1.30 + kubeadm/v1beta3 |                      |                    |                    | ✓ >= v1.7.1        |
+|                                    | v1.5 (v1beta1) (EOL) | v1.6 (v1beta1)     | v1.7 (v1beta1)     |
+|------------------------------------|----------------------|--------------------|--------------------|
+| Kubernetes v1.22 + kubeadm/v1beta3 | ✓  (only workload)   |                    |                    |
+| Kubernetes v1.23 + kubeadm/v1beta3 | ✓  (only workload)   | ✓  (only workload) |                    |
+| Kubernetes v1.24 + kubeadm/v1beta3 | ✓                    | ✓  (only workload) | ✓  (only workload) |
+| Kubernetes v1.25 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓  (only workload) |
+| Kubernetes v1.26 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  |
+| Kubernetes v1.27 + kubeadm/v1beta3 | ✓                    | ✓                  | ✓                  |
+| Kubernetes v1.28 + kubeadm/v1beta3 | ✓ >= v1.5.1          | ✓                  | ✓                  |
+| Kubernetes v1.29 + kubeadm/v1beta3 |                      | ✓ >= v1.6.1        | ✓                  |
+| Kubernetes v1.30 + kubeadm/v1beta3 |                      |                    | ✓ >= v1.7.1        |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | v1.4 (v1beta1) (EOL) | v1.5 (v1beta1)    | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
-|----------------------------|----------------------|-------------------|-------------------|-------------------|
-| Kubernetes v1.21 + etcd/v3 | ✓ (only workload)    |                   |                   |                   |
-| Kubernetes v1.22 + etcd/v3 | ✓ (only workload)    | ✓ (only workload) |                   |                   |
-| Kubernetes v1.23 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |                   |
-| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓                 | ✓ (only workload) | ✓ (only workload) |
-| Kubernetes v1.25 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓ (only workload) |
-| Kubernetes v1.26 + etcd/v3 | ✓                    | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.27 + etcd/v3 | ✓ >= v1.4.2          | ✓                 | ✓                 | ✓                 |
-| Kubernetes v1.28 + etcd/v3 |                      | ✓ >= v1.5.1       | ✓                 | ✓                 |
-| Kubernetes v1.29 + etcd/v3 |                      |                   | ✓ >= v1.6.1       | ✓                 |
-| Kubernetes v1.30 + etcd/v3 |                      |                   |                   | ✓ >= v1.7.1       |
+|                            | v1.5 (v1beta1) (EOL) | v1.6 (v1beta1)    | v1.7 (v1beta1)    |
+|----------------------------|----------------------|-------------------|-------------------|
+| Kubernetes v1.22 + etcd/v3 | ✓ (only workload)    |                   |                   |
+| Kubernetes v1.23 + etcd/v3 | ✓ (only workload)    | ✓ (only workload) |                   |
+| Kubernetes v1.24 + etcd/v3 | ✓                    | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.25 + etcd/v3 | ✓                    | ✓                 | ✓ (only workload) |
+| Kubernetes v1.26 + etcd/v3 | ✓                    | ✓                 | ✓                 |
+| Kubernetes v1.27 + etcd/v3 | ✓                    | ✓                 | ✓                 |
+| Kubernetes v1.28 + etcd/v3 | ✓ >= v1.5.1          | ✓                 | ✓                 |
+| Kubernetes v1.29 + etcd/v3 |                      | ✓ >= v1.6.1       | ✓                 |
+| Kubernetes v1.30 + etcd/v3 |                      |                   | ✓ >= v1.7.1       |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Extracted from #10529

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->