### PR TITLE
🌱  Deprecate obsolete errors pkg

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -98,6 +98,7 @@
           - [v1.5 to v1.6](./developer/providers/migrations/v1.5-to-v1.6.md)
           - [v1.6 to v1.7](./developer/providers/migrations/v1.6-to-v1.7.md)
           - [v1.7 to v1.8](./developer/providers/migrations/v1.7-to-v1.8.md)
+          - [v1.8 to v1.9](./developer/providers/migrations/v1.8-to-v1.9.md)
         - [Provider contracts](./developer/providers/contracts.md)
           - [Cluster Infrastructure](./developer/providers/cluster-infrastructure.md)
           - [Machine Infrastructure](./developer/providers/machine-infrastructure.md)

--- a/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
+++ b/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
@@ -1,0 +1,22 @@
+# Cluster API v1.8 compared to v1.9
+
+This document provides an overview over relevant changes between Cluster API v1.8 and v1.9 for
+maintainers of providers and consumers of our Go API.
+
+## Go version
+
+- The Go version used by Cluster API is Go 1.22.x
+
+## Changes by Kind
+
+### Deprecation
+
+### Removals
+
+### API Changes
+
+### Other
+
+### Suggested changes for providers
+
+- The Errors package was created when capi provider implementation was running as machineActuators that needed to vendor core capi to function. There is no usage recommendations today and its value is questionable since we moved to CRDs that inter-operate mostly via conditions. Instead we plan to drop the dedicated semantic for terminal failure and keep improving Machine lifecycle signal through conditions. Therefore the Errors package [has been deprecated in v1.8](https://github.com/kubernetes-sigs/cluster-api/issues/10784). It's recommented to remove any usage of the currently exported variables.

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -15,4 +15,6 @@ limitations under the License.
 */
 
 // Package errors makes a set of error message handlers available for use by Cluster API Providers.
+//
+// Deprecated: This package will be removed in one of the next releases.
 package errors


### PR DESCRIPTION
The /errors package has its origin in when capi providers were machineActuators that needed to vendor core capi to function. There's no usage recommendations and value is questionable since we moved to CRDs and conditions for interoperability between core and providers. I think we should deprecate it and if there's any use case relying on it we should support it via conditions

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10784

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->