### PR TITLE
🌱 Improve E2E tests for finalizers and ownerRefs

### DIFF
--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -127,7 +128,7 @@ func AssertOwnerReferences(namespace, kubeconfigPath string, ownerGraphFilterFun
 			}
 			for _, f := range allAssertFuncs[v.Object.Kind] {
 				if err := f(types.NamespacedName{Namespace: v.Object.Namespace, Name: v.Object.Name}, v.Owners); err != nil {
-					allErrs = append(allErrs, errors.Wrapf(err, "Unexpected ownerReferences for %s/%s", v.Object.Kind, v.Object.Name))
+					allErrs = append(allErrs, errors.Wrapf(err, "Unexpected ownerReferences for %s, %s", v.Object.Kind, klog.KRef(v.Object.Namespace, v.Object.Name)))
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Small improvements to E2E tests for finalizers and ownerRefs (better logs, finalizer comparison don't consider finalizers order)

/area e2e-testing
