### PR TITLE
🐛 crs: use separate cache for partial metadata watches on secrets to include all secrets

### DIFF
--- a/exp/addons/controllers/alias.go
+++ b/exp/addons/controllers/alias.go
@@ -18,9 +18,9 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -37,12 +37,12 @@ type ClusterResourceSetReconciler struct {
 	WatchFilterValue string
 }
 
-func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, syncPeriod *time.Duration) error {
+func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, partialSecretCache cache.Cache) error {
 	return (&clusterresourcesets.ClusterResourceSetReconciler{
 		Client:           r.Client,
 		Tracker:          r.Tracker,
 		WatchFilterValue: r.WatchFilterValue,
-	}).SetupWithManager(ctx, mgr, options, syncPeriod)
+	}).SetupWithManager(ctx, mgr, options, partialSecretCache)
 }
 
 // ClusterResourceSetBindingReconciler reconciles a ClusterResourceSetBinding object.

--- a/exp/addons/controllers/alias.go
+++ b/exp/addons/controllers/alias.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,12 +37,12 @@ type ClusterResourceSetReconciler struct {
 	WatchFilterValue string
 }
 
-func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, syncPeriod *time.Duration) error {
 	return (&clusterresourcesets.ClusterResourceSetReconciler{
 		Client:           r.Client,
 		Tracker:          r.Tracker,
 		WatchFilterValue: r.WatchFilterValue,
-	}).SetupWithManager(ctx, mgr, options)
+	}).SetupWithManager(ctx, mgr, options, syncPeriod)
 }
 
 // ClusterResourceSetBindingReconciler reconciles a ClusterResourceSetBinding object.

--- a/exp/addons/internal/controllers/predicates/resource_predicates.go
+++ b/exp/addons/internal/controllers/predicates/resource_predicates.go
@@ -24,11 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// ResourceCreateOrUpdate returns a predicate that returns true for create and update events.
-func ResourceCreateOrUpdate(l logr.Logger) predicate.Funcs {
-	return TypedResourceCreateOrUpdate[client.Object](l)
-}
-
 // TypedResourceCreateOrUpdate returns a predicate that returns true for create and update events.
 func TypedResourceCreateOrUpdate[T client.Object](_ logr.Logger) predicate.TypedFuncs[T] {
 	return predicate.TypedFuncs[T]{

--- a/exp/addons/internal/controllers/predicates/resource_predicates.go
+++ b/exp/addons/internal/controllers/predicates/resource_predicates.go
@@ -19,16 +19,22 @@ package predicates
 
 import (
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // ResourceCreateOrUpdate returns a predicate that returns true for create and update events.
-func ResourceCreateOrUpdate(_ logr.Logger) predicate.Funcs {
-	return predicate.Funcs{
-		CreateFunc:  func(event.CreateEvent) bool { return true },
-		UpdateFunc:  func(event.UpdateEvent) bool { return true },
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
-		GenericFunc: func(event.GenericEvent) bool { return false },
+func ResourceCreateOrUpdate(l logr.Logger) predicate.Funcs {
+	return TypedResourceCreateOrUpdate[client.Object](l)
+}
+
+// TypedResourceCreateOrUpdate returns a predicate that returns true for create and update events.
+func TypedResourceCreateOrUpdate[T client.Object](_ logr.Logger) predicate.TypedFuncs[T] {
+	return predicate.TypedFuncs[T]{
+		CreateFunc:  func(event.TypedCreateEvent[T]) bool { return true },
+		UpdateFunc:  func(event.TypedUpdateEvent[T]) bool { return true },
+		DeleteFunc:  func(event.TypedDeleteEvent[T]) bool { return false },
+		GenericFunc: func(event.TypedGenericEvent[T]) bool { return false },
 	}
 }

--- a/exp/addons/internal/controllers/suite_test.go
+++ b/exp/addons/internal/controllers/suite_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 			Client:  mgr.GetClient(),
 			Tracker: tracker,
 		}
-		if err = reconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}, nil); err != nil {
+		if err = reconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}, mgr.GetCache()); err != nil {
 			panic(fmt.Sprintf("Failed to set up cluster resource set reconciler: %v", err))
 		}
 		bindingReconciler := ClusterResourceSetBindingReconciler{

--- a/exp/addons/internal/controllers/suite_test.go
+++ b/exp/addons/internal/controllers/suite_test.go
@@ -56,6 +56,9 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			panic(fmt.Sprintf("Failed to create cache for metadata only Secret watches: %v", err))
 		}
+		if err := mgr.Add(partialSecretCache); err != nil {
+			panic(fmt.Sprintf("Failed to start cache for metadata only Secret watches: %v", err))
+		}
 
 		tracker, err := remote.NewClusterCacheTracker(mgr, remote.ClusterCacheTrackerOptions{})
 		if err != nil {

--- a/exp/addons/internal/controllers/suite_test.go
+++ b/exp/addons/internal/controllers/suite_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 			Client:  mgr.GetClient(),
 			Tracker: tracker,
 		}
-		if err = reconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		if err = reconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}, nil); err != nil {
 			panic(fmt.Sprintf("Failed to set up cluster resource set reconciler: %v", err))
 		}
 		bindingReconciler := ClusterResourceSetBindingReconciler{

--- a/exp/addons/internal/controllers/suite_test.go
+++ b/exp/addons/internal/controllers/suite_test.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -52,6 +54,7 @@ func TestMain(m *testing.M) {
 			Scheme:     mgr.GetScheme(),
 			Mapper:     mgr.GetRESTMapper(),
 			HTTPClient: mgr.GetHTTPClient(),
+			SyncPeriod: ptr.To(time.Minute * 10),
 		})
 		if err != nil {
 			panic(fmt.Sprintf("Failed to create cache for metadata only Secret watches: %v", err))

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -37,11 +38,11 @@ type ExtensionConfigReconciler struct {
 	WatchFilterValue string
 }
 
-func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, partialSecretCache cache.Cache) error {
 	return (&runtimecontrollers.Reconciler{
 		Client:           r.Client,
 		APIReader:        r.APIReader,
 		RuntimeClient:    r.RuntimeClient,
 		WatchFilterValue: r.WatchFilterValue,
-	}).SetupWithManager(ctx, mgr, options)
+	}).SetupWithManager(ctx, mgr, options, partialSecretCache)
 }

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -74,7 +74,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				},
 			},
 			handler.TypedEnqueueRequestsFromMapFunc(
-				secretToExtensionConfigFunc[*metav1.PartialObjectMetadata](r.Client),
+				secretToExtensionConfigFunc(r.Client),
 			),
 		)).
 		WithOptions(options).
