### PR TITLE
🌱 test/framework: scale up should use allocatable memory

### DIFF
--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -158,7 +158,7 @@ func AddScaleUpDeploymentAndWait(ctx context.Context, input AddScaleUpDeployment
 		if _, ok := n.Labels[nodeRoleOldControlPlane]; ok {
 			continue
 		}
-		memory = n.Status.Capacity.Memory() // Assume that all nodes have the same memory.
+		memory = n.Status.Allocatable.Memory() // Assume that all nodes have the same memory.
 		workers++
 	}
 	Expect(memory).ToNot(BeNil(), "failed to get memory for the worker node")


### PR DESCRIPTION
Capacity has the entire memory pool that the node carries, while allocatable is the true memory available for scheduling purposes.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

/area testing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->