### PR TITLE
⚠️ Adjust CC & Cluster controller to block on variable conflicts, deprecate definitionFrom

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -103,6 +103,8 @@ type Topology struct {
 	// patches. They must comply to the corresponding
 	// VariableClasses defined in the ClusterClass.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Variables []ClusterVariable `json:"variables,omitempty"`
 }
 
@@ -319,10 +321,10 @@ type ClusterVariable struct {
 	// Name of the variable.
 	Name string `json:"name"`
 
-	// DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
-	// definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
-	// `.spec.patches` where the patch is external and provides external variables.
-	// This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+	// DefinitionFrom specifies where the definition of this Variable is from.
+	//
+	// Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+	//
 	// +optional
 	DefinitionFrom string `json:"definitionFrom,omitempty"`
 
@@ -340,6 +342,8 @@ type ClusterVariable struct {
 type ControlPlaneVariables struct {
 	// Overrides can be used to override Cluster level variables.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 
@@ -347,6 +351,8 @@ type ControlPlaneVariables struct {
 type MachineDeploymentVariables struct {
 	// Overrides can be used to override Cluster level variables.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 
@@ -354,6 +360,8 @@ type MachineDeploymentVariables struct {
 type MachinePoolVariables struct {
 	// Overrides can be used to override Cluster level variables.
 	// +optional
+	// +listType=map
+	// +listMapKey=name
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -910,7 +910,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterVariable(ref common.Referen
 					},
 					"definitionFrom": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass `.spec.patches` where the patch is external and provides external variables. This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`",
+							Description: "DefinitionFrom specifies where the definition of this Variable is from.\n\nDeprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1141,6 +1141,14 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ControlPlaneVariables(ref common.R
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"overrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Overrides can be used to override Cluster level variables.",
 							Type:        []string{"array"},
@@ -2189,6 +2197,14 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentVariables(ref com
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"overrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Overrides can be used to override Cluster level variables.",
 							Type:        []string{"array"},
@@ -2851,6 +2867,14 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachinePoolVariables(ref common.Re
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"overrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Overrides can be used to override Cluster level variables.",
 							Type:        []string{"array"},
@@ -3676,6 +3700,14 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_Topology(ref common.ReferenceCallb
 						},
 					},
 					"variables": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Variables can be used to customize the Cluster through patches. They must comply to the corresponding VariableClasses defined in the ClusterClass.",
 							Type:        []string{"array"},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1109,10 +1109,10 @@ spec:
                               properties:
                                 definitionFrom:
                                   description: |-
-                                    DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
-                                    definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
-                                    `.spec.patches` where the patch is external and provides external variables.
-                                    This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+                                    DefinitionFrom specifies where the definition of this Variable is from.
+
+
+                                    Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
                                   type: string
                                 name:
                                   description: Name of the variable.
@@ -1132,6 +1132,9 @@ spec:
                               - value
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                         type: object
                     type: object
                   rolloutAfter:
@@ -1155,10 +1158,10 @@ spec:
                       properties:
                         definitionFrom:
                           description: |-
-                            DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
-                            definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
-                            `.spec.patches` where the patch is external and provides external variables.
-                            This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+                            DefinitionFrom specifies where the definition of this Variable is from.
+
+
+                            Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
                           type: string
                         name:
                           description: Name of the variable.
@@ -1178,6 +1181,9 @@ spec:
                       - value
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   version:
                     description: The Kubernetes version of the cluster.
                     type: string
@@ -1511,10 +1517,10 @@ spec:
                                     properties:
                                       definitionFrom:
                                         description: |-
-                                          DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
-                                          definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
-                                          `.spec.patches` where the patch is external and provides external variables.
-                                          This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+                                          DefinitionFrom specifies where the definition of this Variable is from.
+
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
                                         type: string
                                       name:
                                         description: Name of the variable.
@@ -1534,6 +1540,9 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                               type: object
                           required:
                           - class
@@ -1642,10 +1651,10 @@ spec:
                                     properties:
                                       definitionFrom:
                                         description: |-
-                                          DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
-                                          definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
-                                          `.spec.patches` where the patch is external and provides external variables.
-                                          This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+                                          DefinitionFrom specifies where the definition of this Variable is from.
+
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
                                         type: string
                                       name:
                                         description: Name of the variable.
@@ -1665,6 +1674,9 @@ spec:
                                     - value
                                     type: object
                                   type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                               type: object
                           required:
                           - class

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -228,12 +228,12 @@ func (r *Reconciler) reconcile(ctx context.Context, s *scope.Scope) (ctrl.Result
 	// is not up to date.
 	// Note: This doesn't require requeue as a change to ClusterClass observedGeneration will cause an additional reconcile
 	// in the Cluster.
-	if clusterClass.GetGeneration() != clusterClass.Status.ObservedGeneration {
-		return ctrl.Result{}, errors.Errorf("ClusterClass is not successfully reconciled: ClusterClass.status.observedGeneration must be %d, but is %d", clusterClass.GetGeneration(), clusterClass.Status.ObservedGeneration)
-	}
 	if !conditions.Has(clusterClass, clusterv1.ClusterClassVariablesReconciledCondition) ||
 		conditions.IsFalse(clusterClass, clusterv1.ClusterClassVariablesReconciledCondition) {
 		return ctrl.Result{}, errors.Errorf("ClusterClass is not successfully reconciled: status of %s condition on ClusterClass must be \"True\"", clusterv1.ClusterClassVariablesReconciledCondition)
+	}
+	if clusterClass.GetGeneration() != clusterClass.Status.ObservedGeneration {
+		return ctrl.Result{}, errors.Errorf("ClusterClass is not successfully reconciled: ClusterClass.status.observedGeneration must be %d, but is %d", clusterClass.GetGeneration(), clusterClass.Status.ObservedGeneration)
 	}
 
 	// Default and Validate the Cluster variables based on information from the ClusterClass.

--- a/internal/controllers/topology/cluster/patches/engine.go
+++ b/internal/controllers/topology/cluster/patches/engine.go
@@ -158,14 +158,14 @@ func addVariablesForPatch(blueprint *scope.ClusterBlueprint, desired *scope.Clus
 
 	patchVariableDefinitions := definitionsForPatch(blueprint, definitionFrom)
 	// Calculate global variables.
-	globalVariables, err := variables.Global(blueprint.Topology, desired.Cluster, definitionFrom, patchVariableDefinitions)
+	globalVariables, err := variables.Global(blueprint.Topology, desired.Cluster, patchVariableDefinitions)
 	if err != nil {
 		return errors.Wrapf(err, "failed to calculate global variables")
 	}
 	req.Variables = globalVariables
 
 	// Calculate the Control Plane variables.
-	controlPlaneVariables, err := variables.ControlPlane(&blueprint.Topology.ControlPlane, desired.ControlPlane.Object, desired.ControlPlane.InfrastructureMachineTemplate, definitionFrom, patchVariableDefinitions)
+	controlPlaneVariables, err := variables.ControlPlane(&blueprint.Topology.ControlPlane, desired.ControlPlane.Object, desired.ControlPlane.InfrastructureMachineTemplate, patchVariableDefinitions)
 	if err != nil {
 		return errors.Wrapf(err, "failed to calculate ControlPlane variables")
 	}
@@ -201,7 +201,7 @@ func addVariablesForPatch(blueprint *scope.ClusterBlueprint, desired *scope.Clus
 			}
 
 			// Calculate MachineDeployment variables.
-			mdVariables, err := variables.MachineDeployment(mdTopology, md.Object, md.BootstrapTemplate, md.InfrastructureMachineTemplate, definitionFrom, patchVariableDefinitions)
+			mdVariables, err := variables.MachineDeployment(mdTopology, md.Object, md.BootstrapTemplate, md.InfrastructureMachineTemplate, patchVariableDefinitions)
 			if err != nil {
 				return errors.Wrapf(err, "failed to calculate variables for %s", klog.KObj(md.Object))
 			}
@@ -217,7 +217,7 @@ func addVariablesForPatch(blueprint *scope.ClusterBlueprint, desired *scope.Clus
 			}
 
 			// Calculate MachinePool variables.
-			mpVariables, err := variables.MachinePool(mpTopology, mp.Object, mp.BootstrapObject, mp.InfrastructureMachinePoolObject, definitionFrom, patchVariableDefinitions)
+			mpVariables, err := variables.MachinePool(mpTopology, mp.Object, mp.BootstrapObject, mp.InfrastructureMachinePoolObject, patchVariableDefinitions)
 			if err != nil {
 				return errors.Wrapf(err, "failed to calculate variables for %s", klog.KObj(mp.Object))
 			}

--- a/internal/controllers/topology/cluster/patches/engine_test.go
+++ b/internal/controllers/topology/cluster/patches/engine_test.go
@@ -699,7 +699,7 @@ func TestApply(t *testing.T) {
 			},
 		},
 		{
-			name: "Should correctly apply variables for a given patch definitionFrom",
+			name: "Should correctly apply variables with variables without conflicts",
 			varDefinitions: []clusterv1.ClusterClassStatusVariable{
 				{
 					Name: "controlPlaneVariable",
@@ -726,8 +726,9 @@ func TestApply(t *testing.T) {
 					},
 				},
 				{
-					Name:                "infraCluster",
-					DefinitionsConflict: true,
+					Name: "infraCluster",
+					// Note: This variable is defined by multiple patches, but without conflicts.
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 							From: "inline",
@@ -1098,42 +1099,31 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					Variables: &clusterv1.ControlPlaneVariables{
 						Overrides: []clusterv1.ClusterVariable{
 							{
-								Name:           "controlPlaneVariable",
-								DefinitionFrom: "inline",
-								Value:          apiextensionsv1.JSON{Raw: []byte(`"control-plane-override-value"`)},
+								Name:  "controlPlaneVariable",
+								Value: apiextensionsv1.JSON{Raw: []byte(`"control-plane-override-value"`)},
 							},
 						},
 					},
 				},
 				Variables: []clusterv1.ClusterVariable{
 					{
-						Name:           "infraCluster",
-						Value:          apiextensionsv1.JSON{Raw: []byte(`"value99"`)},
-						DefinitionFrom: "inline",
-					},
-					{
-						Name: "infraCluster",
-						// This variable should not be used as it is from "non-used-patch" which is not applied in any test.
-						Value:          apiextensionsv1.JSON{Raw: []byte(`"should-never-be-used"`)},
-						DefinitionFrom: "not-used-patch",
+						Name:  "infraCluster",
+						Value: apiextensionsv1.JSON{Raw: []byte(`"value99"`)},
 					},
 					{
 						Name: "controlPlaneVariable",
 						// This value should be overwritten for the control plane.
-						Value:          apiextensionsv1.JSON{Raw: []byte(`"control-plane-cluster-wide-value"`)},
-						DefinitionFrom: "inline",
+						Value: apiextensionsv1.JSON{Raw: []byte(`"control-plane-cluster-wide-value"`)},
 					},
 					{
 						Name: "defaultMDWorkerVariable",
 						// This value should be overwritten for the default-worker-topo1 MachineDeployment.
-						Value:          apiextensionsv1.JSON{Raw: []byte(`"default-md-cluster-wide-value"`)},
-						DefinitionFrom: "inline",
+						Value: apiextensionsv1.JSON{Raw: []byte(`"default-md-cluster-wide-value"`)},
 					},
 					{
 						Name: "defaultMPWorkerVariable",
 						// This value should be overwritten for the default-mp-worker-topo1 MachinePool.
-						Value:          apiextensionsv1.JSON{Raw: []byte(`"default-mp-cluster-wide-value"`)},
-						DefinitionFrom: "inline",
+						Value: apiextensionsv1.JSON{Raw: []byte(`"default-mp-cluster-wide-value"`)},
 					},
 				},
 				Workers: &clusterv1.WorkersTopology{
@@ -1145,9 +1135,8 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 							Variables: &clusterv1.MachineDeploymentVariables{
 								Overrides: []clusterv1.ClusterVariable{
 									{
-										Name:           "defaultMDWorkerVariable",
-										DefinitionFrom: "inline",
-										Value:          apiextensionsv1.JSON{Raw: []byte(`"default-worker-topo1-override-value"`)},
+										Name:  "defaultMDWorkerVariable",
+										Value: apiextensionsv1.JSON{Raw: []byte(`"default-worker-topo1-override-value"`)},
 									},
 								},
 							},
@@ -1167,9 +1156,8 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 							Variables: &clusterv1.MachinePoolVariables{
 								Overrides: []clusterv1.ClusterVariable{
 									{
-										Name:           "defaultMPWorkerVariable",
-										DefinitionFrom: "inline",
-										Value:          apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-topo1-override-value"`)},
+										Name:  "defaultMPWorkerVariable",
+										Value: apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-topo1-override-value"`)},
 									},
 								},
 							},

--- a/internal/controllers/topology/cluster/patches/variables/variables.go
+++ b/internal/controllers/topology/cluster/patches/variables/variables.go
@@ -31,14 +31,9 @@ import (
 	"sigs.k8s.io/cluster-api/internal/contract"
 )
 
-const (
-	// emptyDefinitionFrom may be supplied in variable values.
-	emptyDefinitionFrom = ""
-)
-
 // Global returns variables that apply to all the templates, including user provided variables
 // and builtin variables for the Cluster object.
-func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster, definitionFrom string, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
+func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
 	variables := []runtimehooksv1.Variable{}
 
 	// Add user defined variables from Cluster.spec.topology.variables.
@@ -47,12 +42,9 @@ func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster, def
 		if variable.Name == runtimehooksv1.BuiltinsName {
 			continue
 		}
-		// Add the variable if it is defined for the current patch or it is defined for all the patches.
-		if variable.DefinitionFrom == emptyDefinitionFrom || variable.DefinitionFrom == definitionFrom {
-			// Add the variable if it has a definition from this patch in the ClusterClass.
-			if _, ok := patchVariableDefinitions[variable.Name]; ok {
-				variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
-			}
+		// Add the variable if it has a definition from this patch in the ClusterClass.
+		if _, ok := patchVariableDefinitions[variable.Name]; ok {
+			variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
 		}
 	}
 
@@ -95,18 +87,15 @@ func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster, def
 }
 
 // ControlPlane returns variables that apply to templates belonging to the ControlPlane.
-func ControlPlane(cpTopology *clusterv1.ControlPlaneTopology, cp, cpInfrastructureMachineTemplate *unstructured.Unstructured, definitionFrom string, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
+func ControlPlane(cpTopology *clusterv1.ControlPlaneTopology, cp, cpInfrastructureMachineTemplate *unstructured.Unstructured, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
 	variables := []runtimehooksv1.Variable{}
 
 	// Add variables overrides for the ControlPlane.
 	if cpTopology.Variables != nil {
 		for _, variable := range cpTopology.Variables.Overrides {
-			// Add the variable if it is defined for the current patch or it is defined for all the patches.
-			if variable.DefinitionFrom == emptyDefinitionFrom || variable.DefinitionFrom == definitionFrom {
-				// Add the variable if it has a definition from this patch in the ClusterClass.
-				if _, ok := patchVariableDefinitions[variable.Name]; ok {
-					variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
-				}
+			// Add the variable if it has a definition from this patch in the ClusterClass.
+			if _, ok := patchVariableDefinitions[variable.Name]; ok {
+				variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
 			}
 		}
 	}
@@ -154,18 +143,15 @@ func ControlPlane(cpTopology *clusterv1.ControlPlaneTopology, cp, cpInfrastructu
 }
 
 // MachineDeployment returns variables that apply to templates belonging to a MachineDeployment.
-func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clusterv1.MachineDeployment, mdBootstrapTemplate, mdInfrastructureMachineTemplate *unstructured.Unstructured, definitionFrom string, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
+func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clusterv1.MachineDeployment, mdBootstrapTemplate, mdInfrastructureMachineTemplate *unstructured.Unstructured, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
 	variables := []runtimehooksv1.Variable{}
 
 	// Add variables overrides for the MachineDeployment.
 	if mdTopology.Variables != nil {
 		for _, variable := range mdTopology.Variables.Overrides {
-			// Add the variable if it is defined for the current patch or it is defined for all the patches.
-			if variable.DefinitionFrom == emptyDefinitionFrom || variable.DefinitionFrom == definitionFrom {
-				// Add the variable if it has a definition from this patch in the ClusterClass.
-				if _, ok := patchVariableDefinitions[variable.Name]; ok {
-					variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
-				}
+			// Add the variable if it has a definition from this patch in the ClusterClass.
+			if _, ok := patchVariableDefinitions[variable.Name]; ok {
+				variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
 			}
 		}
 	}
@@ -207,18 +193,15 @@ func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clus
 }
 
 // MachinePool returns variables that apply to templates belonging to a MachinePool.
-func MachinePool(mpTopology *clusterv1.MachinePoolTopology, mp *expv1.MachinePool, mpBootstrapObject, mpInfrastructureMachinePool *unstructured.Unstructured, definitionFrom string, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
+func MachinePool(mpTopology *clusterv1.MachinePoolTopology, mp *expv1.MachinePool, mpBootstrapObject, mpInfrastructureMachinePool *unstructured.Unstructured, patchVariableDefinitions map[string]bool) ([]runtimehooksv1.Variable, error) {
 	variables := []runtimehooksv1.Variable{}
 
 	// Add variables overrides for the MachinePool.
 	if mpTopology.Variables != nil {
 		for _, variable := range mpTopology.Variables.Overrides {
-			// Add the variable if it is defined for the current patch or it is defined for all the patches.
-			if variable.DefinitionFrom == emptyDefinitionFrom || variable.DefinitionFrom == definitionFrom {
-				// Add the variable if it has a definition from this patch in the ClusterClass.
-				if _, ok := patchVariableDefinitions[variable.Name]; ok {
-					variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
-				}
+			// Add the variable if it has a definition from this patch in the ClusterClass.
+			if _, ok := patchVariableDefinitions[variable.Name]; ok {
+				variables = append(variables, runtimehooksv1.Variable{Name: variable.Name, Value: variable.Value})
 			}
 		}
 	}

--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -56,7 +56,7 @@ func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []c
 		return nil, append(allErrs, err...)
 	}
 
-	// Get a deterministically ordered list of all variables defined in both the Cluster and the ClusterClass.
+	// Get a deterministically ordered list of all variables set in the Cluster and defined the ClusterClass.
 	// Note: If the order is not deterministic variables would be continuously rewritten to the Cluster.
 	allVariables := getAllVariables(values, valuesIndex, definitions)
 
@@ -172,7 +172,11 @@ func defaultValue(currentValue *clusterv1.ClusterVariable, definition *clusterv1
 	return v, nil
 }
 
-// getAllVariables returns a correctly ordered list of all variables defined in the ClusterClass and the Cluster.
+// getAllVariables returns a deterministically ordered list of all variables set in the Cluster and defined the ClusterClass.
+// Ordered means that the list will first contain the existing variable values from the Cluster and
+// then we will add variables from the ClusterClass (only if they don't exist already on the Cluster).
+// This way if we run repeatedly through variable defaulting the order of the variables in Cluster.spec.topology doesn't change.
+// If the order would change, we would be continuously writing the Cluster object (this code is also executed in the Cluster topology controller).
 func getAllVariables(values []clusterv1.ClusterVariable, valuesIndex map[string]*clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable) []clusterv1.ClusterVariable {
 	// allVariables is used to get a full correctly ordered list of variables.
 	allVariables := []clusterv1.ClusterVariable{}

--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -19,7 +19,6 @@ package variables
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -45,20 +44,17 @@ func DefaultMachineVariables(values []clusterv1.ClusterVariable, definitions []c
 func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable, createVariables bool, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
 	var allErrs field.ErrorList
 
-	// Get a map of ClusterVariable values. This function validates that:
-	// - variables are not defined more than once in Cluster spec.
-	// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
-	valuesIndex, err := newValuesIndex(values)
-	if err != nil {
-		var valueStrings []string
-		for _, v := range values {
-			valueStrings = append(valueStrings, fmt.Sprintf("Name: %s DefinitionFrom: %s", v.Name, v.DefinitionFrom))
-		}
-		return nil, append(allErrs, field.Invalid(fldPath, "["+strings.Join(valueStrings, ",")+"]", fmt.Sprintf("cluster variables not valid: %s", err)))
+	// Get an index for variable values.
+	valuesIndex, err := newValuesIndex(fldPath, values)
+	if len(err) > 0 {
+		return nil, append(allErrs, err...)
 	}
 
-	// Get an index for each variable name and definition.
-	defIndex := newDefinitionsIndex(definitions)
+	// Get an index for definitions.
+	defIndex, err := newDefinitionsIndex(fldPath, definitions)
+	if len(err) > 0 {
+		return nil, append(allErrs, err...)
+	}
 
 	// Get a deterministically ordered list of all variables defined in both the Cluster and the ClusterClass.
 	// Note: If the order is not deterministic variables would be continuously rewritten to the Cluster.
@@ -71,14 +67,14 @@ func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []c
 		fldPath := fldPath.Key(variable.Name)
 
 		// Get the variable definition from the ClusterClass. If the variable is not defined add an error.
-		definition, err := defIndex.get(variable.Name, variable.DefinitionFrom)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath, string(variable.Value.Raw), err.Error()))
+		definition, ok := defIndex[variable.Name]
+		if !ok {
+			allErrs = append(allErrs, field.Invalid(fldPath, string(variable.Value.Raw), "variable is not defined"))
 			continue
 		}
 
-		// Get the current value of the variable if it is defined in the Cluster spec.
-		currentValue := getCurrentValue(variable, valuesIndex)
+		// Get the current value of the variable if it is defined in the Cluster spec (nil otherwise).
+		currentValue := valuesIndex[variable.Name]
 
 		// Default the variable.
 		defaultedValue, errs := defaultValue(currentValue, definition, fldPath, createVariables)
@@ -88,7 +84,7 @@ func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []c
 		}
 
 		// Continue if there is no defaulted variable.
-		// NOTE: This happens when the variable doesn't exist on the CLuster before and
+		// NOTE: This happens when the variable doesn't exist on the Cluster before and
 		// there is no top-level default value.
 		if defaultedValue == nil {
 			continue
@@ -102,32 +98,26 @@ func defaultClusterVariables(values []clusterv1.ClusterVariable, definitions []c
 	return defaultedValues, nil
 }
 
-// getCurrentValue returns the value of a variable for its definitionFrom, or for an empty definitionFrom if it exists.
-func getCurrentValue(variable clusterv1.ClusterVariable, valuesMap map[string]map[string]clusterv1.ClusterVariable) *clusterv1.ClusterVariable {
-	// If the value is set in the Cluster spec get the value.
-	if valuesForName, ok := valuesMap[variable.Name]; ok {
-		if value, ok := valuesForName[variable.DefinitionFrom]; ok {
-			return &value
-		}
-	}
-	return nil
-}
-
 // defaultValue defaults a clusterVariable based on the default value in the clusterClassVariable.
-func defaultValue(currentValue *clusterv1.ClusterVariable, definition *statusVariableDefinition, fldPath *field.Path, createVariable bool) (*clusterv1.ClusterVariable, field.ErrorList) {
+func defaultValue(currentValue *clusterv1.ClusterVariable, definition *clusterv1.ClusterClassStatusVariable, fldPath *field.Path, createVariable bool) (*clusterv1.ClusterVariable, field.ErrorList) {
+	// Note: We already validated in newDefinitionsIndex that Definitions is not empty
+	// and we don't have conflicts, so we can just pick the first one
+	def := definition.Definitions[0]
+
 	if currentValue == nil {
 		// Return if the variable does not exist yet and createVariable is false.
 		if !createVariable {
 			return nil, nil
 		}
 		// Return if the variable does not exist yet and there is no top-level default value.
-		if definition.Schema.OpenAPIV3Schema.Default == nil {
+
+		if def.Schema.OpenAPIV3Schema.Default == nil {
 			return nil, nil
 		}
 	}
 
 	// Convert schema to Kubernetes APIExtensions schema.
-	apiExtensionsSchema, errs := convertToAPIExtensionsJSONSchemaProps(&definition.Schema.OpenAPIV3Schema, field.NewPath("schema"))
+	apiExtensionsSchema, errs := convertToAPIExtensionsJSONSchemaProps(&def.Schema.OpenAPIV3Schema, field.NewPath("schema"))
 	if len(errs) > 0 {
 		return nil, field.ErrorList{field.Invalid(fldPath, "",
 			fmt.Sprintf("invalid schema in ClusterClass for variable %q: error to convert schema %v", definition.Name, errs))}
@@ -177,54 +167,30 @@ func defaultValue(currentValue *clusterv1.ClusterVariable, definition *statusVar
 		Value: apiextensionsv1.JSON{
 			Raw: defaultedVariableValue,
 		},
-		DefinitionFrom: definition.From,
 	}
 
 	return v, nil
 }
 
 // getAllVariables returns a correctly ordered list of all variables defined in the ClusterClass and the Cluster.
-func getAllVariables(values []clusterv1.ClusterVariable, valuesIndex map[string]map[string]clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable) []clusterv1.ClusterVariable {
+func getAllVariables(values []clusterv1.ClusterVariable, valuesIndex map[string]*clusterv1.ClusterVariable, definitions []clusterv1.ClusterClassStatusVariable) []clusterv1.ClusterVariable {
 	// allVariables is used to get a full correctly ordered list of variables.
 	allVariables := []clusterv1.ClusterVariable{}
-	uniqueVariableDefinitions := map[string]bool{}
 
 	// Add any values that already exist.
 	allVariables = append(allVariables, values...)
 
 	// Add variables from the ClusterClass, which currently don't exist on the Cluster.
 	for _, variable := range definitions {
-		for _, definition := range variable.Definitions {
-			definitionFrom := definition.From
-
-			// 1) If there is a value in the Cluster with this definitionFrom or with an empty definitionFrom this variable does not need to be defaulted.
-			if _, ok := valuesIndex[variable.Name]; ok {
-				if _, ok := valuesIndex[variable.Name][definitionFrom]; ok {
-					continue
-				}
-				if _, ok := valuesIndex[variable.Name][emptyDefinitionFrom]; ok {
-					continue
-				}
-			}
-
-			// 2) If the definition has no conflicts and no variable of the same name is defined in the Cluster set the definitionFrom to emptyDefinitionFrom.
-			if !variable.DefinitionsConflict && len(valuesIndex[variable.Name]) == 0 {
-				definitionFrom = emptyDefinitionFrom
-			}
-
-			// 3) If a variable with this name and definition has been added already, continue.
-			// This prevents adding the same variable multiple times where the variable is defaulted with an emptyDefinitionFrom.
-			if _, ok := uniqueVariableDefinitions[definitionFrom+variable.Name]; ok {
-				continue
-			}
-
-			// Otherwise add the variable to the list.
-			allVariables = append(allVariables, clusterv1.ClusterVariable{
-				Name:           variable.Name,
-				DefinitionFrom: definitionFrom,
-			})
-			uniqueVariableDefinitions[definitionFrom+variable.Name] = true
+		// If there is a value in the Cluster already this variable does not need to be defaulted.
+		if _, ok := valuesIndex[variable.Name]; ok {
+			continue
 		}
+
+		// Add the variable to the list.
+		allVariables = append(allVariables, clusterv1.ClusterVariable{
+			Name: variable.Name,
+		})
 	}
 	return allVariables
 }

--- a/internal/topology/variables/cluster_variable_defaulting_test.go
+++ b/internal/topology/variables/cluster_variable_defaulting_test.go
@@ -495,7 +495,7 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		{
 			name: "Error if a value is set with non-empty definitionFrom.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set",
+				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set. DefinitionFrom is deprecated, must not be set anymore and is going to be removed in the next apiVersion",
 					"spec.topology.variables[cpu]"),
 				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
 					"spec.topology.variables[cpu]"),

--- a/internal/topology/variables/cluster_variable_defaulting_test.go
+++ b/internal/topology/variables/cluster_variable_defaulting_test.go
@@ -38,10 +38,32 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		{
 			name: "Return error if variable is not defined in ClusterClass",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": no definitions found for variable \"cpu\"",
+				invalid("Invalid value: \"1\": variable is not defined",
 					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{},
+			values: []clusterv1.ClusterVariable{
+				{
+					Name: "cpu",
+					Value: apiextensionsv1.JSON{
+						Raw: []byte(`1`),
+					},
+				},
+			},
+			createVariables: true,
+		},
+		{
+			name: "Return error if variable has no definitions in ClusterClass",
+			wantErrs: []validationMatch{
+				invalidType("Invalid value: \"[Name: cpu]\": variable definitions in the ClusterClass not valid: variable \"cpu\" has no definitions",
+					"spec.topology.variables"),
+			},
+			definitions: []clusterv1.ClusterClassStatusVariable{
+				{
+					Name:        "cpu",
+					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{},
+				},
+			},
 			values: []clusterv1.ClusterVariable{
 				{
 					Name: "cpu",
@@ -282,10 +304,11 @@ func Test_DefaultClusterVariables(t *testing.T) {
 		},
 		// Variables with multiple non-conflicting definitions.
 		{
-			name: "Don't default if a value is set with empty definitionFrom",
+			name: "Don't default if a value is set",
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name: "cpu",
+					Name:                "cpu",
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 							Required: true,
@@ -316,7 +339,6 @@ func Test_DefaultClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`2`),
 					},
-					// This variable does not have definitionConflicts. An unset definitionFrom is valid.
 				},
 			},
 			createVariables: true,
@@ -334,7 +356,8 @@ func Test_DefaultClusterVariables(t *testing.T) {
 			name: "Default many non-conflicting variables to one value in Cluster",
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name: "cpu",
+					Name:                "cpu",
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 
@@ -376,76 +399,20 @@ func Test_DefaultClusterVariables(t *testing.T) {
 			createVariables: true,
 			want: []clusterv1.ClusterVariable{
 				{
-					// As this variable is non-conflicting it can be set only once in the Cluster through defaulting.
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-				},
-			},
-		},
-		{
-			name: "Default many non-conflicting definitions to many values in Cluster when some values are set with definitionFrom",
-			definitions: []clusterv1.ClusterClassStatusVariable{
-				{
-					Name: "cpu",
-					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
-						{
-							Required: true,
-							From:     clusterv1.VariableDefinitionFromInline,
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type:    "integer",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
-								},
-							},
-						},
-						{
-							Required: true,
-							From:     "somepatch",
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type:    "integer",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
-								},
-							},
-						},
-					},
-				},
-			},
-			values: []clusterv1.ClusterVariable{
-				// The variable is set with definitionFrom for one of two definitions.
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`2`),
-					},
-					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-				},
-			},
-			createVariables: true,
-			want: []clusterv1.ClusterVariable{
-				// Expect the value in the Cluster to be retained.
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`2`),
-					},
-					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-				},
-				// Expect defaulting for the definition with no value in the Cluster.
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					DefinitionFrom: "somepatch",
 				},
 			},
 		},
 		// Variables with conflicting definitions.
 		{
-			name: "Default many conflicting definitions to many values in Cluster",
+			name: "Error if there are any variable conflicts",
+			wantErrs: []validationMatch{
+				invalidType("Invalid value: \"[Name: cpu]\": variable definitions in the ClusterClass not valid: variable \"cpu\" has conflicting definitions",
+					"spec.topology.variables"),
+			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
 					Name:                "cpu",
@@ -478,27 +445,13 @@ func Test_DefaultClusterVariables(t *testing.T) {
 			},
 			values:          []clusterv1.ClusterVariable{},
 			createVariables: true,
-			want: []clusterv1.ClusterVariable{
-				// As this variable has conflicting definitions expect one value in the Cluster
-				// for each "DefinitionFrom".
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`2`),
-					},
-					DefinitionFrom: "somepatch",
-				},
-			},
 		},
 		{
-			name: "Default many conflicting definitions to many values in Cluster when some values are set with definitionFrom",
+			name: "Error if there are any variable conflicts when the value is set",
+			wantErrs: []validationMatch{
+				invalidType("Invalid value: \"[Name: cpu]\": variable definitions in the ClusterClass not valid: variable \"cpu\" has conflicting definitions",
+					"spec.topology.variables"),
+			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
 					Name:                "cpu",
@@ -535,34 +488,17 @@ func Test_DefaultClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`3`),
 					},
