### PR TITLE
🌱 [wip] bump controller-gen and regenerate manifests to optimize RBAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER))
 SETUP_ENVTEST_PKG := sigs.k8s.io/controller-runtime/tools/setup-envtest
 
-CONTROLLER_GEN_VER := v0.15.0
+CONTROLLER_GEN_VER := v0.15.1-0.20240618033008-7824932b0cab
 CONTROLLER_GEN_BIN := controller-gen
 CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER))
 CONTROLLER_GEN_PKG := sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
 spec:
   group: bootstrap.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           KubeadmConfig is the Schema for the kubeadmconfigs API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -67,7 +66,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -146,7 +144,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -333,7 +330,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -682,7 +678,6 @@ spec:
                       CACertPath is the path to the SSL certificate authority used to
                       secure comunications between node and control-plane.
                       Defaults to "/etc/kubernetes/pki/ca.crt".
-                      TODO: revisit when there is defaulting from k/k
                     type: string
                   controlPlane:
                     description: |-
@@ -709,9 +704,8 @@ spec:
                         type: object
                     type: object
                   discovery:
-                    description: |-
-                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                      TODO: revisit when there is defaulting from k/k
+                    description: Discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
                     properties:
                       bootstrapToken:
                         description: |-
@@ -771,7 +765,6 @@ spec:
                           TLSBootstrapToken is a token used for TLS bootstrapping.
                           If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
                           If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
-                          TODO: revisit when there is defaulting from k/k
                         type: string
                     type: object
                   kind:
@@ -881,14 +874,11 @@ spec:
                   UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                   script with retries for joins.
 
-
                   This is meant to be an experimental temporary workaround on some environments
                   where joins fail due to timing (and other issues). The long term goal is to add retries to
                   kubeadm proper and use that functionality.
 
-
                   This will add about 40KB to userdata
-
 
                   For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                 type: boolean
@@ -956,7 +946,6 @@ spec:
                 description: |-
                   BootstrapData will be a cloud-init script for now.
 
-
                   Deprecated: Switch to DataSecretName.
                 format: byte
                 type: string
@@ -1000,6 +989,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -1040,7 +1030,6 @@ spec:
       openAPIV3Schema:
         description: |-
           KubeadmConfig is the Schema for the kubeadmconfigs API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -1085,7 +1074,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -1164,7 +1152,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -1348,7 +1335,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -1695,7 +1681,6 @@ spec:
                       CACertPath is the path to the SSL certificate authority used to
                       secure comunications between node and control-plane.
                       Defaults to "/etc/kubernetes/pki/ca.crt".
-                      TODO: revisit when there is defaulting from k/k
                     type: string
                   controlPlane:
                     description: |-
@@ -1719,9 +1704,8 @@ spec:
                         type: object
                     type: object
                   discovery:
-                    description: |-
-                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                      TODO: revisit when there is defaulting from k/k
+                    description: Discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
                     properties:
                       bootstrapToken:
                         description: |-
@@ -1895,14 +1879,11 @@ spec:
                   UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                   script with retries for joins.
 
-
                   This is meant to be an experimental temporary workaround on some environments
                   where joins fail due to timing (and other issues). The long term goal is to add retries to
                   kubeadm proper and use that functionality.
 
-
                   This will add about 40KB to userdata
-
 
                   For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                 type: boolean
@@ -2006,6 +1987,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -2090,7 +2072,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -2169,7 +2150,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -2360,7 +2340,6 @@ spec:
                           type: string
                         description: |-
                           ExtraArgs is an extra set of flags to pass to the control plane component.
-                          TODO: This is temporary and ideally we would like to switch all components to
                           use ComponentConfig + ConfigMaps.
                         type: object
                       extraVolumes:
@@ -2552,7 +2531,6 @@ spec:
                         description: |-
                           AdditionalConfig contains additional configuration to be merged with the Ignition
                           configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
-
 
                           The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
                         type: string
@@ -2771,7 +2749,6 @@ spec:
                       CACertPath is the path to the SSL certificate authority used to
                       secure comunications between node and control-plane.
                       Defaults to "/etc/kubernetes/pki/ca.crt".
-                      TODO: revisit when there is defaulting from k/k
                     type: string
                   controlPlane:
                     description: |-
@@ -2795,9 +2772,8 @@ spec:
                         type: object
                     type: object
                   discovery:
-                    description: |-
-                      Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                      TODO: revisit when there is defaulting from k/k
+                    description: Discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
                     properties:
                       bootstrapToken:
                         description: |-
@@ -3010,17 +2986,13 @@ spec:
                   UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                   script with retries for joins.
 
-
                   This is meant to be an experimental temporary workaround on some environments
                   where joins fail due to timing (and other issues). The long term goal is to add retries to
                   kubeadm proper and use that functionality.
 
-
                   This will add about 40KB to userdata
 
-
                   For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-
 
                   Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
                   When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
 spec:
   group: bootstrap.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -73,7 +72,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -154,7 +152,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -345,7 +342,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -702,7 +698,6 @@ spec:
                               CACertPath is the path to the SSL certificate authority used to
                               secure comunications between node and control-plane.
                               Defaults to "/etc/kubernetes/pki/ca.crt".
-                              TODO: revisit when there is defaulting from k/k
                             type: string
                           controlPlane:
                             description: |-
@@ -730,9 +725,8 @@ spec:
                                 type: object
                             type: object
                           discovery:
-                            description: |-
-                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                              TODO: revisit when there is defaulting from k/k
+                            description: Discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
                             properties:
                               bootstrapToken:
                                 description: |-
@@ -793,7 +787,6 @@ spec:
                                   TLSBootstrapToken is a token used for TLS bootstrapping.
                                   If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
                                   If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
-                                  TODO: revisit when there is defaulting from k/k
                                 type: string
                             type: object
                           kind:
@@ -905,14 +898,11 @@ spec:
                           UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                           script with retries for joins.
 
-
                           This is meant to be an experimental temporary workaround on some environments
                           where joins fail due to timing (and other issues). The long term goal is to add retries to
                           kubeadm proper and use that functionality.
 
-
                           This will add about 40KB to userdata
-
 
                           For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                         type: boolean
@@ -995,7 +985,6 @@ spec:
         description: |-
           KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -1045,7 +1034,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -1126,7 +1114,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -1314,7 +1301,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -1670,7 +1656,6 @@ spec:
                               CACertPath is the path to the SSL certificate authority used to
                               secure comunications between node and control-plane.
                               Defaults to "/etc/kubernetes/pki/ca.crt".
