### PR TITLE
🌱 test: use pause image for autoscaler tests

### DIFF
--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -191,14 +191,14 @@ func AddScaleUpDeploymentAndWait(ctx context.Context, input AddScaleUpDeployment
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "busybox",
-							Image: "busybox",
+							Name:            "pause",
+							Image:           "registry.k8s.io/pause",
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
 								Requests: map[corev1.ResourceName]resource.Quantity{
 									corev1.ResourceMemory: *podMemory,
 								},
 							},
-							Command: []string{"/bin/sh", "-c", "echo \"up\" & sleep infinity"},
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

We currently use `busybox` from dockerhub for autoscaling tests. This changes the dependency to the `registry.k8s.io/pause` image instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing