### PR TITLE
🌱 ipam: add Ready condition failure reasons

### DIFF
--- a/docs/proposals/20220125-ipam-integration.md
+++ b/docs/proposals/20220125-ipam-integration.md
@@ -152,7 +152,8 @@ Both **IPAddressClaims** and **IPAddresses** should be part of Cluster API, whil
 
 An **IPAddressClaim** is used by infrastructure providers to request an IP Address. The claim contains a reference to an IP Pool. Because the pool is provider specific, the IPAM controllers can decide whether to handle a claim by inspecting the group and kind of the pool reference.
 
-If a IPAM controller detects a Claim that references a Pool it controls, it allocates an IP address from that pool and creates an **IPAddress** to fulfil the claim. It also updates the status of the `IPAddressClaim` with a reference to the created Address.
+If a IPAM controller detects a Claim that references a Pool it controls, it allocates an IP address from that pool and creates an **IPAddress** to fulfil the claim. It also updates the status of the `IPAddressClaim` with a reference to the created Address.  
+When allocation fails, the `Ready` condition of the claim should be set to false. Where applicable, the reasons specified in the IPAM api package should be used.
 
 
 ### Pools & IPAM Providers

--- a/exp/ipam/api/v1beta1/condition_consts.go
+++ b/exp/ipam/api/v1beta1/condition_consts.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// These reasons are intended to be used with failed Ready conditions on an [IPAddressClaim].
+const (
+	// AllocationFailedReason is the reason used when allocating an IP address for a claim fails. More details should be
+	// provided in the condition's message.
+	// When the IP pool is full, [PoolExhaustedReason] should be used for better visibility instead.
+	AllocationFailedReason = "AllocationFailed"
+
+	// PoolNotReadyReason is the reason used when the referenced IP pool is not ready.
+	PoolNotReadyReason = "PoolNotReady"
+
+	// PoolExhaustedReason is the reason used when an IP pool referenced by an [IPAddressClaim] is full and no address
+	// can be allocated for the claim.
+	PoolExhaustedReason = "PoolExhausted"
+)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This adds three failure reasons for the Ready condition of IPAddressClaims that should be used by IPAM providers when reconciling claims. The goal is to offer some consistency between providers when observing conditions for e.g. alerting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8424

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ipam