### PR TITLE
🌱 Deprioritize unknown NodeHealthy conditions for deletion

### DIFF
--- a/internal/controllers/machineset/machineset_delete_policy.go
+++ b/internal/controllers/machineset/machineset_delete_policy.go
@@ -146,8 +146,9 @@ func isMachineHealthy(machine *clusterv1.Machine) bool {
 	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
 		return false
 	}
+	// Note: for the sake of prioritization, we are not making any assumption about Health when ConditionUnknown.
 	nodeHealthyCondition := conditions.Get(machine, clusterv1.MachineNodeHealthyCondition)
-	if nodeHealthyCondition != nil && nodeHealthyCondition.Status != corev1.ConditionTrue {
+	if nodeHealthyCondition != nil && nodeHealthyCondition.Status == corev1.ConditionFalse {
 		return false
 	}
 	healthCheckCondition := conditions.Get(machine, clusterv1.MachineHealthCheckSucceededCondition)


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up of https://github.com/kubernetes-sigs/cluster-api/pull/10755#pullrequestreview-2118434311:
For the sake of prioritization, we are not making any assumption about Health when ConditionUnknown.

/area machineset