### PR TITLE
:seedling: Add and expose klog flags

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -101,6 +101,12 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -108,6 +108,12 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 

--- a/main.go
+++ b/main.go
@@ -146,6 +146,12 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -111,6 +111,12 @@ func InitFlags(fs *pflag.FlagSet) {
 	// recommended because it helps in ensuring consistency across different components in the cluster.
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -109,6 +109,12 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 

--- a/test/infrastructure/inmemory/main.go
+++ b/test/infrastructure/inmemory/main.go
@@ -104,6 +104,12 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	logsv1.AddFlags(logOptions, fs)
 
+	// The base logging flags that come from component-base include only basic flags like `v` and `vmodule`.
+	// Add all the flags from `klog` package back and expose all of them.
+	klogflags := flag.NewFlagSet("logging", flag.PanicOnError)
+	klog.InitFlags(klogflags)
+	fs.AddGoFlagSet(klogflags)
+
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Logging to a file is currently not permitted, which is a major limitation on standard deployments where usually both stderr and log files are required.



/area logging