### PR TITLE
🌱  Allow control plane count to be configurable in clusterctl upgrade test.

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -391,9 +391,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			kubernetesVersion = input.E2EConfig.GetVariable(KubernetesVersion)
 		}
 		controlPlaneMachineCount := ptr.To[int64](1)
-
-		// Don't set controlPlaneMachineCount to 0 to satisfy the validation in the cluster template.
-		if input.ControlPlaneMachineCount != nil && *input.ControlPlaneMachineCount != int64(0) {
+		if input.ControlPlaneMachineCount != nil {
 			controlPlaneMachineCount = input.ControlPlaneMachineCount
 		}
 		workerMachineCount := ptr.To[int64](1)
@@ -445,10 +443,6 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		expectedMachinePoolMachineCount, err := calculateExpectedMachinePoolMachineCount(ctx, managementClusterProxy.GetClient(), workloadClusterNamespace, workloadClusterName)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Account for clusters that have a control plane count of 0.
-		if input.ControlPlaneMachineCount != nil && *input.ControlPlaneMachineCount == int64(0) {
-			controlPlaneMachineCount = input.ControlPlaneMachineCount
-		}
 		expectedMachineCount := *controlPlaneMachineCount + expectedMachineDeploymentMachineCount + expectedMachinePoolMachineCount
 
 		Byf("Expect %d Machines and %d MachinePool replicas to exist", expectedMachineCount, expectedMachinePoolNodeCount)

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -130,6 +130,9 @@ type ClusterctlUpgradeSpecInput struct {
 	// If not set, the test will upgrade once to the v1beta1 contract.
 	// For some examples see clusterctl_upgrade_test.go
 	Upgrades []ClusterctlUpgradeSpecInputUpgrade
+
+	// ControlPlaneMachineCount specifies the number of control plane machines to create in the workload cluster.
+	ControlPlaneMachineCount *int64
 }
 
 // ClusterctlUpgradeSpecInputUpgrade defines an upgrade.
@@ -388,6 +391,11 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			kubernetesVersion = input.E2EConfig.GetVariable(KubernetesVersion)
 		}
 		controlPlaneMachineCount := ptr.To[int64](1)
