### PR TITLE
🌱 test: improve output for ValidateResourceVersionStable by using BeComparable instead of Equal

### DIFF
--- a/test/framework/resourceversion_helpers.go
+++ b/test/framework/resourceversion_helpers.go
@@ -41,14 +41,14 @@ func ValidateResourceVersionStable(ctx context.Context, proxy ClusterProxy, name
 			previousResourceVersions = objectsWithResourceVersion
 		}()
 		// This is intentionally failing on the first run.
-		g.Expect(objectsWithResourceVersion).To(Equal(previousResourceVersions))
+		g.Expect(objectsWithResourceVersion).To(BeComparableTo(previousResourceVersions))
 	}, 1*time.Minute, 15*time.Second).Should(Succeed(), "Resource versions never became stable")
 
 	// Verify resource versions are stable for a while.
 	Consistently(func(g Gomega) {
 		objectsWithResourceVersion, err := getObjectsWithResourceVersion(ctx, proxy, namespace, ownerGraphFilterFunction)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(objectsWithResourceVersion).To(Equal(previousResourceVersions))
+		g.Expect(objectsWithResourceVersion).To(BeComparableTo(previousResourceVersions))
 	}, 2*time.Minute, 15*time.Second).Should(Succeed(), "Resource versions didn't stay stable")
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

When hitting a failure with this tests its hard or even not possible to actually see what causes this because the output is unsorted and may be truncated.

Example: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-mink8s-release-1-7/1792576343125266432

This should add an additional output which shows the exact diff instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing