### PR TITLE
🐛 topology: use raw input object for patch calculation in WalkTemplates

### DIFF
--- a/exp/runtime/topologymutation/walker.go
+++ b/exp/runtime/topologymutation/walker.go
@@ -147,14 +147,14 @@ func WalkTemplates(ctx context.Context, decoder runtime.Decoder, req *runtimehoo
 		var patch []byte
 		switch options.patchFormat {
 		case runtimehooksv1.JSONPatchType:
-			patch, err = createJSONPatch(original, modified)
+			patch, err = createJSONPatch(requestItem.Object.Raw, modified)
 			if err != nil {
 				resp.Status = runtimehooksv1.ResponseStatusFailure
 				resp.Message = err.Error()
 				return
 			}
 		case runtimehooksv1.JSONMergePatchType:
-			patch, err = createJSONMergePatch(original, modified)
+			patch, err = createJSONMergePatch(requestItem.Object.Raw, modified)
 			if err != nil {
 				resp.Status = runtimehooksv1.ResponseStatusFailure
 				resp.Message = err.Error()
@@ -174,12 +174,7 @@ func WalkTemplates(ctx context.Context, decoder runtime.Decoder, req *runtimehoo
 }
 
 // createJSONPatch creates a RFC 6902 JSON patch from the original and the modified object.
-func createJSONPatch(original, modified runtime.Object) ([]byte, error) {
-	marshalledOriginal, err := json.Marshal(original)
-	if err != nil {
-		return nil, errors.Errorf("failed to marshal original object: %v", err)
-	}
-
+func createJSONPatch(marshalledOriginal []byte, modified runtime.Object) ([]byte, error) {
 	marshalledModified, err := json.Marshal(modified)
 	if err != nil {
 		return nil, errors.Errorf("failed to marshal modified object: %v", err)
@@ -199,12 +194,7 @@ func createJSONPatch(original, modified runtime.Object) ([]byte, error) {
 }
 
 // createJSONMergePatch creates a RFC 7396 JSON merge patch from the original and the modified object.
-func createJSONMergePatch(original, modified runtime.Object) ([]byte, error) {
-	marshalledOriginal, err := json.Marshal(original)
-	if err != nil {
-		return nil, errors.Errorf("failed to marshal original object: %v", err)
-	}
-
+func createJSONMergePatch(marshalledOriginal []byte, modified runtime.Object) ([]byte, error) {
 	marshalledModified, err := json.Marshal(modified)
 	if err != nil {
 		return nil, errors.Errorf("failed to marshal modified object: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adjusts the WalkTemplates function provided for runtime extensions to use the original input struct to calculate patches.

Before it did use the typed objects to marshal them and create the patch.
This could lead to invalid patches because the Go struct may have fields which the original input did not have.

Example for `VSphereClusterTemplate` from here: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/main/apis/v1beta1/vsphereclustertemplate_types.go#L33

Consider the following input from the patch request (the template referred by the ClusterClass):

```json
{
  "apiVersion": "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
  "kind": "VSphereClusterTemplate",
  "metadata": {
    "name": "quick-start-supervisor",
    "namespace": "k8s-upgrade-with-runtimesdk-csmelk",
  },
  "spec": {
    "template": {
      "spec": {}
    }
  }
}
```

decoding and marshalling again made the following out of it:

```json
{
  "apiVersion": "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
  "kind": "VSphereClusterTemplate",
  "metadata": {
    "name": "quick-start-supervisor",
    "namespace": "k8s-upgrade-with-runtimesdk-csmelk",
  },
  "spec": {
    "template": {
      "spec": {
        "controlPlaneEndpoint": {
          "host": "",
          "port": 0
        }
      }
    }
  }
}
```

Now we calculate the patch based on the following:

```json
{
  "apiVersion": "vmware.infrastructure.cluster.x-k8s.io/v1beta1",
  "kind": "VSphereClusterTemplate",
  "metadata": {
    "name": "quick-start-supervisor",
    "namespace": "k8s-upgrade-with-runtimesdk-csmelk",
  },
  "spec": {
    "template": {
      "spec": {
        "controlPlaneEndpoint": {
          "host": "1.1.1.1",
          "port": 6443
        }
      }
    }
  }
}
```

The old behaviour would have created the following patch:

```json
[
  {
    "op": "replace",
    "path": "/spec/template/spec/controlPlaneEndpoint/host",
    "value": "1.1.1.1"
  },
  {
    "op": "replace",
    "path": "/spec/template/spec/controlPlaneEndpoint/port",
    "value": 30000
  }
]
```

This patch would fail in CAPI to get applied to the template with following error:

```
error computing the desired state of the Cluster topology: failed to apply patches: failed to apply patches for patch "test-patch": failed to apply patch: error applying json patch (RFC6902): replace operation does not apply: do
c is missing path: /spec/template/spec/controlPlaneEndpoint/host: missing value
```

The new behaviour would create the following patch, which would work:

```json
[
  {
    "op": "add",
    "path": "/spec/template/spec/controlPlaneEndpoint",
    "value": {
      "host": "1.1.1.1",
      "port": 6443
    },
  }
]
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area runtime-sdk