### PR TITLE
:book: fix broken kubebuilder link in old docs

### DIFF
--- a/docs/book/src/developer/providers/migrations/v0.3-to-v0.4.md
+++ b/docs/book/src/developer/providers/migrations/v0.3-to-v0.4.md
@@ -92,7 +92,7 @@ If flag has not provided, default value from `controller-runtime` should be used
 In an effort to simplify the management of Cluster API components, and realign with Kubebuilder configuration,
 we're requiring some changes to move all webhooks back into a single deployment manager, and to allow Cluster
 API watch all namespaces it manages.
-For a `/config` folder reference, please use the testdata in the Kubebuilder project: https://github.com/kubernetes-sigs/kubebuilder/tree/master/testdata/project-v3/config
+For a `/config` folder reference, please use the testdata in the Kubebuilder project: https://github.com/kubernetes-sigs/kubebuilder/tree/release-3.15/testdata/project-v3/config
 
 **Pre-requisites**
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation