### PR TITLE
📖 Amend 1.8 release planning

### DIFF
--- a/docs/release/releases/release-1.8.md
+++ b/docs/release/releases/release-1.8.md
@@ -4,29 +4,33 @@
 
 The following table shows the preliminary dates for the `v1.8` release cycle.
 
-| **What**                                             | **Who**      | **When**                    | **Week** |
-|------------------------------------------------------|--------------|-----------------------------|----------|
-| Start of Release Cycle                               | Release Lead | Monday 22nd April 2024      | week 1   |
-| *v1.7.x released* <sup>[1]</sup>                     | Release Lead | Tuesday 23rd April 2024     | week 1   |
-| Schedule finalized                                   | Release Lead | Friday 26th April 2024      | week 1   |
-| Team finalized                                       | Release Lead | Friday 26th April 2024      | week 1   |
-| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 14th May 2024       | week 4   |
-| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 11th June 2024      | week 8   |
-| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 9th July 2024       | week 12  |
-| v1.8.0-beta.0 released                               | Release Lead | Tuesday 16th July 2024      | week 13  |
-| Communicate beta to providers                        | Release Lead | Tuesday 16th July 2024      | week 13  |
-| v1.8.0-beta.x released                               | Release Lead | Tuesday 23rd July 2024      | week 14  |
-| release-1.8 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 30th July 2024      | week 15  |
-| v1.8.0-rc.0 released                                 | Release Lead | Tuesday 30th July 2024      | week 15  |
-| release-1.8 jobs created                             | Release Lead | Tuesday 30th July 2024      | week 15  |
-| v1.8.0-rc.x released                                 | Release Lead | Tuesday 6th August 2024     | week 16  |
-| **v1.8.0 released**                                  | Release Lead | Tuesday 13th August 2024    | week 17  |
-| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 13th August 2024    | week 17  |
-| Organize release retrospective                       | Release Lead | TBC                         | week 17  |
+| **What**                                             | **Who**      | **When**                  | **Week** |
+|------------------------------------------------------|--------------|---------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 22nd April 2024    | week 1   |
+| *v1.7.x released* <sup>[1]</sup>                     | Release Lead | Tuesday 23rd April 2024   | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 26th April 2024    | week 1   |
+| Team finalized                                       | Release Lead | Friday 26th April 2024    | week 1   |
+| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 14th May 2024     | week 4   |
+| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 11th June 2024    | week 8   |
+| *v1.6.x & v1.7.x released*                           | Release Lead | Tuesday 9th July 2024     | week 12  |
+| v1.8.0-beta.0 released                               | Release Lead | Tuesday 16th July 2024    | week 13  |
+| Communicate beta to providers                        | Release Lead | Tuesday 16th July 2024    | week 13  |
+| v1.8.0-beta.x released                               | Release Lead | Tuesday 23rd July 2024    | week 14  |
+| release-1.8 branch created (**Begin [Code Freeze]**) | Release Lead | Tuesday 30th July 2024    | week 15  |
+| v1.8.0-rc.0 released                                 | Release Lead | Tuesday 30th July 2024    | week 15  |
+| release-1.8 jobs created                             | Release Lead | Tuesday 30th July 2024    | week 15  |
+| v1.8.0-rc.x released                                 | Release Lead | Tuesday 6th August 2024   | week 16  |
+| **v1.8.0 released**                                  | Release Lead | Monday 12th August 2024   | week 17  |
+| *v1.6.x & v1.7.x released*                           | Release Lead | Monday 12th August 2024   | week 17  |
+| *v1.8.1 released (tentative)*                        | Release Lead | Thursday 15th August 2024 | week 17  |
+| Organize release retrospective                       | Release Lead | TBC                       | week 17  |
 
-After the `.0` release monthly patch release will be created.
+After the `.0` the .1 release will be created to ensure faster Kubernetes support after K8s 1.31.0 will be available.
+After the `.1` we expect to release monthly patch release (more details will be provided in the 1.9 release schedule).
 
-<sup>[1]</sup> Pending Kubernetes `v1.30` release [scheduled for April 17th](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.30).  This will be the first release cycle implementing faster Kubernetes support as introduced in [this PR](https://github.com/kubernetes-sigs/cluster-api/pull/9971/files#diff-2bf0df29da8afa5540cf65166b0b876393482bedef71d023d87835bb1b3ecbcb).
+Note: This release cycle there are some additional constraints for the .1 release due to planned test infra activities;
+as a consequence .1 timeline has been compressed (from 1 week / 10 days delay of the last release cycle down to 2/3 days)
+and maintainers might change plans also last second to adapt to latest info about infrastructure availability.
 
 ## Release team
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As per last week's office hours, amending the release calendar to handle the latest news about k8s test infra changes planned in August.

- GA date the 12th of August instead of the 13th
- 1.8.1 tentatively scheduled for the 15th of August

/area release