### PR TITLE
🌱 Replace reflect.DeepEqual in tests

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -1558,7 +1557,7 @@ func TestKubeadmConfigReconciler_Reconcile_DiscoveryReconcileBehaviors(t *testin
 			},
 			validateDiscovery: func(g *WithT, c *bootstrapv1.KubeadmConfig) error {
 				d := c.Spec.JoinConfiguration.Discovery
-				g.Expect(reflect.DeepEqual(d.BootstrapToken.CACertHashes, caHash)).To(BeTrue())
+				g.Expect(d.BootstrapToken.CACertHashes).To(BeComparableTo(caHash))
 				return nil
 			},
 		},

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -207,7 +207,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -19,10 +19,10 @@ package controllers
 import (
 	"crypto/sha1" //nolint: gosec
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -1032,7 +1032,7 @@ func configMapHasBeenUpdated(env *envtest.Environment, key client.ObjectKey, new
 			return err
 		}
 
-		if !reflect.DeepEqual(cm.Data, newState.Data) {
+		if !cmp.Equal(cm.Data, newState.Data) {
 			return errors.Errorf("configMap %s hasn't been updated yet", key.Name)
 		}
 

--- a/internal/apis/core/exp/addons/v1alpha3/clusterresourcesetbinding_types_test.go
+++ b/internal/apis/core/exp/addons/v1alpha3/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/internal/apis/core/exp/addons/v1alpha4/clusterresourcesetbinding_types_test.go
+++ b/internal/apis/core/exp/addons/v1alpha4/clusterresourcesetbinding_types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -147,7 +147,7 @@ func TestSetResourceBinding(t *testing.T) {
 			tt.resourceSetBinding.SetBinding(tt.resourceBinding)
 			exist := false
 			for _, b := range tt.resourceSetBinding.Resources {
-				if reflect.DeepEqual(b.ResourceRef, tt.resourceBinding.ResourceRef) {
+				if cmp.Equal(b.ResourceRef, tt.resourceBinding.ResourceRef) {
 					gs.Expect(tt.resourceBinding.Applied).To(BeEquivalentTo(b.Applied))
 					exist = true
 				}

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -19,7 +19,6 @@ package clusterclass
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -188,10 +187,10 @@ func assertStatusVariables(actualClusterClass *clusterv1.ClusterClass) error {
 			if specVar.Required != statusVarDefinition.Required {
 				return errors.Errorf("ClusterClass status variable %s required field does not match. Expecte %v. Got %v", specVar.Name, statusVarDefinition.Required, statusVarDefinition.Required)
 			}
-			if !reflect.DeepEqual(specVar.Schema, statusVarDefinition.Schema) {
+			if !cmp.Equal(specVar.Schema, statusVarDefinition.Schema) {
 				return errors.Errorf("ClusterClass status variable %s schema does not match. Expected %v. Got %v", specVar.Name, specVar.Schema, statusVarDefinition.Schema)
 			}
-			if !reflect.DeepEqual(specVar.Metadata, statusVarDefinition.Metadata) {
+			if !cmp.Equal(specVar.Metadata, statusVarDefinition.Metadata) {
 				return errors.Errorf("ClusterClass status variable %s metadata does not match. Expected %v. Got %v", specVar.Name, specVar.Metadata, statusVarDefinition.Metadata)
 			}
 		}
@@ -719,7 +718,7 @@ func TestReconciler_extensionConfigToClusterClass(t *testing.T) {
 			{NamespacedName: types.NamespacedName{Namespace: onePatchClusterClass.Namespace, Name: onePatchClusterClass.Name}},
 			{NamespacedName: types.NamespacedName{Namespace: twoPatchClusterClass.Namespace, Name: twoPatchClusterClass.Name}},
 		}
-		if got := r.extensionConfigToClusterClass(context.Background(), firstExtConfig); !reflect.DeepEqual(got, firstExtConfigExpected) {
+		if got := r.extensionConfigToClusterClass(context.Background(), firstExtConfig); !cmp.Equal(got, firstExtConfigExpected) {
 			t.Errorf("extensionConfigToClusterClass() = %v, want %v", got, firstExtConfigExpected)
 		}
 
@@ -727,7 +726,7 @@ func TestReconciler_extensionConfigToClusterClass(t *testing.T) {
 		secondExtConfigExpected := []reconcile.Request{
 			{NamespacedName: types.NamespacedName{Namespace: twoPatchClusterClass.Namespace, Name: twoPatchClusterClass.Name}},
 		}
-		if got := r.extensionConfigToClusterClass(context.Background(), secondExtConfig); !reflect.DeepEqual(got, secondExtConfigExpected) {
+		if got := r.extensionConfigToClusterClass(context.Background(), secondExtConfig); !cmp.Equal(got, secondExtConfigExpected) {
 			t.Errorf("extensionConfigToClusterClass() = %v, want %v", got, secondExtConfigExpected)
 		}
 	})

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -18,11 +18,9 @@ package cluster
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1425,7 +1423,7 @@ func TestReconciler_DefaultCluster(t *testing.T) {
 			got := &clusterv1.Cluster{}
 			g.Expect(fakeClient.Get(ctx, client.ObjectKey{Name: tt.initialCluster.Name, Namespace: tt.initialCluster.Namespace}, got)).To(Succeed())
 			// Compare the spec of the two clusters to ensure that variables are defaulted correctly.
-			g.Expect(reflect.DeepEqual(got.Spec, tt.wantCluster.Spec)).To(BeTrue(), cmp.Diff(got.Spec, tt.wantCluster.Spec))
+			g.Expect(got.Spec).To(BeComparableTo(tt.wantCluster.Spec))
 		})
 	}
 }

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1227,7 +1227,7 @@ func Test_aggregateResponses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			aggregateSuccessfulResponses(tt.aggregateResponse, tt.responses)
 
-			if !reflect.DeepEqual(tt.aggregateResponse, tt.want) {
+			if !cmp.Equal(tt.aggregateResponse, tt.want) {
 				t.Errorf("aggregateSuccessfulResponses() got = %v, want %v", tt.aggregateResponse, tt.want)
 			}
 		})

--- a/internal/topology/variables/schema_test.go
+++ b/internal/topology/variables/schema_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package variables
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -196,7 +196,7 @@ func Test_convertToAPIExtensionsJSONSchemaProps(t *testing.T) {
 				}
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !cmp.Equal(got, tt.want) {
 				t.Errorf("convertToAPIExtensionsJSONSchemaProps() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package patch
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,7 +107,7 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				return reflect.DeepEqual(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
+				return cmp.Equal(obj.GetOwnerReferences(), objAfter.GetOwnerReferences())
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -543,7 +542,7 @@ func TestPatchHelper(t *testing.T) {
 					return false
 				}
 
-				return reflect.DeepEqual(obj.Finalizers, objAfter.Finalizers)
+				return cmp.Equal(obj.Finalizers, objAfter.Finalizers)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -628,7 +627,7 @@ func TestPatchHelper(t *testing.T) {
 				}
 
 				return objAfter.Spec.Paused &&
-					reflect.DeepEqual(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
+					cmp.Equal(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -666,7 +665,7 @@ func TestPatchHelper(t *testing.T) {
 				if err := env.Get(ctx, key, objAfter); err != nil {
 					return false
 				}
-				return reflect.DeepEqual(objAfter.Status, obj.Status)
+				return cmp.Equal(objAfter.Status, obj.Status)
 			}, timeout).Should(BeTrue())
 		})
 
@@ -718,7 +717,7 @@ func TestPatchHelper(t *testing.T) {
 
 				return obj.Status.InfrastructureReady == objAfter.Status.InfrastructureReady &&
 					conditions.IsTrue(objAfter, clusterv1.ReadyCondition) &&
-					reflect.DeepEqual(obj.Spec, objAfter.Spec)
+					cmp.Equal(obj.Spec, objAfter.Spec)
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -774,7 +773,7 @@ func TestPatchHelper(t *testing.T) {
 					return false
 				}
 
-				return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
+				return cmp.Equal(obj.Spec, objAfter.Spec) &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())
 		})
@@ -823,8 +822,8 @@ func TestPatchHelper(t *testing.T) {
 					return false
 				}
 
-				return reflect.DeepEqual(obj.Spec, objAfter.Spec) &&
-					reflect.DeepEqual(obj.Status, objAfter.Status) &&
+				return cmp.Equal(obj.Spec, objAfter.Spec) &&
+					cmp.Equal(obj.Status, objAfter.Status) &&
 					obj.GetGeneration() == objAfter.Status.ObservedGeneration
 			}, timeout).Should(BeTrue())
 		})


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8186

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->