### PR TITLE
🐛 Fix log in clusterctl move

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -291,7 +291,7 @@ func getClusterObj(ctx context.Context, proxy Proxy, cluster *node, clusterObj *
 
 	if err := c.Get(ctx, clusterObjKey, clusterObj); err != nil {
 		return errors.Wrapf(err, "error reading Cluster %s/%s",
-			clusterObj.GetNamespace(), clusterObj.GetName())
+			cluster.identity.Namespace, cluster.identity.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The clusterObj will be empty after failure and the log will not print the actual cluster that the cli is trying to get. If there is a bad reference in one of the objects in the graph this leads to a lot of confusion about what's actually failing.

/area clusterctl