### PR TITLE
🐛 MD/MS topo reconciler: only add finalizer for owned MD/MS

### DIFF
--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -18,6 +18,7 @@ package machinedeployment
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +36,7 @@ import (
 	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/labels"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -130,6 +132,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	// Return early if the object or Cluster is paused.
 	if annotations.IsPaused(cluster, md) {
 		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Return early if the MachineDeployment is not topology owned.
+	if !labels.IsTopologyOwned(md) {
+		log.Info(fmt.Sprintf("Reconciliation is skipped because the MachineDeployment does not have the %q label", clusterv1.ClusterTopologyOwnedLabel))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller_test.go
@@ -41,9 +41,14 @@ func TestMachineDeploymentTopologyFinalizer(t *testing.T) {
 	mdBuilder := builder.MachineDeployment(metav1.NamespaceDefault, "md").
 		WithClusterName("fake-cluster").
 		WithBootstrapTemplate(mdBT).
-		WithInfrastructureTemplate(mdIMT)
-
+		WithInfrastructureTemplate(mdIMT).
+		WithLabels(map[string]string{
+			clusterv1.ClusterTopologyOwnedLabel: "",
+		})
 	md := mdBuilder.Build()
+
+	mdWithoutTopologyOwnedLabel := md.DeepCopy()
+	delete(mdWithoutTopologyOwnedLabel.Labels, clusterv1.ClusterTopologyOwnedLabel)
 	mdWithFinalizer := mdBuilder.Build()
 	mdWithFinalizer.Finalizers = []string{clusterv1.MachineDeploymentTopologyFinalizer}
 
@@ -63,6 +68,11 @@ func TestMachineDeploymentTopologyFinalizer(t *testing.T) {
 			name:            "should retain ClusterTopology finalizer on MachineDeployment with finalizer",
 			md:              mdWithFinalizer,
 			expectFinalizer: true,
+		},
+		{
+			name:            "should not add ClusterTopology finalizer on MachineDeployment without topology owned label",
+			md:              mdWithoutTopologyOwnedLabel,
+			expectFinalizer: false,
 		},
 	}
 

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -18,6 +18,7 @@ package machineset
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,7 @@ import (
 	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/labels"
 	clog "sigs.k8s.io/cluster-api/util/log"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -137,6 +139,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	// Return early if the object or Cluster is paused.
 	if annotations.IsPaused(cluster, ms) {
 		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Return early if the MachineSet is not topology owned.
+	if !labels.IsTopologyOwned(ms) {
+		log.Info(fmt.Sprintf("Reconciliation is skipped because the MachineSet does not have the %q label", clusterv1.ClusterTopologyOwnedLabel))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/topology/machineset/machineset_controller_test.go
+++ b/internal/controllers/topology/machineset/machineset_controller_test.go
@@ -58,6 +58,8 @@ func TestMachineSetTopologyFinalizer(t *testing.T) {
 		})
 
 	ms := msBuilder.Build()
+	msWithoutTopologyOwnedLabel := ms.DeepCopy()
+	delete(msWithoutTopologyOwnedLabel.Labels, clusterv1.ClusterTopologyOwnedLabel)
 	msWithFinalizer := msBuilder.Build()
 	msWithFinalizer.Finalizers = []string{clusterv1.MachineSetTopologyFinalizer}
 
@@ -77,6 +79,11 @@ func TestMachineSetTopologyFinalizer(t *testing.T) {
 			name:            "should retain ClusterTopology finalizer on MachineSet with finalizer",
 			ms:              msWithFinalizer,
 			expectFinalizer: true,
+		},
+		{
+			name:            "should not add ClusterTopology finalizer on MachineSet without topology owned label",
+			ms:              msWithoutTopologyOwnedLabel,
+			expectFinalizer: false,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We have hit a case where the MS topology controller adds a finalizer to a MS which doesn't have the topology owned label. This happened because of a Cluster update event. 

So now this PR introduces an additional safeguard to return early if the MS/MD doesn't have the topology owned label.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->