### PR TITLE
:bug: Cluster should be provisoned when cpRef and endpoint is set

### DIFF
--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -86,6 +86,9 @@ func TestClusterReconcilePhases(t *testing.T) {
 				name:      "returns no error if infrastructure ref is nil",
 				cluster:   &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"}},
 				expectErr: false,
+				check: func(g *GomegaWithT, in *clusterv1.Cluster) {
+					g.Expect(in.Status.InfrastructureReady).To(BeTrue())
+				},
 			},
 			{
 				name:         "returns error if unable to reconcile infrastructure ref",
@@ -558,6 +561,26 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 				},
 				Status: clusterv1.ClusterStatus{
 					InfrastructureReady: true,
+				},
+			},
+
+			wantPhase: clusterv1.ClusterPhaseProvisioned,
+		},
+		{
+			name: "no cluster infrastructure, control plane ready and ControlPlaneEndpoint is set",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+						Host: "1.2.3.4",
+						Port: 8443,
+					},
+					ControlPlaneRef: &corev1.ObjectReference{},
+				},
+				Status: clusterv1.ClusterStatus{
+					ControlPlaneReady: true,
 				},
 			},
 


### PR DESCRIPTION
We're currently treating the infrastructureRef as almost a requirement, which in fact isn't and it's an optional reference.

If the Cluster control plane reference is populated, the endpoint is valid, and the control plane is ready, set the phase to provisioned

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->