### PR TITLE
🌱 Log reason for MachineDeployment rollouts / MachineSet creations

### DIFF
--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -23,11 +23,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +37,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/util/compare"
 	"sigs.k8s.io/cluster-api/util/conversion"
 )
 
@@ -371,11 +372,11 @@ func getMachineSetFraction(ms clusterv1.MachineSet, md clusterv1.MachineDeployme
 
 // EqualMachineTemplate returns true if two given machineTemplateSpec are equal,
 // ignoring all the in-place propagated fields, and the version from external references.
-func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) bool {
+func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) (equal bool, diff string, err error) {
 	t1Copy := MachineTemplateDeepCopyRolloutFields(template1)
 	t2Copy := MachineTemplateDeepCopyRolloutFields(template2)
 
-	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
+	return compare.Diff(t1Copy, t2Copy)
 }
 
 // MachineTemplateDeepCopyRolloutFields copies a MachineTemplateSpec
@@ -415,37 +416,67 @@ func MachineTemplateDeepCopyRolloutFields(template *clusterv1.MachineTemplateSpe
 // not face a case where there exists a machine set matching the old logic but there does not exist a machineset matching the new logic.
 // In fact previously not matching MS can now start matching the target. Since there could be multiple matches, lets choose the
 // MS with the most replicas so that there is minimum machine churn.
-func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet, reconciliationTime *metav1.Time) *clusterv1.MachineSet {
+func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet, reconciliationTime *metav1.Time) (*clusterv1.MachineSet, string, error) {
+	if len(msList) == 0 {
+		return nil, "no MachineSets exist for the MachineDeployment", nil
+	}
+
+	// In rare cases, such as after cluster upgrades, Deployment may end up with
+	// having more than one new MachineSets that have the same template,
+	// see https://github.com/kubernetes/kubernetes/issues/40415
+	// We deterministically choose the oldest new MachineSet with matching template hash.
 	sort.Sort(MachineSetsByDecreasingReplicas(msList))
-	for i := range msList {
-		if EqualMachineTemplate(&msList[i].Spec.Template, &deployment.Spec.Template) &&
-			!shouldRolloutAfter(msList[i], reconciliationTime, deployment.Spec.RolloutAfter) {
-			// In rare cases, such as after cluster upgrades, Deployment may end up with
-			// having more than one new MachineSets that have the same template,
-			// see https://github.com/kubernetes/kubernetes/issues/40415
-			// We deterministically choose the oldest new MachineSet with matching template hash.
-			return msList[i]
+
+	var matchingMachineSets []*clusterv1.MachineSet
+	var diffs []string
+	for _, ms := range msList {
+		ms := ms
+
+		equal, diff, err := EqualMachineTemplate(&ms.Spec.Template, &deployment.Spec.Template)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "failed to compare MachineDeployment spec template with MachineSet %s", ms.Name)
+		}
+		if equal {
+			matchingMachineSets = append(matchingMachineSets, ms)
+		} else {
+			diffs = append(diffs, fmt.Sprintf("MachineSet %s: diff: %s", ms.Name, diff))
 		}
 	}
-	// new MachineSet does not exist.
-	return nil
-}
 
