### PR TITLE
:bug: Add race option to detect raced codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -941,7 +941,7 @@ test-cover: ## Run unit and integration tests and generate a coverage report
 
 .PHONY: test-docker-infrastructure
 test-docker-infrastructure: $(SETUP_ENVTEST) ## Run unit and integration tests for docker infrastructure provider
-	cd $(CAPD_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... $(TEST_ARGS)
+	cd $(CAPD_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race ./... $(TEST_ARGS)
 
 .PHONY: test-docker-infrastructure-verbose
 test-docker-infrastructure-verbose: ## Run unit and integration tests for docker infrastructure provider with verbose flag
@@ -949,13 +949,13 @@ test-docker-infrastructure-verbose: ## Run unit and integration tests for docker
 
 .PHONY: test-docker-infrastructure-junit
 test-docker-infrastructure-junit: $(SETUP_ENVTEST) $(GOTESTSUM) ## Run unit and integration tests and generate a junit report for docker infrastructure provider
-	cd $(CAPD_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.infra_docker.exitcode) | tee $(ARTIFACTS)/junit.infra_docker.stdout
+	cd $(CAPD_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.infra_docker.exitcode) | tee $(ARTIFACTS)/junit.infra_docker.stdout
 	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.infra_docker.xml --raw-command cat $(ARTIFACTS)/junit.infra_docker.stdout
 	exit $$(cat $(ARTIFACTS)/junit.infra_docker.exitcode)
 
 .PHONY: test-in-memory-infrastructure
 test-in-memory-infrastructure: $(SETUP_ENVTEST) ## Run unit and integration tests for in-memory infrastructure provider
-	cd $(CAPIM_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... $(TEST_ARGS)
+	cd $(CAPIM_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race ./... $(TEST_ARGS)
 
 .PHONY: test-in-memory-infrastructure-verbose
 test-in-memory-infrastructure-verbose: ## Run unit and integration tests for in-memory infrastructure provider with verbose flag
@@ -963,13 +963,13 @@ test-in-memory-infrastructure-verbose: ## Run unit and integration tests for in-
 
 .PHONY: test-in-memory-infrastructure-junit
 test-in-memory-infrastructure-junit: $(SETUP_ENVTEST) $(GOTESTSUM) ## Run unit and integration tests and generate a junit report for in-memory infrastructure provider
-	cd $(CAPIM_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.infra_inmemory.exitcode) | tee $(ARTIFACTS)/junit.infra_inmemory.stdout
+	cd $(CAPIM_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.infra_inmemory.exitcode) | tee $(ARTIFACTS)/junit.infra_inmemory.stdout
 	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.infra_inmemory.xml --raw-command cat $(ARTIFACTS)/junit.infra_inmemory.stdout
 	exit $$(cat $(ARTIFACTS)/junit.infra_inmemory.exitcode)
 
 .PHONY: test-test-extension
 test-test-extension: $(SETUP_ENVTEST) ## Run unit and integration tests for the test extension
-	cd $(TEST_EXTENSION_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... $(TEST_ARGS)
+	cd $(TEST_EXTENSION_DIR); KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race ./... $(TEST_ARGS)
 
 .PHONY: test-test-extension-verbose
 test-test-extension-verbose: ## Run unit and integration tests with verbose flag
@@ -977,7 +977,7 @@ test-test-extension-verbose: ## Run unit and integration tests with verbose flag
 
 .PHONY: test-test-extension-junit
 test-test-extension-junit: $(SETUP_ENVTEST) $(GOTESTSUM) ## Run unit and integration tests and generate a junit report for the test extension
-	cd $(TEST_EXTENSION_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.test_extension.exitcode) | tee $(ARTIFACTS)/junit.test_extension.stdout
+	cd $(TEST_EXTENSION_DIR); set +o errexit; (KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race -json ./... $(TEST_ARGS); echo $$? > $(ARTIFACTS)/junit.test_extension.exitcode) | tee $(ARTIFACTS)/junit.test_extension.stdout
 	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.test_extension.xml --raw-command cat $(ARTIFACTS)/junit.test_extension.stdout
 	exit $$(cat $(ARTIFACTS)/junit.test_extension.exitcode)
 
@@ -1197,7 +1197,7 @@ release-notes: release-notes-tool
 
 .PHONY: test-release-notes-tool
 test-release-notes-tool:
-	go test -C hack/tools -v -tags tools,integration sigs.k8s.io/cluster-api/hack/tools/release/notes
+	go test -race -C hack/tools -v -tags tools,integration sigs.k8s.io/cluster-api/hack/tools/release/notes
 
 .PHONY: release-provider-issues-tool
 release-provider-issues-tool: # Creates GitHub issues in a pre-defined list of CAPI provider repositories

--- a/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
@@ -50,8 +50,10 @@ func (c *cache) startSyncer(ctx context.Context) error {
 		c.syncQueue.ShutDown()
 	}()
 
+	syncLoopStarted := make(chan struct{})
 	go func() {
 		log.Info("Starting sync loop")
+		syncLoopStarted <- struct{}{}
 		for {
 			select {
 			case <-time.After(c.syncPeriod / 4):
@@ -78,6 +80,8 @@ func (c *cache) startSyncer(ctx context.Context) error {
 		<-ctx.Done()
 		wg.Wait()
 	}()
+
+	<-syncLoopStarted
 
 	if err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 5*time.Second, false, func(context.Context) (done bool, err error) {
 		if atomic.LoadInt64(&workers) < int64(c.syncConcurrency) {

--- a/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
@@ -50,8 +50,10 @@ func (c *cache) startSyncer(ctx context.Context) error {
 		c.syncQueue.ShutDown()
 	}()
 
+	var syncLoopStarted atomic.Bool
 	go func() {
 		log.Info("Starting sync loop")
+		syncLoopStarted.Store(true)
 		for {
 			select {
 			case <-time.After(c.syncPeriod / 4):
@@ -61,15 +63,14 @@ func (c *cache) startSyncer(ctx context.Context) error {
 			}
 		}
 	}()
-
-	var workers int64
+	var workers atomic.Int64
 	go func() {
 		log.Info("Starting sync workers", "count", c.syncConcurrency)
 		wg := &sync.WaitGroup{}
 		wg.Add(c.syncConcurrency)
 		for range c.syncConcurrency {
 			go func() {
-				atomic.AddInt64(&workers, 1)
+				workers.Add(1)
 				defer wg.Done()
 				for c.processSyncWorkItem(ctx) {
 				}
@@ -80,7 +81,16 @@ func (c *cache) startSyncer(ctx context.Context) error {
 	}()
 
 	if err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 5*time.Second, false, func(context.Context) (done bool, err error) {
-		if atomic.LoadInt64(&workers) < int64(c.syncConcurrency) {
+		if !syncLoopStarted.Load() {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("failed to start sync loop: %v", err)
+	}
+
+	if err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 5*time.Second, false, func(context.Context) (done bool, err error) {
+		if workers.Load() < int64(c.syncConcurrency) {
 			return false, nil
 		}
 		return true, nil

--- a/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/sync.go
@@ -50,10 +50,8 @@ func (c *cache) startSyncer(ctx context.Context) error {
 		c.syncQueue.ShutDown()
 	}()
 
-	syncLoopStarted := make(chan struct{})
 	go func() {
 		log.Info("Starting sync loop")
-		syncLoopStarted <- struct{}{}
 		for {
 			select {
 			case <-time.After(c.syncPeriod / 4):
@@ -80,8 +78,6 @@ func (c *cache) startSyncer(ctx context.Context) error {
 		<-ctx.Done()
 		wg.Wait()
 	}()
-
-	<-syncLoopStarted
 
 	if err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 5*time.Second, false, func(context.Context) (done bool, err error) {
 		if atomic.LoadInt64(&workers) < int64(c.syncConcurrency) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I added -race option to go test command. This option can find the raced code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->