### PR TITLE
🌱 Improve E2E ValidateFinalizers and ValidateOwnerRef

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/kubetest"
 )
 
-var _ = Describe("When following the Cluster API quick-start", func() {
+var _ = Describe("When following the Cluster API quick-start FP", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -40,6 +40,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 			InfrastructureProvider: ptr.To("docker"),
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
+				By("Checking that owner references are resilient")
 				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
@@ -49,6 +50,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
+				By("Checking that owner references are updated to the correct API version")
 				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
@@ -58,6 +60,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
+				By("Checking that finalizers are resilient")
 				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
@@ -66,6 +69,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
+				By("Checking that resourceVersions are stable")
 				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 		}
@@ -82,8 +86,9 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 			SkipCleanup:            skipCleanup,
 			Flavor:                 ptr.To("topology"),
 			InfrastructureProvider: ptr.To("docker"),
-			// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.
+				By("Checking that owner references are resilient")
 				framework.ValidateOwnerReferencesResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
@@ -93,6 +98,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that owner references are correctly updated to the correct apiVersion.
+				By("Checking that owner references are updated to the correct API version")
 				framework.ValidateOwnerReferencesOnUpdate(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreOwnerReferenceAssertion,
 					framework.ExpOwnerReferenceAssertions,
@@ -102,6 +108,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 					framework.KubernetesReferenceAssertions,
 				)
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
+				By("Checking that finalizers are resilient")
 				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
 					framework.CoreFinalizersAssertion,
 					framework.KubeadmControlPlaneFinalizersAssertion,
@@ -110,6 +117,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				)
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
+				By("Checking that resourceVersions are stable")
 				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 		}

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/kubetest"
 )
 
-var _ = Describe("When following the Cluster API quick-start FP", func() {
+var _ = Describe("When following the Cluster API quick-start", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -62,7 +62,7 @@ var _ = Describe("When following the Cluster API quick-start FP", func() {
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
 				By("Checking that finalizers are resilient")
 				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
-					framework.CoreFinalizersAssertion,
+					framework.CoreFinalizersAssertionWithLegacyClusters,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
 					framework.DockerInfraFinalizersAssertion,
@@ -110,7 +110,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				// This check ensures that finalizers are resilient - i.e. correctly re-reconciled - when removed.
 				By("Checking that finalizers are resilient")
 				framework.ValidateFinalizersResilience(ctx, proxy, namespace, clusterName, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
-					framework.CoreFinalizersAssertion,
+					framework.CoreFinalizersAssertionWithClassyClusters,
 					framework.KubeadmControlPlaneFinalizersAssertion,
 					framework.ExpFinalizersAssertion,
 					framework.DockerInfraFinalizersAssertion,

--- a/test/framework/finalizers_helpers.go
+++ b/test/framework/finalizers_helpers.go
@@ -124,10 +124,13 @@ func getObjectsWithFinalizers(ctx context.Context, proxy ClusterProxy, namespace
 		Expect(err).ToNot(HaveOccurred())
 
 		setFinalizers := obj.GetFinalizers()
-		expectedFinalizers := allFinalizerAssertions[node.Object.Kind](types.NamespacedName{Namespace: node.Object.Namespace, Name: node.Object.Name})
 
-		if len(setFinalizers) > 0 || len(expectedFinalizers) > 0 {
+		if len(setFinalizers) > 0 {
 			// assert if the expected finalizers are set on the resource
+			var expectedFinalizers []string
+			if assertion, ok := allFinalizerAssertions[node.Object.Kind]; ok {
+				expectedFinalizers = assertion(types.NamespacedName{Namespace: node.Object.Namespace, Name: node.Object.Name})
+			}
 			Expect(setFinalizers).To(Equal(expectedFinalizers), "for resource type %s", node.Object.Kind)
 			objsWithFinalizers[fmt.Sprintf("%s/%s/%s", node.Object.Kind, node.Object.Namespace, node.Object.Name)] = obj
 		}

--- a/test/framework/finalizers_helpers.go
+++ b/test/framework/finalizers_helpers.go
@@ -165,11 +165,9 @@ func assertFinalizersExist(ctx context.Context, proxy ClusterProxy, namespace st
 
 			// verify if this resource has the appropriate Finalizers set
 			expectedFinalizersF, assert := allFinalizerAssertions[obj.GetKind()]
-			if !assert {
-				// NOTE: this case should never happen because all the initialObjsWithFinalizers have been already checked
-				// against a finalizer assertion.
-				continue
-			}
+			// NOTE: this case should never happen because all the initialObjsWithFinalizers have been already checked
+			// against a finalizer assertion.
+			Expect(assert).To(BeTrue(), "finalizer assertions for %s are missing", objKindNamespacedName)
 			parts := strings.Split(objKindNamespacedName, "/")
 			expectedFinalizers := expectedFinalizersF(types.NamespacedName{Namespace: parts[1], Name: parts[2]})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves ValidateFinalizers and ValidateOwnerRef so the functions in input can get the namespaced name of the objects being processed.
This allows to handle differently e.g. secrets with CAPI certificate and secrets with cloud provider credentials

/area e2e-testing