### PR TITLE
:bug: Handle a nil mutator by returning an error, not panicking

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -1329,7 +1329,13 @@ func applyMutators(object client.Object, mutators ...ResourceMutatorFunc) (*unst
 	}
 	u.SetUnstructuredContent(to)
 	for _, mutator := range mutators {
-		if err := mutator(u); err != nil {
+		var err error
+		if mutator != nil {
+			err = mutator(u)
+		} else {
+			err = fmt.Errorf("mutator is nil")
+		}
+		if err != nil {
 			return nil, errors.Wrapf(err, "error applying resource mutator to %q %s/%s",
 				u.GroupVersionKind(), object.GetNamespace(), object.GetName())
 		}

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -1333,7 +1333,7 @@ func applyMutators(object client.Object, mutators ...ResourceMutatorFunc) (*unst
 		if mutator != nil {
 			err = mutator(u)
 		} else {
-			err = fmt.Errorf("mutator is nil")
+			err = errors.New("mutator is nil")
 		}
 		if err != nil {
 			return nil, errors.Wrapf(err, "error applying resource mutator to %q %s/%s",

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -1203,7 +1203,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 				dryRun:    true,
 			}
 
-			err := mover.move(ctx, graph, toProxy, nil)
+			err := mover.move(ctx, graph, toProxy)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -2434,7 +2434,7 @@ func Test_applyMutators(t *testing.T) {
 			}(),
 		},
 		{
-			name:     "return error if any element in mutators slice is nil ",
+			name:     "return error if any element in mutators slice is nil",
 			mutators: []ResourceMutatorFunc{nil},
 			object:   test.NewFakeCluster("example", "example").Objs()[0],
 			wantErr:  true,

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1876,7 +1877,6 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			expectedNamespaces: []string{"namespace-1", "namespace-2"},
 		},
 		{
-
 			name: "ensureNamespaces moves namespace-2 to target which already has namespace-1",
 			fields: fields{
 				objs: cluster2.Objs(),
@@ -2400,6 +2400,51 @@ func TestWaitReadyForMove(t *testing.T) {
 				}
 			}
 			err := waitReadyForMove(ctx, graph.proxy, graph.getMoveNodes(), false, backoff)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func Test_applyMutators(t *testing.T) {
+	tests := []struct {
+		name     string
+		object   client.Object
+		mutators []ResourceMutatorFunc
+		want     *unstructured.Unstructured
+		wantErr  bool
+	}{
+		{
+			name: "do nothing if object is nil",
+		},
+		{
+			name:   "do nothing if mutators is a nil slice",
+			object: test.NewFakeCluster("example", "example").Objs()[0],
+			want: func() *unstructured.Unstructured {
+				g := NewWithT(t)
+				obj := test.NewFakeCluster("example", "example").Objs()[0]
+				u := &unstructured.Unstructured{}
+				to, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+				g.Expect(err).NotTo(HaveOccurred())
+				u.SetUnstructuredContent(to)
+				return u
+			}(),
+		},
+		{
+			name:     "return error if any element in mutators slice is nil ",
+			mutators: []ResourceMutatorFunc{nil},
+			object:   test.NewFakeCluster("example", "example").Objs()[0],
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, err := applyMutators(tt.object, tt.mutators...)
+			g.Expect(got).To(Equal(tt.want))
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I discovered that the `applyMutators` function panics if one of the mutators is nil. I updated the function to return an error on any nil mutator.

The first commit adds unit tests, one of which confirms that `applyMutators` panics if a the mutators slice contains a nil mutator.

The second commit fixes the issue.

The third commit fixes a test that passes a nil mutator. The call is incorrect, but the test has never failed, because it enables dry-run, and that does not exercise the mutators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/kind bug
/area clusterctl