### PR TITLE
🐛 Ensure DockerMachinePool providerIDList is deterministic

### DIFF
--- a/test/framework/resourceversion_helpers.go
+++ b/test/framework/resourceversion_helpers.go
@@ -46,7 +46,7 @@ func ValidateResourceVersionStable(ctx context.Context, proxy ClusterProxy, name
 	}, 1*time.Minute, 15*time.Second).Should(Succeed(), "Resource versions never became stable")
 
 	// Verify resource versions are stable for a while.
-	byf("Check Resource versions remains stable")
+	byf("Check Resource versions remain stable")
 	Consistently(func(g Gomega) {
 		objectsWithResourceVersion, err := getObjectsWithResourceVersion(ctx, proxy, namespace, ownerGraphFilterFunction)
 		g.Expect(err).ToNot(HaveOccurred())

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -302,6 +303,8 @@ func (r *DockerMachinePoolReconciler) reconcileNormal(ctx context.Context, clust
 			dockerMachinePool.Spec.ProviderIDList = append(dockerMachinePool.Spec.ProviderIDList, *dockerMachine.Spec.ProviderID)
 		}
 	}
+	// Ensure the providerIDList is deterministic (getDockerMachines doesn't guarantee a specific order)
+	sort.Strings(dockerMachinePool.Spec.ProviderIDList)
 
 	dockerMachinePool.Status.Replicas = int32(len(dockerMachineList.Items))
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Probably doesn't fix the entire issue, but related to #10838

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->