### PR TITLE
🌱 Flag for old infra machine naming

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+            - "--use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}"
           image: controller:latest
           name: manager

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -93,15 +93,19 @@ type MachineSetReconciler struct {
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
+
+	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
+	DeprecatedInfraMachineNaming bool
 }
 
 func (r *MachineSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinesetcontroller.Reconciler{
-		Client:                    r.Client,
-		UnstructuredCachingClient: r.UnstructuredCachingClient,
-		APIReader:                 r.APIReader,
-		Tracker:                   r.Tracker,
-		WatchFilterValue:          r.WatchFilterValue,
+		Client:                       r.Client,
+		UnstructuredCachingClient:    r.UnstructuredCachingClient,
+		APIReader:                    r.APIReader,
+		Tracker:                      r.Tracker,
+		WatchFilterValue:             r.WatchFilterValue,
+		DeprecatedInfraMachineNaming: r.DeprecatedInfraMachineNaming,
 	}).SetupWithManager(ctx, mgr, options)
 }
 

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+            - "--use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}"
           image: controller:latest
           name: manager

--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -39,16 +39,20 @@ type KubeadmControlPlaneReconciler struct {
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
+
+	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
+	DeprecatedInfraMachineNaming bool
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:              r.Client,
-		SecretCachingClient: r.SecretCachingClient,
-		Tracker:             r.Tracker,
-		EtcdDialTimeout:     r.EtcdDialTimeout,
-		EtcdCallTimeout:     r.EtcdCallTimeout,
-		WatchFilterValue:    r.WatchFilterValue,
+		Client:                       r.Client,
+		SecretCachingClient:          r.SecretCachingClient,
+		Tracker:                      r.Tracker,
+		EtcdDialTimeout:              r.EtcdDialTimeout,
+		EtcdCallTimeout:              r.EtcdCallTimeout,
+		WatchFilterValue:             r.WatchFilterValue,
+		DeprecatedInfraMachineNaming: r.DeprecatedInfraMachineNaming,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -84,6 +84,9 @@ type KubeadmControlPlaneReconciler struct {
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 
+	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
+	DeprecatedInfraMachineNaming bool
+
 	managementCluster         internal.ManagementCluster
 	managementClusterUncached internal.ManagementCluster
 	ssaCache                  ssa.Cache

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -180,12 +180,16 @@ func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx conte
 		UID:        kcp.UID,
 	}
 
+	infraMachineName := machine.Name
+	if r.DeprecatedInfraMachineNaming {
+		infraMachineName = names.SimpleNameGenerator.GenerateName(kcp.Spec.MachineTemplate.InfrastructureRef.Name + "-")
+	}
 	// Clone the infrastructure template
 	infraRef, err := external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 		Client:      r.Client,
 		TemplateRef: &kcp.Spec.MachineTemplate.InfrastructureRef,
 		Namespace:   kcp.Namespace,
-		Name:        machine.Name,
+		Name:        infraMachineName,
 		OwnerRef:    infraCloneOwner,
 		ClusterName: cluster.Name,
 		Labels:      internal.ControlPlaneMachineLabelsForCluster(kcp, cluster.Name),

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -84,10 +84,11 @@ var (
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
 	logOptions                  = logs.NewOptions()
 	// KCP specific flags.
-	kubeadmControlPlaneConcurrency int
-	clusterCacheTrackerConcurrency int
-	etcdDialTimeout                time.Duration
-	etcdCallTimeout                time.Duration
+	kubeadmControlPlaneConcurrency  int
+	clusterCacheTrackerConcurrency  int
+	etcdDialTimeout                 time.Duration
+	etcdCallTimeout                 time.Duration
+	useDeprecatedInfraMachineNaming bool
 )
 
 func init() {
@@ -158,6 +159,10 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.DurationVar(&etcdCallTimeout, "etcd-call-timeout-duration", etcd.DefaultCallTimeout,
 		"Duration that the etcd client waits at most for read and write operations to etcd.")
+
+	fs.BoolVar(&useDeprecatedInfraMachineNaming, "use-deprecated-infra-machine-naming", false,
+		"Use the deprecated naming convention for infra machines where they are named after the InfraMachineTemplate.")
+	_ = fs.MarkDeprecated("use-deprecated-infra-machine-naming", "This flag will be removed in v1.9.")
 
 	flags.AddDiagnosticsOptions(fs, &diagnosticsOptions)
 	flags.AddTLSOptions(fs, &tlsOptions)
@@ -332,12 +337,13 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:              mgr.GetClient(),
-		SecretCachingClient: secretCachingClient,
-		Tracker:             tracker,
-		WatchFilterValue:    watchFilterValue,
-		EtcdDialTimeout:     etcdDialTimeout,
-		EtcdCallTimeout:     etcdCallTimeout,
+		Client:                       mgr.GetClient(),
+		SecretCachingClient:          secretCachingClient,
+		Tracker:                      tracker,
+		WatchFilterValue:             watchFilterValue,
+		EtcdDialTimeout:              etcdDialTimeout,
+		EtcdCallTimeout:              etcdCallTimeout,
+		DeprecatedInfraMachineNaming: useDeprecatedInfraMachineNaming,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")
 		os.Exit(1)

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -87,6 +87,9 @@ type Reconciler struct {
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 
+	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
+	DeprecatedInfraMachineNaming bool
+
 	ssaCache ssa.Cache
 	recorder record.EventRecorder
 }
@@ -497,12 +500,16 @@ func (r *Reconciler) syncReplicas(ctx context.Context, cluster *clusterv1.Cluste
 				log = log.WithValues(bootstrapRef.Kind, klog.KRef(bootstrapRef.Namespace, bootstrapRef.Name))
 			}
 
+			infraMachineName := machine.Name
+			if r.DeprecatedInfraMachineNaming {
+				infraMachineName = names.SimpleNameGenerator.GenerateName(ms.Spec.Template.Spec.InfrastructureRef.Name + "-")
+			}
 			// Create the InfraMachine.
 			infraRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 				Client:      r.UnstructuredCachingClient,
 				TemplateRef: &ms.Spec.Template.Spec.InfrastructureRef,
 				Namespace:   machine.Namespace,
-				Name:        machine.Name,
+				Name:        infraMachineName,
 				ClusterName: machine.Spec.ClusterName,
 				Labels:      machine.Labels,
 				Annotations: machine.Annotations,

--- a/main.go
+++ b/main.go
@@ -101,18 +101,19 @@ var (
 	diagnosticsOptions          = flags.DiagnosticsOptions{}
 	logOptions                  = logs.NewOptions()
 	// core Cluster API specific flags.
-	clusterTopologyConcurrency     int
-	clusterCacheTrackerConcurrency int
-	clusterClassConcurrency        int
-	clusterConcurrency             int
-	extensionConfigConcurrency     int
-	machineConcurrency             int
-	machineSetConcurrency          int
-	machineDeploymentConcurrency   int
-	machinePoolConcurrency         int
-	clusterResourceSetConcurrency  int
-	machineHealthCheckConcurrency  int
-	nodeDrainClientTimeout         time.Duration
+	clusterTopologyConcurrency      int
+	clusterCacheTrackerConcurrency  int
+	clusterClassConcurrency         int
+	clusterConcurrency              int
+	extensionConfigConcurrency      int
+	machineConcurrency              int
+	machineSetConcurrency           int
+	machineDeploymentConcurrency    int
+	machinePoolConcurrency          int
+	clusterResourceSetConcurrency   int
+	machineHealthCheckConcurrency   int
+	nodeDrainClientTimeout          time.Duration
+	useDeprecatedInfraMachineNaming bool
 )
 
 func init() {
@@ -220,6 +221,10 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
+
+	fs.BoolVar(&useDeprecatedInfraMachineNaming, "use-deprecated-infra-machine-naming", false,
+		"Use deprecated infrastructure machine naming")
+	_ = fs.MarkDeprecated("use-deprecated-infra-machine-naming", "This flag will be removed in v1.9.")
 
 	flags.AddDiagnosticsOptions(fs, &diagnosticsOptions)
 	flags.AddTLSOptions(fs, &tlsOptions)
@@ -506,11 +511,12 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) webhooks.ClusterCac
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineSetReconciler{
-		Client:                    mgr.GetClient(),
-		UnstructuredCachingClient: unstructuredCachingClient,
-		APIReader:                 mgr.GetAPIReader(),
-		Tracker:                   tracker,
-		WatchFilterValue:          watchFilterValue,
+		Client:                       mgr.GetClient(),
+		UnstructuredCachingClient:    unstructuredCachingClient,
+		APIReader:                    mgr.GetAPIReader(),
+		Tracker:                      tracker,
+		WatchFilterValue:             watchFilterValue,
+		DeprecatedInfraMachineNaming: useDeprecatedInfraMachineNaming,
 	}).SetupWithManager(ctx, mgr, concurrency(machineSetConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a breaking change to the way InfraMachines are named in v1.7.0. This commit adds a flag to the KCP and core controller for getting the old behavior back. It defaults to disabled so the new behavior stays. It is also marked as deprecated and to be removed in v1.9.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Stop-gap solution for https://github.com/kubernetes-sigs/cluster-api/issues/10463

/area provider/control-plane-kubeadm
/area machineset