### PR TITLE
🌱 Deprecate IP Family builtin variable

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -509,6 +509,7 @@ func (c *Cluster) SetConditions(conditions Conditions) {
 }
 
 // GetIPFamily returns a ClusterIPFamily from the configuration provided.
+//
 // Deprecated: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
 // IPFamily will be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
 func (c *Cluster) GetIPFamily() (ClusterIPFamily, error) {

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -509,8 +509,8 @@ func (c *Cluster) SetConditions(conditions Conditions) {
 }
 
 // GetIPFamily returns a ClusterIPFamily from the configuration provided.
-// Note: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
-// IPFamily may be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
+// Deprecated: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
+// IPFamily will be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
 func (c *Cluster) GetIPFamily() (ClusterIPFamily, error) {
 	var podCIDRs, serviceCIDRs []string
 	if c.Spec.ClusterNetwork != nil {

--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -535,6 +535,7 @@ referenced in patches:
 - `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
 - `builtin.cluster.network.{serviceDomain,services,pods,ipFamily}`
+    - Note: ipFamily is deprecated and will be removed in a future release. see https://github.com/kubernetes-sigs/cluster-api/issues/7521.
 - `builtin.controlPlane.{replicas,version,name}`
     - Please note, these variables are only available when patching control plane or control plane 
       machine templates.

--- a/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
@@ -62,6 +62,7 @@ type ClusterNetworkBuiltins struct {
 	// Pods is the network ranges from which Pod networks are allocated.
 	Pods []string `json:"pods,omitempty"`
 	// IPFamily is the IPFamily the Cluster is operating in. One of Invalid, IPv4, IPv6, DualStack.
+	//
 	// Deprecated: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
 	// IPFamily will be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
 	IPFamily string `json:"ipFamily,omitempty"`

--- a/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
@@ -62,8 +62,8 @@ type ClusterNetworkBuiltins struct {
 	// Pods is the network ranges from which Pod networks are allocated.
 	Pods []string `json:"pods,omitempty"`
 	// IPFamily is the IPFamily the Cluster is operating in. One of Invalid, IPv4, IPv6, DualStack.
-	// Note: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
-	// IPFamily may be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
+	// Deprecated: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.
+	// IPFamily will be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521
 	IPFamily string `json:"ipFamily,omitempty"`
 }
 

--- a/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
+++ b/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
@@ -847,7 +847,7 @@ func schema_runtime_hooks_api_v1alpha1_ClusterNetworkBuiltins(ref common.Referen
 					},
 					"ipFamily": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IPFamily is the IPFamily the Cluster is operating in. One of Invalid, IPv4, IPv6, DualStack. Note: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD. IPFamily may be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521",
+							Description: "IPFamily is the IPFamily the Cluster is operating in. One of Invalid, IPv4, IPv6, DualStack.\n\nDeprecated: IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD. IPFamily will be dropped in a future release. More details at https://github.com/kubernetes-sigs/cluster-api/issues/7521",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/internal/controllers/topology/cluster/patches/variables/variables.go
+++ b/internal/controllers/topology/cluster/patches/variables/variables.go
@@ -68,7 +68,7 @@ func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster, def
 		},
 	}
 	if cluster.Spec.ClusterNetwork != nil {
-		clusterNetworkIPFamily, _ := cluster.GetIPFamily()
+		clusterNetworkIPFamily, _ := cluster.GetIPFamily() //nolint:staticcheck // We tolerate this until removal. See https://github.com/kubernetes-sigs/cluster-api/issues/7521.
 		builtin.Cluster.Network = &runtimehooksv1.ClusterNetworkBuiltins{
 			IPFamily: ipFamilyToString(clusterNetworkIPFamily),
 		}

--- a/test/infrastructure/docker/internal/docker/loadbalancer.go
+++ b/test/infrastructure/docker/internal/docker/loadbalancer.go
@@ -65,7 +65,7 @@ func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerClus
 		return nil, err
 	}
 
-	ipFamily, err := cluster.GetIPFamily()
+	ipFamily, err := cluster.GetIPFamily() //nolint:staticcheck // We tolerate this until removal; after removal IPFamily will become an internal CAPD concept. See https://github.com/kubernetes-sigs/cluster-api/issues/7521.
 	if err != nil {
 		return nil, fmt.Errorf("create load balancer: %s", err)
 	}

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -92,7 +92,7 @@ func NewMachine(ctx context.Context, cluster *clusterv1.Cluster, machine string,
 		return nil, err
 	}
 
-	ipFamily, err := cluster.GetIPFamily()
+	ipFamily, err := cluster.GetIPFamily() //nolint:staticcheck // We tolerate this until removal; after removal IPFamily will become an internal CAPD concept. See https://github.com/kubernetes-sigs/cluster-api/issues/7521.
 	if err != nil {
 		return nil, fmt.Errorf("create docker machine: %s", err)
 	}
@@ -126,7 +126,7 @@ func ListMachinesByCluster(ctx context.Context, cluster *clusterv1.Cluster, labe
 		return nil, err
 	}
 
-	ipFamily, err := cluster.GetIPFamily()
+	ipFamily, err := cluster.GetIPFamily() //nolint:staticcheck // We tolerate this until removal; after removal IPFamily will become an internal CAPD concept. See https://github.com/kubernetes-sigs/cluster-api/issues/7521.
 	if err != nil {
 		return nil, fmt.Errorf("list docker machines by cluster: %s", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
IPFamily is not a concept in Kubernetes. It was originally introduced in CAPI for CAPD.

This PR kicks off the deprecation & removal process, at the end of this process IP Familiy will exist only inside CAPD as a convenience for testing.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/7521 

/area clusterclass