### PR TITLE
🌱  use testing.Setenv instead of os.Setenv

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client_test.go
+++ b/cmd/clusterctl/client/config/cert_manager_client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -77,13 +76,8 @@ func TestCertManagerGet(t *testing.T) {
 			g := NewWithT(t)
 
 			for k, v := range tt.envVars {
-				g.Expect(os.Setenv(k, v)).To(Succeed())
+				t.Setenv(k, v)
 			}
-			defer func() {
-				for k := range tt.envVars {
-					g.Expect(os.Unsetenv(k)).To(Succeed())
-				}
-			}()
 			p := &certManagerClient{
 				reader: tt.fields.reader,
 			}

--- a/cmd/clusterctl/client/config/providers_client_test.go
+++ b/cmd/clusterctl/client/config/providers_client_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"testing"
 
@@ -148,13 +147,8 @@ func Test_providers_List(t *testing.T) {
 			g := NewWithT(t)
 
 			for k, v := range tt.envVars {
-				g.Expect(os.Setenv(k, v)).To(Succeed())
+				t.Setenv(k, v)
 			}
-			defer func() {
-				for k := range tt.envVars {
-					g.Expect(os.Unsetenv(k)).To(Succeed())
-				}
-			}()
 			p := &providersClient{
 				reader: tt.fields.configGetter,
 			}

--- a/cmd/clusterctl/client/repository/overrides_test.go
+++ b/cmd/clusterctl/client/repository/overrides_test.go
@@ -74,13 +74,8 @@ func TestOverrides(t *testing.T) {
 			g := NewWithT(t)
 
 			for k, v := range tt.envVars {
-				g.Expect(os.Setenv(k, v)).To(Succeed())
+				t.Setenv(k, v)
 			}
-			defer func() {
-				for k := range tt.envVars {
-					g.Expect(os.Unsetenv(k)).To(Succeed())
-				}
-			}()
 			provider := config.NewProvider("myinfra", "", clusterctlv1.InfrastructureProviderType)
 			override := newOverride(&newOverrideInput{
 				configVariablesClient: tt.configVarClient,

--- a/cmd/clusterctl/client/repository/overrides_test.go
+++ b/cmd/clusterctl/client/repository/overrides_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package repository
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR is for cleanup.
I replaced from os.Setenv to testing.Setenv

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->