### PR TITLE
🐛 capd: don't add host ports to exposed ports of containers

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -727,7 +727,6 @@ func configurePortMappings(portMappings []PortMapping, config *dockercontainer.C
 		}
 		hostConfig.PortBindings[port] = append(hostConfig.PortBindings[port], mapping)
 		exposedPorts[port] = struct{}{}
-		exposedPorts[nat.Port(fmt.Sprintf("%d/tcp", pm.HostPort))] = struct{}{}
 	}
 
 	config.ExposedPorts = exposedPorts


### PR DESCRIPTION
This fixes an issue when running capd with podmans docker compatibility mode. And it's also incorrect in general.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
CAPD currently adds the host ports that are part of a port mapping to the list of 'exposed ports' of the container. This is incorrect and leads to an error when using CAPD with podman, since capd sets the host port to 0 so an available port is automatically selected.

```
controller.go:324] "Reconciler error" err="failed to create load balancer: error creating container \"capi-quickstart-lb\": Error response from daemon: fill out specgen: port numbers must be between 1 and 65535 (inclusive), got 0" controller="dockercluster" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="DockerCluster"

```

There is no specific documentation around this that I could find. The closest is this: https://github.com/moby/moby/issues/3039

This took way to long 😄 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->