### PR TITLE
📖  Fix CAPZ redirection links in quick-start page

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1538,7 +1538,7 @@ Install the official cloud-provider-azure Helm chart on the workload cluster:
 helm install --kubeconfig=./capi-quickstart.kubeconfig --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=capi-quickstart --set cloudControllerManager.clusterCIDR="192.168.0.0/16"
 ```
 
-For more information, see the [CAPZ book](https://capz.sigs.k8s.io/topics/addons.html).
+For more information, see the [CAPZ book](https://capz.sigs.k8s.io/self-managed/addons).
 
 {{#/tab }}
 {{#tab OpenStack}}
@@ -1778,7 +1778,7 @@ kind delete cluster
 [Akamai (Linode) provider]: https://linode.github.io/cluster-api-provider-linode/introduction.html
 [AWS provider prerequisites]: https://cluster-api-aws.sigs.k8s.io/topics/using-clusterawsadm-to-fulfill-prerequisites.html
 [AWS provider releases]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases
-[Azure Provider Prerequisites]: https://capz.sigs.k8s.io/topics/getting-started.html#prerequisites
+[Azure Provider Prerequisites]: https://capz.sigs.k8s.io/getting-started.html#prerequisites
 [bootstrap cluster]: ../reference/glossary.md#bootstrap-cluster
 [capa]: https://cluster-api-aws.sigs.k8s.io
 [capv-upload-images]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/docs/getting_started.md#uploading-the-machine-images

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1538,7 +1538,7 @@ Install the official cloud-provider-azure Helm chart on the workload cluster:
 helm install --kubeconfig=./capi-quickstart.kubeconfig --repo https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo cloud-provider-azure --generate-name --set infra.clusterName=capi-quickstart --set cloudControllerManager.clusterCIDR="192.168.0.0/16"
 ```
 
-For more information, see the [CAPZ book](https://capz.sigs.k8s.io/self-managed/addons).
+For more information, see the [CAPZ book](https://capz.sigs.k8s.io/self-managed/addons.html).
 
 {{#/tab }}
 {{#tab OpenStack}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the broken links that redirect pages in the CAPZ book.



/label documentation
