### PR TITLE
🌱 Add compare util using go-cmp, modify webhooks & KCP controller

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -131,11 +131,15 @@ func (c *ControlPlane) FailureDomainWithMostMachines(ctx context.Context, machin
 }
 
 // NextFailureDomainForScaleUp returns the failure domain with the fewest number of up-to-date machines.
-func (c *ControlPlane) NextFailureDomainForScaleUp(ctx context.Context) *string {
+func (c *ControlPlane) NextFailureDomainForScaleUp(ctx context.Context) (*string, error) {
 	if len(c.Cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
-		return nil
+		return nil, nil
 	}
-	return failuredomains.PickFewest(ctx, c.FailureDomains().FilterControlPlane(), c.UpToDateMachines())
+	upToDateMachines, err := c.UpToDateMachines()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to determine next failure domain for scale up")
+	}
+	return failuredomains.PickFewest(ctx, c.FailureDomains().FilterControlPlane(), upToDateMachines), nil
 }
 
 // InitialControlPlaneConfig returns a new KubeadmConfigSpec that is to be used for an initializing control plane.
@@ -167,7 +171,7 @@ func (c *ControlPlane) GetKubeadmConfig(machineName string) (*bootstrapv1.Kubead
 }
 
 // MachinesNeedingRollout return a list of machines that need to be rolled out.
-func (c *ControlPlane) MachinesNeedingRollout() (collections.Machines, map[string]string) {
+func (c *ControlPlane) MachinesNeedingRollout() (collections.Machines, map[string]string, error) {
 	// Ignore machines to be deleted.
 	machines := c.Machines.Filter(collections.Not(collections.HasDeletionTimestamp))
 
@@ -175,26 +179,32 @@ func (c *ControlPlane) MachinesNeedingRollout() (collections.Machines, map[strin
 	machinesNeedingRollout := make(collections.Machines, len(machines))
 	rolloutReasons := map[string]string{}
 	for _, m := range machines {
-		reason, needsRollout := NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.InfraResources, c.KubeadmConfigs, c.KCP, m)
+		reason, needsRollout, err := NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.InfraResources, c.KubeadmConfigs, c.KCP, m)
+		if err != nil {
+			return nil, nil, err
+		}
 		if needsRollout {
 			machinesNeedingRollout.Insert(m)
 			rolloutReasons[m.Name] = reason
 		}
 	}
-	return machinesNeedingRollout, rolloutReasons
+	return machinesNeedingRollout, rolloutReasons, nil
 }
 
 // UpToDateMachines returns the machines that are up to date with the control
 // plane's configuration and therefore do not require rollout.
-func (c *ControlPlane) UpToDateMachines() collections.Machines {
+func (c *ControlPlane) UpToDateMachines() (collections.Machines, error) {
 	upToDateMachines := make(collections.Machines, len(c.Machines))
 	for _, m := range c.Machines {
-		_, needsRollout := NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.InfraResources, c.KubeadmConfigs, c.KCP, m)
+		_, needsRollout, err := NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.InfraResources, c.KubeadmConfigs, c.KCP, m)
+		if err != nil {
+			return nil, err
+		}
 		if !needsRollout {
 			upToDateMachines.Insert(m)
 		}
 	}
-	return upToDateMachines
+	return upToDateMachines, nil
 }
 
 // getInfraResources fetches the external infrastructure resource for each machine in the collection and returns a map of machine.Name -> infraResource.

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -208,7 +208,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 			if errors.As(err, &connFailure) {
 				log.Error(err, "Could not connect to workload cluster to fetch status")
 			} else {
-				log.Error(err, "Failed to update KubeadmControlPlane Status")
+				log.Error(err, "Failed to update KubeadmControlPlane status")
 				reterr = kerrors.NewAggregate([]error{reterr, err})
 			}
 		}
@@ -399,7 +399,10 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, controlPl
 	}
 
 	// Control plane machines rollout due to configuration changes (e.g. upgrades) takes precedence over other operations.
-	machinesNeedingRollout, rolloutReasons := controlPlane.MachinesNeedingRollout()
+	machinesNeedingRollout, rolloutReasons, err := controlPlane.MachinesNeedingRollout()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	switch {
 	case len(machinesNeedingRollout) > 0:
 		var reasons []string

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -39,7 +39,11 @@ func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Conte
 	logger := ctrl.LoggerFrom(ctx)
 
 	bootstrapSpec := controlPlane.InitialControlPlaneConfig()
-	fd := controlPlane.NextFailureDomainForScaleUp(ctx)
+	fd, err := controlPlane.NextFailureDomainForScaleUp(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if err := r.cloneConfigsAndGenerateMachine(ctx, controlPlane.Cluster, controlPlane.KCP, bootstrapSpec, fd); err != nil {
 		logger.Error(err, "Failed to create initial control plane Machine")
 		r.recorder.Eventf(controlPlane.KCP, corev1.EventTypeWarning, "FailedInitialization", "Failed to create initial control plane Machine for cluster %s control plane: %v", klog.KObj(controlPlane.Cluster), err)
@@ -60,7 +64,11 @@ func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context,
 
 	// Create the bootstrap configuration
 	bootstrapSpec := controlPlane.JoinControlPlaneConfig()
-	fd := controlPlane.NextFailureDomainForScaleUp(ctx)
+	fd, err := controlPlane.NextFailureDomainForScaleUp(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if err := r.cloneConfigsAndGenerateMachine(ctx, controlPlane.Cluster, controlPlane.KCP, bootstrapSpec, fd); err != nil {
 		logger.Error(err, "Failed to create additional control plane Machine")
 		r.recorder.Eventf(controlPlane.KCP, corev1.EventTypeWarning, "FailedScaleUp", "Failed to create additional control plane Machine for cluster % control plane: %v", klog.KObj(controlPlane.Cluster), err)

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -36,7 +36,11 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, contro
 	// This is necessary for CRDs including scale subresources.
 	controlPlane.KCP.Status.Selector = selector.String()
 
-	controlPlane.KCP.Status.UpdatedReplicas = int32(len(controlPlane.UpToDateMachines()))
+	upToDateMachines, err := controlPlane.UpToDateMachines()
+	if err != nil {
+		return errors.Wrapf(err, "failed to update status")
+	}
+	controlPlane.KCP.Status.UpdatedReplicas = int32(len(upToDateMachines))
 
 	replicas := int32(len(controlPlane.Machines))
 	desiredReplicas := *controlPlane.KCP.Spec.Replicas

--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
@@ -19,7 +19,6 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,9 +30,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/util/compare"
 )
-
-const kubeadmControlPlaneTemplateImmutableMsg = "KubeadmControlPlaneTemplate spec.template.spec field is immutable. Please create new resource instead."
 
 func (webhook *KubeadmControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -115,9 +113,13 @@ func (webhook *KubeadmControlPlaneTemplate) ValidateUpdate(ctx context.Context, 
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new KubeadmControlPlaneTemplate: failed to default new object: %v", err))
 	}
 
-	if !reflect.DeepEqual(newK.Spec.Template.Spec, oldK.Spec.Template.Spec) {
+	equal, diff, err := compare.Diff(oldK.Spec.Template.Spec, newK.Spec.Template.Spec)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new KubeadmControlPlaneTemplate: %v", err))
+	}
+	if !equal {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "template", "spec"), newK, kubeadmControlPlaneTemplateImmutableMsg),
+			field.Invalid(field.NewPath("spec", "template", "spec"), newK, fmt.Sprintf("KubeadmControlPlaneTemplate spec.template.spec field is immutable. Please create new resource instead. Diff: %s", diff)),
 		)
 	}
 

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -71,7 +71,7 @@ func (r *ResourceSetBinding) GetResource(resourceRef ResourceRef) *ResourceBindi
 	return nil
 }
 
-// SetBinding sets resourceBinding for a resource in resourceSetbinding either by updating the existing one or
+// SetBinding sets resourceBinding for a resource in ResourceSetBinding either by updating the existing one or
 // creating a new one.
 func (r *ResourceSetBinding) SetBinding(resourceBinding ResourceBinding) {
 	for i := range r.Resources {

--- a/exp/ipam/internal/webhooks/ipaddressclaim.go
+++ b/exp/ipam/internal/webhooks/ipaddressclaim.go
@@ -19,7 +19,6 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/util/compare"
 )
 
 // SetupWebhookWithManager sets up IPAddressClaim webhooks.
@@ -75,12 +75,14 @@ func (webhook *IPAddressClaim) ValidateUpdate(_ context.Context, oldObj, newObj 
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected an IPAddressClaim but got a %T", newObj))
 	}
 
-	if !reflect.DeepEqual(oldClaim.Spec, newClaim.Spec) {
-		return nil, field.Forbidden(
-			field.NewPath("spec"),
-			"the spec of IPAddressClaim is immutable",
-		)
+	equal, diff, err := compare.Diff(oldClaim.Spec, newClaim.Spec)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new IPAddressClaim spec: %v", err))
 	}
+	if !equal {
+		return nil, field.Forbidden(field.NewPath("spec"), fmt.Sprintf("IPAddressClaim spec is immutable. Diff: %s", diff))
+	}
+
 	return nil, nil
 }
 

--- a/internal/util/compare/equal.go
+++ b/internal/util/compare/equal.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package compare contains utils to compare objects.
+package compare
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+)
+
+// Diff uses cmp.Diff to compare x and y.
+// If cmp.Diff panics, Equal returns an error.
+func Diff(x any, y any) (equal bool, diff string, matchErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			equal = false
+			if err, ok := r.(error); ok {
+				matchErr = errors.Wrapf(err, "error diffing objects")
+				return
+			}
+
+			if errMsg, ok := r.(string); ok {
+				matchErr = errors.Errorf("error diffing objects: %s", errMsg)
+				return
+			}
+
+			matchErr = errors.Errorf("error diffing objects: panic of unknown type %T", r)
+		}
+	}()
+
+	diff = cmp.Diff(x, y)
+
+	if diff != "" {
+		// Replace non-breaking space (NBSP) through a regular space.
+		// This prevents output like this: "\u00a0\u00a0int(\n-\u00a0\t1,\n+\u00a0\t2,\n\u00a0\u00a0)\n"
+		diff = strings.ReplaceAll(diff, "\u00a0", " ")
+		// Replace \t through "  " because it's easier to read in log output
+		diff = strings.ReplaceAll(diff, "\t", "  ")
+		diff = strings.TrimSpace(diff)
+	}
+
+	return diff == "", diff, nil
+}

