### PR TITLE
📖 Document failureReason and Message are considered terminal errors

### DIFF
--- a/docs/book/src/developer/architecture/controllers/cluster.md
+++ b/docs/book/src/developer/architecture/controllers/cluster.md
@@ -51,7 +51,7 @@ is a map, defined as `map[string]FailureDomainSpec`. A unique key must be used f
     - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
 Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the infrastructureCluster object, 
-they cannot be restored anymore (it is considered a terminal error).
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the cluster).
 
 Example:
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/cluster.md
+++ b/docs/book/src/developer/architecture/controllers/cluster.md
@@ -50,8 +50,8 @@ is a map, defined as `map[string]FailureDomainSpec`. A unique key must be used f
     - `controlPlane` (bool): indicates if failure domain is appropriate for running control plane instances.
     - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is 
-considered a terminal error).
+Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the infrastructureCluster object, 
+they cannot be restored anymore (it is considered a terminal error).
 
 Example:
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/cluster.md
+++ b/docs/book/src/developer/architecture/controllers/cluster.md
@@ -50,6 +50,9 @@ is a map, defined as `map[string]FailureDomainSpec`. A unique key must be used f
     - `controlPlane` (bool): indicates if failure domain is appropriate for running control plane instances.
     - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is 
+considered a terminal error).
+
 Example:
 ```yaml
 kind: MyProviderCluster

--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -234,6 +234,9 @@ The `status` object **may** define several fields:
   exist in the cluster. For example, managed control plane providers for AKS, EKS, GKE, etc, should
   set this to `true`. Leaving the field undefined is equivalent to setting the value to `false`.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is
+considered a terminal error).
+
 ## Example usage
 
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -235,7 +235,7 @@ The `status` object **may** define several fields:
   set this to `true`. Leaving the field undefined is equivalent to setting the value to `false`.
 
 Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the control plane object,
-they cannot be restored anymore (it is considered a terminal error).
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the cluster).
 
 ## Example usage
 

--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -234,8 +234,8 @@ The `status` object **may** define several fields:
   exist in the cluster. For example, managed control plane providers for AKS, EKS, GKE, etc, should
   set this to `true`. Leaving the field undefined is equivalent to setting the value to `false`.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is
-considered a terminal error).
+Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the control plane object,
+they cannot be restored anymore (it is considered a terminal error).
 
 ## Example usage
 

--- a/docs/book/src/developer/architecture/controllers/machine-pool.md
+++ b/docs/book/src/developer/architecture/controllers/machine-pool.md
@@ -61,6 +61,9 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureReason` - a string field explaining why a fatal error has occurred, if possible.
 * `failureMessage` - a string field that holds the message contained by the error.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the machine pool, they cannot be restored anymore (this is
+considered a terminal error). 
+
 Example:
 
 ```yaml
@@ -97,7 +100,10 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureMessage` - is a string that holds the message contained by the error.
 * `infrastructureMachineKind` - the kind of the InfraMachines. This should be set if the InfrastructureMachinePool plans to support MachinePool Machines.
 
