### PR TITLE
🌱 Partially revert changes for ":bug: Cluster should be provisoned when cpRef and endpoint is set"

### DIFF
--- a/api/v1beta1/cluster_phase_types.go
+++ b/api/v1beta1/cluster_phase_types.go
@@ -33,12 +33,13 @@ const (
 	// Cluster API Cluster controller after being created.
 	ClusterPhasePending = ClusterPhase("Pending")
 
-	// ClusterPhaseProvisioning is the state when the Cluster has a provider infrastructure
-	// object associated and can start provisioning.
+	// ClusterPhaseProvisioning is the state when the Cluster has a infrastructure
+	// object or a control plane object that can start provisioning the control plane endpoint.
 	ClusterPhaseProvisioning = ClusterPhase("Provisioning")
 
-	// ClusterPhaseProvisioned is the state when its
-	// infrastructure has been created and configured.
+	// ClusterPhaseProvisioned is the state when its control plane endpoint has been created and configured
+	// and the infrastructure object is ready (if defined).
+	// Note: When a cluster reaches this phase parts of the control plane or worker machines might be still provisioning.
 	ClusterPhaseProvisioned = ClusterPhase("Provisioned")
 
 	// ClusterPhaseDeleting is the Cluster state when a delete

--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -52,9 +52,7 @@ func (r *Reconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluste
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioning)
 	}
 
-	if (cluster.Spec.InfrastructureRef == nil || cluster.Status.InfrastructureReady) &&
-		(cluster.Spec.ControlPlaneRef == nil || cluster.Status.ControlPlaneReady) &&
-		cluster.Spec.ControlPlaneEndpoint.IsValid() {
+	if cluster.Status.InfrastructureReady && cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioned)
 	}
 

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -573,14 +573,14 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Spec: clusterv1.ClusterSpec{
-					ControlPlaneEndpoint: clusterv1.APIEndpoint{
+					ControlPlaneEndpoint: clusterv1.APIEndpoint{ // This is set by the control plane ref controller when the cluster endpoint is available.
 						Host: "1.2.3.4",
 						Port: 8443,
 					},
 					ControlPlaneRef: &corev1.ObjectReference{},
 				},
 				Status: clusterv1.ClusterStatus{
-					ControlPlaneReady: true,
+					InfrastructureReady: true, // Note, this is automatically set when there is no cluster infrastructure (no-op).
 				},
 			},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a small improvement on changes introduced by https://github.com/kubernetes-sigs/cluster-api/pull/10873, making sure that cluster provisioned phase isn't including control plane fully ready (which was altering the original semantic of those phases)

Also improved the go comments for the phase const to better reflect current state

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/10885

/area api

cc @vincepri 