-                              TODO: revisit when there is defaulting from k/k
                             type: string
                           controlPlane:
                             description: |-
@@ -1695,9 +1680,8 @@ spec:
                                 type: object
                             type: object
                           discovery:
-                            description: |-
-                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                              TODO: revisit when there is defaulting from k/k
+                            description: Discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
                             properties:
                               bootstrapToken:
                                 description: |-
@@ -1875,14 +1859,11 @@ spec:
                           UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                           script with retries for joins.
 
-
                           This is meant to be an experimental temporary workaround on some environments
                           where joins fail due to timing (and other issues). The long term goal is to add retries to
                           kubeadm proper and use that functionality.
 
-
                           This will add about 40KB to userdata
-
 
                           For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                         type: boolean
@@ -2036,7 +2017,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -2117,7 +2097,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -2312,7 +2291,6 @@ spec:
                                   type: string
                                 description: |-
                                   ExtraArgs is an extra set of flags to pass to the control plane component.
-                                  TODO: This is temporary and ideally we would like to switch all components to
                                   use ComponentConfig + ConfigMaps.
                                 type: object
                               extraVolumes:
@@ -2513,7 +2491,6 @@ spec:
                                 description: |-
                                   AdditionalConfig contains additional configuration to be merged with the Ignition
                                   configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
-
 
                                   The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
                                 type: string
@@ -2734,7 +2711,6 @@ spec:
                               CACertPath is the path to the SSL certificate authority used to
                               secure comunications between node and control-plane.
                               Defaults to "/etc/kubernetes/pki/ca.crt".
-                              TODO: revisit when there is defaulting from k/k
                             type: string
                           controlPlane:
                             description: |-
@@ -2759,9 +2735,8 @@ spec:
                                 type: object
                             type: object
                           discovery:
-                            description: |-
-                              Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                              TODO: revisit when there is defaulting from k/k
+                            description: Discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
                             properties:
                               bootstrapToken:
                                 description: |-
@@ -2978,17 +2953,13 @@ spec:
                           UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                           script with retries for joins.
 
-
                           This is meant to be an experimental temporary workaround on some environments
                           where joins fail due to timing (and other issues). The long term goal is to add retries to
                           kubeadm proper and use that functionality.
 
-
                           This will add about 40KB to userdata
 
-
                           For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-
 
                           Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
                           When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml

--- a/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_metadata.yaml
+++ b/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_metadata.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: metadata.clusterctl.cluster.x-k8s.io
 spec:
   group: clusterctl.cluster.x-k8s.io
@@ -44,7 +44,6 @@ spec:
                 contract:
                   description: |-
                     Contract defines the Cluster API contract supported by this series.
-
 
                     The value is an API Version, e.g. `v1alpha3`.
                   type: string

--- a/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
+++ b/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: providers.clusterctl.cluster.x-k8s.io
 spec:
   group: clusterctl.cluster.x-k8s.io
@@ -67,7 +67,6 @@ spec:
             description: |-
               WatchedNamespace indicates the namespace where the provider controller is watching.
               If empty the provider controller is watching for objects in all namespaces.
-
 
               Deprecated: providers complying with the Cluster API v1alpha4 contract or above must watch all namespaces; this field will be removed in a future version of this API
             type: string

--- a/cmd/clusterctl/config/manifest/clusterctl-api.yaml
+++ b/cmd/clusterctl/config/manifest/clusterctl-api.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: providers.clusterctl.cluster.x-k8s.io
 spec:
   group: clusterctl.cluster.x-k8s.io
@@ -66,7 +66,6 @@ spec:
             description: |-
               WatchedNamespace indicates the namespace where the provider controller is watching.
               If empty the provider controller is watching for objects in all namespaces.
-
 
               Deprecated: providers complying with the Cluster API v1alpha4 contract or above must watch all namespaces; this field will be removed in a future version of this API
             type: string

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: clusterresourcesetbindings.addons.cluster.x-k8s.io
 spec:
   group: addons.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -118,7 +117,6 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: clusterresourcesets.addons.cluster.x-k8s.io
 spec:
   group: addons.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterResourceSet is the Schema for the clusterresourcesets API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -170,6 +169,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -196,7 +196,6 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterResourceSet is the Schema for the clusterresourcesets API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -345,6 +344,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: clusterclasses.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -29,7 +29,6 @@ spec:
       openAPIV3Schema:
         description: |-
           ClusterClass is a template which can be used to create managed topologies.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -63,7 +62,6 @@ spec:
                       MachineTemplate defines the metadata and infrastructure information
                       for control plane machines.
 
-
                       This field is supported if and only if the control plane provider template
                       referenced above is Machine based and supports setting replicas.
                     properties:
@@ -84,7 +82,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -120,7 +117,6 @@ spec:
                     description: |-
                       Metadata is the metadata applied to the machines of the ControlPlane.
                       At runtime this metadata is merged with the corresponding metadata from the topology.
-
 
                       This field is supported if and only if the control plane provider template
                       referenced is Machine based.
@@ -161,7 +157,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -218,7 +213,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -298,7 +292,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -352,7 +345,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -479,13 +471,11 @@ spec:
                           to consider a Machine unhealthy if a corresponding Node isn't associated
                           through a `Spec.ProviderID` field.
 
-
                           The duration set in this field is compared to the greatest of:
                           - Cluster's infrastructure ready condition timestamp (if and when available)
                           - Control Plane's initialized condition timestamp (if and when available)
                           - Machine's infrastructure ready condition timestamp (if and when available)
                           - Machine's metadata creation timestamp
-
 
                           Defaults to 10 minutes.
                           If you wish to disable this feature, set the value explicitly to 0.
@@ -494,7 +484,6 @@ spec:
                         description: |-
                           RemediationTemplate is a reference to a remediation template
                           provided by an infrastructure provider.
-
 
                           This field is completely optional, when filled, the MachineHealthCheck controller
                           creates a new object from the template referenced and hands off remediation of the machine to
@@ -512,7 +501,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -581,7 +569,6 @@ spec:
                       MachineInfrastructure defines the metadata and infrastructure information
                       for control plane machines.
 
-
                       This field is supported if and only if the control plane provider template
                       referenced above is Machine based and supports setting replicas.
                     properties:
@@ -602,7 +589,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -640,7 +626,6 @@ spec:
                       if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the
                       ControlPlane.
                       At runtime this metadata is merged with the corresponding metadata from the topology.
