### PR TITLE
🌱 test: improve autoscale tests for to/from zero and running autoscaler in bootstrap cluster

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -62,6 +62,7 @@ type AutoscalerSpecInput struct {
 	InfrastructureMachineTemplateKind     string
 	InfrastructureMachinePoolTemplateKind string
 	InfrastructureMachinePoolKind         string
+	InfrastructureAPIGroup                string
 	AutoscalerVersion                     string
 
 	// InstallOnManagementCluster steers if the autoscaler should get installed to the management or workload cluster.
@@ -184,6 +185,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 			InfrastructureMachineTemplateKind:     input.InfrastructureMachineTemplateKind,
 			InfrastructureMachinePoolTemplateKind: input.InfrastructureMachinePoolTemplateKind,
 			InfrastructureMachinePoolKind:         input.InfrastructureMachinePoolKind,
+			InfrastructureAPIGroup:                input.InfrastructureAPIGroup,
 			WorkloadYamlPath:                      autoscalerWorkloadYAMLPath,
 			ManagementClusterProxy:                input.BootstrapClusterProxy,
 			WorkloadClusterProxy:                  workloadClusterProxy,

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -260,7 +260,9 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 			By("Scaling the MachineDeployment scale up deployment to zero")
 			framework.ScaleScaleUpDeploymentAndWait(ctx, framework.ScaleScaleUpDeploymentAndWaitInput{
 				ClusterProxy: workloadClusterProxy,
-				Replicas:     mpOriginalReplicas + 0,
+				// We need to sum up the expected number of MachineDeployment replicas and the current
+				// number of MachinePool replicas because otherwise the pods get scheduled on the MachinePool nodes.
+				Replicas: mpOriginalReplicas + 0,
 			}, input.E2EConfig.GetIntervals(specName, "wait-autoscaler")...)
 
 			By("Checking the MachineDeployment finished scaling down to zero")
@@ -274,7 +276,9 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 			By("Scaling the MachineDeployment scale up deployment to 1")
 			framework.ScaleScaleUpDeploymentAndWait(ctx, framework.ScaleScaleUpDeploymentAndWaitInput{
 				ClusterProxy: workloadClusterProxy,
-				Replicas:     mpOriginalReplicas + 1,
+				// We need to sum up the expected number of MachineDeployment replicas and the current
+				// number of MachinePool replicas because otherwise the pods get scheduled on the MachinePool nodes.
+				Replicas: mpOriginalReplicas + 1,
 			}, input.E2EConfig.GetIntervals(specName, "wait-autoscaler")...)
 
 			By("Checking the MachineDeployment finished scaling up")

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -405,19 +405,6 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 					WaitForMachinePool: input.E2EConfig.GetIntervals(specName, "wait-controllers"),
 				})
 			}
-
-			By("Disabling the autoscaler for MachineDeployments to test MachinePools")
-			framework.DisableAutoscalerForMachinePoolTopologyAndWait(ctx, framework.DisableAutoscalerForMachinePoolTopologyAndWaitInput{
-				ClusterProxy:                  input.BootstrapClusterProxy,
-				Cluster:                       clusterResources.Cluster,
-				WaitForAnnotationsToBeDropped: input.E2EConfig.GetIntervals(specName, "wait-controllers"),
-			})
-
-			By("Deleting the MachineDeployment scale up deployment")
-			framework.DeleteScaleUpDeploymentAndWait(ctx, framework.DeleteScaleUpDeploymentAndWaitInput{
-				ClusterProxy:  workloadClusterProxy,
-				WaitForDelete: input.E2EConfig.GetIntervals(specName, "wait-autoscaler"),
-			})
 		}
 
 		By("PASSED!")

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -70,6 +70,10 @@ type AutoscalerSpecInput struct {
 	InstallOnManagementCluster bool
 
 	// ScaleToAndFromZero enables tests to scale to and from zero.
+	// To enable `ScaleToAndFromZero` the following needs to be implemented:
+	// * either provide the relevant annotations on the MachineDeployment or MachinePool
+	// * for MachineDeployments: implement .status.capacity on the InfraMachineTemplate
+	// * for MachinePools: implement .status.capacity on the InfraMachinePool
 	ScaleToAndFromZero bool
 
 	// Allows to inject a function to be run after test namespace is created.

--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -64,9 +64,17 @@ type AutoscalerSpecInput struct {
 	InfrastructureMachinePoolKind         string
 	AutoscalerVersion                     string
 
+	// InstallOnManagementCluster steers if the autoscaler should get installed to the management or workload cluster.
+	// Depending on the CI environments, there may be no connectivity from the workload to the management cluster.
+	InstallOnManagementCluster bool
+
 	// Allows to inject a function to be run after test namespace is created.
 	// If not specified, this is a no-op.
 	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+
+	// Allows to inject a function to be run after autoscaling test finished.
+	// If not specified this is a no-op.
+	PostAutoscalingTest func(managementClusterProxy framework.ClusterProxy, namespace, clusterName string)
 }
 
 // AutoscalerSpec implements a test for the autoscaler, and more specifically for the autoscaler
@@ -173,6 +181,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 			WorkloadClusterProxy:                  workloadClusterProxy,
 			Cluster:                               clusterResources.Cluster,
 			AutoscalerVersion:                     input.AutoscalerVersion,
+			AutoscalerOnManagementCluster:         input.InstallOnManagementCluster,
 		}, input.E2EConfig.GetIntervals(specName, "wait-controllers")...)
 
 		By("Creating workload that forces the system to scale up")