@@ -192,8 +192,8 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, extensionConfig *runti
 
 // secretToExtensionConfigFunc returns a func which maps a secret to ExtensionConfigs with the corresponding
 // InjectCAFromSecretAnnotation to reconcile them on updates of the secrets.
-func secretToExtensionConfigFunc[T client.Object](ctrlClient client.Client) handler.TypedMapFunc[T] {
-	return func(ctx context.Context, o T) []reconcile.Request {
+func secretToExtensionConfigFunc(ctrlClient client.Client) handler.TypedMapFunc[*metav1.PartialObjectMetadata] {
+	return func(ctx context.Context, o *metav1.PartialObjectMetadata) []reconcile.Request {
 		result := []ctrl.Request{}
 
 		extensionConfigs := runtimev1.ExtensionConfigList{}

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -24,13 +24,16 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
@@ -59,13 +62,21 @@ type Reconciler struct {
 	WatchFilterValue string
 }
 
-func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, partialSecretCache cache.Cache) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&runtimev1.ExtensionConfig{}).
-		WatchesMetadata(
-			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(r.secretToExtensionConfig),
-		).
+		WatchesRawSource(source.Kind(
+			partialSecretCache,
+			&metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			},
+			handler.TypedEnqueueRequestsFromMapFunc(
+				secretToExtensionConfigFunc[*metav1.PartialObjectMetadata](r.Client),
+			),
+		)).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
@@ -179,27 +190,29 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, extensionConfig *runti
 	return ctrl.Result{}, nil
 }
 
-// secretToExtensionConfig maps a secret to ExtensionConfigs with the corresponding InjectCAFromSecretAnnotation
-// to reconcile them on updates of the secrets.
-func (r *Reconciler) secretToExtensionConfig(ctx context.Context, secret client.Object) []reconcile.Request {
-	result := []ctrl.Request{}
+// secretToExtensionConfigFunc returns a func which maps a secret to ExtensionConfigs with the corresponding
+// InjectCAFromSecretAnnotation to reconcile them on updates of the secrets.
+func secretToExtensionConfigFunc[T client.Object](ctrlClient client.Client) handler.TypedMapFunc[T] {
+	return func(ctx context.Context, o T) []reconcile.Request {
+		result := []ctrl.Request{}
 
-	extensionConfigs := runtimev1.ExtensionConfigList{}
-	indexKey := secret.GetNamespace() + "/" + secret.GetName()
+		extensionConfigs := runtimev1.ExtensionConfigList{}
+		indexKey := o.GetNamespace() + "/" + o.GetName()
 
-	if err := r.Client.List(
-		ctx,
-		&extensionConfigs,
-		client.MatchingFields{injectCAFromSecretAnnotationField: indexKey},
-	); err != nil {
-		return nil
+		if err := ctrlClient.List(
+			ctx,
+			&extensionConfigs,
+			client.MatchingFields{injectCAFromSecretAnnotationField: indexKey},
+		); err != nil {
+			return nil
+		}
+
+		for _, ext := range extensionConfigs.Items {
+			result = append(result, ctrl.Request{NamespacedName: client.ObjectKey{Name: ext.Name}})
+		}
+
+		return result
 	}
-
-	for _, ext := range extensionConfigs.Items {
-		result = append(result, ctrl.Request{NamespacedName: client.ObjectKey{Name: ext.Name}})
-	}
-
-	return result
 }
 
 // discoverExtensionConfig attempts to discover the Handlers for an ExtensionConfig.

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -74,7 +74,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				},
 			},
 			handler.TypedEnqueueRequestsFromMapFunc(
-				r.secretToExtensionConfigFunc,
+				r.secretToExtensionConfig,
 			),
 		)).
 		WithOptions(options).