-
 
                       This field is supported if and only if the control plane provider template
                       referenced is Machine based.
@@ -716,7 +701,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -773,7 +757,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -1215,13 +1198,11 @@ spec:
                                 to consider a Machine unhealthy if a corresponding Node isn't associated
                                 through a `Spec.ProviderID` field.
 
-
                                 The duration set in this field is compared to the greatest of:
                                 - Cluster's infrastructure ready condition timestamp (if and when available)
                                 - Control Plane's initialized condition timestamp (if and when available)
                                 - Machine's infrastructure ready condition timestamp (if and when available)
                                 - Machine's metadata creation timestamp
-
 
                                 Defaults to 10 minutes.
                                 If you wish to disable this feature, set the value explicitly to 0.
@@ -1230,7 +1211,6 @@ spec:
                               description: |-
                                 RemediationTemplate is a reference to a remediation template
                                 provided by an infrastructure provider.
-
 
                                 This field is completely optional, when filled, the MachineHealthCheck controller
                                 creates a new object from the template referenced and hands off remediation of the machine to
@@ -1248,7 +1228,6 @@ spec:
                                     the event) or if no container name is specified "spec.containers[2]" (container with
                                     index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                     referencing a part of an object.
-                                    TODO: this design is not final and this field is subject to change in the future.
                                   type: string
                                 kind:
                                   description: |-
@@ -1375,19 +1354,15 @@ spec:
                                   description: |-
                                     MaxInFlight determines how many in flight remediations should happen at the same time.
 
-
                                     Remediation only happens on the MachineSet with the most current revision, while
                                     older MachineSets (usually present during rollout operations) aren't allowed to remediate.
-
 
                                     Note: In general (independent of remediations), unhealthy machines are always
                                     prioritized during scale down operations over healthy ones.
 
-
                                     MaxInFlight can be set to a fixed number or a percentage.
                                     Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
                                     the desired replicas.
-
 
                                     If not set, remediation is limited to all machines (bounded by replicas)
                                     under the active MachineSet's management.
@@ -1482,7 +1457,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -1536,7 +1510,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -1696,7 +1669,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -1750,7 +1722,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: clusters.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -114,7 +114,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -160,7 +159,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -237,6 +235,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -314,7 +313,6 @@ spec:
       openAPIV3Schema:
         description: |-
           Cluster is the Schema for the clusters API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -403,7 +401,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -449,7 +446,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -500,7 +496,6 @@ spec:
                         description: |-
                           Metadata is the metadata applied to the machines of the ControlPlane.
                           At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
-
 
                           This field is supported if and only if the control plane provider template
                           referenced in the ClusterClass is Machine based.
@@ -654,6 +649,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -820,7 +816,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -866,7 +861,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -922,13 +916,10 @@ spec:
                             description: |-
                               Enable controls if a MachineHealthCheck should be created for the target machines.
 
-
                               If false: No MachineHealthCheck will be created.
-
 
                               If not set(default): A MachineHealthCheck will be created if it is defined here or
                                in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
-
 
                               If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
                               block if `enable` is true and no MachineHealthCheck definition is available.
@@ -947,13 +938,11 @@ spec:
                               to consider a Machine unhealthy if a corresponding Node isn't associated
                               through a `Spec.ProviderID` field.
 
-
                               The duration set in this field is compared to the greatest of:
                               - Cluster's infrastructure ready condition timestamp (if and when available)
                               - Control Plane's initialized condition timestamp (if and when available)
                               - Machine's infrastructure ready condition timestamp (if and when available)
                               - Machine's metadata creation timestamp
-
 
                               Defaults to 10 minutes.
                               If you wish to disable this feature, set the value explicitly to 0.
@@ -962,7 +951,6 @@ spec:
                             description: |-
                               RemediationTemplate is a reference to a remediation template
                               provided by an infrastructure provider.
-
 
                               This field is completely optional, when filled, the MachineHealthCheck controller
                               creates a new object from the template referenced and hands off remediation of the machine to
@@ -980,7 +968,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -1139,7 +1126,6 @@ spec:
                       RolloutAfter performs a rollout of the entire cluster one component at a time,
                       control plane first and then machine deployments.
 
-
                       Deprecated: This field has no function and is going to be removed in the next apiVersion.
                     format: date-time
                     type: string
@@ -1214,13 +1200,10 @@ spec:
                                   description: |-
                                     Enable controls if a MachineHealthCheck should be created for the target machines.
 
-
                                     If false: No MachineHealthCheck will be created.
-
 
                                     If not set(default): A MachineHealthCheck will be created if it is defined here or
                                      in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
-
 
                                     If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
                                     block if `enable` is true and no MachineHealthCheck definition is available.
@@ -1239,13 +1222,11 @@ spec:
                                     to consider a Machine unhealthy if a corresponding Node isn't associated
                                     through a `Spec.ProviderID` field.
 
-
                                     The duration set in this field is compared to the greatest of:
                                     - Cluster's infrastructure ready condition timestamp (if and when available)
                                     - Control Plane's initialized condition timestamp (if and when available)
                                     - Machine's infrastructure ready condition timestamp (if and when available)
                                     - Machine's metadata creation timestamp
-
 
                                     Defaults to 10 minutes.
                                     If you wish to disable this feature, set the value explicitly to 0.
@@ -1254,7 +1235,6 @@ spec:
                                   description: |-
                                     RemediationTemplate is a reference to a remediation template
                                     provided by an infrastructure provider.
-
 
                                     This field is completely optional, when filled, the MachineHealthCheck controller
                                     creates a new object from the template referenced and hands off remediation of the machine to
@@ -1272,7 +1252,6 @@ spec:
                                         the event) or if no container name is specified "spec.containers[2]" (container with
                                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                         referencing a part of an object.
-                                        TODO: this design is not final and this field is subject to change in the future.
                                       type: string
                                     kind:
                                       description: |-
@@ -1417,19 +1396,15 @@ spec:
                                       description: |-
                                         MaxInFlight determines how many in flight remediations should happen at the same time.
 
-
                                         Remediation only happens on the MachineSet with the most current revision, while
                                         older MachineSets (usually present during rollout operations) aren't allowed to remediate.
-
 
                                         Note: In general (independent of remediations), unhealthy machines are always
                                         prioritized during scale down operations over healthy ones.
 
-
                                         MaxInFlight can be set to a fixed number or a percentage.
                                         Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
                                         the desired replicas.
-
 
                                         If not set, remediation is limited to all machines (bounded by replicas)
                                         under the active MachineSet's management.

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: machinedeployments.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -46,7 +46,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachineDeployment is the Schema for the machinedeployments API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -239,16 +238,13 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
 
-
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -270,7 +266,6 @@ spec:
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/identifiers#names
 
-
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
                       namespace:
@@ -280,11 +275,9 @@ spec:
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
 
-
                           Must be a DNS_LABEL.
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/namespaces
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -294,7 +287,6 @@ spec:
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         items:
@@ -374,7 +366,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -407,7 +398,6 @@ spec:
                             description: |-
                               Data contains the bootstrap data, such as cloud-init details scripts.
                               If nil, the Machine should remain in the Pending state.
-
 
                               Deprecated: Switch to DataSecretName.
                             type: string
@@ -444,7 +434,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -602,7 +591,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachineDeployment is the Schema for the machinedeployments API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -837,7 +825,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -899,7 +886,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -1012,6 +998,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -1157,7 +1144,6 @@ spec:
                   Number of desired machines.
                   This is a pointer to distinguish between explicit zero and not specified.
 
-
                   Defaults to:
                   * if the Kubernetes autoscaler min size and max size annotations are set:
                     - if it's a new MachineDeployment, use min size
@@ -1257,19 +1243,15 @@ spec:
                         description: |-
                           MaxInFlight determines how many in flight remediations should happen at the same time.
 
-
                           Remediation only happens on the MachineSet with the most current revision, while
                           older MachineSets (usually present during rollout operations) aren't allowed to remediate.
-
 
                           Note: In general (independent of remediations), unhealthy machines are always
                           prioritized during scale down operations over healthy ones.
 
-
                           MaxInFlight can be set to a fixed number or a percentage.
                           Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
                           the desired replicas.
-
 
                           If not set, remediation is limited to all machines (bounded by replicas)
                           under the active MachineSet's management.
@@ -1393,7 +1375,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -1455,7 +1436,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: machinehealthchecks.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -38,7 +38,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachineHealthCheck is the Schema for the machinehealthchecks API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -85,7 +84,6 @@ spec:
                   RemediationTemplate is a reference to a remediation template
                   provided by an infrastructure provider.
 
-
                   This field is completely optional, when filled, the MachineHealthCheck controller
                   creates a new object from the template referenced and hands off remediation of the machine to
                   a controller that lives outside of Cluster API.
@@ -102,7 +100,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -252,6 +249,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -320,7 +318,6 @@ spec:
         description: |-
           MachineHealthCheck is the Schema for the machinehealthchecks API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -368,7 +365,6 @@ spec:
                   RemediationTemplate is a reference to a remediation template
                   provided by an infrastructure provider.
 
-
                   This field is completely optional, when filled, the MachineHealthCheck controller
                   creates a new object from the template referenced and hands off remediation of the machine to
                   a controller that lives outside of Cluster API.
@@ -385,7 +381,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -544,6 +539,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -650,13 +646,11 @@ spec:
                   to consider a Machine unhealthy if a corresponding Node isn't associated
                   through a `Spec.ProviderID` field.
 
-
                   The duration set in this field is compared to the greatest of:
                   - Cluster's infrastructure ready condition timestamp (if and when available)
                   - Control Plane's initialized condition timestamp (if and when available)
                   - Machine's infrastructure ready condition timestamp (if and when available)
                   - Machine's metadata creation timestamp
-
 
                   Defaults to 10 minutes.
                   If you wish to disable this feature, set the value explicitly to 0.
@@ -665,7 +659,6 @@ spec:
                 description: |-
                   RemediationTemplate is a reference to a remediation template
                   provided by an infrastructure provider.
-
 
                   This field is completely optional, when filled, the MachineHealthCheck controller
                   creates a new object from the template referenced and hands off remediation of the machine to
@@ -683,7 +676,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: machinepools.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -38,7 +38,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachinePool is the Schema for the machinepools API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -176,16 +175,13 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
 
-
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -207,7 +203,6 @@ spec:
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/identifiers#names
 
-
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
                       namespace:
@@ -217,11 +212,9 @@ spec:
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
 
-
                           Must be a DNS_LABEL.
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/namespaces
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -231,7 +224,6 @@ spec:
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         items:
@@ -311,7 +303,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -344,7 +335,6 @@ spec:
                             description: |-
                               Data contains the bootstrap data, such as cloud-init details scripts.
                               If nil, the Machine should remain in the Pending state.
-
 
                               Deprecated: Switch to DataSecretName.
                             type: string
@@ -381,7 +371,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -495,6 +484,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -517,24 +507,8 @@ spec:
                 description: NodeRefs will point to the corresponding Nodes if it
                   they exist.
                 items:
-                  description: |-
-                    ObjectReference contains enough information to let you inspect or modify the referred object.
-                    ---
-                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                        Those cannot be well described when embedded.
-                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                        and the version of the actual struct is irrelevant.
-                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -548,7 +522,6 @@ spec:
                         the event) or if no container name is specified "spec.containers[2]" (container with
                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                         referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
                       description: |-
@@ -640,7 +613,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachinePool is the Schema for the machinepools API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -752,7 +724,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -814,7 +785,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -928,6 +898,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -950,24 +921,8 @@ spec:
                 description: NodeRefs will point to the corresponding Nodes if it
                   they exist.
                 items:
-                  description: |-
-                    ObjectReference contains enough information to let you inspect or modify the referred object.
-                    ---
-                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                        Those cannot be well described when embedded.
-                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                        and the version of the actual struct is irrelevant.
-                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -981,7 +936,6 @@ spec:
                         the event) or if no container name is specified "spec.containers[2]" (container with
                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                         referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
                       description: |-
@@ -1189,7 +1143,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -1251,7 +1204,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -1399,24 +1351,8 @@ spec:
                 description: NodeRefs will point to the corresponding Nodes if it
                   they exist.
                 items:
-                  description: |-
-                    ObjectReference contains enough information to let you inspect or modify the referred object.
-                    ---
-                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
-                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
-                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
-                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
-                        Those cannot be well described when embedded.
-                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
-                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
-                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
-                        and the version of the actual struct is irrelevant.
-                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
-                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
-
-
-                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
-                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
                   properties:
                     apiVersion:
                       description: API version of the referent.
@@ -1430,7 +1366,6 @@ spec:
                         the event) or if no container name is specified "spec.containers[2]" (container with
                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                         referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
                       description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: machines.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -42,7 +42,6 @@ spec:
       openAPIV3Schema:
         description: |-
           Machine is the Schema for the machines API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -90,7 +89,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -123,7 +121,6 @@ spec:
                     description: |-
                       Data contains the bootstrap data, such as cloud-init details scripts.
                       If nil, the Machine should remain in the Pending state.
-
 
                       Deprecated: Switch to DataSecretName.
                     type: string
@@ -160,7 +157,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -284,6 +280,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -294,7 +291,6 @@ spec:
                   reconciling the Machine and will contain a more verbose string suitable
                   for logging and human consumption.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -303,7 +299,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -315,7 +310,6 @@ spec:
                   reconciling the Machine and will contain a succinct value suitable
                   for machine interpretation.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -324,7 +318,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -354,7 +347,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -439,7 +431,6 @@ spec:
         description: |-
           Machine is the Schema for the machines API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -486,7 +477,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -548,7 +538,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -672,6 +661,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -682,7 +672,6 @@ spec:
                   reconciling the Machine and will contain a more verbose string suitable
                   for logging and human consumption.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -691,7 +680,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -703,7 +691,6 @@ spec:
                   reconciling the Machine and will contain a succinct value suitable
                   for machine interpretation.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -712,7 +699,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -798,7 +784,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -924,7 +909,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -986,7 +970,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -1138,7 +1121,6 @@ spec:
                   reconciling the Machine and will contain a more verbose string suitable
                   for logging and human consumption.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -1147,7 +1129,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -1159,7 +1140,6 @@ spec:
                   reconciling the Machine and will contain a succinct value suitable
                   for machine interpretation.
 
-
                   This field should not be set for transitive errors that a controller
                   faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -1168,7 +1148,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the controller, or the
                   responsible controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the Machine object and/or logged in the
@@ -1254,7 +1233,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: machinesets.cluster.x-k8s.io
 spec:
   group: cluster.x-k8s.io
@@ -37,7 +37,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachineSet is the Schema for the machinesets API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -168,16 +167,13 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
 
-
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -199,7 +195,6 @@ spec:
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/identifiers#names
 
-
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
                       namespace:
@@ -209,11 +204,9 @@ spec:
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
 
-
                           Must be a DNS_LABEL.
                           Cannot be updated.
                           More info: http://kubernetes.io/docs/user-guide/namespaces
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         type: string
@@ -223,7 +216,6 @@ spec:
                           been deleted, this object will be garbage collected. If this object is managed by a controller,
                           then an entry in this list will point to this controller, with the controller field set to true.
                           There cannot be more than one managing controller.
-
 
                           Deprecated: This field has no function and is going to be removed in a next release.
                         items:
@@ -303,7 +295,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -336,7 +327,6 @@ spec:
                             description: |-
                               Data contains the bootstrap data, such as cloud-init details scripts.
                               If nil, the Machine should remain in the Pending state.
-
 
                               Deprecated: Switch to DataSecretName.
                             type: string
@@ -373,7 +363,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -454,7 +443,6 @@ spec:
                   interpretation, while FailureMessage will contain a more verbose
                   string suitable for logging and human consumption.
 
-
                   These fields should not be set for transitive errors that a
                   controller faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -463,7 +451,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the machine controller, or the
                   responsible machine controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the MachineSet object and/or logged in the
@@ -531,7 +518,6 @@ spec:
       openAPIV3Schema:
         description: |-
           MachineSet is the Schema for the machinesets API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -692,7 +678,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -754,7 +739,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -865,6 +849,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -879,7 +864,6 @@ spec:
                   interpretation, while FailureMessage will contain a more verbose
                   string suitable for logging and human consumption.
 
-
                   These fields should not be set for transitive errors that a
                   controller faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -888,7 +872,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the machine controller, or the
                   responsible machine controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the MachineSet object and/or logged in the
@@ -1008,7 +991,6 @@ spec:
                 description: |-
                   Replicas is the number of desired replicas.
                   This is a pointer to distinguish between explicit zero and unspecified.
-
 
                   Defaults to:
                   * if the Kubernetes autoscaler min size and max size annotations are set:
@@ -1135,7 +1117,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -1197,7 +1178,6 @@ spec:
                               the event) or if no container name is specified "spec.containers[2]" (container with
                               index 2 in this pod). This syntax is chosen only to have some well-defined way of
                               referencing a part of an object.
-                              TODO: this design is not final and this field is subject to change in the future.
                             type: string
                           kind:
                             description: |-
@@ -1334,7 +1314,6 @@ spec:
                   interpretation, while FailureMessage will contain a more verbose
                   string suitable for logging and human consumption.
 
-
                   These fields should not be set for transitive errors that a
                   controller faces that are expected to be fixed automatically over
                   time (like service outages), but instead indicate that something is
@@ -1343,7 +1322,6 @@ spec:
                   of terminal errors would be invalid combinations of settings in the
                   spec, values that are unsupported by the machine controller, or the
                   responsible machine controller itself being critically misconfigured.
-
 
                   Any transient errors that occur during the reconciliation of Machines
                   can be added as events to the MachineSet object and/or logged in the

--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: ipaddressclaims.ipam.cluster.x-k8s.io
 spec:
   group: ipam.cluster.x-k8s.io
@@ -92,9 +92,7 @@ spec:
                       This field is effectively required, but due to backwards compatibility is
                       allowed to be empty. Instances of this type with an empty value here are
                       almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -229,9 +227,7 @@ spec:
                       This field is effectively required, but due to backwards compatibility is
                       allowed to be empty. Instances of this type with an empty value here are
                       almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: ipaddresses.ipam.cluster.x-k8s.io
 spec:
   group: ipam.cluster.x-k8s.io
