### PR TITLE
🐛 capd: fix nil pointer in dockermachinepool controller

### DIFF
--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
@@ -312,16 +312,19 @@ func (r *DockerMachinePoolReconciler) deleteMachinePoolMachine(ctx context.Conte
 // propagateMachineDeleteAnnotation returns the DockerMachines for a MachinePool and for each DockerMachine, it copies the owner
 // Machine's delete annotation to each DockerMachine if it's present. This is done just in time to ensure that the annotations are
 // up to date when we sort for DockerMachine deletion.
-func (r *DockerMachinePoolReconciler) propagateMachineDeleteAnnotation(ctx context.Context, dockerMachineSet map[string]infrav1.DockerMachine) ([]infrav1.DockerMachine, error) {
+func (r *DockerMachinePoolReconciler) propagateMachineDeleteAnnotation(ctx context.Context, dockerMachineMap map[string]infrav1.DockerMachine) ([]infrav1.DockerMachine, error) {
 	_ = ctrl.LoggerFrom(ctx)
 
 	dockerMachines := []infrav1.DockerMachine{}
-	for _, dockerMachine := range dockerMachineSet {
+	for _, dockerMachine := range dockerMachineMap {
 		machine, err := util.GetOwnerMachine(ctx, r.Client, dockerMachine.ObjectMeta)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error getting owner Machine for DockerMachine %s/%s", dockerMachine.Namespace, dockerMachine.Name)
 		}
 		if machine != nil && machine.Annotations != nil {
+			if dockerMachine.Annotations == nil {
+				dockerMachine.Annotations = map[string]string{}
+			}
 			if _, hasDeleteAnnotation := machine.Annotations[clusterv1.DeleteMachineAnnotation]; hasDeleteAnnotation {
 				dockerMachine.Annotations[clusterv1.DeleteMachineAnnotation] = machine.Annotations[clusterv1.DeleteMachineAnnotation]
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixes nil pointer which occurred e.g. here:

- https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-mink8s-main/1812401250918993920
- CAPD logs: https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-e2e-mink8s-main/1812401250918993920/artifacts/clusters/bootstrap/logs/capd-system/capd-controller-manager/capd-controller-manager-64d8bd4d45-77kh8/manager.log

```
{"ts":1720949295165.3877,"caller":"controller/controller.go:110","msg":"Observed a panic in reconciler: assignment to entry in nil map","controller":"dockermachinepool","controllerGroup":"infrastructure.cluster.x-k8s.io","controllerKind":"DockerMachinePool","DockerMachinePool":{"name":"autoscaler-qynhbr-mp-0-4hrqc","namespace":"autoscaler-wh9wa3"},"namespace":"autoscaler-wh9wa3","name":"autoscaler-qynhbr-mp-0-4hrqc","reconcileID":"5982a440-3d63-4817-b8fa-549b825f7753","v":0}
panic: assignment to entry in nil map [recovered]
	panic: assignment to entry in nil map

goroutine 325 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x1d48ca0?, 0x2370970?})
	runtime/panic.go:770 +0x132
sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers.(*DockerMachinePoolReconciler).propagateMachineDeleteAnnotation(0xc0004fa8c0, {0x23955e0, 0xc00062fb00}, 0xc000fd8290)
	sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go:326 +0x253
sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers.(*DockerMachinePoolReconciler).reconcileDockerMachines(0xc0004fa8c0, {0x23955e0, 0xc00062fb00}, 0xc0012041a0, 0xc000418848, 0xc001716c40)
	sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go:190 +0x112c
sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers.(*DockerMachinePoolReconciler).reconcileNormal(0xc0004fa8c0, {0x23955e0, 0xc00062fb00}, 0xc0012041a0, 0xc000418848, 0xc001716c40)
	sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go:288 +0x13e
sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers.(*DockerMachinePoolReconciler).Reconcile(0xc0004fa8c0, {0x23955e0, 0xc00062f6e0}, {{{0xc0010b1410?, 0x3?}, {0xc0000585c0?, 0xc000accd10?}}})
	sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go:157 +0x8b0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x239c460?, {0x23955e0?, 0xc00062f6e0?}, {{{0xc0010b1410?, 0xb?}, {0xc0000585c0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:114 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000330840, {0x2395618, 0xc0004df950}, {0x1e0ab60, 0xc001935920})
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:311 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000330840, {0x2395618, 0xc0004df950})
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:261 +0x1be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:222 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 102
	sigs.k8s.io/controller-runtime@v0.18.4/pkg/internal/controller/controller.go:218 +0x486
```

[triage link](https://storage.googleapis.com/k8s-triage/index.html?job=.*-cluster-api-.*&xjob=.*-provider-.*&xtest=TestClusterResourceSetReconciler#e3708e0293e399338888)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area provider/infrastructure-docker