### PR TITLE
🌱 Stop bumping cel-go via dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -43,6 +43,9 @@ updates:
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - dependency-name: "google.golang.org/grpc"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Note: We have to keep this 100% in sync with k8s.io, so we get exactly the behavior
+  # that the k8s.io CEL code expects.
+  - dependency-name: "github.com/google/cel-go"
     # Ignore kind as its upgraded manually.
   - dependency-name: "sigs.k8s.io/kind"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.4.2
 	github.com/gobuffalo/flect v1.0.2
+	// Note: This must be kept in sync with the version used by k8s.io.
 	github.com/google/cel-go v0.17.8
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v53 v53.2.0


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->