@@ -72,9 +72,7 @@ spec:
                       This field is effectively required, but due to backwards compatibility is
                       allowed to be empty. Instances of this type with an empty value here are
                       almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -172,9 +170,7 @@ spec:
                       This field is effectively required, but due to backwards compatibility is
                       allowed to be empty. Instances of this type with an empty value here are
                       almost certainly wrong.
-                      TODO: Add other useful fields. apiVersion, kind, uid?
                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: extensionconfigs.runtime.cluster.x-k8s.io
 spec:
   group: runtime.cluster.x-k8s.io
@@ -62,7 +62,6 @@ spec:
                       Service is a reference to the Kubernetes service for the Extension server.
                       Note: Exactly one of `url` or `service` must be specified.
 
-
                       If the Extension server is running within a cluster, then you should use `service`.
                     properties:
                       name:
@@ -93,17 +92,13 @@ spec:
                       (`scheme://host:port/path`).
                       Note: Exactly one of `url` or `service` must be specified.
 
-
                       The scheme must be "https".
-
 
                       The `host` should not refer to a service running in the cluster; use
                       the `service` field instead.
 
-
                       A path is optional, and if present may be any string permissible in
                       a URL. If a path is set it will be used as prefix to the hook-specific path.
-
 
                       Attempting to use a user or basic auth e.g. "user:password@" is not
                       allowed. Fragments ("#...") and query parameters ("?...") are not

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,6 +15,17 @@ rules:
 - apiGroups:
   - addons.cluster.x-k8s.io
   resources:
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
   - '*'
   verbs:
   - create
@@ -24,14 +35,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - addons.cluster.x-k8s.io
-  resources:
-  - clusterresourcesets/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -53,113 +56,12 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - bootstrap.cluster.x-k8s.io
-  - controlplane.cluster.x-k8s.io
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - bootstrap.cluster.x-k8s.io
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusterclasses
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusterclasses
   - clusterclasses/status
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - clusters
   - clusters/status
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinedeployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinedeployments
-  - machinedeployments/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinehealthchecks
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinehealthchecks
   - machinehealthchecks/status
   verbs:
   - get
@@ -170,54 +72,13 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
-  - machinepools
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
+  - machinedeployments
+  - machinedeployments/status
+  - machinehealthchecks
   - machinepools
   - machinepools/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machines
   - machines/status
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinesets
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machinesets
   - machinesets/status
   verbs:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
   group: controlplane.cluster.x-k8s.io
@@ -57,7 +57,6 @@ spec:
         description: |-
           KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -97,7 +96,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -150,7 +148,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -230,7 +227,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -419,7 +415,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -773,7 +768,6 @@ spec:
                           CACertPath is the path to the SSL certificate authority used to
                           secure comunications between node and control-plane.
                           Defaults to "/etc/kubernetes/pki/ca.crt".
-                          TODO: revisit when there is defaulting from k/k
                         type: string
                       controlPlane:
                         description: |-
@@ -800,9 +794,8 @@ spec:
                             type: object
                         type: object
                       discovery:
-                        description: |-
-                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                          TODO: revisit when there is defaulting from k/k
+                        description: Discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
                         properties:
                           bootstrapToken:
                             description: |-
@@ -862,7 +855,6 @@ spec:
                               TLSBootstrapToken is a token used for TLS bootstrapping.
                               If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
                               If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
-                              TODO: revisit when there is defaulting from k/k
                             type: string
                         type: object
                       kind:
@@ -973,14 +965,11 @@ spec:
                       UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                       script with retries for joins.
 
-
                       This is meant to be an experimental temporary workaround on some environments
                       where joins fail due to timing (and other issues). The long term goal is to add retries to
                       kubeadm proper and use that functionality.
 
-
                       This will add about 40KB to userdata
-
 
                       For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                     type: boolean
@@ -1144,6 +1133,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -1261,7 +1251,6 @@ spec:
         description: |-
           KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -1308,7 +1297,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -1388,7 +1376,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -1574,7 +1561,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -1927,7 +1913,6 @@ spec:
                           CACertPath is the path to the SSL certificate authority used to
                           secure comunications between node and control-plane.
                           Defaults to "/etc/kubernetes/pki/ca.crt".
-                          TODO: revisit when there is defaulting from k/k
                         type: string
                       controlPlane:
                         description: |-
@@ -1951,9 +1936,8 @@ spec:
                             type: object
                         type: object
                       discovery:
-                        description: |-
-                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                          TODO: revisit when there is defaulting from k/k
+                        description: Discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
                         properties:
                           bootstrapToken:
                             description: |-
@@ -2129,14 +2113,11 @@ spec:
                       UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                       script with retries for joins.
 
-
                       This is meant to be an experimental temporary workaround on some environments
                       where joins fail due to timing (and other issues). The long term goal is to add retries to
                       kubeadm proper and use that functionality.
 
-
                       This will add about 40KB to userdata
-
 
                       For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                     type: boolean
@@ -2221,7 +2202,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -2382,6 +2362,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -2556,7 +2537,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -2636,7 +2616,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -2829,7 +2808,6 @@ spec:
                               type: string
                             description: |-
                               ExtraArgs is an extra set of flags to pass to the control plane component.
-                              TODO: This is temporary and ideally we would like to switch all components to
                               use ComponentConfig + ConfigMaps.
                             type: object
                           extraVolumes:
@@ -3026,7 +3004,6 @@ spec:
                             description: |-
                               AdditionalConfig contains additional configuration to be merged with the Ignition
                               configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
-
 
                               The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
                             type: string
@@ -3246,7 +3223,6 @@ spec:
                           CACertPath is the path to the SSL certificate authority used to
                           secure comunications between node and control-plane.
                           Defaults to "/etc/kubernetes/pki/ca.crt".
-                          TODO: revisit when there is defaulting from k/k
                         type: string
                       controlPlane:
                         description: |-
@@ -3270,9 +3246,8 @@ spec:
                             type: object
                         type: object
                       discovery:
-                        description: |-
-                          Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                          TODO: revisit when there is defaulting from k/k
+                        description: Discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
                         properties:
                           bootstrapToken:
                             description: |-
@@ -3487,17 +3462,13 @@ spec:
                       UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                       script with retries for joins.
 
-
                       This is meant to be an experimental temporary workaround on some environments
                       where joins fail due to timing (and other issues). The long term goal is to add retries to
                       kubeadm proper and use that functionality.
 
-
                       This will add about 40KB to userdata
 
-
                       For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-
 
                       Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
                       When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
@@ -3606,7 +3577,6 @@ spec:
                           the event) or if no container name is specified "spec.containers[2]" (container with
                           index 2 in this pod). This syntax is chosen only to have some well-defined way of
                           referencing a part of an object.
-                          TODO: this design is not final and this field is subject to change in the future.
                         type: string
                       kind:
                         description: |-
@@ -3688,17 +3658,17 @@ spec:
                       to remediate an unhealthy machine.\nA retry happens when a machine
                       that was created as a replacement for an unhealthy machine also
                       fails.\nFor example, given a control plane with three machines
