### PR TITLE
🐛 Drop caBundle from CRDs to support Kubernetes 1.31

### DIFF
--- a/bootstrap/kubeadm/config/crd/patches/webhook_in_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/patches/webhook_in_kubeadmconfigs.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: capi-kubeadm-bootstrap-webhook-service

--- a/bootstrap/kubeadm/config/crd/patches/webhook_in_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/patches/webhook_in_kubeadmconfigtemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_clusterclasses.yaml
+++ b/config/crd/patches/webhook_in_clusterclasses.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_clusterresourcesetbindings.yaml
+++ b/config/crd/patches/webhook_in_clusterresourcesetbindings.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_clusterresourcesets.yaml
+++ b/config/crd/patches/webhook_in_clusterresourcesets.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_clusters.yaml
+++ b/config/crd/patches/webhook_in_clusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_machinedeployments.yaml
+++ b/config/crd/patches/webhook_in_machinedeployments.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_machinehealthchecks.yaml
+++ b/config/crd/patches/webhook_in_machinehealthchecks.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_machinepools.yaml
+++ b/config/crd/patches/webhook_in_machinepools.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_machines.yaml
+++ b/config/crd/patches/webhook_in_machines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_machinesets.yaml
+++ b/config/crd/patches/webhook_in_machinesets.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/controlplane/kubeadm/config/crd/patches/webhook_in_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/patches/webhook_in_kubeadmcontrolplanes.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/controlplane/kubeadm/config/crd/patches/webhook_in_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/patches/webhook_in_kubeadmcontrolplanetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
+++ b/docs/book/src/developer/providers/migrations/v1.7-to-v1.8.md
@@ -30,3 +30,6 @@ maintainers of providers and consumers of our Go API.
 - `remote.NewClusterCacheTracker` now has options to configure QPS & Burst. It's highly recommended to implement corresponding flags
   the same way as core Cluster API (see PR: https://github.com/kubernetes-sigs/cluster-api/pull/10880).
 - There were changes made to flags in core CAPI (https://github.com/kubernetes-sigs/cluster-api/pull/10883, https://github.com/kubernetes-sigs/cluster-api/pull/10880). It's recommended to adopt these changes in providers as well. 
+- To support Kubernetes 1.31, providers should stop setting caBundle to invalid values in there CRDs (see core CAPI PR: https://github.com/kubernetes-sigs/cluster-api/pull/10972)
+  Setting caBundle to `Cg==` is a pattern that is widely spread across the ecosystem but it will stop working with Kubernetes 1.31.
+  Please see the following Slack thread for details: https://kubernetes.slack.com/archives/C0EG7JC6T/p1722441161968339

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockerclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockerclustertemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinepools.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinepooltemplates.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinepooltemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/patches/webhook_in_dockermachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemoryclusters.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemoryclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemoryclustertemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemoryclustertemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemorymachines.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemorymachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemorymachinetemplates.yaml
+++ b/test/infrastructure/inmemory/config/crd/patches/webhook_in_inmemorymachinetemplates.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Starting with Kubernetes 1.31 it won't be possible anymore to continuously apply CRDs that are setting caBundle to an invalid value (in our case `Cg==`). The solution is to simply drop the caBundle field (it was never actually required by kube-apiserver).

For more details see: https://kubernetes.slack.com/archives/C0EG7JC6T/p1722441161968339

Let me know if you have any questions. 

Going to backport this into all supported releases. It's never great to set the caBundle to an invalid value, even before Kubernetes 1.31


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->