### PR TITLE
🐛 bootstrap: fix useExperimentalRetryJoin for kubernetes v1.31

### DIFF
--- a/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
+++ b/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
@@ -19,6 +19,7 @@ package cloudinit
 import (
 	"testing"
 
+	"github.com/blang/semver/v4"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 
@@ -276,5 +277,41 @@ func TestNewJoinControlPlaneExperimentalRetry(t *testing.T) {
 	}
 	for _, f := range expectedFiles {
 		g.Expect(out).To(ContainSubstring(f))
+	}
+}
+
+func Test_useKubeadmBootstrapScriptPre1_31(t *testing.T) {
+	tests := []struct {
+		name          string
+		parsedversion semver.Version
+		want          bool
+	}{
+		{
+			name:          "true for version for v1.30",
+			parsedversion: semver.MustParse("1.30.99"),
+			want:          true,
+		},
+		{
+			name:          "true for version for v1.28",
+			parsedversion: semver.MustParse("1.28.0"),
+			want:          true,
+		},
+		{
+			name:          "false for v1.31.0",
+			parsedversion: semver.MustParse("1.31.0"),
+			want:          false,
+		},
+		{
+			name:          "false for v1.31.0-beta.0",
+			parsedversion: semver.MustParse("1.31.0-beta.0"),
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := useKubeadmBootstrapScriptPre1_31(tt.parsedversion); got != tt.want {
+				t.Errorf("useKubeadmBootstrapScriptPre1_31() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/bootstrap/kubeadm/internal/cloudinit/kubeadm-bootstrap-script-pre-k8s-1-31.sh
+++ b/bootstrap/kubeadm/internal/cloudinit/kubeadm-bootstrap-script-pre-k8s-1-31.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -128,8 +128,10 @@ retry-command kubeadm join phase control-plane-prepare kubeconfig
 retry-command kubeadm join phase control-plane-prepare control-plane
 # {{ end }}
 retry-command kubeadm join phase kubelet-start
-
-# Run kubeadm join and skip all already executed phases.
-try-or-die-command kubeadm join --skip-phases preflight,control-plane-prepare,kubelet-start
+# {{ if .ControlPlane }}
+try-or-die-command kubeadm join phase control-plane-join etcd
+retry-command kubeadm join phase control-plane-join update-status
+retry-command kubeadm join phase control-plane-join mark-control-plane
+# {{ end }}
 
 log::success_exit

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -535,6 +535,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 			Mounts:              scope.Config.Spec.Mounts,
 			DiskSetup:           scope.Config.Spec.DiskSetup,
 			KubeadmVerbosity:    verbosityFlag,
+			KubernetesVersion:   parsedVersion,
 		},
 		InitConfiguration:    initdata,
 		ClusterConfiguration: clusterdata,
@@ -656,6 +657,7 @@ func (r *KubeadmConfigReconciler) joinWorker(ctx context.Context, scope *Scope) 
 			DiskSetup:            scope.Config.Spec.DiskSetup,
 			KubeadmVerbosity:     verbosityFlag,
 			UseExperimentalRetry: scope.Config.Spec.UseExperimentalRetryJoin,
+			KubernetesVersion:    parsedVersion,
 		},
 		JoinConfiguration: joinData,
 	}
@@ -774,6 +776,7 @@ func (r *KubeadmConfigReconciler) joinControlplane(ctx context.Context, scope *S
 			DiskSetup:            scope.Config.Spec.DiskSetup,
 			KubeadmVerbosity:     verbosityFlag,
 			UseExperimentalRetry: scope.Config.Spec.UseExperimentalRetryJoin,
+			KubernetesVersion:    parsedVersion,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This adds a new script for useExperimentalRetryJoin for kubernetes >= v1.31 due to the following changes:
* control-plane update-status phase got removed
* new phases got added for the ControlPlaneKubeletLocalMode feature gate

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