-                      M1, M2, M3:\n\n\n\tM1 become unhealthy; remediation happens,
-                      and M1-1 is created as a replacement.\n\tIf M1-1 (replacement
-                      of M1) has problems while bootstrapping it will become unhealthy,
+                      M1, M2, M3:\n\n\tM1 become unhealthy; remediation happens, and
+                      M1-1 is created as a replacement.\n\tIf M1-1 (replacement of
+                      M1) has problems while bootstrapping it will become unhealthy,
                       and then be\n\tremediated; such operation is considered a retry,
                       remediation-retry #1.\n\tIf M1-2 (replacement of M1-1) becomes
-                      unhealthy, remediation-retry #2 will happen, etc.\n\n\nA retry
+                      unhealthy, remediation-retry #2 will happen, etc.\n\nA retry
                       could happen only after RetryPeriod from the previous retry.\nIf
                       a machine is marked as unhealthy after MinHealthyPeriod from
                       the previous remediation expired,\nthis is not considered a
                       retry anymore because the new issue is assumed unrelated from
-                      the previous one.\n\n\nIf not set, the remedation will be retried
+                      the previous one.\n\nIf not set, the remedation will be retried
                       infinitely."
                     format: int32
                     type: integer
@@ -3707,23 +3677,22 @@ spec:
                       KCP will consider any failure to a machine unrelated\nfrom the
                       previous one. In this case the remediation is not considered
                       a retry anymore, and thus the retry\ncounter restarts from 0.
-                      For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\n\tM1
+                      For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\tM1
                       become unhealthy; remediation happens, and M1-1 is created as
                       a replacement.\n\tIf M1-1 (replacement of M1) has problems within
                       the 1hr after the creation, also\n\tthis machine will be remediated
                       and this operation is considered a retry - a problem related\n\tto
-                      the original issue happened to M1 -.\n\n\n\tIf instead the problem
+                      the original issue happened to M1 -.\n\n\tIf instead the problem
                       on M1-1 is happening after MinHealthyPeriod expired, e.g. four
                       days after\n\tm1-1 has been created as a remediation of M1,
                       the problem on M1-1 is considered unrelated to\n\tthe original
-                      issue happened to M1.\n\n\nIf not set, this value is defaulted
+                      issue happened to M1.\n\nIf not set, this value is defaulted
                       to 1h."
                     type: string
                   retryPeriod:
                     description: |-
                       RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
                       for an unhealthy machine (a retry).
-
 
                       If not set, a retry will happen immediately.
                     type: string

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
 spec:
   group: controlplane.cluster.x-k8s.io
@@ -27,7 +27,6 @@ spec:
       openAPIV3Schema:
         description: |-
           KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -84,7 +83,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -166,7 +164,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -356,7 +353,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -716,7 +712,6 @@ spec:
                                   CACertPath is the path to the SSL certificate authority used to
                                   secure comunications between node and control-plane.
                                   Defaults to "/etc/kubernetes/pki/ca.crt".
-                                  TODO: revisit when there is defaulting from k/k
                                 type: string
                               controlPlane:
                                 description: |-
@@ -741,9 +736,8 @@ spec:
                                     type: object
                                 type: object
                               discovery:
-                                description: |-
-                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                                  TODO: revisit when there is defaulting from k/k
+                                description: Discovery specifies the options for the
+                                  kubelet to use during the TLS Bootstrap process
                                 properties:
                                   bootstrapToken:
                                     description: |-
@@ -923,14 +917,11 @@ spec:
                               UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                               script with retries for joins.
 
-
                               This is meant to be an experimental temporary workaround on some environments
                               where joins fail due to timing (and other issues). The long term goal is to add retries to
                               kubeadm proper and use that functionality.
 
-
                               This will add about 40KB to userdata
-
 
                               For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
                             type: boolean
@@ -1017,7 +1008,6 @@ spec:
                                   the event) or if no container name is specified "spec.containers[2]" (container with
                                   index 2 in this pod). This syntax is chosen only to have some well-defined way of
                                   referencing a part of an object.
-                                  TODO: this design is not final and this field is subject to change in the future.
                                 type: string
                               kind:
                                 description: |-
@@ -1237,7 +1227,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -1319,7 +1308,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -1516,7 +1504,6 @@ spec:
                                       type: string
                                     description: |-
                                       ExtraArgs is an extra set of flags to pass to the control plane component.
-                                      TODO: This is temporary and ideally we would like to switch all components to
                                       use ComponentConfig + ConfigMaps.
                                     type: object
                                   extraVolumes:
@@ -1721,7 +1708,6 @@ spec:
                                     description: |-
                                       AdditionalConfig contains additional configuration to be merged with the Ignition
                                       configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
-
 
                                       The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
                                     type: string
@@ -1942,7 +1928,6 @@ spec:
                                   CACertPath is the path to the SSL certificate authority used to
                                   secure comunications between node and control-plane.
                                   Defaults to "/etc/kubernetes/pki/ca.crt".
-                                  TODO: revisit when there is defaulting from k/k
                                 type: string
                               controlPlane:
                                 description: |-
@@ -1967,9 +1952,8 @@ spec:
                                     type: object
                                 type: object
                               discovery:
-                                description: |-
-                                  Discovery specifies the options for the kubelet to use during the TLS Bootstrap process
-                                  TODO: revisit when there is defaulting from k/k
+                                description: Discovery specifies the options for the
+                                  kubelet to use during the TLS Bootstrap process
                                 properties:
                                   bootstrapToken:
                                     description: |-
@@ -2188,17 +2172,13 @@ spec:
                               UseExperimentalRetryJoin replaces a basic kubeadm command with a shell
                               script with retries for joins.
 
-
                               This is meant to be an experimental temporary workaround on some environments
                               where joins fail due to timing (and other issues). The long term goal is to add retries to
                               kubeadm proper and use that functionality.
 
-
                               This will add about 40KB to userdata
 
-
                               For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-
 
                               Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
                               When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
@@ -2343,20 +2323,19 @@ spec:
                               attempting to remediate an unhealthy machine.\nA retry
                               happens when a machine that was created as a replacement
                               for an unhealthy machine also fails.\nFor example, given
