### PR TITLE
🌱 tilt: ensure in-tree providers always use start.sh to allow restarts

### DIFF
--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -77,22 +77,28 @@ var (
 	// which is containing "hard-coded" tilt-provider.yaml files for the providers managed in the Cluster API repository.
 	providers = map[string]tiltProviderConfig{
 		"core": {
-			Context: ptr.To("."),
+			Context:           ptr.To("."),
+			hardCodedProvider: true,
 		},
 		"kubeadm-bootstrap": {
-			Context: ptr.To("bootstrap/kubeadm"),
+			Context:           ptr.To("bootstrap/kubeadm"),
+			hardCodedProvider: true,
 		},
 		"kubeadm-control-plane": {
-			Context: ptr.To("controlplane/kubeadm"),
+			Context:           ptr.To("controlplane/kubeadm"),
+			hardCodedProvider: true,
 		},
 		"docker": {
-			Context: ptr.To("test/infrastructure/docker"),
+			Context:           ptr.To("test/infrastructure/docker"),
+			hardCodedProvider: true,
 		},
 		"in-memory": {
-			Context: ptr.To("test/infrastructure/inmemory"),
+			Context:           ptr.To("test/infrastructure/inmemory"),
+			hardCodedProvider: true,
 		},
 		"test-extension": {
-			Context: ptr.To("test/extension"),
+			Context:           ptr.To("test/extension"),
+			hardCodedProvider: true,
 		},
 	}
 
@@ -137,6 +143,9 @@ type tiltProviderConfig struct {
 	ApplyProviderYaml *bool    `json:"apply_provider_yaml,omitempty"`
 	KustomizeFolder   *string  `json:"kustomize_folder,omitempty"`
 	KustomizeOptions  []string `json:"kustomize_options,omitempty"`
+
+	// hardCodedProvider is used for providers hardcoded in the Tiltfile to always set cmd for them to start.sh to allow restarts.
+	hardCodedProvider bool
 }
 
 func init() {
@@ -354,7 +363,7 @@ func tiltResources(ctx context.Context, ts *tiltSettings) error {
 				debugConfig = &d
 			}
 			extraArgs := ts.ExtraArgs[providerName]
-			tasks[providerName] = workloadTask(providerName, "provider", "manager", "manager", liveReloadDeps, debugConfig, extraArgs, kustomizeFolder, kustomizeOptions, getProviderObj(config.Version))
+			tasks[providerName] = workloadTask(providerName, "provider", "manager", "manager", liveReloadDeps, debugConfig, extraArgs, config.hardCodedProvider, kustomizeFolder, kustomizeOptions, getProviderObj(config.Version))
 		}
 	}
 
@@ -693,7 +702,7 @@ func kustomizeTask(path, out string) taskFunction {
 // workloadTask generates a task for creating the component yaml for a workload and saving the output on a file.
 // NOTE: This task has several sub steps including running kustomize, envsubst, fixing components for debugging,
 // and adding the workload resource mimicking what clusterctl init does.
-func workloadTask(name, workloadType, binaryName, containerName string, liveReloadDeps []string, debugConfig *tiltSettingsDebugConfig, extraArgs tiltSettingsExtraArgs, path string, options []string, getAdditionalObject func(string, []unstructured.Unstructured) (*unstructured.Unstructured, error)) taskFunction {
+func workloadTask(name, workloadType, binaryName, containerName string, liveReloadDeps []string, debugConfig *tiltSettingsDebugConfig, extraArgs tiltSettingsExtraArgs, hardCodedProvider bool, path string, options []string, getAdditionalObject func(string, []unstructured.Unstructured) (*unstructured.Unstructured, error)) taskFunction {
 	return func(ctx context.Context, prefix string, errCh chan error) {
 		args := []string{"build"}
 		args = append(args, options...)
@@ -725,7 +734,7 @@ func workloadTask(name, workloadType, binaryName, containerName string, liveRelo
 			return
 		}
 
-		if err := prepareWorkload(prefix, binaryName, containerName, objs, liveReloadDeps, debugConfig, extraArgs); err != nil {
+		if err := prepareWorkload(prefix, binaryName, containerName, objs, liveReloadDeps, debugConfig, extraArgs, hardCodedProvider); err != nil {
 			errCh <- err
 			return
 		}
@@ -794,7 +803,7 @@ func writeIfChanged(prefix string, path string, yaml []byte) error {
 // If there are extra_args given for the workload, we append those to the ones that already exist in the deployment.
 // This has the affect that the appended ones will take precedence, as those are read last.
 // Finally, we modify the deployment to enable prometheus metrics scraping.
-func prepareWorkload(prefix, binaryName, containerName string, objs []unstructured.Unstructured, liveReloadDeps []string, debugConfig *tiltSettingsDebugConfig, extraArgs tiltSettingsExtraArgs) error {
+func prepareWorkload(prefix, binaryName, containerName string, objs []unstructured.Unstructured, liveReloadDeps []string, debugConfig *tiltSettingsDebugConfig, extraArgs tiltSettingsExtraArgs, hardcodedProvider bool) error {
 	// Update provider namespaces to have the pod security standard enforce label set to privileged.
 	// This is required because we remove the SecurityContext from provider deployments below to make tilt work.
 	updateNamespacePodSecurityStandard(objs)
@@ -805,7 +814,7 @@ func prepareWorkload(prefix, binaryName, containerName string, objs []unstructur
 			}
 
 			cmd := []string{"/" + binaryName}
-			if len(liveReloadDeps) > 0 || debugConfig != nil {
+			if len(liveReloadDeps) > 0 || debugConfig != nil || hardcodedProvider {
 				cmd = []string{"sh", "/start.sh", "/" + binaryName}
 			}
 			args := append(container.Args, []string(extraArgs)...)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The in-tree providers have hardcoded their provider options in `Tiltbuild`. Therefor the values we have in `tilt-prepare` do not reflect the real ones.

Since implementing #10244, when using a `tilt-settings.yaml` file without debug configuration for the in-tree providers, tilt-prepare won't adjust the cmd to use `start.sh` and because of that restarts via tilt did not work anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10810

/area devtools