### PR TITLE
:bug: Fix default namespace of RemediationTemplate for ClusterClass and Topology

### DIFF
--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -75,9 +75,17 @@ func (webhook *ClusterClass) Default(_ context.Context, obj runtime.Object) erro
 		defaultNamespace(in.Spec.ControlPlane.MachineInfrastructure.Ref, in.Namespace)
 	}
 
+	if in.Spec.ControlPlane.MachineHealthCheck != nil {
+		defaultNamespace(in.Spec.ControlPlane.MachineHealthCheck.RemediationTemplate, in.Namespace)
+	}
+
 	for i := range in.Spec.Workers.MachineDeployments {
 		defaultNamespace(in.Spec.Workers.MachineDeployments[i].Template.Bootstrap.Ref, in.Namespace)
 		defaultNamespace(in.Spec.Workers.MachineDeployments[i].Template.Infrastructure.Ref, in.Namespace)
+
+		if in.Spec.Workers.MachineDeployments[i].MachineHealthCheck != nil {
+			defaultNamespace(in.Spec.Workers.MachineDeployments[i].MachineHealthCheck.RemediationTemplate, in.Namespace)
+		}
 	}
 
 	for i := range in.Spec.Workers.MachinePools {

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -65,12 +65,18 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 		WithControlPlaneInfrastructureMachineTemplate(
 			builder.InfrastructureMachineTemplate("", "cpInfra1").
 				Build()).
+		WithControlPlaneMachineHealthCheck(&clusterv1.MachineHealthCheckClass{
+			RemediationTemplate: &corev1.ObjectReference{},
+		}).
 		WithWorkerMachineDeploymentClasses(
 			*builder.MachineDeploymentClass("aa").
 				WithInfrastructureTemplate(
 					builder.InfrastructureMachineTemplate("", "infra1").Build()).
 				WithBootstrapTemplate(
 					builder.BootstrapTemplate("", "bootstrap1").Build()).
+				WithMachineHealthCheckClass(&clusterv1.MachineHealthCheckClass{
+					RemediationTemplate: &corev1.ObjectReference{},
+				}).
 				Build()).
 		WithWorkerMachinePoolClasses(
 			*builder.MachinePoolClass("aa").
@@ -97,9 +103,11 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 	g.Expect(in.Spec.Infrastructure.Ref.Namespace).To(Equal(namespace))
 	g.Expect(in.Spec.ControlPlane.Ref.Namespace).To(Equal(namespace))
 	g.Expect(in.Spec.ControlPlane.MachineInfrastructure.Ref.Namespace).To(Equal(namespace))
+	g.Expect(in.Spec.ControlPlane.MachineHealthCheck.RemediationTemplate.Namespace).To(Equal(namespace))
 	for i := range in.Spec.Workers.MachineDeployments {
 		g.Expect(in.Spec.Workers.MachineDeployments[i].Template.Bootstrap.Ref.Namespace).To(Equal(namespace))
 		g.Expect(in.Spec.Workers.MachineDeployments[i].Template.Infrastructure.Ref.Namespace).To(Equal(namespace))
+		g.Expect(in.Spec.Workers.MachineDeployments[i].MachineHealthCheck.RemediationTemplate.Namespace).To(Equal(namespace))
 	}
 	for i := range in.Spec.Workers.MachinePools {
 		g.Expect(in.Spec.Workers.MachinePools[i].Template.Bootstrap.Ref.Namespace).To(Equal(namespace))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Adds namespace defaulting for the ClusterClass & Cluster.spec.topology.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10805

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->