-                              a control plane with three machines M1, M2, M3:\n\n\n\tM1
+                              a control plane with three machines M1, M2, M3:\n\n\tM1
                               become unhealthy; remediation happens, and M1-1 is created
                               as a replacement.\n\tIf M1-1 (replacement of M1) has
                               problems while bootstrapping it will become unhealthy,
                               and then be\n\tremediated; such operation is considered
                               a retry, remediation-retry #1.\n\tIf M1-2 (replacement
                               of M1-1) becomes unhealthy, remediation-retry #2 will
-                              happen, etc.\n\n\nA retry could happen only after RetryPeriod
+                              happen, etc.\n\nA retry could happen only after RetryPeriod
                               from the previous retry.\nIf a machine is marked as
                               unhealthy after MinHealthyPeriod from the previous remediation
                               expired,\nthis is not considered a retry anymore because
                               the new issue is assumed unrelated from the previous
-                              one.\n\n\nIf not set, the remedation will be retried
-                              infinitely."
+                              one.\n\nIf not set, the remedation will be retried infinitely."
                             format: int32
                             type: integer
                           minHealthyPeriod:
@@ -2365,23 +2344,22 @@ spec:
                               the previous one. In this case the remediation is not
                               considered a retry anymore, and thus the retry\ncounter
                               restarts from 0. For example, assuming MinHealthyPeriod
-                              is set to 1h (default)\n\n\n\tM1 become unhealthy; remediation
+                              is set to 1h (default)\n\n\tM1 become unhealthy; remediation
                               happens, and M1-1 is created as a replacement.\n\tIf
                               M1-1 (replacement of M1) has problems within the 1hr
                               after the creation, also\n\tthis machine will be remediated
                               and this operation is considered a retry - a problem
-                              related\n\tto the original issue happened to M1 -.\n\n\n\tIf
+                              related\n\tto the original issue happened to M1 -.\n\n\tIf
                               instead the problem on M1-1 is happening after MinHealthyPeriod
                               expired, e.g. four days after\n\tm1-1 has been created
                               as a remediation of M1, the problem on M1-1 is considered
-                              unrelated to\n\tthe original issue happened to M1.\n\n\nIf
+                              unrelated to\n\tthe original issue happened to M1.\n\nIf
                               not set, this value is defaulted to 1h."
                             type: string
                           retryPeriod:
                             description: |-
                               RetryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
                               for an unhealthy machine (a retry).
-
 
                               If not set, a retry will happen immediately.
                             type: string

--- a/controlplane/kubeadm/config/rbac/role.yaml
+++ b/controlplane/kubeadm/config/rbac/role.yaml
@@ -43,13 +43,6 @@ rules:
   resources:
   - clusters
   - clusters/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machinepools
   verbs:
   - get

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockerclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerCluster is the Schema for the dockerclusters API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -127,6 +126,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -175,7 +175,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerCluster is the Schema for the dockerclusters API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -295,6 +294,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -427,9 +427,7 @@ spec:
                           This field is effectively required, but due to backwards compatibility is
                           allowed to be empty. Instances of this type with an empty value here are
                           almost certainly wrong.
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockerclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -27,7 +27,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerClusterTemplate is the Schema for the dockerclustertemplates API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -247,9 +246,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockermachinepools.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerMachinePool is the Schema for the dockermachinepools API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -139,6 +138,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -221,7 +221,6 @@ spec:
         description: |-
           DockerMachinePool is the Schema for the dockermachinepools API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -337,6 +336,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -569,7 +569,6 @@ spec:
                       description: |-
                         Bootstrapped is true when the kubeadm bootstrapping has been run
                         against this machine
-
 
                         Deprecated: This field will be removed in the next apiVersion.
                         When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepooltemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockermachinepooltemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockermachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerMachine is the Schema for the dockermachines API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -153,6 +152,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -184,7 +184,6 @@ spec:
         description: |-
           DockerMachine is the Schema for the dockermachines API.
 
-
           Deprecated: This type will be removed in one of the next releases.
         properties:
           apiVersion:
@@ -314,6 +313,7 @@ spec:
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
+                  - lastTransitionTime
                   - status
                   - type
                   type: object
@@ -388,7 +388,6 @@ spec:
                 description: |-
                   Bootstrapped is true when the kubeadm bootstrapping has been run
                   against this machine
-
 
                   Deprecated: This field will be removed in the next apiVersion.
                   When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: dockermachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -22,7 +22,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerMachineTemplate is the Schema for the dockermachinetemplates API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -119,7 +118,6 @@ spec:
       openAPIV3Schema:
         description: |-
           DockerMachineTemplate is the Schema for the dockermachinetemplates API.
-
 
           Deprecated: This type will be removed in one of the next releases.
         properties:
@@ -278,7 +276,6 @@ spec:
                         description: |-
                           Bootstrapped is true when the kubeadm bootstrapping has been run
                           against this machine
-
 
                           Deprecated: This field will be removed in the next apiVersion.
                           When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.

--- a/test/infrastructure/docker/config/rbac/role.yaml
+++ b/test/infrastructure/docker/config/rbac/role.yaml
@@ -8,13 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
@@ -36,17 +29,9 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusters
-  - machines
-  - machinesets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
   - machinepools
   - machinepools/status
+  - machinesets
   verbs:
   - get
   - list
@@ -64,45 +49,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - dockerclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - dockerclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - dockermachinepools
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - dockermachinepools/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - dockermachines
   verbs:
   - create
@@ -115,6 +62,8 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - dockerclusters/status
+  - dockermachinepools/status
   - dockermachines/status
   verbs:
   - get

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclusters.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: inmemoryclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclustertemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: inmemoryclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachines.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: inmemorymachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachinetemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
   name: inmemorymachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/inmemory/config/rbac/role.yaml
+++ b/test/infrastructure/inmemory/config/rbac/role.yaml
@@ -28,14 +28,6 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusters
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
   - machines
   - machinesets
   verbs:
@@ -46,25 +38,6 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - inmemoryclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - inmemoryclusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
   - inmemorymachines
   verbs:
   - create
@@ -77,6 +50,7 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - inmemoryclusters/status
   - inmemorymachines/status
   verbs:
   - get


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

uses controller-gen from https://github.com/kubernetes-sigs/controller-tools/pull/937

**What this PR does / why we need it**:

Bumps controller-gen to commit https://github.com/kubernetes-sigs/controller-tools/commit/ed2fbe2406fa0bc6a18aa090384bcf803d17342e .

This includes:

* https://github.com/kubernetes-sigs/controller-tools/pull/937

Which deduplicates rbac stuff and makes the roles better readable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Area example:
/area dependency