@@ -190,13 +190,13 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, extensionConfig *runti
 	return ctrl.Result{}, nil
 }
 
-// secretToExtensionConfigFunc returns a func which maps a secret to ExtensionConfigs with the corresponding
-// InjectCAFromSecretAnnotation to reconcile them on updates of the secrets.
-func (r *Reconciler) secretToExtensionConfigFunc(ctx context.Context, o *metav1.PartialObjectMetadata) []reconcile.Request {
+// secretToExtensionConfig maps a secret to ExtensionConfigs with the corresponding InjectCAFromSecretAnnotation
+// to reconcile them on updates of the secrets.
+func (r *Reconciler) secretToExtensionConfig(ctx context.Context, secret *metav1.PartialObjectMetadata) []reconcile.Request {
 	result := []ctrl.Request{}
 
 	extensionConfigs := runtimev1.ExtensionConfigList{}
-	indexKey := o.GetNamespace() + "/" + o.GetName()
+	indexKey := secret.GetNamespace() + "/" + secret.GetName()
 
 	if err := r.Client.List(
 		ctx,

--- a/main.go
+++ b/main.go
@@ -360,7 +360,7 @@ func main() {
 
 	setupChecks(mgr)
 	setupIndexes(ctx, mgr)
-	tracker := setupReconcilers(ctx, mgr)
+	tracker := setupReconcilers(ctx, mgr, syncPeriod)
 	setupWebhooks(mgr, tracker)
 
 	setupLog.Info("Starting manager", "version", version.Get().String())
@@ -389,7 +389,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager) {
 	}
 }
 
-func setupReconcilers(ctx context.Context, mgr ctrl.Manager) webhooks.ClusterCacheTrackerReader {
+func setupReconcilers(ctx context.Context, mgr ctrl.Manager, syncPeriod time.Duration) webhooks.ClusterCacheTrackerReader {
 	secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
 		HTTPClient: mgr.GetHTTPClient(),
 		Cache: &client.CacheOptions{
@@ -542,7 +542,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) webhooks.ClusterCac
 			Client:           mgr.GetClient(),
 			Tracker:          tracker,
 			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
+		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency), &syncPeriod); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSet")
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -449,10 +449,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 			// Use DefaultTransform to drop objects we don't expect to get into this cache.
 			obj, ok := in.(*metav1.PartialObjectMetadata)
 			if !ok {
-				panic(fmt.Errorf("cache expected to only get PartialObjectMetadata, got %T", in))
+				panic(fmt.Sprintf("cache expected to only get PartialObjectMetadata, got %T", in))
 			}
 			if obj.GetObjectKind().GroupVersionKind() != corev1.SchemeGroupVersion.WithKind("Secret") {
-				panic(fmt.Errorf("cache expected to only get Secrets, got %s", obj.GetObjectKind()))
+				panic(fmt.Sprintf("cache expected to only get Secrets, got %s", obj.GetObjectKind()))
 			}
 			// Additionally strip managed fields.
 			return cache.TransformStripManagedFields()(obj)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR introduces a separate cache which is used in the clusterresourceset_controller for watching secrets.

Previously the `WatchesMetadata` for secrets in `clusterresourcesset_controller` did inherit the LabelSelector configured in `main.go`:

https://github.com/kubernetes-sigs/cluster-api/blob/main/main.go#L322-L329

This label selector gets passed through in controller-runtime for the informer which gets created for the watch.

Secrets for clusterresourcesets may apply for multiple clusters, so the label selector may not even exist at the secrets referred by clusterresourcesets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10557

/area clusterresourceset
