### PR TITLE
🌱 use testing.TempDir instead of os.MkdirTemp

### DIFF
--- a/cmd/clusterctl/client/repository/client_test.go
+++ b/cmd/clusterctl/client/repository/client_test.go
@@ -18,7 +18,6 @@ package repository
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -34,8 +33,7 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 
 	ctx := context.Background()
 
-	tmpDir := createTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	dst1 := createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "")
 	dst2 := createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v2.0.0/bootstrap-components.yaml", "")

--- a/cmd/clusterctl/client/repository/overrides_test.go
+++ b/cmd/clusterctl/client/repository/overrides_test.go
@@ -100,8 +100,7 @@ func TestGetLocalOverrides(t *testing.T) {
 	t.Run("returns contents of file successfully", func(t *testing.T) {
 		g := NewWithT(t)
 
-		tmpDir := createTempDir(t)
-		defer os.RemoveAll(tmpDir)
+		tmpDir := t.TempDir()
 
 		createLocalTestProviderFile(t, tmpDir, "infrastructure-myinfra/v1.0.1/infra-comp.yaml", "foo: bar")
 

--- a/cmd/clusterctl/client/repository/repository_local_test.go
+++ b/cmd/clusterctl/client/repository/repository_local_test.go
@@ -129,16 +129,6 @@ func Test_localRepository_newLocalRepository(t *testing.T) {
 	}
 }
 
-func createTempDir(t *testing.T) string {
-	t.Helper()
-
-	dir, err := os.MkdirTemp("", "cc")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	return dir
-}
-
 func createLocalTestProviderFile(t *testing.T, tmpDir, path, msg string) string {
 	t.Helper()
 
@@ -155,8 +145,7 @@ func createLocalTestProviderFile(t *testing.T, tmpDir, path, msg string) string 
 func Test_localRepository_newLocalRepository_Latest(t *testing.T) {
 	g := NewWithT(t)
 
-	tmpDir := createTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Create several release directories
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "foo: bar")
@@ -182,8 +171,7 @@ func Test_localRepository_newLocalRepository_Latest(t *testing.T) {
 }
 
 func Test_localRepository_GetFile(t *testing.T) {
-	tmpDir := createTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Provider 1: URL is for the only release available
 	dst1 := createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "foo: bar")
@@ -319,8 +307,7 @@ func Test_localRepository_GetFile(t *testing.T) {
 }
 
 func Test_localRepository_GetVersions(t *testing.T) {
-	tmpDir := createTempDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// Provider 1: has a single release available
 	dst1 := createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "foo: bar")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR is for cleanup.
I replaced from os.MkdirTemp to t.TempDir. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->