--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -268,7 +268,7 @@ type ScaleScaleUpDeploymentAndWaitInput struct {
 	Replicas     int32
 }
 
-// ScaleScaleUpDeploymentAndWait deletes the scale up deployment and waits for it to be deleted.
+// ScaleScaleUpDeploymentAndWait scales the scale up deployment to a given value and waits for it to be deleted.
 func ScaleScaleUpDeploymentAndWait(ctx context.Context, input ScaleScaleUpDeploymentAndWaitInput, intervals ...interface{}) {
 	By("Retrieving the scale up deployment")
 	deployment := &appsv1.Deployment{}

--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -268,7 +268,7 @@ type ScaleScaleUpDeploymentAndWaitInput struct {
 	Replicas     int32
 }
 
-// ScaleScaleUpDeploymentAndWait scales the scale up deployment to a given value and waits for it to be deleted.
+// ScaleScaleUpDeploymentAndWait scales the scale up deployment to a given value and waits for it to become ready.
 func ScaleScaleUpDeploymentAndWait(ctx context.Context, input ScaleScaleUpDeploymentAndWaitInput, intervals ...interface{}) {
 	By("Retrieving the scale up deployment")
 	deployment := &appsv1.Deployment{}

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -528,7 +528,7 @@ func DeployUnevictablePod(ctx context.Context, input DeployUnevictablePodInput) 
 					Containers: []corev1.Container{
 						{
 							Name:  "web",
-							Image: "registry.k8s.io/pause:latest",
+							Image: "registry.k8s.io/pause:3.10",
 						},
 					},
 				},

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -648,5 +648,6 @@ func AssertMachineDeploymentReplicas(ctx context.Context, input AssertMachineDep
 		g.Expect(input.Getter.Get(ctx, key, md)).To(Succeed(), fmt.Sprintf("failed to get MachineDeployment %s", klog.KObj(input.MachineDeployment)))
 		g.Expect(md.Spec.Replicas).Should(Not(BeNil()), fmt.Sprintf("MachineDeployment %s replicas should not be nil", klog.KObj(md)))
 		g.Expect(*md.Spec.Replicas).Should(Equal(input.Replicas), fmt.Sprintf("MachineDeployment %s replicas should match expected replicas", klog.KObj(md)))
+		g.Expect(md.Status.Replicas).Should(Equal(input.Replicas), fmt.Sprintf("MachineDeployment %s status.replicas should match expected replicas", klog.KObj(md)))
 	}, input.WaitForMachineDeployment...).Should(Succeed())
 }

--- a/test/framework/machinepool_helpers.go
+++ b/test/framework/machinepool_helpers.go
@@ -365,5 +365,6 @@ func AssertMachinePoolReplicas(ctx context.Context, input AssertMachinePoolRepli
 		g.Expect(input.Getter.Get(ctx, key, mp)).To(Succeed(), fmt.Sprintf("failed to get MachinePool %s", klog.KObj(input.MachinePool)))
 		g.Expect(mp.Spec.Replicas).Should(Not(BeNil()), fmt.Sprintf("MachinePool %s replicas should not be nil", klog.KObj(mp)))
 		g.Expect(*mp.Spec.Replicas).Should(Equal(input.Replicas), fmt.Sprintf("MachinePool %s replicas should match expected replicas", klog.KObj(mp)))
+		g.Expect(mp.Status.Replicas).Should(Equal(input.Replicas), fmt.Sprintf("MachinePool %s status.replicas should match expected replicas", klog.KObj(mp)))
 	}, input.WaitForMachinePool...).Should(Succeed())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adjusts autoscale tests to:

* Allow running cluster-autoscaler inside the management cluster
  * Note: for providers there may be no connectivity from the workload to the management cluster running in kind
* make machinepool's optional for the test:
  * Note: not all providers support machinepools (e.g. CAPV)
* add option for scale to/from zero tests

/area e2e-testing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->