### PR TITLE
🐛 [release-1.6] docker: ignore kubeadm preflight check for FileContent--proc-sys-net-bridge-bridge-nf-call-ip6tables

### DIFF
--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
@@ -56,7 +56,7 @@ func (a *runCmd) Commands() ([]provisioning.Cmd, error) {
 }
 
 // ignorePreflightErrors are preflight errors that fail in CAPD and thus we have to ignore them.
-const ignorePreflightErrors = "SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
+const ignorePreflightErrors = "SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,FileContent--proc-sys-net-bridge-bridge-nf-call-ip6tables"
 
 func hackKubeadmIgnoreErrors(c provisioning.Cmd) provisioning.Cmd {
 	// case kubeadm commands are defined as a string

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
@@ -71,7 +71,7 @@ func TestRunCmdRun(t *testing.T) {
 				},
 			},
 			expectedCmds: []provisioning.Cmd{
-				{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config /run/kubeadm/kubeadm.yaml"}},
+				{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,FileContent--proc-sys-net-bridge-bridge-nf-call-ip6tables --config /run/kubeadm/kubeadm.yaml"}},
 			},
 		},
 	}
@@ -101,11 +101,11 @@ runcmd:
 
 	r.Cmds[0] = hackKubeadmIgnoreErrors(r.Cmds[0])
 
-	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm.yaml"}}
+	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,FileContent--proc-sys-net-bridge-bridge-nf-call-ip6tables --config=/run/kubeadm/kubeadm.yaml"}}
 	g.Expect(r.Cmds[0]).To(BeComparableTo(expected0))
 
 	r.Cmds[1] = hackKubeadmIgnoreErrors(r.Cmds[1])
 
-	expected1 := provisioning.Cmd{Cmd: "kubeadm", Args: []string{"join", "--ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables", "--config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
+	expected1 := provisioning.Cmd{Cmd: "kubeadm", Args: []string{"join", "--ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,FileContent--proc-sys-net-bridge-bridge-nf-call-ip6tables", "--config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
 	g.Expect(r.Cmds[1]).To(BeComparableTo(expected1))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Looks like `br-netfilter` is not loaded anymore in CI.

This ignores the preflight check which also got dropped in v1.30.

xref [Slack](https://kubernetes.slack.com/archives/C8TSNPY4T/p1721839442841439)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Area example:
/area provider/infrastructure-docker