### PR TITLE
:bug: When infrastructureRef is nil, set InfrastructureReadyCondition to true

### DIFF
--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -153,6 +153,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, cluster *clust
 	if cluster.Spec.InfrastructureRef == nil {
 		// If the infrastructure ref is not set, marking the infrastructure as ready (no-op).
 		cluster.Status.InfrastructureReady = true
+		conditions.MarkTrue(cluster, clusterv1.InfrastructureReadyCondition)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -88,6 +88,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				expectErr: false,
 				check: func(g *GomegaWithT, in *clusterv1.Cluster) {
 					g.Expect(in.Status.InfrastructureReady).To(BeTrue())
+					g.Expect(conditions.IsTrue(in, clusterv1.InfrastructureReadyCondition)).To(BeTrue())
 				},
 			},
 			{


### PR DESCRIPTION
… to true

Some clients, like MachineHealthCheck are checking this condition to continue operations. Set it for backward compatibility

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area api