### PR TITLE
🌱 Drop support for INIT env variables in clusterctl upgrade test

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
+++ b/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
@@ -17,6 +17,10 @@ maintainers of providers and consumers of our Go API.
 
 ### Other
 
+- The support for INIT env variables was dropped in the clusterctl upgrade tests. If you were using `INIT_WITH_BINARY`,
+  `INIT_WITH_PROVIDERS_CONTRACT` or `INIT_WITH_KUBERNETES_VERSION` consider using the corresponding fields in `ClusterctlUpgradeSpecInput`.
+  If you prefer to use environment variables, read them e.g. via `os.Getenv` and then set the spec fields accordingly.
+
 ### Suggested changes for providers
 
 - From Cluster API v1.7 the manager pods are created with `terminationMessagePolicy` set to `FallbackToLogsOnError` for the manager container. This offers the chance that the pod's termination message will contain something useful if the manager exits unexpectedly, which in turn makes debugging easier. We also recommend this setting to provider managers. For an example, see the corresponding change in [CAPV](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2988) or [CAPO](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2070).


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8535

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->