### PR TITLE
🌱 fix loopvar linter issue and usage of deprecated grpc function

### DIFF
--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -149,7 +149,6 @@ func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error)
 		Endpoints:   []string{config.Endpoint}, // NOTE: endpoint is used only as a host for certificate validation, the network connection is defined by DialOptions.
 		DialTimeout: config.DialTimeout,
 		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), // block until the underlying connection is up
 			grpc.WithContextDialer(dialer.DialContextWithAddr),
 		},
 		TLS: config.TLSConfig,

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -430,8 +430,6 @@ func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*cluste
 	var matchingMachineSets []*clusterv1.MachineSet
 	var diffs []string
 	for _, ms := range msList {
-		ms := ms
-
 		equal, diff, err := EqualMachineTemplate(&ms.Spec.Template, &deployment.Spec.Template)
 		if err != nil {
 			return nil, "", errors.Wrapf(err, "failed to compare MachineDeployment spec template with MachineSet %s", ms.Name)
@@ -459,7 +457,6 @@ func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*cluste
 
 	// Pick the first matching MachineSet that has been created after RolloutAfter.
 	for _, ms := range matchingMachineSets {
-		ms := ms
 		if ms.CreationTimestamp.After(deployment.Spec.RolloutAfter.Time) {
 			return ms, "", nil
 		}

--- a/test/infrastructure/inmemory/pkg/server/mux_test.go
+++ b/test/infrastructure/inmemory/pkg/server/mux_test.go
@@ -369,7 +369,6 @@ func TestAPI_PortForward(t *testing.T) {
 		DialTimeout: 2 * time.Second,
 
 		DialOptions: []grpc.DialOption{
-			grpc.WithBlock(), // block until the underlying connection is up
 			grpc.WithContextDialer(dialer2.DialContextWithAddr),
 		},
 		TLS: &tls.Config{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Follow-up from #10699

Dropping the GRPC WithBlock function should be okay according to the docs:

> `FailOnNonTempDialError`, `WithBlock`, and `WithReturnConnectionError` are three
> `DialOption`s that are only supported by `Dial` because they only affect the
> behavior of `Dial` itself. `WithBlock` causes `Dial` to wait until the
> `ClientConn` reports its `State` as `connectivity.Connected`.  The other two deal
> with returning connection errors before the timeout (`WithTimeout` or on the
> context when using `DialContext`).
> 
> The reason these options can be a problem is that connections with a
> `ClientConn` are dynamic -- they may come and go over time.  If your client
> successfully connects, the server could go down 1 second later, and your RPCs
> will fail.  "Knowing you are connected" does not tell you much in this regard.
> 
> Additionally, _all_ RPCs created on an "idle" or a "connecting" `ClientConn`
> will wait until their deadline or until a connection is established before
> failing.  This means that you don't need to check that a `ClientConn` is "ready"
> before starting your RPCs.  By default, RPCs will fail if the `ClientConn`
> enters the "transient failure" state, but setting `WaitForReady(true)` on a
> call will cause it to queue even in the "transient failure" state, and it will
> only ever fail due to a deadline, a server response, or a connection loss after
> the RPC was sent to a server.
> 
> Some users of `Dial` use it as a way to validate the configuration of their
> system.  If you wish to maintain this behavior but migrate to `NewClient`, you
> can call `State` and `WaitForStateChange` until the channel is connected.
> However, if this fails, it does not mean that your configuration was bad - it
> could also mean the service is not reachable by the client due to connectivity
> reasons.

source: https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#especially-bad-using-deprecated-dialoptions

But let's see what our test suite says. If it does not work out, we should add a call to WaitForStateChange via `	etcdClient.ActiveConnection().WaitForStateChange` to check for the connection to be ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area dependency