### PR TITLE
🐛 Fix metadata assert failure in clusterclass rollout test

### DIFF
--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -407,7 +407,7 @@ func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clust
 			ccControlPlaneTemplateMachineTemplateMetadata.Labels,
 		),
 	))
-	g.Expect(controlPlaneMachineTemplateMetadata.Annotations).To(BeEquivalentTo(
+	g.Expect(union(controlPlaneMachineTemplateMetadata.Annotations)).To(BeEquivalentTo(
 		union(
 			cluster.Spec.Topology.ControlPlane.Metadata.Annotations,
 			clusterClass.Spec.ControlPlane.Metadata.Annotations,
@@ -466,8 +466,8 @@ func assertControlPlaneMachines(g Gomega, clusterObjects clusterObjects, cluster
 			union(
 				machineMetadata.Annotations,
 			).without(g, controlplanev1.KubeadmClusterConfigurationAnnotation),
-		).To(BeEquivalentTo(
-			controlPlaneMachineTemplateMetadata.Annotations,
+		).To(BeEquivalentTo(union(
+			controlPlaneMachineTemplateMetadata.Annotations),
 		))
 
 		// ControlPlane Machine InfrastructureMachine.metadata
@@ -516,8 +516,8 @@ func assertControlPlaneMachines(g Gomega, clusterObjects clusterObjects, cluster
 			union(
 				bootstrapConfigMetadata.Annotations,
 			).without(g, clusterv1.MachineCertificatesExpiryDateAnnotation),
-		).To(BeEquivalentTo(
-			controlPlaneMachineTemplateMetadata.Annotations,
+		).To(BeEquivalentTo(union(
+			controlPlaneMachineTemplateMetadata.Annotations),
 		))
 
 		// ControlPlane Machine Node.metadata
@@ -580,7 +580,7 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 				mdClass.Template.Metadata.Labels,
 			),
 		))
-		g.Expect(machineDeployment.Spec.Template.Annotations).To(BeEquivalentTo(
+		g.Expect(union(machineDeployment.Spec.Template.Annotations)).To(BeEquivalentTo(
 			union(
 				mdTopology.Metadata.Annotations,
 				mdClass.Template.Metadata.Annotations,
@@ -693,7 +693,7 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 				mpClass.Template.Metadata.Labels,
 			),
 		))
-		g.Expect(machinePool.Spec.Template.Annotations).To(BeEquivalentTo(
+		g.Expect(union(machinePool.Spec.Template.Annotations)).To(BeEquivalentTo(
 			union(
 				mpTopology.Metadata.Annotations,
 				mpClass.Template.Metadata.Annotations,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add union() to convert a potential nil map to an empty map, otherwise the test will faile due to compare a nil map and an empty one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10839

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area testing