### PR TITLE
🌱 test: export method and types for ClusterUpgradeWithRuntimeSDK

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -54,8 +54,8 @@ func hookResponsesConfigMapName(clusterName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, hookResponsesConfigMapNameSuffix)
 }
 
-// clusterUpgradeWithRuntimeSDKSpecInput is the input for clusterUpgradeWithRuntimeSDKSpec.
-type clusterUpgradeWithRuntimeSDKSpecInput struct {
+// ClusterUpgradeWithRuntimeSDKSpecInput is the input for clusterUpgradeWithRuntimeSDKSpec.
+type ClusterUpgradeWithRuntimeSDKSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	ClusterctlConfigPath  string
 	BootstrapClusterProxy framework.ClusterProxy
@@ -89,21 +89,27 @@ type clusterUpgradeWithRuntimeSDKSpecInput struct {
 	// Allows to inject a function to be run after the cluster is upgraded.
 	// If not specified, this is a no-op.
 	PostUpgrade func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
+
+	// ExtensionNamespace is the namespace where the service for the Runtime SDK is located
+	// and is used to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionNamespace string
+	// ExtensionServiceName is the service to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionServiceName string
 }
 
-// clusterUpgradeWithRuntimeSDKSpec implements a spec that upgrades a cluster and runs the Kubernetes conformance suite.
+// ClusterUpgradeWithRuntimeSDKSpec implements a spec that upgrades a cluster and runs the Kubernetes conformance suite.
 // Upgrading a cluster refers to upgrading the control-plane and worker nodes (managed by MD and machine pools).
 // NOTE: This test only works with a KubeadmControlPlane.
 // NOTE: This test works with Clusters with and without ClusterClass.
 // When using ClusterClass the ClusterClass must have the variables "etcdImageTag" and "coreDNSImageTag" of type string.
 // Those variables should have corresponding patches which set the etcd and CoreDNS tags in KCP.
-func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() clusterUpgradeWithRuntimeSDKSpecInput) {
+func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() ClusterUpgradeWithRuntimeSDKSpecInput) {
 	const (
 		specName = "k8s-upgrade-with-runtimesdk"
 	)
 
 	var (
-		input         clusterUpgradeWithRuntimeSDKSpecInput
+		input         ClusterUpgradeWithRuntimeSDKSpecInput
 		namespace     *corev1.Namespace
 		cancelWatches context.CancelFunc
 
@@ -124,6 +130,9 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersionUpgradeFrom))
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersionUpgradeTo))
+
+		Expect(input.ExtensionNamespace).ToNot(BeEmpty())
+		Expect(input.ExtensionServiceName).ToNot(BeEmpty())
 
 		if input.ControlPlaneMachineCount == nil {
 			controlPlaneMachineCount = 1
@@ -153,7 +162,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 		By("Deploy Test Extension ExtensionConfig")
 
 		Expect(input.BootstrapClusterProxy.GetClient().Create(ctx,
-			extensionConfig(specName, namespace.Name))).
+			extensionConfig(specName, namespace.Name, input.ExtensionNamespace, input.ExtensionServiceName))).
 			To(Succeed(), "Failed to create the extension config")
 
 		By("Creating a workload cluster; creation waits for BeforeClusterCreateHook to gate the operation")
@@ -291,7 +300,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 	AfterEach(func() {
 		// Delete the extensionConfig first to ensure the BeforeDeleteCluster hook doesn't block deletion.
 		Eventually(func() error {
-			return input.BootstrapClusterProxy.GetClient().Delete(ctx, extensionConfig(specName, namespace.Name))
+			return input.BootstrapClusterProxy.GetClient().Delete(ctx, extensionConfig(specName, namespace.Name, input.ExtensionNamespace, input.ExtensionServiceName))
 		}, 10*time.Second, 1*time.Second).Should(Succeed(), "delete extensionConfig failed")
 
 		// Dumps all the resources in the spec Namespace, then cleanups the cluster object and the spec Namespace itself.
@@ -401,7 +410,7 @@ func machineSetPreflightChecksTestHandler(ctx context.Context, c client.Client, 
 // We make sure this cluster-wide object does not conflict with others by using a random generated
 // name and a NamespaceSelector selecting on the namespace of the current test.
 // Thus, this object is "namespaced" to the current test even though it's a cluster-wide object.
-func extensionConfig(name, namespace string) *runtimev1.ExtensionConfig {
+func extensionConfig(name, namespace, extensionNamespace, extensionServiceName string) *runtimev1.ExtensionConfig {
 	return &runtimev1.ExtensionConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			// Note: We have to use a constant name here as we have to be able to reference it in the ClusterClass
@@ -409,15 +418,15 @@ func extensionConfig(name, namespace string) *runtimev1.ExtensionConfig {
 			Name: name,
 			Annotations: map[string]string{
 				// Note: this assumes the test extension get deployed in the default namespace defined in its own runtime-extensions-components.yaml
-				runtimev1.InjectCAFromSecretAnnotation: "test-extension-system/test-extension-webhook-service-cert",
+				runtimev1.InjectCAFromSecretAnnotation: fmt.Sprintf("%s/%s-cert", extensionNamespace, extensionServiceName),
 			},
 		},
 		Spec: runtimev1.ExtensionConfigSpec{
 			ClientConfig: runtimev1.ClientConfig{
 				Service: &runtimev1.ServiceReference{
-					Name: "test-extension-webhook-service",
+					Name: extensionServiceName,
 					// Note: this assumes the test extension get deployed in the default namespace defined in its own runtime-extensions-components.yaml
-					Namespace: "test-extension-system",
+					Namespace: extensionNamespace,
 				},
 			},
 			NamespaceSelector: &metav1.LabelSelector{

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -30,14 +30,14 @@ import (
 )
 
 var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [ClusterClass]", func() {
-	clusterUpgradeWithRuntimeSDKSpec(ctx, func() clusterUpgradeWithRuntimeSDKSpecInput {
+	ClusterUpgradeWithRuntimeSDKSpec(ctx, func() ClusterUpgradeWithRuntimeSDKSpecInput {
 		version, err := semver.ParseTolerant(e2eConfig.GetVariable(KubernetesVersionUpgradeFrom))
 		Expect(err).ToNot(HaveOccurred(), "Invalid argument, KUBERNETES_VERSION_UPGRADE_FROM is not a valid version")
 		if version.LT(semver.MustParse("1.24.0")) {
 			Fail("This test only supports upgrades from Kubernetes >= v1.24.0")
 		}
 
-		return clusterUpgradeWithRuntimeSDKSpecInput{
+		return ClusterUpgradeWithRuntimeSDKSpecInput{
 			E2EConfig:              e2eConfig,
 			ClusterctlConfigPath:   clusterctlConfigPath,
 			BootstrapClusterProxy:  bootstrapClusterProxy,
@@ -50,7 +50,9 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
-			Flavor: ptr.To("upgrades-runtimesdk"),
+			Flavor:               ptr.To("upgrades-runtimesdk"),
+			ExtensionNamespace:   "test-extension-system",
+			ExtensionServiceName: "test-extension-webhook-service",
 		}
 	})
 })

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -50,9 +50,13 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
-			Flavor:               ptr.To("upgrades-runtimesdk"),
-			ExtensionNamespace:   "test-extension-system",
-			ExtensionServiceName: "test-extension-webhook-service",
+			Flavor: ptr.To("upgrades-runtimesdk"),
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
 		}
 	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Exports the method and types to run `ClusterUpgradeWithRuntimeSDK` in provider e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area testing