### PR TITLE
🌱 Optimize dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,22 +7,29 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
   commit-message:
       prefix: ":seedling:"
   labels:
     - "area/ci"
     - "ok-to-test"
 
-# Main Go module
+# Go modules
 - package-ecosystem: "gomod"
-  directory: "/"
+  directories:
+  - "/"
+  - "/test"
+  - "/hack/tools"
   schedule:
     interval: "weekly"
     day: "monday"
   ## group all dependencies with a k8s.io prefix into a single PR.
   groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
+    all-go-mod-patch-and-minor:
+      patterns: [ "*" ]
+      update-types: [ "patch", "minor" ]
   ignore:
   # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
@@ -37,66 +44,6 @@ updates:
     # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
   - dependency-name: "sigs.k8s.io/kustomize/api"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "area/dependency"
-    - "ok-to-test"
-
-  # Test Go module
-- package-ecosystem: "gomod"
-  directory: "/test"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  ignore:
-    # Ignore controller-runtime as its upgraded manually.
-    - dependency-name: "sigs.k8s.io/controller-runtime"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-    - dependency-name: "k8s.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "go.etcd.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "google.golang.org/grpc"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
-    - dependency-name: "sigs.k8s.io/kustomize/api"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "area/dependency"
-    - "ok-to-test"
-
-  # Hack/tools Go module
-- package-ecosystem: "gomod"
-  directory: "/hack/tools"
-  schedule:
-    interval: "weekly"
-    day: "wednesday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  ignore:
-    # Ignore controller-runtime as its upgraded manually.
-    - dependency-name: "sigs.k8s.io/controller-runtime"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-    - dependency-name: "k8s.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "go.etcd.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "google.golang.org/grpc"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
-    - dependency-name: "sigs.k8s.io/kustomize/api"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   commit-message:
     prefix: ":seedling:"
   labels:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR aims to reduce dependabot toil by:
* bumping all GitHub actions in a single PR
* bumping all patch & minor versions in a single PR
  * This should lead rarely to issues (e.g. compile issues), if it does we can still fixup the PR by pushing an additional commit.
* bumping all go modules in a single PR
  * https://github.com/dependabot/dependabot-core/issues/1595
  * https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

Ideally we'll mostly get 2 PRs every week, one for actions one for go dependencies

I would like to experiment a bit with this config. If it works out well we can keep it (and also use it in other repos like e.g. CAPV)

Example PRs:
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2980
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2981
* https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2982

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->