### PR TITLE
:bug: Patch helper should be able to patch non-spec objects

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +45,7 @@ type Helper struct {
 	beforeObject client.Object
 	before       *unstructured.Unstructured
 	after        *unstructured.Unstructured
-	changes      map[string]bool
+	changes      sets.Set[string]
 
 	isConditionsSetter bool
 }
@@ -157,7 +158,7 @@ func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) e
 
 // patch issues a patch for metadata and spec.
 func (h *Helper) patch(ctx context.Context, obj client.Object) error {
-	if !h.shouldPatch("metadata") && !h.shouldPatch("spec") {
+	if !h.shouldPatch(specPatch) {
 		return nil
 	}
 	beforeObject, afterObject, err := h.calculatePatch(obj, specPatch)
@@ -169,7 +170,7 @@ func (h *Helper) patch(ctx context.Context, obj client.Object) error {
 
 // patchStatus issues a patch if the status has changed.
 func (h *Helper) patchStatus(ctx context.Context, obj client.Object) error {
-	if !h.shouldPatch("status") {
+	if !h.shouldPatch(statusPatch) {
 		return nil
 	}
 	beforeObject, afterObject, err := h.calculatePatch(obj, statusPatch)
@@ -285,13 +286,18 @@ func (h *Helper) calculatePatch(afterObj client.Object, focus patchType) (client
 	return beforeObj, afterObj, nil
 }
 
-func (h *Helper) shouldPatch(in string) bool {
-	return h.changes[in]
+func (h *Helper) shouldPatch(focus patchType) bool {
+	if focus == specPatch {
+		// If we're looking to patch anything other than status,
+		// return true if the changes map has any fields after removing `status`.
+		return h.changes.Clone().Delete("status").Len() > 0
+	}
+	return h.changes.Has(string(focus))
 }
 
 // calculate changes tries to build a patch from the before/after objects we have
 // and store in a map which top-level fields (e.g. `metadata`, `spec`, `status`, etc.) have changed.
-func (h *Helper) calculateChanges(after client.Object) (map[string]bool, error) {
+func (h *Helper) calculateChanges(after client.Object) (sets.Set[string], error) {
 	// Calculate patch data.
 	patch := client.MergeFrom(h.beforeObject)
 	diff, err := patch.Data(after)
@@ -306,9 +312,9 @@ func (h *Helper) calculateChanges(after client.Object) (map[string]bool, error) 
 	}
 
 	// Return the map.
-	res := make(map[string]bool, len(patchDiff))
+	res := sets.New[string]()
 	for key := range patchDiff {
-		res[key] = true
+		res.Insert(key)
 	}
 	return res, nil
 }

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -31,6 +31,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
@@ -720,6 +721,56 @@ func TestPatchHelper(t *testing.T) {
 					cmp.Equal(obj.Spec, objAfter.Spec)
 			}, timeout).Should(BeTrue())
 		})
+	})
+
+	t.Run("should patch a corev1.ConfigMap object", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "node-patch-test-",
+				Namespace:    ns.Name,
+				Annotations: map[string]string{
+					"test": "1",
+				},
+			},
+			Data: map[string]string{
+				"1": "value",
+			},
+		}
+
+		t.Log("Creating a ConfigMap object")
+		g.Expect(env.Create(ctx, obj)).To(Succeed())
+		defer func() {
+			g.Expect(env.Delete(ctx, obj)).To(Succeed())
+		}()
+		key := util.ObjectKey(obj)
+
+		t.Log("Checking that the object has been created")
+		g.Eventually(func() error {
+			obj := obj.DeepCopy()
+			return env.Get(ctx, key, obj)
+		}).Should(Succeed())
+
+		t.Log("Creating a new patch helper")
+		patcher, err := NewHelper(obj, env)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		t.Log("Adding a new Data value")
+		obj.Data["1"] = "value1"
+		obj.Data["2"] = "value2"
+
+		t.Log("Patching the ConfigMap")
+		g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+
+		t.Log("Validating the object has been updated")
+		objAfter := &corev1.ConfigMap{}
+		g.Eventually(func() bool {
+			g.Expect(env.Get(ctx, key, objAfter)).To(Succeed())
+			return len(objAfter.Data) == 2
+		}, timeout).Should(BeTrue())
+		g.Expect(objAfter.Data["1"]).To(Equal("value1"))
+		g.Expect(objAfter.Data["2"]).To(Equal("value2"))
 	})
 
 	t.Run("Should update Status.ObservedGeneration when using WithStatusObservedGeneration option", func(t *testing.T) {


### PR DESCRIPTION
Currently, patch helper is only useful for CRD or any other object that has spec/status fields, where status is considered a subresource.

Some types like ConfigMap (and others) don't rely on spec being a top level resource, but instead have other top level fields like `data`.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->