-					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
 				},
 			},
 			createVariables: true,
-			want: []clusterv1.ClusterVariable{
-				// As this variable has conflicting definitions expect one value in the Cluster
-				// for each "DefinitionFrom" and retain values set in Cluster.
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`3`),
-					},
-					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`2`),
-					},
-					DefinitionFrom: "somepatch",
-				},
-			},
 		},
 		{
-			name: "Error if a value is set with empty and non-empty definitionFrom.",
+			name: "Error if a value is set with non-empty definitionFrom.",
 			wantErrs: []validationMatch{
-				invalid("cluster variables not valid: variable \"cpu\" is defined with a mix of empty and non-empty values for definitionFrom",
-					"spec.topology.variables"),
+				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set",
+					"spec.topology.variables[cpu]"),
+				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
+					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
@@ -593,23 +529,22 @@ func Test_DefaultClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					// Mix of empty and non-empty definitionFrom is not valid.
-					DefinitionFrom: "",
 				},
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`2`),
 					},
+					// Non-empty definitionFrom is not valid.
 					DefinitionFrom: "somepatch",
 				},
 			},
 		},
 		{
-			name: "Error if a value is set twice with the same definitionFrom.",
+			name: "Error if a value is set twice.",
 			wantErrs: []validationMatch{
-				invalid("cluster variables not valid: variable \"cpu\" is defined more than once",
-					"spec.topology.variables"),
+				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
+					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
@@ -635,20 +570,17 @@ func Test_DefaultClusterVariables(t *testing.T) {
 				},
 			},
 			values: []clusterv1.ClusterVariable{
-				// Identical definitionFrom and name for two different values.
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					DefinitionFrom: "",
 				},
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`2`),
 					},
