### PR TITLE
🌱 Log error when calling a Runtime Extension gets an error that is ignored because of failure policy

### DIFF
--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -346,7 +346,7 @@ func (c *client) CallExtension(ctx context.Context, hook runtimecatalog.Hook, fo
 		ignore := *registration.FailurePolicy == runtimev1.FailurePolicyIgnore
 		if _, ok := err.(errCallingExtensionHandler); ok && ignore {
 			// Update the response to a default success response and return.
-			log.Info(fmt.Sprintf("ignoring error calling extension handler because of FailurePolicy %q", *registration.FailurePolicy))
+			log.Error(err, fmt.Sprintf("ignoring error calling extension handler because of FailurePolicy %q", *registration.FailurePolicy))
 			response.SetStatus(runtimehooksv1.ResponseStatusSuccess)
 			response.SetMessage("")
 			return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* Log an error when Lifecycle Hook Runtime Extension fails while we set `Ignore` as Failure Policy. 
    * I want the error to be on logs even if ignored for investigation.

```
E0808 14:00:07.430045       1 client.go:349] "ignoring error calling extension handler because of FailurePolicy \"Ignore\"" err="http call failed: Post \"https://test-extension-webhook-service.test-extension-system.svc:443/hooks.runtime.cluster.x-k8s.io/v1alpha1/beforeclustercreate/before-cluster-create?timeout=10s\": dial tcp 10.96.93.238:443: connect: connection refused" controller="topology/cluster" controllerGroup="cluster.x-k8s.io" controllerKind="Cluster" Cluster="default/capi-quickstart" namespace="default" name="capi-quickstart" reconcileID="8dc4c6bd-f70b-4179-bc80-0df5afcfbf6c" hook="BeforeClusterCreate" extensionHandler="before-cluster-create.test-runtime-sdk-extensionconfig" hook="BeforeClusterCreate"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

