### PR TITLE
🐛 Fix race condition in TestPatchHelper test

### DIFF
--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -974,7 +974,10 @@ func TestPatchHelper(t *testing.T) {
 		g.Expect(env.Delete(ctx, cluster)).To(Succeed())
 
 		// Ensure cluster still exists & get Cluster with deletionTimestamp set
-		g.Expect(env.Get(ctx, key, cluster)).To(Succeed())
+		// Note: Using the APIReader to ensure we get the cluster with deletionTimestamp is set.
+		// This is realistic because finalizers are removed in reconcileDelete code and that is only
+		// run if the deletionTimestamp is set.
+		g.Expect(env.GetAPIReader().Get(ctx, key, cluster)).To(Succeed())
 
 		// Patch helper will first remove the finalizer and then it will get a not found error when
 		// trying to patch status. This test validates that the not found error is ignored.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This test has been failing pretty regularly since we merged the test yesterday (#10866)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->