### PR TITLE
🌱 Improve reconcile state logs (don't log empty diff)

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -175,9 +175,12 @@ func dryRunSSAPatch(ctx context.Context, dryRunCtx *dryRunSSAPatchInput) (bool, 
 			ShouldFilter: ssa.IsPathIgnored([]contract.Path{[]string{"metadata", "managedFields"}}),
 		})
 
-		changes, err = json.Marshal(diff.Object)
-		if err != nil {
-			return false, false, nil, errors.Wrapf(err, "failed to marshal diff")
+		// changes should be empty (not "{}") if diff.Object is empty
+		if len(diff.Object) != 0 {
+			changes, err = json.Marshal(diff.Object)
+			if err != nil {
+				return false, false, nil, errors.Wrapf(err, "failed to marshal diff")
+			}
 		}
 	}
 

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
@@ -388,7 +388,7 @@ func TestServerSideApply(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(p0.HasChanges()).To(BeTrue())
 		g.Expect(p0.HasSpecChanges()).To(BeFalse())
-		g.Expect(p0.Changes()).To(Equal([]byte(`{}`))) // Note: metadata.managedFields have been removed from the diff to reduce log verbosity.
+		g.Expect(p0.Changes()).To(BeEmpty()) // Note: metadata.managedFields have been removed from the diff to reduce log verbosity.
 
 		// Create the object using server side apply
 		g.Expect(p0.Patch(ctx)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Currently we get a few logs like this in our e2e tests
```
{"ts":1722858941941.0283,"caller":"cluster/reconcile_state.go:317","msg":"Patching DockerMachineTemplate/quick-start-itkrd6-ks4hk, diff: {}","controller":"topology/cluster","controllerGroup":"cluster.x-k8s.io","controllerKind":"Cluster","Cluster":{"name":"quick-start-itkrd6","namespace":"quick-start-k6hnu4"},"namespace":"quick-start-k6hnu4","name":"quick-start-itkrd6","reconcileID":"da094763-efac-489d-9df5-9c518faa3e18","resource":{"group":"infrastructure.cluster.x-k8s.io","version":"v1beta1","resource":"DockerMachineTemplate"},"DockerMachineTemplate":{"name":"quick-start-itkrd6-ks4hk","namespace":"quick-start-k6hnu4"},"v":0}
```

This PR ensures that an empty diff is returned as "" instead of "{}" so our log statements are omitting the diff entirely


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->