### PR TITLE
🌱 Enable kubeadm ControlPlaneKubeletLocalMode feature gate in e2e tests

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -480,6 +480,20 @@ spec:
             path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/v"
             valueFrom:
               variable: kubeletLogLevel
+  - name: kubeadmFeatureGate
+    description: "Sets the ControlPlaneKubeletLocalMode feature gate for Kubernetes >= 1.31"
+    definitions:
+      - selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/featureGates"
+            value:
+              ControlPlaneKubeletLocalMode: true
+    enabledIf: '{{ semverCompare ">= v1.31.0-0" .builtin.controlPlane.version }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR is a test to figure out if setting the feature flag would solve an issue that we found in CI. We will eventually revert this PR but for now we want to now if the feature gate would fix this issue.

The issue:
* Since we bumped our tests to Kubernetes 1.31 the "When testing Cluster API working on self-hosted clusters using ClusterClass with a HA control plane" test has been failing pretty frequently 
* The root cause is that in some case a 1.31 kubelet tries to list services from a 1.30 apiserver
* This fails because the 1.30 apiserver does not support field selectors for spec.clusterIP: https://github.com/kubernetes/kubernetes/pull/123905
* The problem is that kubeadm join configures the kubelet to use the apiserver loadbalancer instead of the local apiserver.
* With the feature gate enabled kubeadm should use the local apiserver endpoint instead

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->