### PR TITLE
🌱 Remove previously deprecated --metrics-bind-addr flag

### DIFF
--- a/docs/book/src/reference/ports.md
+++ b/docs/book/src/reference/ports.md
@@ -2,7 +2,7 @@
 
 Name      | Port Number | Description |
 ---       | ---         | ---
-`metrics` |             | Port that exposes the metrics. This can be customized by setting the `--metrics-bind-addr` flag when starting the manager. The default is to only listen on `localhost:8080`
+`diagnostics-address` |             | Port that exposes the metrics, the pprof endpoint and an endpoint to change the log level. This can be customized by setting the `--diagnostics-address` flag when starting the manager. The default port is  `8443`.
 `webhook` | `9443`      | Webhook server port. To disable this set `--webhook-port` flag to `0`.
 `health`  | `9440`      | Port that exposes the health endpoint. CThis can be customized by setting the `--health-addr` flag when starting the manager.
 `profiler`|             | Expose the pprof profiler. By default is not configured. Can set the `--profiler-address` flag. e.g. `--profiler-address 6060`

--- a/util/flags/manager_test.go
+++ b/util/flags/manager_test.go
@@ -53,22 +53,6 @@ func TestGetManagerOptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid tls + metrics bind addr",
-			managerOptions: ManagerOptions{
-				TLSMinVersion:   "VersionTLS13",
-				TLSCipherSuites: []string{"TLS_AES_256_GCM_SHA384"},
-				MetricsBindAddr: ":8080",
-			},
-			wantTLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS13,
-				CipherSuites: []uint16{tls.TLS_AES_256_GCM_SHA384},
-			},
-			wantMetricsOptions: &metricsserver.Options{
-				BindAddress: ":8080",
-			},
-			wantErr: false,
-		},
-		{
 			name: "valid tls + insecure diagnostics + diagnostics address",
 			managerOptions: ManagerOptions{
 				TLSMinVersion:       "VersionTLS13",


### PR DESCRIPTION
Removes MetricsBindAddr flag 


**What this PR does / why we need it**:
follows : https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/release-lead#track-remove-previously-deprecated-code

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/11092

/area util
