### PR TITLE
🌱 Make ClusterResourceSet controller more predictable

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -179,20 +179,15 @@ func (r *ClusterResourceSetReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// When there are more than one ClusterResourceSet targeting the same cluster,
 		// there might be conflict when reconciling those ClusterResourceSet in parallel because they all try to
 		// patch the same ClusterResourceSetBinding Object.
-		// In case of patching conflicts we don't want to go on exponential backlog, otherwise it might take an
+		// In case of patching conflicts we don't want to go on exponential backoff, otherwise it might take an
 		// arbitrary long time to get to stable state due to the backoff delay quickly growing.
-		// Instead, we are requeing with an interval to make the system a little bit more predictable (and stabilize tests).
-		// NOTE: The fact that we rely on conflict errors + requeue to reach the stable state isn't ideal, and
-		// it might also become an issue at scale.
-		// e.g. From an empirical observation, it takes 20s for 10 ClusterResourceSet to get to a stable state
-		// on the same ClusterResourceSetBinding; with less ClusterResourceSet the issue is less relevant
-		// (e.g. with 5 ClusterResourceSet it takes about 4 seconds).
+		// Instead, we are requeueing with an interval to make the system a little bit more predictable (and stabilize tests).
 		// NOTE: Conflicts happens mostly when ClusterResourceSetBinding is initialized / an entry is added for each
 		// cluster resource set targeting the same cluster.
 		for _, err := range errs {
 			if aggregate, ok := err.(kerrors.Aggregate); ok {
 				if len(aggregate.Errors()) == 1 && apierrors.IsConflict(aggregate.Errors()[0]) {
-					log.Info("Conflict in patching a ClusterResourceSetBinding that is updated by more than one ClusterResourceSet, requeing")
+					log.Info("Conflict in patching a ClusterResourceSetBinding that is updated by more than one ClusterResourceSet, requeueing")
 					return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
 				}
 			}

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -176,6 +176,27 @@ func (r *ClusterResourceSetReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Return an aggregated error if errors occurred.
 	if len(errs) > 0 {
+		// When there are more than one ClusterResourceSet targeting the same cluster,
+		// there might be conflict when reconciling those ClusterResourceSet in parallel because they all try to
+		// patch the same ClusterResourceSetBinding Object.
+		// In case of patching conflicts we don't want to go on exponential backlog, otherwise it might take an
+		// arbitrary long time to get to stable state due to the backoff delay quickly growing.
+		// Instead, we are requeing with an interval to make the system a little bit more predictable (and stabilize tests).
+		// NOTE: The fact that we rely on conflict errors + requeue to reach the stable state isn't ideal, and
+		// it might also become an issue at scale.
+		// e.g. From an empirical observation, it takes 20s for 10 ClusterResourceSet to get to a stable state
+		// on the same ClusterResourceSetBinding; with less ClusterResourceSet the issue is less relevant
+		// (e.g. with 5 ClusterResourceSet it takes about 4 seconds).
+		// NOTE: Conflicts happens mostly when ClusterResourceSetBinding is initialized / an entry is added for each
+		// cluster resource set targeting the same cluster.
+		for _, err := range errs {
+			if aggregate, ok := err.(kerrors.Aggregate); ok {
+				if len(aggregate.Errors()) == 1 && apierrors.IsConflict(aggregate.Errors()[0]) {
+					log.Info("Conflict in patching a ClusterResourceSetBinding that is updated by more than one ClusterResourceSet, requeing")
+					return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
+				}
+			}
+		}
 		return ctrl.Result{}, kerrors.NewAggregate(errs)
 	}
 

--- a/exp/addons/internal/controllers/suite_test.go
+++ b/exp/addons/internal/controllers/suite_test.go
@@ -38,8 +38,9 @@ import (
 )
 
 var (
-	env *envtest.Environment
-	ctx = ctrl.SetupSignalHandler()
+	env     *envtest.Environment
+	tracker *remote.ClusterCacheTracker
+	ctx     = ctrl.SetupSignalHandler()
 )
 
 func TestMain(m *testing.M) {
@@ -76,7 +77,7 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("Failed to start cache for metadata only Secret watches: %v", err))
 		}
 
-		tracker, err := remote.NewClusterCacheTracker(mgr, remote.ClusterCacheTrackerOptions{})
+		tracker, err = remote.NewClusterCacheTracker(mgr, remote.ClusterCacheTrackerOptions{})
 		if err != nil {
 			panic(fmt.Sprintf("Failed to create new cluster cache tracker: %v", err))
 		}

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -383,7 +383,7 @@ func (e *Environment) waitForWebhooks() {
 
 // CreateKubeconfigSecret generates a new Kubeconfig secret from the envtest config.
 func (e *Environment) CreateKubeconfigSecret(ctx context.Context, cluster *clusterv1.Cluster) error {
-	return e.Create(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(e.Config, cluster)))
+	return e.CreateAndWait(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(e.Config, cluster)))
 }
 
 // Cleanup deletes all the given objects.


### PR DESCRIPTION
**What this PR does / why we need it**:
ClusterResource set controller doesn't have an ideal implementation for cases where many ClusterResourceSets are targeting the same cluster (might be also the API is not specifically designed for this use case).

This PR is making this case a little bit more predictable, by avoiding a potential impact of exponential backoff delay quickly growing, but it is not solving the underlying issue.

At least, this should help in getting rid of some flakiness in our tests, and there is also a comment providing some more context on what's going on.

Another positive effect of this PR is that it remove a lot of noise from the logs

/area clusterresourceset

Related to #10854