### PR TITLE
🐛 test: filter cluster-wide objects asserted in ResourceVersion tests to exclude objects of parallel tests

### DIFF
--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -39,11 +39,18 @@ type OwnerGraphNode struct {
 	Owners []metav1.OwnerReference
 }
 
+// GetOwnerGraphFilterFunction allows filtering the objects returned by GetOwnerGraph.
+// The function has to return true for objects which should be kept.
+// NOTE: this function signature is exposed to allow implementation of E2E tests; there is
+// no guarantee about the stability of this API. Using this test with providers may require
+// a custom implementation of this function, or the OwnerGraph it returns.
+type GetOwnerGraphFilterFunction func(u unstructured.Unstructured) bool
+
 // GetOwnerGraph returns a graph with all the objects considered by clusterctl move as nodes and the OwnerReference relationship between those objects as edges.
 // NOTE: this data structure is exposed to allow implementation of E2E tests verifying that CAPI can properly rebuild its
 // own owner references; there is no guarantee about the stability of this API. Using this test with providers may require
 // a custom implementation of this function, or the OwnerGraph it returns.
-func GetOwnerGraph(ctx context.Context, namespace, kubeconfigPath string) (OwnerGraph, error) {
+func GetOwnerGraph(ctx context.Context, namespace, kubeconfigPath string, filterFn GetOwnerGraphFilterFunction) (OwnerGraph, error) {
 	p := newProxy(Kubeconfig{Path: kubeconfigPath, Context: ""})
 	invClient := newInventoryClient(p, nil)
 
@@ -57,14 +64,14 @@ func GetOwnerGraph(ctx context.Context, namespace, kubeconfigPath string) (Owner
 
 	// graph.Discovery can not be used here as it will use the latest APIVersion for ownerReferences - not those
 	// present in the object `metadata.ownerReferences`.
-	owners, err := discoverOwnerGraph(ctx, namespace, graph)
+	owners, err := discoverOwnerGraph(ctx, namespace, graph, filterFn)
 	if err != nil {
 		return OwnerGraph{}, errors.Wrap(err, "failed to discovery ownerGraph types")
 	}
 	return owners, nil
 }
 
-func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph) (OwnerGraph, error) {
+func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph, filterFn GetOwnerGraphFilterFunction) (OwnerGraph, error) {
 	selectors := []client.ListOption{}
 	if namespace != "" {
 		selectors = append(selectors, client.InNamespace(namespace))
@@ -102,6 +109,10 @@ func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph) (
 			}
 		}
 		for _, obj := range objList.Items {
+			// Exclude the objects via the filter function.
+			if filterFn != nil && !filterFn(obj) {
+				continue
+			}
 			// Exclude the kube-root-ca.crt ConfigMap from the owner graph.
 			if obj.GetKind() == "ConfigMap" && obj.GetName() == "kube-root-ca.crt" {
 				continue

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -85,6 +85,10 @@ type clusterUpgradeWithRuntimeSDKSpecInput struct {
 	// Allows to inject a function to be run after test namespace is created.
 	// If not specified, this is a no-op.
 	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+
+	// Allows to inject a function to be run after the cluster is upgraded.
+	// If not specified, this is a no-op.
+	PostMachinesProvisioned func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
 }
 
 // clusterUpgradeWithRuntimeSDKSpec implements a spec that upgrades a cluster and runs the Kubernetes conformance suite.
@@ -259,6 +263,11 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 			Count:             int(clusterResources.ExpectedTotalNodes()),
 			WaitForNodesReady: input.E2EConfig.GetIntervals(specName, "wait-nodes-ready"),
 		})
+
+		if input.PostMachinesProvisioned != nil {
+			log.Logf("Calling PostMachinesProvisioned for cluster %s", klog.KRef(namespace.Name, clusterResources.Cluster.Name))
+			input.PostMachinesProvisioned(input.BootstrapClusterProxy, namespace.Name, clusterName)
+		}
 
 		By("Dumping resources and deleting the workload cluster; deletion waits for BeforeClusterDeleteHook to gate the operation")
 		dumpAndDeleteCluster(ctx, input.BootstrapClusterProxy, namespace.Name, clusterName, input.ArtifactFolder)

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -88,7 +88,7 @@ type clusterUpgradeWithRuntimeSDKSpecInput struct {
 
 	// Allows to inject a function to be run after the cluster is upgraded.
 	// If not specified, this is a no-op.
-	PostMachinesProvisioned func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
+	PostUpgrade func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
 }
 
 // clusterUpgradeWithRuntimeSDKSpec implements a spec that upgrades a cluster and runs the Kubernetes conformance suite.
@@ -264,9 +264,9 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 			WaitForNodesReady: input.E2EConfig.GetIntervals(specName, "wait-nodes-ready"),
 		})
 
-		if input.PostMachinesProvisioned != nil {
+		if input.PostUpgrade != nil {
 			log.Logf("Calling PostMachinesProvisioned for cluster %s", klog.KRef(namespace.Name, clusterResources.Cluster.Name))
-			input.PostMachinesProvisioned(input.BootstrapClusterProxy, namespace.Name, clusterName)
+			input.PostUpgrade(input.BootstrapClusterProxy, namespace.Name, clusterResources.Cluster.Name)
 		}
 
 		By("Dumping resources and deleting the workload cluster; deletion waits for BeforeClusterDeleteHook to gate the operation")

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/cluster-api/test/framework"
 )
 
 var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [ClusterClass]", func() {
@@ -41,6 +43,11 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 			ArtifactFolder:         artifactFolder,
 			SkipCleanup:            skipCleanup,
 			InfrastructureProvider: ptr.To("docker"),
+			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
+				// continuous reconciles when everything should be stable.
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
+			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor: ptr.To("upgrades-runtimesdk"),
 		}

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -46,7 +46,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor: ptr.To("upgrades-runtimesdk"),

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 
+	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
@@ -43,10 +44,10 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 			ArtifactFolder:         artifactFolder,
 			SkipCleanup:            skipCleanup,
 			InfrastructureProvider: ptr.To("docker"),
-			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor: ptr.To("upgrades-runtimesdk"),

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -39,7 +39,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 			InfrastructureProvider: ptr.To("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -48,7 +48,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -57,7 +57,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -65,7 +65,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
 			},
 		}
 	})
@@ -83,7 +83,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 			InfrastructureProvider: ptr.To("docker"),
 			// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -92,7 +92,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -101,7 +101,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -109,7 +109,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
 			},
 		}
 	})

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -39,7 +39,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 			InfrastructureProvider: ptr.To("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName,
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -48,7 +48,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName,
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -57,7 +57,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName,
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -65,7 +65,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace)
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
 			},
 		}
 	})
@@ -83,7 +83,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 			InfrastructureProvider: ptr.To("docker"),
 			// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName,
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -92,7 +92,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName,
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -101,7 +101,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName,
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -109,7 +109,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace)
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.GetOwnerGraphFilterByClusterNameFunc(clusterName))
 			},
 		}
 	})

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 
+	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/kubetest"
 )
@@ -39,7 +40,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 			InfrastructureProvider: ptr.To("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -48,7 +49,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -57,7 +58,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -65,7 +66,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 		}
 	})
@@ -83,7 +84,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 			InfrastructureProvider: ptr.To("docker"),
 			// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
-				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -92,7 +93,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
-				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
 					framework.DockerInfraOwnerReferenceAssertions,
@@ -101,7 +102,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
-				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, framework.SkipClusterObjectsWithoutNameContains(clusterName),
+				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
@@ -109,7 +110,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, framework.SkipClusterObjectsWithoutNameContains(clusterName))
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 		}
 	})

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -382,11 +382,11 @@ func setClusterPause(ctx context.Context, cli client.Client, clusterKey types.Na
 	Expect(cli.Patch(ctx, cluster, pausePatch)).To(Succeed())
 }
 
-// GetOwnerGraphFilterByClusterNameFunc is used in e2e tests where the owner graph gets queried
-// to filter out cluster-wide objects which don't have the clusterName in their
-// object name. This avoids assertions on objects which are part of in-parallel
+// SkipClusterObjectsWithoutNameContains is used in e2e tests where the owner graph
+// gets queried to filter out cluster-wide objects which don't have the clusterName
+// in their object name. This avoids assertions on objects which are part of in-parallel
 // running tests like ExtensionConfig.
-func GetOwnerGraphFilterByClusterNameFunc(clusterName string) func(u unstructured.Unstructured) bool {
+func SkipClusterObjectsWithoutNameContains(clusterName string) func(u unstructured.Unstructured) bool {
 	return func(u unstructured.Unstructured) bool {
 		// Ignore cluster-wide objects which don't have the clusterName in their object
 		// name to avoid asserting on cluster-wide objects which get created or deleted

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -382,22 +382,6 @@ func setClusterPause(ctx context.Context, cli client.Client, clusterKey types.Na
 	Expect(cli.Patch(ctx, cluster, pausePatch)).To(Succeed())
 }
 
-// SkipClusterObjectsWithoutNameContains is used in e2e tests where the owner graph
-// gets queried to filter out cluster-wide objects which don't have the clusterName
-// in their object name. This avoids assertions on objects which are part of in-parallel
-// running tests like ExtensionConfig.
-func SkipClusterObjectsWithoutNameContains(clusterName string) func(u unstructured.Unstructured) bool {
-	return func(u unstructured.Unstructured) bool {
-		// Ignore cluster-wide objects which don't have the clusterName in their object
-		// name to avoid asserting on cluster-wide objects which get created or deleted
-		// by tests which run in-parallel (e.g. ExtensionConfig).
-		if u.GetNamespace() == "" && !strings.Contains(u.GetName(), clusterName) {
-			return false
-		}
-		return true
-	}
-}
-
 // forceClusterClassReconcile force reconciliation of the ClusterClass associated with the Cluster if one exists. If the
 // Cluster has no ClusterClass this is a no-op.
 func forceClusterClassReconcile(ctx context.Context, cli client.Client, clusterKey types.NamespacedName) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In a rare test case where k8s-upgrade-with-runtime-sdk and the quickstart tests's assertion on `ValidateResourceVersionStable` are run in-parallel, we can have a flaky test because:

Getting the owner graph included the RuntimeExtension. When `k8s-upgrade-with-runtime-sdk` finishes, it deleted the CR again, so the assertion in `ValidateResourceVersionStable` failed and the test failed.

xref: [failure occurency](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/10552/pull-cluster-api-e2e-main/1786405514213593088)

Also: enables the `ValidateResourceVersionStable` test for the `k8s-upgrade-with-runtime-sdk` to also test the ExtensionConfig.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing