### PR TITLE
🌱 Improve TestReconcileMachinePoolMachines unit test

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -1322,20 +1322,20 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		cluster := builder.Cluster(ns.Name, clusterName).Build()
-		g.Expect(env.Create(ctx, cluster)).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, cluster)).To(Succeed())
 
 		t.Run("Should do nothing if machines already exist", func(*testing.T) {
 			machinePool := getMachinePool(2, "machinepool-test-1", clusterName, ns.Name)
-			g.Expect(env.Create(ctx, &machinePool)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, &machinePool)).To(Succeed())
 
 			infraMachines := getInfraMachines(2, machinePool.Name, clusterName, ns.Name)
 			for i := range infraMachines {
-				g.Expect(env.Create(ctx, &infraMachines[i])).To(Succeed())
+				g.Expect(env.CreateAndWait(ctx, &infraMachines[i])).To(Succeed())
 			}
 
 			machines := getMachines(2, machinePool.Name, clusterName, ns.Name)
 			for i := range machines {
-				g.Expect(env.Create(ctx, &machines[i])).To(Succeed())
+				g.Expect(env.CreateAndWait(ctx, &machines[i])).To(Succeed())
 			}
 
 			infraConfig := map[string]interface{}{
@@ -1365,7 +1365,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 					"infrastructureMachineKind": builder.GenericInfrastructureMachineKind,
 				},
 			}
-			g.Expect(env.Create(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
 			r := &MachinePoolReconciler{
 				Client:   env,
@@ -1394,11 +1394,11 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 
 		t.Run("Should create two machines if two infra machines exist", func(*testing.T) {
 			machinePool := getMachinePool(2, "machinepool-test-2", clusterName, ns.Name)
-			g.Expect(env.Create(ctx, &machinePool)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, &machinePool)).To(Succeed())
 
 			infraMachines := getInfraMachines(2, machinePool.Name, clusterName, ns.Name)
 			for i := range infraMachines {
-				g.Expect(env.Create(ctx, &infraMachines[i])).To(Succeed())
+				g.Expect(env.CreateAndWait(ctx, &infraMachines[i])).To(Succeed())
 			}
 
 			infraConfig := map[string]interface{}{
@@ -1428,7 +1428,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 					"infrastructureMachineKind": builder.GenericInfrastructureMachineKind,
 				},
 			}
-			g.Expect(env.Create(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
 			r := &MachinePoolReconciler{
 				Client:   env,
@@ -1487,7 +1487,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 					},
 				},
 			}
-			g.Expect(env.Create(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
 			r := &MachinePoolReconciler{
 				Client:   env,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

we can see in the failing test results (i.e. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-test-mink8s-main/1830171842158006272) that this line https://github.com/kubernetes-sigs/cluster-api/blob/703cc70e450f334d9e391294180898f234b08415/exp/internal/controllers/machinepool_controller_phases.go#L437 is only logging once, whereas in the successful tests ([example](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-test-main/1830262439854215168)) , it logs twice as 2 `infraMachine`s are recognized and the 2 machinepool machines are created accordingly

my theory is that a cache sync delay is causing this flake as only 1 of the expected `infraMachine`s is found in the cache when `reconcileMachines` gets called

this pr updates the method called to Create objects in this set of unit test to the "preferred" method:
- [CreateAndWait](https://pkg.go.dev/sigs.k8s.io/cluster-api/internal/test/envtest#Environment.CreateAndWait): 
> "CreateAndWait creates the given object and waits for the cache to be updated accordingly."  

instead of `Create()`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11070 
(hopefully)

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machinepool