### PR TITLE
🌱 Use setup-envtest from CR main (05/2024) to use envtest binaries from CT releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,11 @@ KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
 KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v5
 
-SETUP_ENVTEST_VER := v0.0.0-20240215143116-d0396a3d6f9f
+# This is a commit from CR main (22.05.2024).
+# Intentionally using a commit from main to use a setup-envtest version
+# that uses binaries from controller-tools, not GCS.
+# CR PR: https://github.com/kubernetes-sigs/controller-runtime/pull/2811
+SETUP_ENVTEST_VER := v0.0.0-20240522175850-2e9781e9fc60
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest

--- a/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
+++ b/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
@@ -24,3 +24,6 @@ maintainers of providers and consumers of our Go API.
 ### Suggested changes for providers
 
 - From Cluster API v1.7 the manager pods are created with `terminationMessagePolicy` set to `FallbackToLogsOnError` for the manager container. This offers the chance that the pod's termination message will contain something useful if the manager exits unexpectedly, which in turn makes debugging easier. We also recommend this setting to provider managers. For an example, see the corresponding change in [CAPV](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2988) or [CAPO](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2070).
+- It's highly recommended to move to a new setup-envtest version that uses envtest binaries from controller-tools releases
+  instead of the deprecated GCS bucket. More details can be found in [#10569](https://github.com/kubernetes-sigs/cluster-api/pull/10569)
+  and [kubernetes-sigs/controller-runtime#2811](https://github.com/kubernetes-sigs/controller-runtime/pull/2811).


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Context: https://github.com/kubernetes-sigs/controller-runtime/pull/2811

I'm going to backport this to all branches (and also CAPV)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->