+
+		// Don't set controlPlaneMachineCount to 0 to satisfy the validation in the cluster template.
+		if input.ControlPlaneMachineCount != nil && *input.ControlPlaneMachineCount != int64(0) {
+			controlPlaneMachineCount = input.ControlPlaneMachineCount
+		}
 		workerMachineCount := ptr.To[int64](1)
 
 		log.Logf("Creating the workload cluster with name %q using the %q template (Kubernetes %s, %d control-plane machines, %d worker machines)",
@@ -436,6 +444,11 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		expectedMachinePoolNodeCount := calculateExpectedMachinePoolNodeCount(ctx, managementClusterProxy.GetClient(), workloadClusterUnstructured, coreCAPIStorageVersion)
 		expectedMachinePoolMachineCount, err := calculateExpectedMachinePoolMachineCount(ctx, managementClusterProxy.GetClient(), workloadClusterNamespace, workloadClusterName)
 		Expect(err).ToNot(HaveOccurred())
+
+		// Account for clusters that have a control plane count of 0.
+		if input.ControlPlaneMachineCount != nil && *input.ControlPlaneMachineCount == int64(0) {
+			controlPlaneMachineCount = input.ControlPlaneMachineCount
+		}
 		expectedMachineCount := *controlPlaneMachineCount + expectedMachineDeploymentMachineCount + expectedMachinePoolMachineCount
 
 		Byf("Expect %d Machines and %d MachinePool replicas to exist", expectedMachineCount, expectedMachinePoolNodeCount)

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -378,49 +378,29 @@ func ConfigClusterWithBinary(_ context.Context, clusterctlBinaryPath string, inp
 	Expect(err).ToNot(HaveOccurred())
 	clusterctlSupportsGenerateCluster := version.GTE(semver.MustParse("1.0.0"))
 
-	var cmd *exec.Cmd
+	var command string
 	if clusterctlSupportsGenerateCluster {
-		log.Logf("clusterctl generate cluster %s --infrastructure %s --kubernetes-version %s --control-plane-machine-count %d --worker-machine-count %d --flavor %s",
-			input.ClusterName,
-			valueOrDefault(input.InfrastructureProvider),
-			input.KubernetesVersion,
-			*input.ControlPlaneMachineCount,
-			*input.WorkerMachineCount,
-			valueOrDefault(input.Flavor),
-		)
-		cmd = exec.Command(clusterctlBinaryPath, "generate", "cluster", //nolint:gosec // We don't care about command injection here.
-			input.ClusterName,
-			"--infrastructure", input.InfrastructureProvider,
-			"--kubernetes-version", input.KubernetesVersion,
-			"--control-plane-machine-count", fmt.Sprint(*input.ControlPlaneMachineCount),
-			"--worker-machine-count", fmt.Sprint(*input.WorkerMachineCount),
-			"--flavor", input.Flavor,
-			"--target-namespace", input.Namespace,
-			"--config", input.ClusterctlConfigPath,
-			"--kubeconfig", input.KubeconfigPath,
-		)
+		command = "generate"
 	} else {
-		log.Logf("clusterctl config cluster %s --infrastructure %s --kubernetes-version %s --control-plane-machine-count %d --worker-machine-count %d --flavor %s",
-			input.ClusterName,
-			valueOrDefault(input.InfrastructureProvider),
-			input.KubernetesVersion,
-			*input.ControlPlaneMachineCount,
-			*input.WorkerMachineCount,
-			valueOrDefault(input.Flavor),
-		)
-		cmd = exec.Command(clusterctlBinaryPath, "config", "cluster", //nolint:gosec // We don't care about command injection here.
-			input.ClusterName,
-			"--infrastructure", input.InfrastructureProvider,
-			"--kubernetes-version", input.KubernetesVersion,
-			"--control-plane-machine-count", fmt.Sprint(*input.ControlPlaneMachineCount),
-			"--worker-machine-count", fmt.Sprint(*input.WorkerMachineCount),
-			"--flavor", input.Flavor,
-			"--target-namespace", input.Namespace,
-			"--config", input.ClusterctlConfigPath,
-			"--kubeconfig", input.KubeconfigPath,
-		)
+		command = "config"
 	}
 
+	args := []string{command, "cluster",
+		input.ClusterName,
+		"--infrastructure", input.InfrastructureProvider,
+		"--kubernetes-version", input.KubernetesVersion,
+		"--worker-machine-count", fmt.Sprint(*input.WorkerMachineCount),
+		"--flavor", input.Flavor,
+		"--target-namespace", input.Namespace,
+		"--config", input.ClusterctlConfigPath,
+		"--kubeconfig", input.KubeconfigPath,
+	}
+	if input.ControlPlaneMachineCount != nil && *input.ControlPlaneMachineCount > 0 {
+		args = append(args, "--control-plane-machine-count", fmt.Sprint(*input.ControlPlaneMachineCount))
+	}
+	log.Logf("clusterctl %s", strings.Join(args, " "))
+
+	cmd := exec.Command(clusterctlBinaryPath, args...) //nolint:gosec // We don't care about command injection here.
 	out, err := cmd.Output()
 	_ = os.WriteFile(filepath.Join(input.LogFolder, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName)), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
 	var stdErr string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Currently, the clusterctl upgrade test [hard-codes the controlPlaneMachineCount to 1](https://github.com/kubernetes-sigs/cluster-api/blob/74dcfd5fe52ab68bd4d2d6773970c62846afa545/test/e2e/clusterctl_upgrade.go#L393). There are some scenarios, such as CAPZ's managed cluster, that create a cluster without a control plane machine. This PR will add a fix to add support for those scenarios.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area testing