### PR TITLE
 🌱 Allow users to specify webhook server cert and key names

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -75,6 +75,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -149,7 +151,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -243,9 +251,11 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port:    webhookPort,
-				CertDir: webhookCertDir,
-				TLSOpts: tlsOptionOverrides,
+				Port:     webhookPort,
+				CertDir:  webhookCertDir,
+				CertName: webhookCertName,
+				KeyName:  webhookKeyName,
+				TLSOpts:  tlsOptionOverrides,
 			},
 		),
 	}

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -79,6 +79,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -148,7 +150,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -253,9 +261,11 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port:    webhookPort,
-				CertDir: webhookCertDir,
-				TLSOpts: tlsOptionOverrides,
+				Port:     webhookPort,
+				CertDir:  webhookCertDir,
+				CertName: webhookCertName,
+				KeyName:  webhookKeyName,
+				TLSOpts:  tlsOptionOverrides,
 			},
 		),
 	}

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
@@ -84,7 +84,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
 }
 
 func main() {
@@ -279,7 +279,7 @@ well with practices like unit testing and generally makes the entire system more
 
 ### Error messages
 
-RuntimeExtension authors should be aware that error messages are surfaced as a conditions in Kubernetes resources 
+RuntimeExtension authors should be aware that error messages are surfaced as a conditions in Kubernetes resources
 and recorded in Cluster API controller's logs. As a consequence:
 
 - Error message must not contain any sensitive information.
@@ -291,16 +291,16 @@ and recorded in Cluster API controller's logs. As a consequence:
 <h1>Caution</h1>
 
 If an error message is not deterministic and it changes at every call even if the problem is the same, it could
-lead to to Kubernetes resources conditions continuously changing, and this generates a denial attack to 
+lead to to Kubernetes resources conditions continuously changing, and this generates a denial attack to
 controllers processing those resource that might impact system stability.
 
 </aside>
 
 ### ExtensionConfig
 
-To register your runtime extension apply the ExtensionConfig resource in the management cluster, including your CA 
-certs, ClusterIP service associated with the app and namespace, and the target namespace for the given extension. Once 
-created, the extension will detect the associated service and discover the associated Hooks. For clarification, you can 
+To register your runtime extension apply the ExtensionConfig resource in the management cluster, including your CA
+certs, ClusterIP service associated with the app and namespace, and the target namespace for the given extension. Once
+created, the extension will detect the associated service and discover the associated Hooks. For clarification, you can
 check the status of the ExtensionConfig. Below is an example of `ExtensionConfig` -
 
 ```yaml
@@ -328,7 +328,7 @@ spec:
 
 Settings can be added to the ExtensionConfig object in the form of a map with string keys and values. These settings are
 sent with each request to hooks registered by that ExtensionConfig. Extension developers can implement behavior in their
-extensions to alter behavior based on these settings. Settings should be well documented by extension developers so that 
+extensions to alter behavior based on these settings. Settings should be well documented by extension developers so that
 ClusterClass authors can understand usage and expected behaviour.
 
 Settings can be provided for individual external patches by providing them in the ClusterClass `.spec.patches[*].external.settings`.
@@ -382,7 +382,7 @@ curl -X 'POST' 'http://127.0.0.1:8001/api/v1/namespaces/default/services/https:w
   -d '{"apiVersion":"hooks.runtime.cluster.x-k8s.io/v1alpha1","kind":"DiscoveryRequest"}' | jq
 ```
 
-For more details about the API of the Runtime Extensions please see <button onclick="openSwaggerUI()">Swagger UI</button>.  
+For more details about the API of the Runtime Extensions please see <button onclick="openSwaggerUI()">Swagger UI</button>.
 For more details on proxy support please see [Proxies in Kubernetes](https://kubernetes.io/docs/concepts/cluster-administration/proxies/).
 
 <script>

--- a/exp/runtime/server/server.go
+++ b/exp/runtime/server/server.go
@@ -70,6 +70,16 @@ type Options struct {
 	// It is used to set webhook.Server.CertDir.
 	CertDir string
 
+	// CertName is the server certificate name. Defaults to tls.crt.
+	//
+	// Note: This option is only used when TLSOpts does not set GetCertificate.
+	CertName string
+
+	// KeyName is the server key name. Defaults to tls.key.
+	//
+	// Note: This option is only used when TLSOpts does not set GetCertificate.
+	KeyName string
+
 	// TLSOpts is used to allow configuring the TLS config used for the server.
 	// This also allows providing a certificate via GetCertificate.
 	TLSOpts []func(*tls.Config)
@@ -86,14 +96,20 @@ func New(options Options) (*Server, error) {
 	if options.CertDir == "" {
 		options.CertDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
 	}
+	if options.CertName == "" {
+		options.CertName = "tls.crt"
+	}
+	if options.KeyName == "" {
+		options.KeyName = "tls.key"
+	}
 
 	webhookServer := webhook.NewServer(
 		webhook.Options{
 			Port:       options.Port,
 			Host:       options.Host,
 			CertDir:    options.CertDir,
-			CertName:   "tls.crt",
-			KeyName:    "tls.key",
+			CertName:   options.CertName,
+			KeyName:    options.KeyName,
 			TLSOpts:    options.TLSOpts,
 			WebhookMux: http.NewServeMux(),
 		},

--- a/main.go
+++ b/main.go
@@ -96,6 +96,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -216,7 +218,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -325,9 +333,11 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port:    webhookPort,
-				CertDir: webhookCertDir,
-				TLSOpts: tlsOptionOverrides,
+				Port:     webhookPort,
+				CertDir:  webhookCertDir,
+				CertName: webhookCertName,
+				KeyName:  webhookKeyName,
+				TLSOpts:  tlsOptionOverrides,
 			},
 		),
 	}

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -82,6 +82,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -140,7 +142,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -203,10 +211,12 @@ func main() {
 
 	// Create an HTTP server for serving Runtime Extensions.
 	runtimeExtensionWebhookServer, err := server.New(server.Options{
-		Port:    webhookPort,
-		CertDir: webhookCertDir,
-		TLSOpts: tlsOptionOverrides,
-		Catalog: catalog,
+		Port:     webhookPort,
+		CertDir:  webhookCertDir,
+		CertName: webhookCertName,
+		KeyName:  webhookKeyName,
+		TLSOpts:  tlsOptionOverrides,
+		Catalog:  catalog,
 	})
 	if err != nil {
 		setupLog.Error(err, "error creating runtime extension webhook server")

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -82,6 +82,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -150,7 +152,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -249,9 +257,11 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port:    webhookPort,
-				CertDir: webhookCertDir,
-				TLSOpts: tlsOptionOverrides,
+				Port:     webhookPort,
+				CertDir:  webhookCertDir,
+				CertName: webhookCertName,
+				KeyName:  webhookKeyName,
+				TLSOpts:  tlsOptionOverrides,
 			},
 		),
 	}

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -76,6 +76,8 @@ var (
 	restConfigBurst             int
 	webhookPort                 int
 	webhookCertDir              string
+	webhookCertName             string
+	webhookKeyName              string
 	healthAddr                  string
 	tlsOptions                  = flags.TLSOptions{}
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
@@ -145,7 +147,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port")
 
 	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
-		"Webhook cert dir, only used when webhook-port is specified.")
+		"Webhook cert dir.")
+
+	fs.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt",
+		"Webhook cert name.")
+
+	fs.StringVar(&webhookKeyName, "webhook-key-name", "tls.key",
+		"Webhook key name.")
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
@@ -228,9 +236,11 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port:    webhookPort,
-				CertDir: webhookCertDir,
-				TLSOpts: tlsOptionOverrides,
+				Port:     webhookPort,
+				CertDir:  webhookCertDir,
+				CertName: webhookCertName,
+				KeyName:  webhookKeyName,
+				TLSOpts:  tlsOptionOverrides,
 			},
 		),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area api