### PR TITLE
 🌱 Cleanup owner files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -15,6 +15,7 @@ aliases:
   # tasks on the repo, or otherwise approve any PRS.
   cluster-api-admins:
   - fabriziopandini
+  - sbueringer
   - vincepri
 
   # non-admin folks who have write-access and can approve any PRs in the repo
@@ -31,7 +32,6 @@ aliases:
   - jackfrancis
   - JoelSpeed
   - richardcase
-  - stmcginnis
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for controllers/topology
@@ -53,10 +53,7 @@ aliases:
   # -----------------------------------------------------------
 
   cluster-api-bootstrap-provider-kubeadm-ignition-maintainers:
-  cluster-api-bootstrap-provider-kubeadm-ignition-reviewers:
-  - dongsupark
-  - invidian
-  - johananl
+  cluster-api-bootstrap-provider-kubeadm-ignition-reviewers: []
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for controlplane/kubeadm
@@ -109,8 +106,7 @@ aliases:
   # OWNER_ALIASES for docs
   # -----------------------------------------------------------
 
-  cluster-api-docs-maintainers:
-  - oscr
+  cluster-api-docs-maintainers: []
   cluster-api-docs-reviewers:
   - elmiko
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As reminded in this week's SIG chair and lead meeting, it is important to keep our owner files up to date.

I made a pass based on [reviewer stats](https://k8s.devstats.cncf.io/d/13/developer-activity-counts-by-repository-group?orgId=1&var-period_name=Last+year&var-metric=reviews&var-repogroup_name=All&var-repo_name=kubernetes-sigs%2Fcluster-api&var-country_name=All&from=1558110159436&to=1715962959436&viewPanel=5). 

If by chance I made some error, please don't hesitate to reach out.

Let me take this moment to thank you again emeritus reviewers for all the great work in the project so far:
- @stmcginnis 
- @dongsupark 
- @invidian
- @johananl
- @oscr 

/area security
/hold let's give folks time to comment on this PR + I will bring it up next week in the office hour