-**Note:** Infrastructure providers can support MachinePool Machines by having the InfraMachinePool set the `infrastructureMachineKind` to the kind of their InfrastructureMachines. The InfrastructureMachinePool will be responsible for creating InfrastructureMachines as the MachinePool is scaled up, and the MachinePool controller will create Machines for each InfrastructureMachine and set the ownerRef. The InfrastructureMachinePool will be responsible for deleting the Machines as the MachinePool is scaled down in order for the Machine deletion workflow to function properly. In addition, the InfrastructureMachines must also have the following labels set by the InfrastructureMachinePool: `cluster.x-k8s.io/cluster-name` and `cluster.x-k8s.io/pool-name`. The `MachinePoolNameLabel` must also be formatted with `capilabels.MustFormatValue()` so that it will not exceed character limits.
+Note: once any of `failureMessage` or `failureMessage` surface on the machine pool, they cannot be restored anymore (it is
+considered a terminal error).
+
+Note: Infrastructure providers can support MachinePool Machines by having the InfraMachinePool set the `infrastructureMachineKind` to the kind of their InfrastructureMachines. The InfrastructureMachinePool will be responsible for creating InfrastructureMachines as the MachinePool is scaled up, and the MachinePool controller will create Machines for each InfrastructureMachine and set the ownerRef. The InfrastructureMachinePool will be responsible for deleting the Machines as the MachinePool is scaled down in order for the Machine deletion workflow to function properly. In addition, the InfrastructureMachines must also have the following labels set by the InfrastructureMachinePool: `cluster.x-k8s.io/cluster-name` and `cluster.x-k8s.io/pool-name`. The `MachinePoolNameLabel` must also be formatted with `capilabels.MustFormatValue()` so that it will not exceed character limits.
 
 Example
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/machine-pool.md
+++ b/docs/book/src/developer/architecture/controllers/machine-pool.md
@@ -62,7 +62,7 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureMessage` - a string field that holds the message contained by the error.
 
 Note: once any of `failureReason` or `failureMessage` surface on the machine pool who is referencing the bootstrap config object, 
-they cannot be restored anymore (this is considered a terminal error). 
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine pool). 
 
 Example:
 
@@ -101,7 +101,7 @@ The `status` object **may** define several fields that do not affect functionali
 * `infrastructureMachineKind` - the kind of the InfraMachines. This should be set if the InfrastructureMachinePool plans to support MachinePool Machines.
 
 Note: once any of `failureReason` or `failureMessage` surface on the machine pool who is referencing the InfrastructureMachinePool object, 
-they cannot be restored anymore (it is considered a terminal error).
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine pool).
 
 Note: Infrastructure providers can support MachinePool Machines by having the InfraMachinePool set the `infrastructureMachineKind` to the kind of their InfrastructureMachines. The InfrastructureMachinePool will be responsible for creating InfrastructureMachines as the MachinePool is scaled up, and the MachinePool controller will create Machines for each InfrastructureMachine and set the ownerRef. The InfrastructureMachinePool will be responsible for deleting the Machines as the MachinePool is scaled down in order for the Machine deletion workflow to function properly. In addition, the InfrastructureMachines must also have the following labels set by the InfrastructureMachinePool: `cluster.x-k8s.io/cluster-name` and `cluster.x-k8s.io/pool-name`. The `MachinePoolNameLabel` must also be formatted with `capilabels.MustFormatValue()` so that it will not exceed character limits.
 

--- a/docs/book/src/developer/architecture/controllers/machine-pool.md
+++ b/docs/book/src/developer/architecture/controllers/machine-pool.md
@@ -61,8 +61,8 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureReason` - a string field explaining why a fatal error has occurred, if possible.
 * `failureMessage` - a string field that holds the message contained by the error.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine pool, they cannot be restored anymore (this is
-considered a terminal error). 
+Note: once any of `failureReason` or `failureMessage` surface on the machine pool who is referencing the bootstrap config object, 
+they cannot be restored anymore (this is considered a terminal error). 
 
 Example:
 
@@ -100,8 +100,8 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureMessage` - is a string that holds the message contained by the error.
 * `infrastructureMachineKind` - the kind of the InfraMachines. This should be set if the InfrastructureMachinePool plans to support MachinePool Machines.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine pool, they cannot be restored anymore (it is
-considered a terminal error).
+Note: once any of `failureReason` or `failureMessage` surface on the machine pool who is referencing the InfrastructureMachinePool object, 
+they cannot be restored anymore (it is considered a terminal error).
 
 Note: Infrastructure providers can support MachinePool Machines by having the InfraMachinePool set the `infrastructureMachineKind` to the kind of their InfrastructureMachines. The InfrastructureMachinePool will be responsible for creating InfrastructureMachines as the MachinePool is scaled up, and the MachinePool controller will create Machines for each InfrastructureMachine and set the ownerRef. The InfrastructureMachinePool will be responsible for deleting the Machines as the MachinePool is scaled down in order for the Machine deletion workflow to function properly. In addition, the InfrastructureMachines must also have the following labels set by the InfrastructureMachinePool: `cluster.x-k8s.io/cluster-name` and `cluster.x-k8s.io/pool-name`. The `MachinePoolNameLabel` must also be formatted with `capilabels.MustFormatValue()` so that it will not exceed character limits.
 

--- a/docs/book/src/developer/architecture/controllers/machine.md
+++ b/docs/book/src/developer/architecture/controllers/machine.md
@@ -61,6 +61,10 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureReason` - a string field explaining why a fatal error has occurred, if possible.
 * `failureMessage` - a string field that holds the message contained by the error.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
+considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
+automatically remediated.
+
 Example:
 
 ```yaml
@@ -104,6 +108,10 @@ external DNS names, and/or internal DNS names for the provider's machine instanc
 defined as:
     - `type` (string): one of `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`
     - `address` (string)
+
+Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore  (this is
+considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
+automatically remediated.
 
 Example:
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/machine.md
+++ b/docs/book/src/developer/architecture/controllers/machine.md
@@ -61,9 +61,9 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureReason` - a string field explaining why a fatal error has occurred, if possible.
 * `failureMessage` - a string field that holds the message contained by the error.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
-considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
-automatically remediated.
+Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the bootstrap config object, 
+they cannot be restored anymore (it is considered a terminal error). 
+Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Example:
 
@@ -109,9 +109,9 @@ defined as:
     - `type` (string): one of `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`
     - `address` (string)
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore  (this is
-considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
-automatically remediated.
+Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the infrastructureMachine object, 
+they cannot be restored anymore  (this is considered a terminal error). 
+Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Example:
 ```yaml

--- a/docs/book/src/developer/architecture/controllers/machine.md
+++ b/docs/book/src/developer/architecture/controllers/machine.md
@@ -62,7 +62,7 @@ The `status` object **may** define several fields that do not affect functionali
 * `failureMessage` - a string field that holds the message contained by the error.
 
 Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the bootstrap config object, 
-they cannot be restored anymore (it is considered a terminal error). 
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine). 
 Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Example:
@@ -110,7 +110,7 @@ defined as:
     - `address` (string)
 
 Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the infrastructureMachine object, 
-they cannot be restored anymore  (this is considered a terminal error). 
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine). 
 Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Example:

--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -27,8 +27,8 @@ A bootstrap provider must define an API type for bootstrap resources. The type:
         2. `failureMessage` (string): indicates there is a fatal problem reconciling the bootstrap data;
             meant to be a more descriptive value than `failureReason`
 
-Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the bootstrap config object, 
-they cannot be restored anymore (it is considered a terminal error). 
+Note: once any of `failureReason` or `failureMessage` surface on the machine/machine pool who is referencing the bootstrap config object, 
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine/machine pool). 
 Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Note: because the `dataSecretName` is part of `status`, this value must be deterministically recreatable from the data in the

--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -27,6 +27,10 @@ A bootstrap provider must define an API type for bootstrap resources. The type:
         2. `failureMessage` (string): indicates there is a fatal problem reconciling the bootstrap data;
             meant to be a more descriptive value than `failureReason`
 
+Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
+considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
+automatically remediated.
+
 Note: because the `dataSecretName` is part of `status`, this value must be deterministically recreatable from the data in the
 `Cluster`, `Machine`, and/or bootstrap resource. If the name is randomly generated, it is not always possible to move
 the resource and its associated secret from one management cluster to another.

--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -27,9 +27,9 @@ A bootstrap provider must define an API type for bootstrap resources. The type:
         2. `failureMessage` (string): indicates there is a fatal problem reconciling the bootstrap data;
             meant to be a more descriptive value than `failureReason`
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
-considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
-automatically remediated.
+Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the bootstrap config object, 
+they cannot be restored anymore (it is considered a terminal error). 
+Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 Note: because the `dataSecretName` is part of `status`, this value must be deterministically recreatable from the data in the
 `Cluster`, `Machine`, and/or bootstrap resource. If the name is randomly generated, it is not always possible to move

--- a/docs/book/src/developer/providers/cluster-infrastructure.md
+++ b/docs/book/src/developer/providers/cluster-infrastructure.md
@@ -37,7 +37,7 @@ A cluster infrastructure provider must define an API type for "infrastructure cl
             - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
 Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the infrastructureCluster object,
-they cannot be restored anymore (it is considered a terminal error).
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the cluster).
 
 ### InfraClusterTemplate Resources
 

--- a/docs/book/src/developer/providers/cluster-infrastructure.md
+++ b/docs/book/src/developer/providers/cluster-infrastructure.md
@@ -36,6 +36,9 @@ A cluster infrastructure provider must define an API type for "infrastructure cl
             - `controlPlane` (bool): indicates if failure domain is appropriate for running control plane instances.
             - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is
+considered a terminal error).
+
 ### InfraClusterTemplate Resources
 
 For a given InfraCluster resource, you should also add a corresponding InfraClusterTemplate resources:

--- a/docs/book/src/developer/providers/cluster-infrastructure.md
+++ b/docs/book/src/developer/providers/cluster-infrastructure.md
@@ -36,8 +36,8 @@ A cluster infrastructure provider must define an API type for "infrastructure cl
             - `controlPlane` (bool): indicates if failure domain is appropriate for running control plane instances.
             - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the cluster, they cannot be restored anymore (it is
-considered a terminal error).
+Note: once any of `failureReason` or `failureMessage` surface on the cluster who is referencing the infrastructureCluster object,
+they cannot be restored anymore (it is considered a terminal error).
 
 ### InfraClusterTemplate Resources
 

--- a/docs/book/src/developer/providers/machine-infrastructure.md
+++ b/docs/book/src/developer/providers/machine-infrastructure.md
@@ -46,7 +46,7 @@ A machine infrastructure provider must define an API type for "infrastructure ma
    1. A Ready condition to represent the overall operational state of the component. It can be based on the summary of more detailed conditions existing on the same object, e.g. instanceReady, SecurityGroupsReady conditions.
 
 Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the infrastructureMachine object,
-they cannot be restored anymore  (this is considered a terminal error).
+they cannot be restored anymore (it is considered a terminal error; the only way to recover is to delete and recreate the machine).
 Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 ### InfraMachineTemplate Resources

--- a/docs/book/src/developer/providers/machine-infrastructure.md
+++ b/docs/book/src/developer/providers/machine-infrastructure.md
@@ -45,9 +45,9 @@ A machine infrastructure provider must define an API type for "infrastructure ma
 7. Should have a conditions field with the following:
    1. A Ready condition to represent the overall operational state of the component. It can be based on the summary of more detailed conditions existing on the same object, e.g. instanceReady, SecurityGroupsReady conditions.
 
-Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
-considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
-automatically remediated.
+Note: once any of `failureReason` or `failureMessage` surface on the machine who is referencing the infrastructureMachine object,
+they cannot be restored anymore  (this is considered a terminal error).
+Also, if the machine is under control of a MachineHealthCheck instance, the machine will be automatically remediated.
 
 ### InfraMachineTemplate Resources
 

--- a/docs/book/src/developer/providers/machine-infrastructure.md
+++ b/docs/book/src/developer/providers/machine-infrastructure.md
@@ -45,6 +45,9 @@ A machine infrastructure provider must define an API type for "infrastructure ma
 7. Should have a conditions field with the following:
    1. A Ready condition to represent the overall operational state of the component. It can be based on the summary of more detailed conditions existing on the same object, e.g. instanceReady, SecurityGroupsReady conditions.
 
+Note: once any of `failureMessage` or `failureMessage` surface on the machine, they cannot be restored anymore (it is
+considered a terminal error). Also, if the machine is under control of a MachineHealthCheck instance, the machine will be
+automatically remediated.
 
 ### InfraMachineTemplate Resources
 

--- a/docs/book/src/tasks/automated-machine-management/healthchecking.md
+++ b/docs/book/src/tasks/automated-machine-management/healthchecking.md
@@ -20,7 +20,7 @@ A MachineHealthCheck is a resource within the Cluster API which allows users to 
 A MachineHealthCheck is defined on a management cluster and scoped to a particular workload cluster.
 
 When defining a MachineHealthCheck, users specify a timeout for each of the conditions that they define to check on the Machine's Node.
-If any of these conditions are met for the duration of the timeout, the Machine will be remediated.
+If any of these conditions are met for the duration of the timeout, the Machine will be remediated. Also, Machines with `failureMessage` or `failureMessage` (terminal failures) are automatically remediated.
 By default, the action of remediating a Machine should trigger a new Machine to be created to replace the failed one, but providers are allowed to plug in more sophisticated external remediation solutions.
 
 ## Creating a MachineHealthCheck


### PR DESCRIPTION
**What this PR does / why we need it**:
To document in the book that error surfaced by failureReason and Message are considered terminal errors by CAPI controllers (Fatal error = Terminal error, it cannot be recovered)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/7191

/area documentation
