### PR TITLE
🌱 Set terminationMessagePolicy to FallbackToLogsOnError for all managers

### DIFF
--- a/bootstrap/kubeadm/config/manager/manager.yaml
+++ b/bootstrap/kubeadm/config/manager/manager.yaml
@@ -62,6 +62,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,6 +62,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -61,6 +61,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:

--- a/test/extension/config/default/manager.yaml
+++ b/test/extension/config/default/manager.yaml
@@ -48,6 +48,7 @@ spec:
             privileged: false
             runAsUser: 65532
             runAsGroup: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -58,6 +58,7 @@ spec:
             name: dockersock
         securityContext:
           privileged: true
+        terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:

--- a/test/infrastructure/inmemory/config/manager/manager.yaml
+++ b/test/infrastructure/inmemory/config/manager/manager.yaml
@@ -52,6 +52,7 @@ spec:
           privileged: false
           runAsUser: 65532
           runAsGroup: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:


### PR DESCRIPTION
This ensures we have a useful termination message in the Pod if a manager exits unexpectedly.

/area logging