### PR TITLE
🐛 always declare try-or-die-command function in kubeadm-bootstrap-script.sh

### DIFF
--- a/bootstrap/kubeadm/internal/cloudinit/kubeadm-bootstrap-script.sh
+++ b/bootstrap/kubeadm/internal/cloudinit/kubeadm-bootstrap-script.sh
@@ -106,7 +106,6 @@ function retry-command() {
   fi
 }
 
-# {{ if .ControlPlane }}
 function try-or-die-command() {
   local kubeadm_return
   log::info "running '$*'"
@@ -118,7 +117,6 @@ function try-or-die-command() {
     log::error_exit "fatal error, exiting" "${kubeadm_return}"
   fi
 }
-# {{ end }}
 
 retry-command kubeadm join phase preflight --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests
 # {{ if .ControlPlane }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

When I tried to join a worker node to a 1.31 cluster, I encountered the following error during cloud-init:

```
[2024-08-22 23:34:18] /usr/local/bin/kubeadm-bootstrap-script: line 111: try-or-die-command: command not found
```

It appears that before 1.31, we only use `try-or-die-command` when joining a control plane - https://github.com/kubernetes-sigs/cluster-api/blob/main/bootstrap/kubeadm/internal/cloudinit/kubeadm-bootstrap-script-pre-k8s-1-31.sh#L131-L132. However, for >= 1.31, we use `try-or-die-command` for kubeadm join regardless of the node role. This PR removes the if condition around the function so that it's available when joining both control plane and worker nodes.


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

