### PR TITLE
📖 Add Cluster API release-1.9 timeline document

### DIFF
--- a/docs/release/releases/release-1.9.md
+++ b/docs/release/releases/release-1.9.md
@@ -1,0 +1,38 @@
+# Cluster API v1.9
+
+## Timeline
+
+The following table shows the preliminary dates for the `v1.9` release cycle.
+
+| **What**                                             | **Who**      | **When**                    | **Week** |
+|------------------------------------------------------|--------------|-----------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 19th August 2024     | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 23rd August 2024     | week 1   |
+| Team finalized                                       | Release Lead | Friday 23rd August 2024     | week 1   |
+| *v1.7.x & v1.8.x released*                           | Release Lead | Tuesday 10th September 2024 | week 4   |
+| *v1.7.x & v1.8.x released*                           | Release Lead | Tuesday 8th October 2024    | week 8   |
+| *v1.7.x & v1.8.x released*                           | Release Lead | Tuesday 5th November 2024   | week 12  |
+| v1.9.0-beta.0 released                               | Release Lead | Tuesday 5th November 2024   | week 12  |
+| Communicate beta to providers                        | Comms Lead   | Tuesday 5th November 2024   | week 12  |
+| Communicate upcoming code freeze to the community    | Comms Lead   | Tuesday 5th November 2024   | week 12  |
+| KubeCon idle week                                    | ---          | ---                         | week 13  |
+| v1.9.0-beta.x released                               | Release Lead | Tuesday 19th November 2024  | week 14  |
+| release-1.9 branch created (**Begin Code Freeze**)   | Release Lead | Tuesday 26th November 2024  | week 15  |
+| v1.9.0-rc.0 released                                 | Release Lead | Tuesday 26th November 2024  | week 15  |
+| release-1.9 jobs created                             | Release Lead | Tuesday 26th November 2024  | week 15  |
+| v1.9.0-rc.x released                                 | Release Lead | Tuesday 3rd December 2024   | week 16  |
+| **v1.9.0 released**                                  | Release Lead | Tuesday 10th December 2024  | week 17  |
+| *v1.7.x & v1.8.x released*                           | Release Lead | Tuesday 10th December 2024  | week 17  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 17  |
+| *v1.9.1 released (tentative)*                         | Release Lead | Tuesday 17th December 2024  | week 18  |
+
+After the .0 the .1 release will be created to ensure faster Kubernetes support after K8s 1.32.0 will be available. After the .1 we expect to release monthly patch release (more details will be provided in the 1.10 release schedule).
+
+## Release team
+
+| **Role**                                  | **Lead** (**GitHub / Slack ID**) | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|----------------------------------|----------------------------------------|
+| Release Lead                              | TBD                              | TBD                                    |
+| Communications/Docs/Release Notes Manager | TBD                              | TBD                                    |
+| CI Signal/Bug Triage/Automation Manager   | TBD                              | TBD                                    |
+| Maintainer                                | TBD                              | TBD                                    |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds release-1.9 cycle schedule document with preliminary dates taking into account [Kubecon US 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) between November 12-15, 2024 on week 13th in the schedule.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/10472
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

