### PR TITLE
🌱 Ensure CRS controller always add ownerReference to resources

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -358,13 +358,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 			continue
 		}
 
-		// Ensure an ownerReference to the clusterResourceSet is on the resource.
-		if err := r.ensureResourceOwnerRef(ctx, clusterResourceSet, unstructuredObj); err != nil {
-			log.Error(err, "Failed to add ClusterResourceSet as resource owner reference",
-				"Resource type", unstructuredObj.GetKind(), "Resource name", unstructuredObj.GetName())
-			errList = append(errList, err)
-		}
-
 		resourceScope, err := reconcileScopeForResource(clusterResourceSet, resource, resourceSetBinding, unstructuredObj)
 		if err != nil {
 			resourceSetBinding.SetBinding(addonsv1.ResourceBinding{

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -276,6 +276,40 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 	log := ctrl.LoggerFrom(ctx, "Cluster", klog.KObj(cluster))
 	ctx = ctrl.LoggerInto(ctx, log)
 
+	// Iterate all resources and ensure an ownerReference to the clusterResourceSet is on the resource.
+	// NOTE: we have to do this before getting a remote client, otherwise owner reference won't be created until it is
+	// possible to connect to the remote cluster.
+	errList := []error{}
+	objList := make([]*unstructured.Unstructured, len(clusterResourceSet.Spec.Resources))
+	for i, resource := range clusterResourceSet.Spec.Resources {
+		unstructuredObj, err := r.getResource(ctx, resource, cluster.GetNamespace())
+		if err != nil {
+			if err == ErrSecretTypeNotSupported {
+				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
+			} else {
+				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+
+				// Continue without adding the error to the aggregate if we can't find the resource.
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+			}
+			errList = append(errList, err)
+			continue
+		}
+
+		// Ensure an ownerReference to the clusterResourceSet is on the resource.
+		if err := r.ensureResourceOwnerRef(ctx, clusterResourceSet, unstructuredObj); err != nil {
+			log.Error(err, "Failed to add ClusterResourceSet as resource owner reference",
+				"Resource type", unstructuredObj.GetKind(), "Resource name", unstructuredObj.GetName())
+			errList = append(errList, err)
+		}
+		objList[i] = unstructuredObj
+	}
+	if len(errList) > 0 {
+		return kerrors.NewAggregate(errList)
+	}
+
 	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
 	if err != nil {
 		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RemoteClusterClientFailedReason, clusterv1.ConditionSeverityError, err.Error())
@@ -313,24 +347,14 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		Name:       clusterResourceSet.Name,
 		UID:        clusterResourceSet.UID,
 	}))
-	var errList []error
+
 	resourceSetBinding := clusterResourceSetBinding.GetOrCreateBinding(clusterResourceSet)
 
 	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
-	for _, resource := range clusterResourceSet.Spec.Resources {
-		unstructuredObj, err := r.getResource(ctx, resource, cluster.GetNamespace())
-		if err != nil {
-			if err == ErrSecretTypeNotSupported {
-				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.WrongSecretTypeReason, clusterv1.ConditionSeverityWarning, err.Error())
-			} else {
-				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
-
-				// Continue without adding the error to the aggregate if we can't find the resource.
-				if apierrors.IsNotFound(err) {
-					continue
-				}
-			}
-			errList = append(errList, err)
+	for i, resource := range clusterResourceSet.Spec.Resources {
+		unstructuredObj := objList[i]
+		if unstructuredObj == nil {
+			// Continue without adding the error to the aggregate if we can't find the resource.
 			continue
 		}
 

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -310,19 +310,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		return kerrors.NewAggregate(errList)
 	}
 
-	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
-	if err != nil {
-		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RemoteClusterClientFailedReason, clusterv1.ConditionSeverityError, err.Error())
-		return err
-	}
-
-	// Ensure that the Kubernetes API Server service has been created in the remote cluster before applying the ClusterResourceSet to avoid service IP conflict.
-	// This action is required when the remote cluster Kubernetes version is lower than v1.25.
-	// TODO: Remove this action once CAPI no longer supports Kubernetes versions below v1.25. See: https://github.com/kubernetes-sigs/cluster-api/issues/7804
-	if err = ensureKubernetesServiceCreated(ctx, remoteClient); err != nil {
-		return errors.Wrapf(err, "failed to retrieve the Service for Kubernetes API Server of the cluster %s/%s", cluster.Namespace, cluster.Name)
-	}
-
 	// Get ClusterResourceSetBinding object for the cluster.
 	clusterResourceSetBinding, err := r.getOrCreateClusterResourceSetBinding(ctx, cluster, clusterResourceSet)
 	if err != nil {
@@ -349,6 +336,19 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 	}))
 
 	resourceSetBinding := clusterResourceSetBinding.GetOrCreateBinding(clusterResourceSet)
+
+	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
+	if err != nil {
+		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RemoteClusterClientFailedReason, clusterv1.ConditionSeverityError, err.Error())
+		return err
+	}
+
+	// Ensure that the Kubernetes API Server service has been created in the remote cluster before applying the ClusterResourceSet to avoid service IP conflict.
+	// This action is required when the remote cluster Kubernetes version is lower than v1.25.
+	// TODO: Remove this action once CAPI no longer supports Kubernetes versions below v1.25. See: https://github.com/kubernetes-sigs/cluster-api/issues/7804
+	if err := ensureKubernetesServiceCreated(ctx, remoteClient); err != nil {
+		return errors.Wrapf(err, "failed to retrieve the Service for Kubernetes API Server of the cluster %s/%s", cluster.Namespace, cluster.Name)
+	}
 
 	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
 	for i, resource := range clusterResourceSet.Spec.Resources {

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -345,8 +345,13 @@ metadata:
 		}
 		g.Eventually(func() bool {
 			m := &corev1.ConfigMap{}
-			err := env.Get(ctx, cmKey, m)
-			return err == nil
+			if err := env.Get(ctx, cmKey, m); err != nil {
+				return false
+			}
+			if len(m.OwnerReferences) != 1 || m.OwnerReferences[0].Name != crsInstance.Name {
+				return false
+			}
+			return true
 		}, timeout).Should(BeTrue())
 
 		// When the ConfigMap resource is created, CRS should get reconciled immediately.
@@ -445,8 +450,13 @@ metadata:
 		}
 		g.Eventually(func() bool {
 			m := &corev1.Secret{}
-			err := env.Get(ctx, cmKey, m)
-			return err == nil
+			if err := env.Get(ctx, cmKey, m); err != nil {
+				return false
+			}
+			if len(m.OwnerReferences) != 1 || m.OwnerReferences[0].Name != crsInstance.Name {
+				return false
+			}
+			return true
 		}, timeout).Should(BeTrue())
 
 		// When the Secret resource is created, CRS should get reconciled immediately.

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1021,7 +1021,7 @@ metadata:
 					return false
 				}
 			}
-			return true
+			return len(binding.Spec.Bindings) != 0
 		}, timeout).Should(BeTrue())
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While testing owner references resilience for CAPV I discovered that the CRS controller do not apply owner references to resources in case there is no connection to the workload cluster.

This PR fixes this issue.

Area example:
/area clusterresourceset