### PR TITLE
🌱 Allow ClusterCacheTracker to set CacheByObject

### DIFF
--- a/controllers/remote/cluster_cache_tracker.go
+++ b/controllers/remote/cluster_cache_tracker.go
@@ -69,6 +69,8 @@ var ErrClusterLocked = errors.New("cluster is locked already")
 type ClusterCacheTracker struct {
 	log logr.Logger
 
+	cacheByObject map[client.Object]cache.ByObject
+
 	clientUncachedObjects []client.Object
 	clientQPS             float32
 	clientBurst           int
@@ -114,6 +116,9 @@ type ClusterCacheTrackerOptions struct {
 	// Log is the logger used throughout the lifecycle of caches.
 	// Defaults to a no-op logger if it's not set.
 	Log *logr.Logger
+
+	// CacheByObject restricts the cache's ListWatch to the desired fields per GVK at the specified object.
+	CacheByObject map[client.Object]cache.ByObject
 
 	// ClientUncachedObjects instructs the Client to never cache the following objects,
 	// it'll instead query the API server directly.
@@ -191,6 +196,7 @@ func NewClusterCacheTracker(manager ctrl.Manager, options ClusterCacheTrackerOpt
 		controllerPodMetadata: controllerPodMetadata,
 		log:                   *options.Log,
 		clientUncachedObjects: options.ClientUncachedObjects,
+		cacheByObject:         options.CacheByObject,
 		clientQPS:             options.ClientQPS,
 		clientBurst:           options.ClientBurst,
 		client:                manager.GetClient(),
@@ -485,6 +491,7 @@ func (t *ClusterCacheTracker) createCachedClient(ctx context.Context, config *re
 		HTTPClient: httpClient,
 		Scheme:     t.scheme,
 		Mapper:     mapper,
+		ByObject:   t.cacheByObject,
 	}
 	remoteCache, err := cache.New(config, cacheOptions)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Allows the tracker to specify which objects should be cached, and how.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->