### PR TITLE
🌱 Update implicit skipping remediation for Cluster/MD pause

### DIFF
--- a/docs/book/src/tasks/automated-machine-management/healthchecking.md
+++ b/docs/book/src/tasks/automated-machine-management/healthchecking.md
@@ -209,12 +209,21 @@ This is useful for dynamically scaling clusters where the number of machines kee
 
 ## Skipping Remediation
 
-There are scenarios where remediation for a machine may be undesirable (eg. during cluster migration using `clusterctl move`). For such cases, MachineHealthCheck provides 2 mechanisms to skip machines for remediation.
+There are scenarios where remediation for a machine may be undesirable (eg.
+during cluster migration using `clusterctl move`). For such cases,
+MachineHealthCheck provides the following mechanisms to skip remediation.
 
-Implicit skipping when the resource is paused (using `cluster.x-k8s.io/paused` annotation):
-- When a cluster is paused, none of the machines in that cluster are considered for remediation.
-- When a machine is paused, only that machine is not considered for remediation.
-- A cluster or a machine is usually paused automatically by Cluster API when it detects a migration.
+- Users can skip remediation for a specific machine by setting the
+`cluster.x-k8s.io/skip-remediation` annotation on it.
+- Paused Machines (Machines with the `cluster.x-k8s.io/paused` annotation) are
+not considered for remediation.
+- If a specific MHC resource is paused (using `cluster.x-k8s.io/paused` annotation),
+it will stop to remediate the corresponding target machines.
+- If the Cluster is paused (using the `cluster.x-k8s.io/paused` annotation or by
+setting `cluster.spec.paused` to true), all the MHC resources belonging to the
+Cluster will be implicitly paused, and thus stop remediating target machines.
+
+Note: the last option (pausing the Cluster) is the one used by `clusterctl move`.
 
 Explicit skipping using `cluster.x-k8s.io/skip-remediation` annotation:
 - Users can also skip any machine for remediation by setting the `cluster.x-k8s.io/skip-remediation` for that machine.


### PR DESCRIPTION
The current documentation is a bit ambiguous since Cluster cannot be paused using paused annotation. This PR updates the docs and specifies that Cluster and MD expect `Spec.Paused = true` for it to be paused.
Signed-off-by: Kashif Khan <kashif.khan@est.tech>

/area documentation
