### PR TITLE
🌱 Preserve finalizers during MS/Machine reconciliation

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_sync_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync_test.go
@@ -642,6 +642,8 @@ func TestComputeDesiredMachineSet(t *testing.T) {
 			"ms-label-1":                           "ms-value-1",
 		}
 		existingMS.Annotations = nil
+		// Pre-existing finalizer should be preserved.
+		existingMS.Finalizers = []string{"pre-existing-finalizer"}
 		existingMS.Spec.Template.Labels = map[string]string{
 			clusterv1.MachineDeploymentUniqueLabel: uniqueID,
 			"ms-label-2":                           "ms-value-2",
@@ -657,6 +659,9 @@ func TestComputeDesiredMachineSet(t *testing.T) {
 		expectedMS.UID = existingMSUID
 		expectedMS.Name = deployment.Name + "-" + uniqueID
 		expectedMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+		// Pre-existing finalizer should be preserved.
+		expectedMS.Finalizers = []string{"pre-existing-finalizer"}
+
 		expectedMS.Spec.Template.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
 
 		g := NewWithT(t)
@@ -676,6 +681,8 @@ func TestComputeDesiredMachineSet(t *testing.T) {
 			"ms-label-1":                           "ms-value-1",
 		}
 		existingMS.Annotations = nil
+		// Pre-existing finalizer should be preserved.
+		existingMS.Finalizers = []string{"pre-existing-finalizer"}
 		existingMS.Spec.Template.Labels = map[string]string{
 			clusterv1.MachineDeploymentUniqueLabel: uniqueID,
 			"ms-label-2":                           "ms-value-2",
@@ -698,6 +705,8 @@ func TestComputeDesiredMachineSet(t *testing.T) {
 		expectedMS.UID = existingMSUID
 		expectedMS.Name = deployment.Name + "-" + uniqueID
 		expectedMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+		// Pre-existing finalizer should be preserved.
+		expectedMS.Finalizers = []string{"pre-existing-finalizer"}
 		expectedMS.Spec.Template.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
 
 		g := NewWithT(t)
@@ -764,6 +773,9 @@ func assertMachineSet(g *WithT, actualMS *clusterv1.MachineSet, expectedMS *clus
 	}
 	// Check Namespace
 	g.Expect(actualMS.Namespace).Should(Equal(expectedMS.Namespace))
+
+	// Check finalizers
+	g.Expect(actualMS.Finalizers).Should(Equal(expectedMS.Finalizers))
 
 	// Check Replicas
 	g.Expect(actualMS.Spec.Replicas).ShouldNot(BeNil())

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
@@ -637,10 +638,18 @@ func (r *Reconciler) computeDesiredMachine(machineSet *clusterv1.MachineSet, exi
 	if existingMachine != nil {
 		desiredMachine.SetName(existingMachine.Name)
 		desiredMachine.SetUID(existingMachine.UID)
+
+		// Preserve all existing finalizers (including foregroundDeletion finalizer).
+		finalizers := existingMachine.Finalizers
+		// Ensure MachineFinalizer is set.
+		if !sets.New[string](finalizers...).Has(clusterv1.MachineFinalizer) {
+			finalizers = append(finalizers, clusterv1.MachineFinalizer)
+		}
+		desiredMachine.Finalizers = finalizers
+
 		desiredMachine.Spec.Bootstrap.ConfigRef = existingMachine.Spec.Bootstrap.ConfigRef
 		desiredMachine.Spec.InfrastructureRef = existingMachine.Spec.InfrastructureRef
 	}
-
 	// Set the in-place mutable fields.
 	// When we create a new Machine we will just create the Machine with those fields.
 	// When we update an existing Machine will we update the fields on the existing Machine (in-place mutate).

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -1620,6 +1620,8 @@ func TestComputeDesiredMachine(t *testing.T) {
 	existingMachine.UID = "abc-123-existing-machine-1"
 	existingMachine.Labels = nil
 	existingMachine.Annotations = nil
+	// Pre-existing finalizer should be preserved.
+	existingMachine.Finalizers = []string{"pre-existing-finalizer"}
 	existingMachine.Spec.InfrastructureRef = corev1.ObjectReference{
 		Kind:       "GenericInfrastructureMachine",
 		Name:       "infra-machine-1",
@@ -1637,6 +1639,8 @@ func TestComputeDesiredMachine(t *testing.T) {
 	expectedUpdatedMachine := skeletonMachine.DeepCopy()
 	expectedUpdatedMachine.Name = existingMachine.Name
 	expectedUpdatedMachine.UID = existingMachine.UID
+	// Pre-existing finalizer should be preserved.
+	expectedUpdatedMachine.Finalizers = []string{"pre-existing-finalizer", clusterv1.MachineFinalizer}
 	expectedUpdatedMachine.Spec.InfrastructureRef = *existingMachine.Spec.InfrastructureRef.DeepCopy()
 	expectedUpdatedMachine.Spec.Bootstrap.ConfigRef = existingMachine.Spec.Bootstrap.ConfigRef.DeepCopy()
 

--- a/test/e2e/md_scale.go
+++ b/test/e2e/md_scale.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -123,6 +124,17 @@ func MachineDeploymentScaleSpec(ctx context.Context, inputGetter func() MachineD
 			Replicas:                  1,
 			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		})
+
+		By("Deleting the MachineDeployment with foreground deletion")
+		foreground := metav1.DeletePropagationForeground
+		framework.DeleteAndWaitMachineDeployment(ctx, framework.DeleteAndWaitMachineDeploymentInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			MachineDeployment:         clusterResources.MachineDeployments[0],
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			DeletePropagationPolicy:   &foreground,
+		})
+
 		By("PASSED!")
 	})
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We had some discussion around what the proper behavior is. 

My current take is:
* MS controller should ensure its own finalizer is set
* MD/MS controller should preserve all existing finalizers (including foregroundDeletion)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->