### PR TITLE
📖 Minor fix to configuration.md

### DIFF
--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -100,7 +100,7 @@ The value string is a possibly signed sequence of decimal numbers, each with opt
 
 If no value is specified, or the format is invalid, the default value of 10 minutes will be used.
 
-Please note that the configuration above will be considered also when doing `clusterctl upgrade plan` or `clusterctl upgrade plan`.
+Please note that the configuration above will be considered also when doing `clusterctl upgrade plan` or `clusterctl upgrade apply`.
 
 ## Migrating to user-managed cert-manager
 


### PR DESCRIPTION
**What this PR does / why we need it**:

📖 Minor fixed to configuration.md

Instead of duplicating the same command `clusterctl upgrade plan`, change one side to `clusterctl upgrade apply`. Ordered according to https://cluster-api.sigs.k8s.io/clusterctl/commands/commands

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
