### PR TITLE
🌱 Update Config generation to use inClusterConfig

### DIFF
--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -131,22 +132,7 @@ func (k *proxy) ValidateKubernetesVersion() error {
 
 // GetConfig returns the config for a kubernetes client.
 func (k *proxy) GetConfig() (*rest.Config, error) {
-	config, err := k.configLoadingRules.Load()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load Kubeconfig")
-	}
-
-	configOverrides := &clientcmd.ConfigOverrides{
-		CurrentContext: k.kubeconfig.Context,
-		Timeout:        k.timeout.String(),
-	}
-	restConfig, err := clientcmd.NewDefaultClientConfig(*config, configOverrides).ClientConfig()
-	if err != nil {
-		if strings.HasPrefix(err.Error(), "invalid configuration:") {
-			return nil, errors.New(strings.Replace(err.Error(), "invalid configuration:", "invalid kubeconfig file; clusterctl requires a valid kubeconfig file to connect to the management cluster:", 1))
-		}
-		return nil, err
-	}
+	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
 	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go doesn't generate throttling log messages

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -147,7 +147,7 @@ func (k *proxy) GetConfig() (*rest.Config, error) {
 		}
 		restConfig, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, err
+			return nil, errors.New(strings.Replace(err.Error(), "invalid configuration:", "invalid kubeconfig file and failed to create inClusterConfig as well:", 1))
 		}
 	}
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we cannot use clusterctl binary from inside the pod because it can not find the cluster. This PR updates config generation to use GetConfigOrDie() method from `controller-runtime` so that clusterctl can discover the cluster even kubeconfig is not provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6286


/area clusterctl
--> [area/clusterctl](https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aopen+label%3Aarea%2Fclusterctl+sort%3Aupdated-desc)