-					DefinitionFrom: "",
 				},
 			},
 		},
@@ -670,21 +602,23 @@ func Test_DefaultClusterVariable(t *testing.T) {
 	tests := []struct {
 		name                 string
 		clusterVariable      *clusterv1.ClusterVariable
-		clusterClassVariable *statusVariableDefinition
+		clusterClassVariable *clusterv1.ClusterClassStatusVariable
 		createVariable       bool
 		want                 *clusterv1.ClusterVariable
 		wantErrs             []validationMatch
 	}{
 		{
 			name: "Default new integer variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "cpu",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "integer",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+							},
 						},
 					},
 				},
@@ -699,14 +633,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default new integer variable if variable creation is disabled",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "cpu",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "integer",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+							},
 						},
 					},
 				},
@@ -716,14 +652,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing integer variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "cpu",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "integer",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "integer",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`1`)},
+							},
 						},
 					},
 				},
@@ -744,14 +682,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new string variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "location",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "string",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "string",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+							},
 						},
 					},
 				},
@@ -766,14 +706,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing string variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "location",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "string",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "string",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+							},
 						},
 					},
 				},
@@ -794,14 +736,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new number variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "cpu",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "number",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "number",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+							},
 						},
 					},
 				},
@@ -816,14 +760,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing number variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "cpu",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "number",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "number",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
+							},
 						},
 					},
 				},
@@ -844,14 +790,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new boolean variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "correct",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "boolean",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "boolean",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+							},
 						},
 					},
 				},
@@ -866,14 +814,16 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing boolean variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "correct",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "boolean",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "boolean",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+							},
 						},
 					},
 				},
@@ -894,23 +844,25 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new object variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type: "string",
-								},
-								"noProxy": {
-									Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type: "string",
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -927,23 +879,25 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default new object variable if there is no top-level default",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type:    "boolean",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
-								},
-								"url": {
-									Type: "string",
-								},
-								"noProxy": {
-									Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type:    "boolean",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
+									},
+									"url": {
+										Type: "string",
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -955,24 +909,26 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new object variable if there is a top-level default",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{"url":"test-url"}`)},
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type:    "boolean",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
-								},
-								"url": {
-									Type: "string",
-								},
-								"noProxy": {
-									Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{"url":"test-url"}`)},
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type:    "boolean",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
+									},
+									"url": {
+										Type: "string",
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -990,24 +946,26 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default new object variable if there is a top-level default (which is an empty object)",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type:    "boolean",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
-								},
-								"url": {
-									Type: "string",
-								},
-								"noProxy": {
-									Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type:    "boolean",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`false`)},
+									},
+									"url": {
+										Type: "string",
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -1025,23 +983,25 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing object variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type: "string",
-								},
-								"noProxy": {
-									Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": true}`)},
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type: "string",
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -1064,25 +1024,27 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default nested fields of existing object variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
 
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
-							Properties: map[string]clusterv1.JSONSchemaProps{
-								"enabled": {
-									Type: "boolean",
-								},
-								"url": {
-									Type:    "string",
-									Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-								},
-								"noProxy": {
-									Type: "string",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{"enabled": false}`)},
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type:    "string",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+									},
+									"noProxy": {
+										Type: "string",
+									},
 								},
 							},
 						},
@@ -1099,32 +1061,35 @@ func Test_DefaultClusterVariable(t *testing.T) {
 			want: &clusterv1.ClusterVariable{
 				Name: "httpProxy",
 				Value: apiextensionsv1.JSON{
+					// url is added by defaulting.
 					Raw: []byte(`{"enabled":false,"url":"https://example.com"}`),
 				},
 			},
 		},
 		{
 			name: "Default new map variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type:    "object",
-							Default: &apiextensionsv1.JSON{Raw: []byte(`{"proxy":{"enabled":false}}`)},
-							AdditionalProperties: &clusterv1.JSONSchemaProps{
-								Type: "object",
-								Properties: map[string]clusterv1.JSONSchemaProps{
-									"enabled": {
-										Type: "boolean",
-									},
-									"url": {
-										Type:    "string",
-										Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-									},
-									"noProxy": {
-										Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "object",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`{"proxy":{"enabled":false}}`)},
+								AdditionalProperties: &clusterv1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]clusterv1.JSONSchemaProps{
+										"enabled": {
+											Type: "boolean",
+										},
+										"url": {
+											Type:    "string",
+											Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+										},
+										"noProxy": {
+											Type: "string",
+										},
 									},
 								},
 							},
@@ -1142,25 +1107,27 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Default nested fields of existing map variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "httpProxy",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "object",
-							AdditionalProperties: &clusterv1.JSONSchemaProps{
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 								Type: "object",
-								Properties: map[string]clusterv1.JSONSchemaProps{
-									"enabled": {
-										Type: "boolean",
-									},
-									"url": {
-										Type:    "string",
-										Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
-									},
-									"noProxy": {
-										Type: "string",
+								AdditionalProperties: &clusterv1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]clusterv1.JSONSchemaProps{
+										"enabled": {
+											Type: "boolean",
+										},
+										"url": {
+											Type:    "string",
+											Default: &apiextensionsv1.JSON{Raw: []byte(`"https://example.com"`)},
+										},
+										"noProxy": {
+											Type: "string",
+										},
 									},
 								},
 							},
@@ -1178,31 +1145,34 @@ func Test_DefaultClusterVariable(t *testing.T) {
 			want: &clusterv1.ClusterVariable{
 				Name: "httpProxy",
 				Value: apiextensionsv1.JSON{
+					// url is added by defaulting.
 					Raw: []byte(`{"proxy1":{"enabled":false,"url":"https://example.com"},"proxy2":{"enabled":false,"url":"https://example.com"}}`),
 				},
 			},
 		},
 		{
 			name: "Default new array variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "testVariable",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "array",
-							Items: &clusterv1.JSONSchemaProps{
-								Type: "object",
-								Properties: map[string]clusterv1.JSONSchemaProps{
-									"enabled": {
-										Type: "boolean",
-									},
-									"url": {
-										Type: "string",
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "array",
+								Items: &clusterv1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]clusterv1.JSONSchemaProps{
+										"enabled": {
+											Type: "boolean",
+										},
+										"url": {
+											Type: "string",
+										},
 									},
 								},
+								Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 							},
-							Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 						},
 					},
 				},
@@ -1217,26 +1187,28 @@ func Test_DefaultClusterVariable(t *testing.T) {
 		},
 		{
 			name: "Don't default existing array variable",
-			clusterClassVariable: &statusVariableDefinition{
+			clusterClassVariable: &clusterv1.ClusterClassStatusVariable{
 				Name: "testVariable",
-				ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
+				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
+					{
 
-					Required: true,
-					Schema: clusterv1.VariableSchema{
-						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-							Type: "array",
-							Items: &clusterv1.JSONSchemaProps{
-								Type: "object",
-								Properties: map[string]clusterv1.JSONSchemaProps{
-									"enabled": {
-										Type: "boolean",
-									},
-									"url": {
-										Type: "string",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "array",
+								Items: &clusterv1.JSONSchemaProps{
+									Type: "object",
+									Properties: map[string]clusterv1.JSONSchemaProps{
+										"enabled": {
+											Type: "boolean",
+										},
+										"url": {
+											Type: "string",
+										},
 									},
 								},
+								Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 							},
-							Default: &apiextensionsv1.JSON{Raw: []byte(`[{"enabled":false,"url":"123"},{"enabled":false,"url":"456"}]`)},
 						},
 					},
 				},
@@ -1273,37 +1245,28 @@ func Test_getAllVariables(t *testing.T) {
 	g := NewWithT(t)
 	t.Run("Expect values to be correctly consolidated in allVariables", func(*testing.T) {
 		expectedValues := []clusterv1.ClusterVariable{
-			// var1 has a value with no DefinitionFrom set and only one definition. It should be retained as is.
+			// var1 is set and has only one definition.
+			// It should be retained as is.
 			{
 				Name: "var1",
 			},
 
-			// var2 has a value with DefinitionFrom "inline". It has a second definition with DefinitionFrom "somepatch".
-			// The value for the first definition should be retained and a value for the second definition should be added.
+			// var2 is set and has two definitions.
+			// The value should be retained and no additional value should be added.
 			{
-				Name:           "var2",
-				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-			},
-			{
-				Name:           "var2",
-				DefinitionFrom: "somepatch",
+				Name: "var2",
 			},
 
-			// var3 had no values. It has two conflicting definitions. A value for each definition should be added.
+			// var3 is not set and has only one definition.
+			// One additional value should be added.
 			{
-				Name:           "var3",
-				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
-			},
-			{
-				Name:           "var3",
-				DefinitionFrom: "somepatch",
+				Name: "var3",
 			},
 
-			// var4 had no values. It has two non-conflicting definitions. A single value with emptyDefinitionFrom should
-			// be added.
+			// var4 is not set and has two definitions.
+			// One additional value should be added.
 			{
-				Name:           "var4",
-				DefinitionFrom: emptyDefinitionFrom,
+				Name: "var4",
 			},
 		}
 
@@ -1312,8 +1275,7 @@ func Test_getAllVariables(t *testing.T) {
 				Name: "var1",
 			},
 			{
-				Name:           "var2",
-				DefinitionFrom: clusterv1.VariableDefinitionFromInline,
+				Name: "var2",
 			},
 		}
 		definitions := []clusterv1.ClusterClassStatusVariable{
@@ -1355,21 +1317,11 @@ func Test_getAllVariables(t *testing.T) {
 				},
 			},
 			{
-				Name:                "var3",
-				DefinitionsConflict: true,
+				Name: "var3",
 				Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 					{
 						Required: false,
 						From:     clusterv1.VariableDefinitionFromInline,
-						Schema: clusterv1.VariableSchema{
-							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-								Type: "string",
-							},
-						},
-					},
-					{
-						Required: true,
-						From:     "somepatch",
 						Schema: clusterv1.VariableSchema{
 							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 								Type: "string",
@@ -1403,8 +1355,8 @@ func Test_getAllVariables(t *testing.T) {
 			},
 		}
 
-		valuesIndex, err := newValuesIndex(values)
-		g.Expect(err).ToNot(HaveOccurred())
+		valuesIndex, err := newValuesIndex(field.NewPath("spec", "topology", "variables"), values)
+		g.Expect(err).To(BeEmpty())
 		got := getAllVariables(values, valuesIndex, definitions)
 		g.Expect(got).To(BeComparableTo(expectedValues))
 	})

--- a/internal/topology/variables/cluster_variable_validation_test.go
+++ b/internal/topology/variables/cluster_variable_validation_test.go
@@ -268,7 +268,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 		{
 			name: "Fail if DefinitionFrom not empty.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set",
+				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set. DefinitionFrom is deprecated, must not be set anymore and is going to be removed in the next apiVersion",
 					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
@@ -338,7 +338,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 		{
 			name: "Fail if DefinitionFrom not empty and value is set twice.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set",
+				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set. DefinitionFrom is deprecated, must not be set anymore and is going to be removed in the next apiVersion",
 					"spec.topology.variables[cpu]"),
 				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
 					"spec.topology.variables[cpu]"),
@@ -2183,7 +2183,7 @@ func Test_ValidateMachineVariables(t *testing.T) {
 		{
 			name: "Fail if value DefinitionFrom is not empty",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set",
+				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set. DefinitionFrom is deprecated, must not be set anymore and is going to be removed in the next apiVersion",
 					"spec.topology.workers.machineDeployments[mdTopologyName].variables.overrides[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{

--- a/internal/topology/variables/cluster_variable_validation_test.go
+++ b/internal/topology/variables/cluster_variable_validation_test.go
@@ -115,7 +115,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 		{
 			name: "Error when no value for required definition.",
 			wantErrs: []validationMatch{
-				required("Required value: required variable with name \"cpu\" must be defined",
+				required("Required value: required variable \"cpu\" must be set",
 					"spec.topology.variables"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
@@ -211,7 +211,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 		{
 			name: "Error if value has no definition.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"\\\"us-east-1\\\"\": no definitions found for variable \"location\"",
+				invalid("Invalid value: \"\\\"us-east-1\\\"\": variable is not defined",
 					"spec.topology.variables[location]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{},
@@ -228,10 +228,11 @@ func Test_ValidateClusterVariables(t *testing.T) {
 		},
 		// Non-conflicting definition tests.
 		{
-			name: "Pass if a value with empty definitionFrom set for a non-conflicting definition",
+			name: "Pass if a value set for a non-conflicting definition",
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name: "cpu",
+					Name:                "cpu",
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 							Schema: clusterv1.VariableSchema{
@@ -265,55 +266,9 @@ func Test_ValidateClusterVariables(t *testing.T) {
 			validateRequired: true,
 		},
 		{
-			name: "Pass when there is a separate value for each required definition with no definition conflicts.",
-			definitions: []clusterv1.ClusterClassStatusVariable{
-				{
-					Name: "cpu",
-					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
-						{
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-							From:     clusterv1.VariableDefinitionFromInline,
-							Required: true,
-						},
-						{
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-							From:     "somepatch",
-							Required: true,
-						},
-					},
-				},
-			},
-			values: []clusterv1.ClusterVariable{
-				// Each value is set individually.
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					DefinitionFrom: "somepatch",
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`2`),
-					},
-					DefinitionFrom: "inline",
-				},
-			},
-			validateRequired: true,
-		},
-		{
-			name: "Fail if value DefinitionFrom field does not match any definition.",
+			name: "Fail if DefinitionFrom not empty.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": no definitions found for variable \"cpu\" from \"non-existent-patch\"",
+				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set",
 					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
@@ -324,7 +279,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 							From: clusterv1.VariableDefinitionFromInline,
 							Schema: clusterv1.VariableSchema{
 								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "string",
+									Type: "integer",
 								},
 							},
 						},
@@ -337,17 +292,17 @@ func Test_ValidateClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					// This definition does not exist.
-					DefinitionFrom: "non-existent-patch",
+					// Non-empty definitionFrom is not valid.
+					DefinitionFrom: clusterv1.VariableDefinitionFromInline,
 				},
 			},
 			validateRequired: true,
 		},
 		{
-			name: "Fail if a value is set twice with the same definitionFrom.",
+			name: "Fail if a value is set twice.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"[Name: cpu DefinitionFrom: somepatch,Name: cpu DefinitionFrom: somepatch]\": cluster variables not valid: variable \"cpu\" from \"somepatch\" is defined more than once",
-					"spec.topology.variables"),
+				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
+					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
@@ -370,23 +325,23 @@ func Test_ValidateClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					DefinitionFrom: "somepatch",
 				},
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`2`),
 					},
-					DefinitionFrom: "somepatch",
 				},
 			},
 			validateRequired: true,
 		},
 		{
-			name: "Fail if a value is set with empty and non-empty definitionFrom.",
+			name: "Fail if DefinitionFrom not empty and value is set twice.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"[Name: cpu DefinitionFrom: ,Name: cpu DefinitionFrom: somepatch]\": cluster variables not valid: variable \"cpu\" is defined with a mix of empty and non-empty values for definitionFrom",
-					"spec.topology.variables"),
+				invalid("Invalid value: \"2\": variable \"cpu\" has DefinitionFrom set",
+					"spec.topology.variables[cpu]"),
+				invalid("Invalid value: \"2\": variable \"cpu\" is set more than once",
+					"spec.topology.variables[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
@@ -417,31 +372,28 @@ func Test_ValidateClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					// Mix of empty and non-empty definitionFrom is not valid.
-					DefinitionFrom: "",
 				},
 				{
 					Name: "cpu",
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`2`),
 					},
+					// Non-empty definitionFrom is not valid.
 					DefinitionFrom: "somepatch",
 				},
 			},
 			validateRequired: true,
 		},
 		{
-			name: "Fail when values invalid by their definition schema.",
+			name: "Fail when value invalid by their definition schema.",
 			wantErrs: []validationMatch{
 				invalidType("Invalid value: \"1\": must be of type string: \"integer\"",
-					"spec.topology.variables[cpu].value"),
-				invalidType("Invalid value: \"\\\"one\\\"\": must be of type integer: \"string\"",
 					"spec.topology.variables[cpu].value"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
 					Name:                "cpu",
-					DefinitionsConflict: true,
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 							From: clusterv1.VariableDefinitionFromInline,
@@ -455,7 +407,7 @@ func Test_ValidateClusterVariables(t *testing.T) {
 							From: "somepatch",
 							Schema: clusterv1.VariableSchema{
 								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
+									Type: "string",
 								},
 							},
 						},
@@ -468,176 +420,38 @@ func Test_ValidateClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					DefinitionFrom: "inline",
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`"one"`),
-					},
-					DefinitionFrom: "somepatch",
 				},
 			},
 			validateRequired: true,
 		},
 		// Conflicting definition tests.
 		{
-			name: "Pass with a value provided for each conflicting definition.",
-			definitions: []clusterv1.ClusterClassStatusVariable{
-				{
-					Name:                "cpu",
-					DefinitionsConflict: true,
-					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
-						{
-							From: clusterv1.VariableDefinitionFromInline,
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "string",
-								},
-							},
-						},
-						{
-							From: "somepatch",
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-						},
-					},
-				},
-			},
-			values: []clusterv1.ClusterVariable{
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`"one"`),
-					},
-					DefinitionFrom: "inline",
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					DefinitionFrom: "somepatch",
-				},
-			},
-			validateRequired: true,
-		},
-		{
-			name: "Pass if non-required definition value doesn't include definitionFrom for each required definition when definitions conflict.",
-			definitions: []clusterv1.ClusterClassStatusVariable{
-				{
-					Name:                "cpu",
-					DefinitionsConflict: true,
-					// There are conflicting definitions which means values should include a `definitionFrom` field.
-					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
-						{
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-							From:     "somepatch",
-							Required: true,
-						},
-						// This variable is not required so it does not need a value.
-						{
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-							From:     "anotherpatch",
-							Required: false,
-						},
-					},
-				},
-			},
-			values: []clusterv1.ClusterVariable{
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					DefinitionFrom: "somepatch",
-				},
-			},
-			validateRequired: true,
-		},
-		{
-			name: "Fail if value doesn't include definitionFrom when definitions conflict.",
+			name: "Fail if variables have definitions conflict.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": variable \"cpu\" has conflicting definitions. It requires a non-empty `definitionFrom`",
-					"spec.topology.variables[cpu]"),
-			},
-			definitions: []clusterv1.ClusterClassStatusVariable{
-				{
-					Name: "cpu",
-					// There are conflicting definitions which means values should include a `definitionFrom` field.
-					DefinitionsConflict: true,
-					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
-						{
-							From: clusterv1.VariableDefinitionFromInline,
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "string",
-								},
-							},
-						},
-						{
-							From: "somepatch",
-							Schema: clusterv1.VariableSchema{
-								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
-								},
-							},
-						},
-					},
-				},
-			},
-			values: []clusterv1.ClusterVariable{
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`1`),
-					},
-					// No definitionFrom
-				},
-			},
-			validateRequired: true,
-		},
-		{
-			name: "Fail if value doesn't include definitionFrom for each required definition when definitions conflict.",
-			wantErrs: []validationMatch{
-				required("Required value: required variable with name \"cpu\" from \"inline\" must be defined",
+				invalidType("Invalid value: \"[Name: cpu]\": variable definitions in the ClusterClass not valid: variable \"cpu\" has conflicting definitions",
 					"spec.topology.variables"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
-					Name:                "cpu",
+					Name: "cpu",
+					// There are conflicting definitions which means the conflict has to be resolved first.
 					DefinitionsConflict: true,
-					// There are conflicting definitions which means values should include a `definitionFrom` field.
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
-
+							From: clusterv1.VariableDefinitionFromInline,
 							Schema: clusterv1.VariableSchema{
 								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 									Type: "string",
 								},
 							},
-							From:     clusterv1.VariableDefinitionFromInline,
-							Required: true,
 						},
 						{
+							From: "somepatch",
 							Schema: clusterv1.VariableSchema{
 								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 									Type: "integer",
 								},
 							},
-							From:     "somepatch",
-							Required: true,
 						},
 					},
 				},
@@ -648,7 +462,6 @@ func Test_ValidateClusterVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					DefinitionFrom: "somepatch",
 				},
 			},
 			validateRequired: true,
@@ -2353,7 +2166,7 @@ func Test_ValidateMachineVariables(t *testing.T) {
 		{
 			name: "Error if value has no definition.",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"\\\"us-east-1\\\"\": no definitions found for variable \"location\"",
+				invalid("Invalid value: \"\\\"us-east-1\\\"\": variable is not defined",
 					"spec.topology.workers.machineDeployments[mdTopologyName].variables.overrides[location]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{},
@@ -2368,9 +2181,9 @@ func Test_ValidateMachineVariables(t *testing.T) {
 			},
 		},
 		{
-			name: "Fail if value DefinitionFrom field does not match any definition.",
+			name: "Fail if value DefinitionFrom is not empty",
 			wantErrs: []validationMatch{
-				invalid("Invalid value: \"1\": no definitions found for variable \"cpu\" from \"non-existent-patch\"",
+				invalid("Invalid value: \"1\": variable \"cpu\" has DefinitionFrom set",
 					"spec.topology.workers.machineDeployments[mdTopologyName].variables.overrides[cpu]"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
@@ -2394,23 +2207,21 @@ func Test_ValidateMachineVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`),
 					},
