### PR TITLE
🌱 [WIP] Use websockets with fallback to SPDY

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/proxy/dial.go
+++ b/test/infrastructure/inmemory/pkg/server/proxy/dial.go
@@ -26,7 +26,9 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )
@@ -39,6 +41,7 @@ type Dialer struct {
 	clientset      *kubernetes.Clientset
 	proxyTransport http.RoundTripper
 	upgrader       spdy.Upgrader
+	restConfig     *rest.Config
 	timeout        time.Duration
 }
 
@@ -74,6 +77,7 @@ func NewDialer(p Proxy, options ...func(*Dialer) error) (*Dialer, error) {
 	dialer.proxyTransport = proxyTransport
 	dialer.upgrader = upgrader
 	dialer.clientset = clientset
+	dialer.restConfig = p.KubeConfig
 	return dialer, nil
 }
 
@@ -92,7 +96,17 @@ func (d *Dialer) DialContext(_ context.Context, _ string, addr string) (net.Conn
 		Name(addr).
 		SubResource("portforward")
 
-	dialer := spdy.NewDialer(d.upgrader, &http.Client{Transport: d.proxyTransport}, "POST", req.URL())
+	spdyDialer := spdy.NewDialer(d.upgrader, &http.Client{Transport: d.proxyTransport}, "POST", req.URL())
+
+	websocketDialer, err := portforward.NewSPDYOverWebsocketDialer(req.URL(), d.restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// First attempt tunneling (websocket) dialer, then fallback to spdy dialer.
+	dialer := portforward.NewFallbackDialer(websocketDialer, spdyDialer, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
 
 	// Create a new connection from the dialer.
 	//


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In Kubernetes they switched over to using websockets per default instead of SPDY and only fallback to spdy:

- xref: https://github.com/kubernetes/kubernetes/pull/125528

/area provider/control-plane-kubeadm

Note: The inmemory provider currently only supports SPDY on server-side.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->