### PR TITLE
⚠️ Add x-kubernetes unique validation for the Conditions list

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -89,6 +89,8 @@ type Condition struct {
 // ANCHOR: Conditions
 
 // Conditions provide observations of the operational state of a Cluster API resource.
+// +listType=map
+// +listMapKey=type
 type Conditions []Condition
 
 // ANCHOR_END: Conditions

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -3746,6 +3746,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               dataSecretName:
                 description: DataSecretName is the name of the secret that stores
                   the bootstrap data script.

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -520,6 +520,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration reflects the generation of the most
                   recently observed ClusterResourceSet.

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -2037,6 +2037,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed
                   by the controller.

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1709,6 +1709,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               controlPlaneReady:
                 description: |-
                   ControlPlaneReady denotes if the control plane became ready during initial provisioning

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1565,6 +1565,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: The generation observed by the deployment controller.
                 format: int64

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -839,6 +839,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               currentHealthy:
                 description: total number of healthy machines counted by this machine
                   health check

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1331,6 +1331,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               failureMessage:
                 description: |-
                   FailureMessage indicates that there is a problem reconciling the state,

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1113,6 +1113,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               deletion:
                 description: |-
                   deletion contains information relating to removal of the Machine.

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1303,6 +1303,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               failureMessage:
                 type: string
               failureReason:

--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
@@ -141,6 +141,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true
@@ -276,6 +279,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -213,6 +213,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               handlers:
                 description: Handlers defines the current ExtensionHandlers supported
                   by an Extension.

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -4452,6 +4452,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               failureMessage:
                 description: |-
                   ErrorMessage indicates that there is a terminal problem reconciling the

--- a/internal/test/builder/crd/test.cluster.x-k8s.io_phase0obj.yaml
+++ b/internal/test/builder/crd/test.cluster.x-k8s.io_phase0obj.yaml
@@ -95,6 +95,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/internal/test/builder/crd/test.cluster.x-k8s.io_phase1obj.yaml
+++ b/internal/test/builder/crd/test.cluster.x-k8s.io_phase1obj.yaml
@@ -96,6 +96,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               v1beta2:
                 description: Phase1ObjStatusV1Beta2 defines the status.V1Beta2 of
                   a Phase1Obj.

--- a/internal/test/builder/crd/test.cluster.x-k8s.io_phase2obj.yaml
+++ b/internal/test/builder/crd/test.cluster.x-k8s.io_phase2obj.yaml
@@ -164,6 +164,9 @@ spec:
                           - type
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
                     type: object
                 type: object
             type: object

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -489,6 +489,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               failureDomains:
                 additionalProperties:
                   description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -533,6 +533,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               infrastructureMachineKind:
                 description: InfrastructureMachineKind is the kind of the infrastructure
                   resources behind MachinePool Machines.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -497,6 +497,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               loadBalancerConfigured:
                 description: |-
                   LoadBalancerConfigured denotes that the machine has been

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclusters.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemoryclusters.yaml
@@ -115,6 +115,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               ready:
                 description: Ready denotes that the in-memory cluster (infrastructure)
                   is ready.

--- a/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachines.yaml
+++ b/test/infrastructure/inmemory/config/crd/bases/infrastructure.cluster.x-k8s.io_inmemorymachines.yaml
@@ -213,6 +213,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               ready:
                 description: Ready denotes that the machine is ready
                 type: boolean


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The cluster-api/util/conditions.Set method is already applying deduplication using Type as a key (https://github.com/m-messiah/cluster-api/blob/ff54cbff5c72de1aa486b09e4e866b37637c59bd/util/conditions/setter.go#L41), but the constraint was not visible in CRDs.
The PR adds two kubebuilder comments to treat `Conditions` as a map with Type as a key and prevent duplications on the kube-apiserver level.


For example, CRD manifest for CR that has `Conditions clusterv1.Conditions` in its status:
```patch
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
                  type: array
```


/area api
