### PR TITLE
✨ Collect additional logs with CAPD log collector

### DIFF
--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -35,7 +35,16 @@ import (
 )
 
 // DockerLogCollector collect logs from a CAPD workload cluster.
-type DockerLogCollector struct{}
+type DockerLogCollector struct {
+	AdditionalLogs []AdditionalLogs
+}
+
+// AdditionalLogs is a struct to hold instruction for additional logs that need to be collected.
+type AdditionalLogs struct {
+	OutputFileName string
+	Command        string
+	Args           []string
+}
 
 // machineContainerName return a container name using the same rule used in CAPD.
 // NOTE: if the cluster name is already included in the machine name, the cluster name is not add thus
@@ -149,7 +158,8 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 			return osExec.Command("tar", "--extract", "--file", tempfileName, "--directory", outputDir).Run() //nolint:gosec // We don't care about command injection here.
 		}
 	}
-	return errors.AggregateConcurrent([]func() error{
+
+	collectFuncs := []func() error{
 		execToPathFn(
 			"journal.log",
 			"journalctl", "--no-pager", "--output=short-precise",
@@ -175,7 +185,13 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 			"journalctl", "--no-pager", "--output=short-precise", "-u", "containerd.service",
 		),
 		copyDirFn("/var/log/pods", "pods"),
-	})
+	}
+
+	for _, additionalLogs := range k.AdditionalLogs {
+		collectFuncs = append(collectFuncs, execToPathFn(additionalLogs.OutputFileName, additionalLogs.Command, additionalLogs.Args...))
+	}
+
+	return errors.AggregateConcurrent(collectFuncs)
 }
 
 // fileOnHost is a helper to create a file at path


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I want to be able to collect more system logs from CAPD clusters than currently offered. This PR introduces a change to the DockerLogCollector structure that allows specifing additional systems logs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area testing