-func shouldRolloutAfter(ms *clusterv1.MachineSet, reconciliationTime *metav1.Time, rolloutAfter *metav1.Time) bool {
-	if ms == nil {
-		return false
+	if len(matchingMachineSets) == 0 {
+		return nil, fmt.Sprintf("couldn't find MachineSet matching MachineDeployment spec template: %s", strings.Join(diffs, ",")), nil
 	}
-	if reconciliationTime == nil || rolloutAfter == nil {
-		return false
+
+	// If RolloutAfter is not set, pick the first matching MachineSet.
+	if deployment.Spec.RolloutAfter == nil {
+		return matchingMachineSets[0], "", nil
 	}
-	return ms.CreationTimestamp.Before(rolloutAfter) && rolloutAfter.Before(reconciliationTime)
+
+	// If reconciliation time is before RolloutAfter, pick the first matching MachineSet.
+	if reconciliationTime.Before(deployment.Spec.RolloutAfter) {
+		return matchingMachineSets[0], "", nil
+	}
+
+	// Pick the first matching MachineSet that has been created after RolloutAfter.
+	for _, ms := range matchingMachineSets {
+		ms := ms
+		if ms.CreationTimestamp.After(deployment.Spec.RolloutAfter.Time) {
+			return ms, "", nil
+		}
+	}
+
+	// If no matching MachineSet was created after RolloutAfter, trigger creation of a new MachineSet.
+	return nil, fmt.Sprintf("RolloutAfter on MachineDeployment set to %s, no MachineSet has been created afterwards", deployment.Spec.RolloutAfter.Format(time.RFC3339)), nil
 }
 
 // FindOldMachineSets returns the old machine sets targeted by the given Deployment, within the given slice of MSes.
 // Returns a list of machine sets which contains all old machine sets.
-func FindOldMachineSets(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet, reconciliationTime *metav1.Time) []*clusterv1.MachineSet {
+func FindOldMachineSets(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet, reconciliationTime *metav1.Time) ([]*clusterv1.MachineSet, error) {
 	allMSs := make([]*clusterv1.MachineSet, 0, len(msList))
-	newMS := FindNewMachineSet(deployment, msList, reconciliationTime)
+	newMS, _, err := FindNewMachineSet(deployment, msList, reconciliationTime)
+	if err != nil {
+		return nil, err
+	}
 	for _, ms := range msList {
 		// Filter out new machine set
 		if newMS != nil && ms.UID == newMS.UID {
@@ -453,7 +484,7 @@ func FindOldMachineSets(deployment *clusterv1.MachineDeployment, msList []*clust
 		}
 		allMSs = append(allMSs, ms)
 	}
-	return allMSs
+	return allMSs, nil
 }
 
 // GetReplicaCountForMachineSets returns the sum of Replicas of the given machine sets.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up of this PR #10628 for Machinedeployments

Initial rollout:

```
I0528 09:14:11.164279      17 machinedeployment_sync.go:175] "Creating new MachineSet, no MachineSets exist for the MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/capi-quickstart-md-0" namespace="default" name="capi-quickstart-md-0" reconcileID="acc1a765-03f6-4e2d-a815-148efc8e5b36" Cluster="default/capi-quickstart" MachineSet="default/capi-quickstart-md-0-fqhwx"
```

Rollout because existing MachineSets don't match

```
I0528 09:14:42.812951      17 machinedeployment_sync.go:175] "Creating new MachineSet, couldn't find MachineSet matching MachineDeployment spec template: MachineSet capi-quickstart-md-0-fqhwx: diff: &v1beta1.MachineTemplateSpec{\n    ObjectMeta: {},\n    Spec: v1beta1.MachineSpec{\n      ClusterName:       \"capi-quickstart\",\n      Bootstrap:         {ConfigRef: &{Kind: \"KubeadmConfigTemplate\", Namespace: \"default\", Name: \"capi-quickstart-md-0\", APIVersion: \"bootstrap.cluster.x-k8s.io\", ...}},\n      InfrastructureRef: {Kind: \"DockerMachineTemplate\", Namespace: \"default\", Name: \"capi-quickstart-md-0\", APIVersion: \"infrastructure.cluster.x-k8s.io\", ...},\n-     Version:           &\"v1.25.0\",\n+     Version:           &\"v1.26.0\",\n      ProviderID:        nil,\n      FailureDomain:     nil,\n      ... // 3 identical fields\n    },\n  }" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/capi-quickstart-md-0" namespace="default" name="capi-quickstart-md-0" reconcileID="7d8b34ad-1777-4f0b-a8df-edec28eae702" Cluster="default/capi-quickstart" MachineSet="default/capi-quickstart-md-0-b4w2w"
```

Message properly formatted: (only \n replaced with new line)
```
Creating new MachineSet, couldn't find MachineSet matching MachineDeployment spec template: MachineSet capi-quickstart-md-0-fqhwx: diff: &v1beta1.MachineTemplateSpec{
    ObjectMeta: {},
    Spec: v1beta1.MachineSpec{
      ClusterName:       \"capi-quickstart\",
      Bootstrap:         {ConfigRef: &{Kind: \"KubeadmConfigTemplate\", Namespace: \"default\", Name: \"capi-quickstart-md-0\", APIVersion: \"bootstrap.cluster.x-k8s.io\", ...}},
      InfrastructureRef: {Kind: \"DockerMachineTemplate\", Namespace: \"default\", Name: \"capi-quickstart-md-0\", APIVersion: \"infrastructure.cluster.x-k8s.io\", ...},
-     Version:           &\"v1.25.0\",
+     Version:           &\"v1.26.0\",
      ProviderID:        nil,
      FailureDomain:     nil,
      ... // 3 identical fields
    },
  }

```

Rollout because of RolloutAfter

```
I0528 09:17:20.864224      17 machinedeployment_sync.go:175] "Creating new MachineSet, RolloutAfter on MachineDeployment set to 2024-05-28T09:15:00Z, no MachineSet has been created afterwards" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/capi-quickstart-md-0" namespace="default" name="capi-quickstart-md-0" reconcileID="4418d85d-8524-4a02-b4f5-e8083ab19056" Cluster="default/capi-quickstart" MachineSet="default/capi-quickstart-md-0-bd78w"
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #8186

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->