--- a/internal/util/compare/equal_test.go
+++ b/internal/util/compare/equal_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compare
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestDiff(t *testing.T) {
+	type test struct {
+		name      string
+		x, y      interface{}
+		wantEqual bool
+		wantDiff  string
+		wantError string
+	}
+
+	tests := []test{
+		{
+			name:      "Equal integers, no diff",
+			x:         1,
+			y:         1,
+			wantEqual: true,
+		},
+		{
+			name:      "Different integers, diff",
+			x:         1,
+			y:         2,
+			wantEqual: false,
+			wantDiff: `int(
+-   1,
++   2,
+  )`,
+		},
+		{
+			name: "Different labels, diff",
+			x: map[string]string{
+				clusterv1.ClusterNameLabel:          "cluster-1",
+				clusterv1.ClusterTopologyOwnedLabel: "",
+			},
+			y: map[string]string{
+				clusterv1.ClusterNameLabel: "cluster-2",
+			},
+			wantEqual: false,
+			wantDiff: `map[string]string{
+-   "cluster.x-k8s.io/cluster-name":   "cluster-1",
++   "cluster.x-k8s.io/cluster-name":   "cluster-2",
+-   "topology.cluster.x-k8s.io/owned": "",
+  }`,
+		},
+		{
+			name: "Diff unexported fields, error",
+			x:    struct{ a, b, c int }{1, 2, 3},
+			y:    struct{ a, b, c int }{1, 2, 4},
+			wantError: `error diffing objects: cannot handle unexported field at root.a:
+	"sigs.k8s.io/cluster-api/internal/util/compare".(struct { a int; b int; c int })
+consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			gotEqual, gotDiff, err := Diff(tt.x, tt.y)
+
+			if tt.wantError != "" {
+				g.Expect(err.Error()).To(BeComparableTo(tt.wantError))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+
+				g.Expect(gotEqual).To(Equal(tt.wantEqual))
+				g.Expect(gotDiff).To(BeComparableTo(tt.wantDiff))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Needs a bit more work and some manual tests (want to see how the diffs are looking in logs)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8186

Example logs for KCP controller
```
I0516 16:01:22.008912      58 controller.go:412] "Rolling out Control Plane machines: Machine capi-quickstart-control-plane-xvq7h needs rollout: Machine KubeadmConfig ClusterConfiguration is outdated: diff: &v1beta1.ClusterConfiguration{\n    ... // 3 identical fields\n    KubernetesVersion:    \"\",\n    ControlPlaneEndpoint: \"\",\n    APIServer: v1beta1.APIServer{\n      ControlPlaneComponent: {},\n      CertSANs: []string{\n        \"localhost\",\n-       \"127.0.0.1\",\n        \"0.0.0.0\",\n        \"host.docker.internal\",\n      },\n      TimeoutForControlPlane: nil,\n    },\n    ControllerManager: {ExtraArgs: {\"enable-hostpath-provisioner\": \"true\"}},\n    Scheduler:         {},\n    ... // 5 identical fields\n  }" controller="kubeadmcontrolplane" controllerGroup="controlplane.cluster.x-k8s.io" controllerKind="KubeadmControlPlane" KubeadmControlPlane="default/capi-quickstart-control-plane" namespace="default" name="capi-quickstart-control-plane" reconcileID="93e4bce7-00da-44c7-9421-a714ecf996ca" Cluster="default/capi-quickstart" machinesNeedingRollout=["capi-quickstart-control-plane-xvq7h"]
```

Message after removing escaping
```
Rolling out Control Plane machines: Machine capi-quickstart-control-plane-xvq7h needs rollout: Machine KubeadmConfig ClusterConfiguration is outdated: diff: &v1beta1.ClusterConfiguration{
    ... // 3 identical fields
    KubernetesVersion:    "",
    ControlPlaneEndpoint: "",
    APIServer: v1beta1.APIServer{
      ControlPlaneComponent: {},
      CertSANs: []string{
        "localhost",
-       "127.0.0.1",
        "0.0.0.0",
        "host.docker.internal",
      },
      TimeoutForControlPlane: nil,
    },
    ControllerManager: {ExtraArgs: {"enable-hostpath-provisioner": "true"}},
    Scheduler:         {},
    ... // 5 identical fields
  }
```

Example for webhook
```
k apply -f /var/folders/v0/mny6w2dd33gfzwmwxb3wyyx40000gq/T/kubectl-edit-3932073547.yaml
[kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/quick-start-control-plane-2](http://kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/quick-start-control-plane-2) configured
[kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/quick-start-control-plane-3](http://kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/quick-start-control-plane-3) configured
The KubeadmControlPlaneTemplate "quick-start-control-plane" is invalid: spec.template.spec: Invalid value: v1beta1.KubeadmControlPlaneTemplate{TypeMeta:v1.TypeMeta{Kind:"KubeadmControlPlaneTemplate", APIVersion:"[controlplane.cluster.x-k8s.io/v1beta1](http://controlplane.cluster.x-k8s.io/v1beta1)"}, ObjectMeta:v1.ObjectMeta{Name:"quick-start-control-plane", GenerateName:"", Namespace:"default", SelfLink:"", UID:"288374d2-7a3b-4a26-9606-0627bd06db1d", ResourceVersion:"2293", Generation:2, CreationTimestamp:time.Date(2024, time.May, 16, 16, 6, 12, 0, time.Local), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string{"[kubectl.kubernetes.io/last-applied-configuration](http://kubectl.kubernetes.io/last-applied-configuration)":"{\"apiVersion\":\"[controlplane.cluster.x-k8s.io/v1beta1](http://controlplane.cluster.x-k8s.io/v1beta1)\",\"kind\":\"KubeadmControlPlaneTemplate\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2024-05-16T16:06:12Z\",\"generation\":1,\"name\":\"quick-start-control-plane\",\"namespace\":\"default\",\"resourceVersion\":\"2293\",\"uid\":\"288374d2-7a3b-4a26-9606-0627bd06db1d\"},\"spec\":{\"template\":{\"metadata\":{},\"spec\":{\"kubeadmConfigSpec\":{\"clusterConfiguration\":{\"apiServer\":{\"certSANs\":[\"localhost\",\"0.0.0.0\",\"host.docker.internal\"]},\"controllerManager\":{\"extraArgs\":{\"enable-hostpath-provisioner\":\"true\"}},\"dns\":{},\"etcd\":{},\"networking\":{},\"scheduler\":{}},\"files\":[{\"content\":\"SOMETESTCONTENT\\n\",\"path\":\"abc\"}],\"format\":\"cloud-config\",\"initConfiguration\":{\"localAPIEndpoint\":{},\"nodeRegistration\":{\"criSocket\":\"/var/run/containerd/containerd.sock\",\"imagePullPolicy\":\"IfNotPresent\",\"kubeletExtraArgs\":{\"eviction-hard\":\"nodefs.available\\u003c0%,nodefs.inodesFree\\u003c0%,imagefs.available\\u003c0%\"}}},\"joinConfiguration\":{\"discovery\":{},\"nodeRegistration\":{\"criSocket\":\"/var/run/containerd/containerd.sock\",\"imagePullPolicy\":\"IfNotPresent\",\"kubeletExtraArgs\":{\"eviction-hard\":\"nodefs.available\\u003c0%,nodefs.inodesFree\\u003c0%,imagefs.available\\u003c0%\"}}}},\"rolloutStrategy\":{\"rollingUpdate\":{\"maxSurge\":1},\"type\":\"RollingUpdate\"}}}}}\n"}, OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ManagedFields:[]v1.ManagedFieldsEntry{v1.ManagedFieldsEntry{Manager:"kubectl-client-side-apply", Operation:"Update", APIVersion:"[controlplane.cluster.x-k8s.io/v1beta1](http://controlplane.cluster.x-k8s.io/v1beta1)", Time:time.Date(2024, time.May, 16, 16, 7, 25, 0, time.Local), FieldsType:"FieldsV1", FieldsV1:(*v1.FieldsV1)(0x4000a540a8), Subresource:""}}}, Spec:v1beta1.KubeadmControlPlaneTemplateSpec{Template:v1beta1.KubeadmControlPlaneTemplateResource{ObjectMeta:v1beta1.ObjectMeta{Labels:map[string]string(nil), Annotations:map[string]string(nil)}, Spec:v1beta1.KubeadmControlPlaneTemplateResourceSpec{MachineTemplate:(*v1beta1.KubeadmControlPlaneTemplateMachineTemplate)(nil), KubeadmConfigSpec:v1beta1.KubeadmConfigSpec{ClusterConfiguration:(*v1beta1.ClusterConfiguration)(0x4000d862c0), InitConfiguration:(*v1beta1.InitConfiguration)(0x40000ea620), JoinConfiguration:(*v1beta1.JoinConfiguration)(0x4001172000), Files:[]v1beta1.File{v1beta1.File{Path:"abc", Owner:"", Permissions:"", Encoding:"", Append:false, Content:"SOMETESTCONTENT\n", ContentFrom:(*v1beta1.FileSource)(nil)}}, DiskSetup:(*v1beta1.DiskSetup)(nil), Mounts:[]v1beta1.MountPoints(nil), PreKubeadmCommands:[]string(nil), PostKubeadmCommands:[]string(nil), Users:[]v1beta1.User(nil), NTP:(*v1beta1.NTP)(nil), Format:"cloud-config", Verbosity:(*int32)(nil), UseExperimentalRetryJoin:false, Ignition:(*v1beta1.IgnitionSpec)(nil)}, RolloutBefore:(*v1beta1.RolloutBefore)(nil), RolloutAfter:<nil>, RolloutStrategy:(*v1beta1.RolloutStrategy)(0x4000a54150), RemediationStrategy:(*v1beta1.RemediationStrategy)(nil)}}}}: KubeadmControlPlaneTemplate spec.template.spec field is immutable. Please create new resource instead. Diff: v1beta1.KubeadmControlPlaneTemplateResourceSpec{
    MachineTemplate: nil,
    KubeadmConfigSpec: v1beta1.KubeadmConfigSpec{
      ClusterConfiguration: &v1beta1.ClusterConfiguration{
        ... // 3 identical fields
        KubernetesVersion:    "",
        ControlPlaneEndpoint: "",
        APIServer: v1beta1.APIServer{
          ControlPlaneComponent: {},
          CertSANs: []string{
            "localhost",
-           "127.0.0.1",
            "0.0.0.0",
            "host.docker.internal",
          },
          TimeoutForControlPlane: nil,
        },
        ControllerManager: {ExtraArgs: {"enable-hostpath-provisioner": "true"}},
        Scheduler:         {},
        ... // 5 identical fields
      },
      InitConfiguration: &{NodeRegistration: {CRISocket: "/var/run/containerd/containerd.sock", KubeletExtraArgs: {"eviction-hard": "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%"}, ImagePullPolicy: "IfNotPresent"}},
      JoinConfiguration: &{NodeRegistration: {CRISocket: "/var/run/containerd/containerd.sock", KubeletExtraArgs: {"eviction-hard": "nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%"}, ImagePullPolicy: "IfNotPresent"}},
      ... // 11 identical fields
    },
    RolloutBefore: nil,
    RolloutAfter:  nil,
    ... // 2 identical fields
  }
```

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->