### PR TITLE
:bug: test/framework isDockerCluster should check that infra ref is present

### DIFF
--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -478,7 +478,7 @@ func (p *clusterProxy) isDockerCluster(ctx context.Context, namespace string, na
 		return cl.Get(ctx, key, cluster)
 	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to get %s", key)
 
-	return cluster.Spec.InfrastructureRef.Kind == "DockerCluster"
+	return cluster.Spec.InfrastructureRef != nil && cluster.Spec.InfrastructureRef.Kind == "DockerCluster"
 }
 
 func (p *clusterProxy) fixConfig(ctx context.Context, name string, config *api.Config) {


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

```
 sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).isDockerCluster(0x1400079a100?, {0x10232c318, 0x140007a8960}, {0x14000a28618, 0x17}, {0x14000764170, 0xc})
        /Users/vincepri/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.8.0-rc.0/framework/cluster_proxy.go:481 +0x200
    sigs.k8s.io/cluster-api/test/framework.(*clusterProxy).GetWorkloadCluster(0x14000399ea0, {0x10232c318, 0x140007a8960}, {0x14000a28618, 0x17}, {0x14000764170, 0xc}, {0x0, 0x0, 0x0})
        /Users/vincepri/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.8.0-rc.0/framework/cluster_proxy.go:358 +0x20c
    sigs.k8s.io/cluster-api/test/framework.DumpAllResourcesAndLogs({0x10232c318, 0x140007a8960}, {0x10233ce58, 0x14000399ea0}, {0x14000567540, 0x5a}, 0x140007a6160, 0x14000a3a820)
        /Users/vincepri/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.8.0-rc.0/framework/spec_helpers.go:77 +0x3a0
    sigs.k8s.io/cluster-api/test/framework.DumpSpecResourcesAndCleanup({0x10232c318, 0x140007a8960}, {0x101928048, 0xb}, {0x10233ce58, 0x14000399ea0}, {0x14000567540?, 0x10364f0e0?}, 0x140007a6160, 0x14000595c70, ...)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->