### PR TITLE
🌱 Add nilIsZero to all KSM metric configs where needed

### DIFF
--- a/config/metrics/crd-metrics-config.yaml
+++ b/config/metrics/crd-metrics-config.yaml
@@ -64,6 +64,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a clusterclass.
@@ -79,6 +80,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -175,6 +177,7 @@ spec:
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet
     - name: created
       help: Unix creation timestamp.
@@ -212,6 +215,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a cluster.
@@ -227,6 +231,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
   - groupVersionKind:
       group: controlplane.cluster.x-k8s.io
@@ -348,6 +353,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a kubeadmcontrolplane.
@@ -363,6 +369,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -447,6 +454,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a kubeadmconfig.
@@ -462,6 +470,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -609,6 +618,7 @@ spec:
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet
     - name: created
       help: Unix creation timestamp.
@@ -646,6 +656,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a machine.
@@ -661,6 +672,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -868,6 +880,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a machinedeployment.
@@ -883,6 +896,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -937,6 +951,7 @@ spec:
           path:
           - status
           - currentHealthy
+          nilIsZero: true
         type: Gauge
     - name: status_expected_machines
       help: Total number of pods counted by this machinehealthcheck.
@@ -945,6 +960,7 @@ spec:
           path:
           - status
           - expectedMachines
+          nilIsZero: true
         type: Gauge
     - name: status_remediations_allowed
       help: Number of machine remediations that are currently allowed.
@@ -953,6 +969,7 @@ spec:
           path:
           - status
           - remediationsAllowed
+          nilIsZero: true
         type: Gauge
     - name: created
       help: Unix creation timestamp.
@@ -990,6 +1007,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a machinehealthcheck.
@@ -1005,6 +1023,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -1104,6 +1123,7 @@ spec:
           path:
           - status
           - fullyLabeledReplicas
+          nilIsZero: true
         type: Gauge
     - name: status_replicas_ready
       help: The number of ready replicas per machineset.
@@ -1159,6 +1179,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a machineset.
@@ -1174,6 +1195,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.
@@ -1310,6 +1332,7 @@ spec:
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet
     - name: created
       help: Unix creation timestamp.
@@ -1347,6 +1370,7 @@ spec:
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a machinepool.
@@ -1362,6 +1386,7 @@ spec:
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge
     - name: owner
       help: Owner references.

--- a/config/metrics/templates/cluster.yaml
+++ b/config/metrics/templates/cluster.yaml
@@ -76,4 +76,5 @@
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet

--- a/config/metrics/templates/common_metrics.yaml
+++ b/config/metrics/templates/common_metrics.yaml
@@ -34,6 +34,7 @@
           - conditions
           valueFrom:
           - status
+          nilIsZero: true
         type: StateSet
     - name: status_condition_last_transition_time
       help: The condition last transition time of a ${RESOURCE}.
@@ -49,4 +50,5 @@
           - conditions
           valueFrom:
           - lastTransitionTime
+          nilIsZero: true
         type: Gauge

--- a/config/metrics/templates/machine.yaml
+++ b/config/metrics/templates/machine.yaml
@@ -127,4 +127,5 @@
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet

--- a/config/metrics/templates/machinehealthcheck.yaml
+++ b/config/metrics/templates/machinehealthcheck.yaml
@@ -34,6 +34,7 @@
           path:
           - status
           - currentHealthy
+          nilIsZero: true
         type: Gauge
     - name: status_expected_machines
       help: Total number of pods counted by this machinehealthcheck.
@@ -42,6 +43,7 @@
           path:
           - status
           - expectedMachines
+          nilIsZero: true
         type: Gauge
     - name: status_remediations_allowed
       help: Number of machine remediations that are currently allowed.
@@ -50,4 +52,5 @@
           path:
           - status
           - remediationsAllowed
+          nilIsZero: true
         type: Gauge

--- a/config/metrics/templates/machinepool.yaml
+++ b/config/metrics/templates/machinepool.yaml
@@ -116,4 +116,5 @@
           path:
           - status
           - phase
+          nilIsZero: true
         type: StateSet

--- a/config/metrics/templates/machineset.yaml
+++ b/config/metrics/templates/machineset.yaml
@@ -79,6 +79,7 @@
           path:
           - status
           - fullyLabeledReplicas
+          nilIsZero: true
         type: Gauge
     - name: status_replicas_ready
       help: The number of ready replicas per machineset.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `nilIsZero: true` to the status conditions `StateSets` and to other status fields.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/cc @chrischdi 