### PR TITLE
🌱 Ensure unhealthy machines get deletion priority

### DIFF
--- a/internal/controllers/machineset/machineset_delete_policy.go
+++ b/internal/controllers/machineset/machineset_delete_policy.go
@@ -150,5 +150,9 @@ func isMachineHealthy(machine *clusterv1.Machine) bool {
 	if nodeHealthyCondition != nil && nodeHealthyCondition.Status != corev1.ConditionTrue {
 		return false
 	}
+	healthCheckCondition := conditions.Get(machine, clusterv1.MachineHealthCheckSucceededCondition)
+	if healthCheckCondition != nil && healthCheckCondition.Status == corev1.ConditionFalse {
+		return false
+	}
 	return true
 }

--- a/internal/controllers/machineset/machineset_delete_policy_test.go
+++ b/internal/controllers/machineset/machineset_delete_policy_test.go
@@ -68,6 +68,17 @@ func TestMachineToDelete(t *testing.T) {
 			},
 		},
 	}
+	healthyCheckConditionFalseMachine := &clusterv1.Machine{
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineHealthCheckSucceededCondition,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		desc     string
@@ -220,6 +231,18 @@ func TestMachineToDelete(t *testing.T) {
 			},
 			expect: []*clusterv1.Machine{
 				nodeHealthyConditionUnknownMachine,
+			},
+		},
+		{
+			desc: "func=randomDeletePolicy, NodeHealthyConditionFalseMachine, diff=1",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				healthyMachine,
+				healthyCheckConditionFalseMachine,
+				healthyMachine,
+			},
+			expect: []*clusterv1.Machine{
+				healthyCheckConditionFalseMachine,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently merged https://github.com/kubernetes-sigs/cluster-api/pull/10712 under the assumption that when deleting machines on older MachineSets, unhealthy machines were prioritized.

This is only true for machines with `NodeHealthy` not set or false, but not for machines with `HealthCheckSucceeded` set to false by MHC.

This PR fixes this, and thus ongoing rollouts now contribute to a faster remediation of unhealthy machines.

/area machineset

cc @vincepri @enxebre @sbueringer 