-					// This definition does not exist.
+					// Non-empty definitionFrom is not valid.
 					DefinitionFrom: "non-existent-patch",
 				},
 			},
 		},
 		{
-			name: "Fail when values invalid by their definition schema.",
+			name: "Fail when value invalid by their definition schema.",
 			wantErrs: []validationMatch{
 				invalidType("Invalid value: \"1\": must be of type string: \"integer\"",
-					"spec.topology.workers.machineDeployments[mdTopologyName].variables.overrides[cpu].value"),
-				invalidType("Invalid value: \"\\\"one\\\"\": must be of type integer: \"string\"",
 					"spec.topology.workers.machineDeployments[mdTopologyName].variables.overrides[cpu].value"),
 			},
 			definitions: []clusterv1.ClusterClassStatusVariable{
 				{
 					Name:                "cpu",
-					DefinitionsConflict: true,
+					DefinitionsConflict: false,
 					Definitions: []clusterv1.ClusterClassStatusVariableDefinition{
 						{
 							From: clusterv1.VariableDefinitionFromInline,
@@ -2424,7 +2235,7 @@ func Test_ValidateMachineVariables(t *testing.T) {
 							From: "somepatch",
 							Schema: clusterv1.VariableSchema{
 								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-									Type: "integer",
+									Type: "string",
 								},
 							},
 						},
@@ -2437,14 +2248,6 @@ func Test_ValidateMachineVariables(t *testing.T) {
 					Value: apiextensionsv1.JSON{
 						Raw: []byte(`1`), // not a string
 					},
-					DefinitionFrom: "inline",
-				},
-				{
-					Name: "cpu",
-					Value: apiextensionsv1.JSON{
-						Raw: []byte(`"one"`), // not an integer
-					},
-					DefinitionFrom: "somepatch",
 				},
 			},
 		},

--- a/internal/topology/variables/utils.go
+++ b/internal/topology/variables/utils.go
@@ -17,137 +17,72 @@ limitations under the License.
 package variables
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-const (
-	// emptyDefinitionFrom is the definitionFrom value used when none is supplied by the user.
-	emptyDefinitionFrom = ""
-)
-
-// newValuesIndex return a map of ClusterVariable values per name and definitionsFrom.
+// newValuesIndex returns a map of ClusterVariable per name.
 // This function validates that:
-// - variables are not defined more than once in Cluster spec/
-// - variables with the same name do not have a mix of empty and non-empty DefinitionFrom.
-func newValuesIndex(values []clusterv1.ClusterVariable) (map[string]map[string]clusterv1.ClusterVariable, error) {
-	valuesMap := map[string]map[string]clusterv1.ClusterVariable{}
-	errs := []error{}
+// - DefinitionFrom is not set
+// - variables are not defined more than once.
+func newValuesIndex(fldPath *field.Path, values []clusterv1.ClusterVariable) (map[string]*clusterv1.ClusterVariable, field.ErrorList) {
+	valuesMap := map[string]*clusterv1.ClusterVariable{}
+	errs := field.ErrorList{}
 	for _, value := range values {
-		c := value
-		_, ok := valuesMap[c.Name]
-		if !ok {
-			valuesMap[c.Name] = map[string]clusterv1.ClusterVariable{}
+		// Check that the variable has DefinitionFrom not set.
+		if value.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
+			errs = append(errs, field.Invalid(fldPath.Key(value.Name), string(value.Value.Raw), fmt.Sprintf("variable %q has DefinitionFrom set", value.Name)))
 		}
-		// Check that the variable has not been defined more than once with the same definitionFrom.
-		if _, ok := valuesMap[c.Name][c.DefinitionFrom]; ok {
-			if c.DefinitionFrom == "" {
-				errs = append(errs, errors.Errorf("variable %q is defined more than once", c.Name))
-			} else {
-				errs = append(errs, errors.Errorf("variable %q from %q is defined more than once", c.Name, c.DefinitionFrom))
-			}
-			continue
+
+		// Check that the variable has not been defined more than once.
+		if _, ok := valuesMap[value.Name]; ok {
+			errs = append(errs, field.Invalid(fldPath.Key(value.Name), string(value.Value.Raw), fmt.Sprintf("variable %q is set more than once", value.Name)))
 		}
+
 		// Add the variable.
-		valuesMap[c.Name][c.DefinitionFrom] = c
+		valuesMap[value.Name] = &value
 	}
 	if len(errs) > 0 {
-		return nil, kerrors.NewAggregate(errs)
-	}
-	// Validate that the variables do not have incompatible values in their `definitionFrom` fields.
-	if err := validateValuesDefinitionFrom(valuesMap); err != nil {
-		return nil, err
+		return nil, errs
 	}
 
 	return valuesMap, nil
 }
 
-// validateValuesDefinitionFrom validates that variables are not defined with both an empty DefinitionFrom and a
-// non-empty DefinitionFrom.
-func validateValuesDefinitionFrom(values map[string]map[string]clusterv1.ClusterVariable) error {
-	var errs []error
-	for name, valuesForName := range values {
-		for _, value := range valuesForName {
-			// Append an error if the value has a non-empty definitionFrom but there's also a value with
-			// an empty DefinitionFrom.
-			if _, ok := valuesForName[emptyDefinitionFrom]; ok && value.DefinitionFrom != emptyDefinitionFrom {
-				errs = append(errs, errors.Errorf("variable %q is defined with a mix of empty and non-empty values for definitionFrom", name))
-				break // No need to check other values for this variable.
-			}
+// newDefinitionIndex returns a map of ClusterClassStatusVariable per name.
+// This function validates that:
+// - variables have definitions
+// - variables don't have conflicting definitions.
+func newDefinitionsIndex(fldPath *field.Path, definitions []clusterv1.ClusterClassStatusVariable) (map[string]*clusterv1.ClusterClassStatusVariable, field.ErrorList) {
+	definitionsMap := map[string]*clusterv1.ClusterClassStatusVariable{}
+	errs := []error{}
+	for _, definition := range definitions {
+		// Check that the definition has definitions.
+		if len(definition.Definitions) == 0 {
+			errs = append(errs, errors.Errorf("variable %q has no definitions", definition.Name))
 		}
+
+		// Check that the definitions have no conflict.
+		if definition.DefinitionsConflict {
+			errs = append(errs, errors.Errorf("variable %q has conflicting definitions", definition.Name))
+		}
+
+		// Add the definition.
+		definitionsMap[definition.Name] = &definition
 	}
 	if len(errs) > 0 {
-		return kerrors.NewAggregate(errs)
-	}
-	return nil
-}
-
-type statusVariableDefinition struct {
-	*clusterv1.ClusterClassStatusVariableDefinition
-	Name      string
-	Conflicts bool
-}
-
-type definitionsIndex map[string]map[string]*statusVariableDefinition
-
-// newDefinitionsIndex returns a definitionsIndex with ClusterClassStatusVariable definitions by name and definition.From.
-// This index has special handling for variables with no definition conflicts in the `get` method.
-func newDefinitionsIndex(definitions []clusterv1.ClusterClassStatusVariable) definitionsIndex {
-	i := definitionsIndex{}
-	for _, def := range definitions {
-		i.store(def)
-	}
-	return i
-}
-func (i definitionsIndex) store(definition clusterv1.ClusterClassStatusVariable) {
-	for _, d := range definition.Definitions {
-		if _, ok := i[definition.Name]; !ok {
-			i[definition.Name] = map[string]*statusVariableDefinition{}
+		var definitionStrings []string
+		for _, d := range definitions {
+			definitionStrings = append(definitionStrings, fmt.Sprintf("Name: %s", d.Name))
 		}
-		i[definition.Name][d.From] = &statusVariableDefinition{
-			Name:                                 definition.Name,
-			Conflicts:                            definition.DefinitionsConflict,
-			ClusterClassStatusVariableDefinition: d.DeepCopy(),
-		}
-	}
-}
-
-// get returns a statusVariableDefinition for a given name and definitionFrom. If the definition has no conflicts it can
-// be retrieved using an emptyDefinitionFrom.
-// Return an error if the definition is not found or if the definitionFrom is empty and there are conflicts in the definitions.
-func (i definitionsIndex) get(name, definitionFrom string) (*statusVariableDefinition, error) {
-	// If no variable with this name exists return an error.
-	if _, ok := i[name]; !ok {
-		return nil, errors.Errorf("no definitions found for variable %q", name)
+		return nil, field.ErrorList{field.TypeInvalid(fldPath, "["+strings.Join(definitionStrings, ",")+"]", fmt.Sprintf("variable definitions in the ClusterClass not valid: %s", kerrors.NewAggregate(errs)))}
 	}
 
-	// If the definition exists for the specific definitionFrom, return it.
-	if def, ok := i[name][definitionFrom]; ok {
-		return def, nil
-	}
-
-	// If definitionFrom is empty and there are no conflicts return a definition with an emptyDefinitionFrom.
-	if definitionFrom == emptyDefinitionFrom {
-		for _, def := range i[name] {
-			if !def.Conflicts {
-				return &statusVariableDefinition{
-					Name:      def.Name,
-					Conflicts: def.Conflicts,
-					ClusterClassStatusVariableDefinition: &clusterv1.ClusterClassStatusVariableDefinition{
-						// Return the definition with an empty definitionFrom. This ensures when a user gets
-						// a definition with an emptyDefinitionFrom, the return value also has emptyDefinitionFrom.
-						// This is used in variable defaulting to ensure variables that only need one value for multiple
-						// definitions have an emptyDefinitionFrom.
-						From:     emptyDefinitionFrom,
-						Required: def.Required,
-						Schema:   def.Schema,
-					},
-				}, nil
-			}
-			return nil, errors.Errorf("variable %q has conflicting definitions. It requires a non-empty `definitionFrom`", name)
-		}
-	}
-	return nil, errors.Errorf("no definitions found for variable %q from %q", name, definitionFrom)
+	return definitionsMap, nil
 }

--- a/internal/topology/variables/utils.go
+++ b/internal/topology/variables/utils.go
@@ -37,7 +37,7 @@ func newValuesIndex(fldPath *field.Path, values []clusterv1.ClusterVariable) (ma
 	for _, value := range values {
 		// Check that the variable has DefinitionFrom not set.
 		if value.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
-			errs = append(errs, field.Invalid(fldPath.Key(value.Name), string(value.Value.Raw), fmt.Sprintf("variable %q has DefinitionFrom set", value.Name)))
+			errs = append(errs, field.Invalid(fldPath.Key(value.Name), string(value.Value.Raw), fmt.Sprintf("variable %q has DefinitionFrom set. DefinitionFrom is deprecated, must not be set anymore and is going to be removed in the next apiVersion", value.Name)))
 		}
 
 		// Check that the variable has not been defined more than once.

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -298,6 +298,9 @@ func (webhook *Cluster) validateTopology(ctx context.Context, oldCluster, newClu
 	// metadata in topology should be valid
 	allErrs = append(allErrs, validateTopologyMetadata(newCluster.Spec.Topology, fldPath)...)
 
+	// ensure deprecationFrom is not set
+	allErrs = append(allErrs, validateTopologyDefinitionFrom(newCluster.Spec.Topology, fldPath)...)
+
 	// upgrade concurrency should be a numeric value.
 	if concurrency, ok := newCluster.Annotations[clusterv1.ClusterTopologyUpgradeConcurrencyAnnotation]; ok {
 		concurrencyAnnotationField := field.NewPath("metadata", "annotations", clusterv1.ClusterTopologyUpgradeConcurrencyAnnotation)
@@ -990,6 +993,62 @@ func validateTopologyMetadata(topology *clusterv1.Topology, fldPath *field.Path)
 			)...)
 		}
 	}
+	return allErrs
+}
+
+func validateTopologyDefinitionFrom(topology *clusterv1.Topology, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, variable := range topology.Variables {
+		if variable.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("variables").Key(variable.Name),
+				string(variable.Value.Raw),
+				fmt.Sprintf("variable %q has DefinitionFrom set", variable.Name)),
+			)
+		}
+	}
+
+	if topology.ControlPlane.Variables != nil {
+		for _, variable := range topology.ControlPlane.Variables.Overrides {
+			if variable.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
+				allErrs = append(allErrs, field.Invalid(
+					fldPath.Child("controlPlane", "variables", "overrides").Key(variable.Name),
+					string(variable.Value.Raw),
+					fmt.Sprintf("variable %q has DefinitionFrom set", variable.Name)),
+				)
+			}
+		}
+	}
+
+	if topology.Workers != nil {
+		for _, md := range topology.Workers.MachineDeployments {
+			if md.Variables != nil {
+				for _, variable := range md.Variables.Overrides {
+					if variable.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
+						allErrs = append(allErrs, field.Invalid(
+							fldPath.Child("workers", "machineDeployments").Key(md.Name).Child("variables", "overrides").Key(variable.Name),
+							string(variable.Value.Raw),
+							fmt.Sprintf("variable %q has DefinitionFrom set", variable.Name)),
+						)
+					}
+				}
+			}
+		}
+		for _, mp := range topology.Workers.MachinePools {
+			if mp.Variables != nil {
+				for _, variable := range mp.Variables.Overrides {
+					if variable.DefinitionFrom != "" { //nolint:staticcheck // Intentionally using the deprecated field here to check that it is not set.
+						allErrs = append(allErrs, field.Invalid(
+							fldPath.Child("workers", "machinePools").Key(mp.Name).Child("variables", "overrides").Key(variable.Name),
+							string(variable.Value.Raw),
+							fmt.Sprintf("variable %q has DefinitionFrom set", variable.Name)),
+						)
+					}
+				}
+			}
+		}
+	}
+
 	return allErrs
 }
 

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
@@ -38,9 +38,5 @@ spec:
     variables:
       - name: kubeadmControlPlaneMaxSurge
         value: "1"
-      # imageRepository has definitions for both an inline patch and the test-patch. This value is required in the
-      # test-patch and requires definitionFrom to reflect that.
       - name: imageRepository
-        definitionFrom: test-patch
         value: "kindest"
-

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -51,17 +51,6 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachinePoolTemplate
             name: quick-start-default-worker-machinepooltemplate
-  variables:
-  # This variable is not used in any patch, but is here to ensure the variable discovered from the runtime hook is correctly
-  # used.
-  - name: imageRepository
-    required: true
-    schema:
-      openAPIV3Schema:
-        type: string
-        default: "registry.k8s.io"
-        example: "registry.k8s.io"
-        description: "imageRepository sets the container registry to pull images from. If empty, `registry.k8s.io` will be used by default."
   patches:
   - name: test-patch
     external:

--- a/test/extension/handlers/topologymutation/handler_integration_test.go
+++ b/test/extension/handlers/topologymutation/handler_integration_test.go
@@ -73,9 +73,8 @@ func TestHandler(t *testing.T) {
 	clusterVariableImageRepository := "kindest"
 	cluster.Spec.Topology.Variables = []clusterv1.ClusterVariable{
 		{
-			DefinitionFrom: "test-patch",
-			Name:           "imageRepository",
-			Value:          apiextensionsv1.JSON{Raw: []byte("\"" + clusterVariableImageRepository + "\"")},
+			Name:  "imageRepository",
+			Value: apiextensionsv1.JSON{Raw: []byte("\"" + clusterVariableImageRepository + "\"")},
 		},
 	}
 	clusterClassFile := "./testdata/clusterclass-quick-start-runtimesdk.yaml"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR contains the following changes:
* ClusterClass controller will now set VariablesReconciled condition on the ClusterClass to false if there are variable conflicts
  * The consequence of that will be that the Cluster topology controller will stop reconciling corresponding clusters until the conflicts are resvoled
* Deprecation of the definitionFrom field
* Add "name" as a map key for variable arrays. This will allow separate ownership per variable
* Corresponding changes & cleanups to the variable defaulting and validation code


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10666

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->