### PR TITLE
🐛 test: Ensure all ownerRef assertions for some Kind are evaluated

### DIFF
--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -102,10 +102,10 @@ func ValidateOwnerReferencesResilience(ctx context.Context, proxy ClusterProxy, 
 }
 
 func AssertOwnerReferences(namespace, kubeconfigPath string, ownerGraphFilterFunction clusterctlcluster.GetOwnerGraphFilterFunction, assertFuncs ...map[string]func(reference []metav1.OwnerReference) error) {
-	allAssertFuncs := map[string]func(reference []metav1.OwnerReference) error{}
+	allAssertFuncs := map[string][]func(reference []metav1.OwnerReference) error{}
 	for _, m := range assertFuncs {
 		for k, v := range m {
-			allAssertFuncs[k] = v
+			allAssertFuncs[k] = append(allAssertFuncs[k], v)
 		}
 	}
 	Eventually(func() error {
@@ -125,8 +125,10 @@ func AssertOwnerReferences(namespace, kubeconfigPath string, ownerGraphFilterFun
 				allErrs = append(allErrs, fmt.Errorf("kind %s does not have an associated ownerRef assertion function", v.Object.Kind))
 				continue
 			}
-			if err := allAssertFuncs[v.Object.Kind](v.Owners); err != nil {
-				allErrs = append(allErrs, errors.Wrapf(err, "Unexpected ownerReferences for %s/%s", v.Object.Kind, v.Object.Name))
+			for _, f := range allAssertFuncs[v.Object.Kind] {
+				if err := f(v.Owners); err != nil {
+					allErrs = append(allErrs, errors.Wrapf(err, "Unexpected ownerReferences for %s/%s", v.Object.Kind, v.Object.Name))
+				}
 			}
 		}
 		return kerrors.NewAggregate(allErrs)
@@ -308,7 +310,6 @@ var DockerInfraOwnerReferenceAssertions = map[string]func([]metav1.OwnerReferenc
 	dockerMachineKind: func(owners []metav1.OwnerReference) error {
 		// The DockerMachine must be owned and controlled by a Machine or a DockerMachinePool.
 		return HasOneOfExactOwners(owners, []metav1.OwnerReference{machineController}, []metav1.OwnerReference{machineController, dockerMachinePoolController})
-
 	},
 	dockerMachineTemplateKind: func(owners []metav1.OwnerReference) error {
 		// Base DockerMachineTemplates referenced in a ClusterClass must be owned by the ClusterClass.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The assertFuncs are passed as a list*. Previously, if two assertFuncs were defined for the same Kind, the assertFunc that appeared later in the list would overwrite the one that appeared earlier.

If someone introduced a second assertFunc for a given Kind, they would receive no signal that the first assertFunc was overwritten. A test relying on the first assertion would give a false positive.

With this change, if two or more assertFuncs are defined for the same Kind, both are evaluated.

\* Example:
https://github.com/kubernetes-sigs/cluster-api/blob/99866da16d2cb24cc7fda10884cc21f79ef741b2/test/e2e/quick_start_test.go#L44-L49

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing