### PR TITLE
🐛 Speed up ignoring terminating Pods when draining unreachable Nodes

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -670,8 +670,18 @@ func (r *Reconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, 
 	}
 
 	if noderefutil.IsNodeUnreachable(node) {
-		// When the node is unreachable and some pods are not evicted for as long as this timeout, we ignore them.
-		drainer.SkipWaitForDeleteTimeoutSeconds = 60 * 5 // 5 minutes
+		// Kubelet is unreachable, pods will never disappear.
+
+		// SkipWaitForDeleteTimeoutSeconds ensures the drain completes
+		// even if pod objects are not deleted.
+		drainer.SkipWaitForDeleteTimeoutSeconds = 1
+
+		// kube-apiserver sets the `deletionTimestamp` to a future date computed using the grace period.
+		// We are effectively waiting for GracePeriodSeconds + SkipWaitForDeleteTimeoutSeconds.
+		// Override the grace period of pods to reduce the time needed to skip them.
+		drainer.GracePeriodSeconds = 1
+
+		log.V(5).Info("Node is unreachable, draining will ignore gracePeriod. PDBs are still honored.")
 	}
 
 	if err := kubedrain.RunCordonOrUncordon(drainer, node, true); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR reduces the time we wait for pod deletion in the case of unreachable nodes: we currently wait for the deletionTimestamp to be 5 minutes old. The goal is to allow MHC to replace unreachable nodes faster.

This PR aligns the behavior of CAPI with OpenShift MAPI: https://github.com/openshift/machine-api-operator/blob/dcf1387cb69f8257345b2062cff79a6aefb1f5d9/pkg/controller/machine/drain_controller.go#L164-L171 

This PR is a result from a discussion [here](https://github.com/kubernetes-sigs/cluster-api/pull/10662#issuecomment-2139805627).

**Which issue(s) this PR fixes** 
Fixes #10705

Area example:
/area machine