### PR TITLE
🐛Check errors for IsNotFound after patching spec and status 

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -146,8 +146,11 @@ func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) e
 	if err := h.patch(ctx, obj); err != nil {
 		errs = append(errs, err)
 	}
+
 	if err := h.patchStatus(ctx, obj); err != nil {
-		errs = append(errs, err)
+		if !(apierrors.IsNotFound(err) && !obj.GetDeletionTimestamp().IsZero() && len(obj.GetFinalizers()) == 0) {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
~~This allows the patch helper to ignore patching the status when creating a patch.~~

The solution for the issue below was to check the object if the finalizers are removed and if the DeletionTimeStamp was not nil and the error after patching the status/spec was `IsNotFound`.  This will cut down on noise as well as achieve with not exposing the internals of the patch helper.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #10786

/area util


