### PR TITLE
:seedling: Bump go version to 1.22.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.22.2
+GO_VERSION ?= 1.22.3
 GO_DIRECTIVE_VERSION ?= 1.22.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -184,7 +184,7 @@ def load_provider_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22.2 as tilt-helper
+FROM golang:1.22.3 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22
 # Support live reloading with Tilt
@@ -195,7 +195,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.22.2 as tilt
+FROM golang:1.22.3 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.22.2"
+    GO_VERSION = "1.22.3"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What this PR does / why we need it**:
* Bumping go to the latest released version 1.22.3 https://groups.google.com/g/golang-announce/c/wkkO4P9stm0/m/IcuqZRViCgAJ for v1.8.0 release cycle [Bump the Go version](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#continuously-bump-the-go-version) task

**Which issue(s) this PR fixes**:
* Part of: https://github.com/kubernetes-sigs/cluster-api/issues/10472

/area dependency