### PR TITLE
🐛 Increase timeout for TestClusterResourceSetReconciler test

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -1065,7 +1065,7 @@ metadata:
 				}
 			}
 			g.Expect(binding.OwnerReferences).To(HaveLen(10))
-		}, 4*timeout).Should(Succeed())
+		}, 8*timeout).Should(Succeed())
 		t.Log("Deleting the created ClusterResourceSet instances")
 		g.Expect(env.DeleteAllOf(ctx, &addonsv1.ClusterResourceSet{}, client.InNamespace(ns.Name))).To(Succeed())
 		g.Expect(env.DeleteAllOf(ctx, &addonsv1.ClusterResourceSetBinding{}, client.InNamespace(ns.Name))).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the flaky test: TestClusterResourceSetReconciler/Should_handle_applying_multiple_ClusterResourceSets_concurrently_to_the_same_cluster. This test was failing due to timeout issue:

```
 clusterresourceset_controller_test.go:1068: 
        Timed out after 60.001s.
        The function passed to Eventually failed at /home/prow/go/src/sigs.k8s.io/cluster-api/exp/addons/internal/controllers/clusterresourceset_controller_test.go:1062 with:
        Expected
            <[]v1beta1.ResourceBinding | len:0, cap:0>: nil
        to have length 2
```

Increasing timeout helped to solve the issue. The objects will be eventually created if the timeout is bit longer. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/10854

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area ci 