### PR TITLE
🌱 golangci: add comments to enabled linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,62 +4,55 @@ run:
   build-tags:
     - tools
     - e2e
-  skip-files:
-    - "zz_generated.*\\.go$"
-    - "vendored_openapi\\.go$"
-    # We don't want to invest time to fix new linter findings in old API types.
-    - "internal/apis/.*"
   allow-parallel-runners: true
 
 linters:
   disable-all: true
   enable:
-  - asasalint
-  - asciicheck
-  - bidichk
-  - bodyclose
-  - containedctx
-  - copyloopvar
-  - dogsled
-  - dupword
-  - durationcheck
-  - errcheck
-  - errchkjson
-  - gci
-  - ginkgolinter
-  - goconst
-  - gocritic
-  - godot
-  - gofmt
-  - goimports
-  - goprintffuncname
-  - gosec
-  - gosimple
-  - govet
-  - importas
-  - ineffassign
-  - intrange
-  - loggercheck
-  - misspell
-  - nakedret
-  - nilerr
-  - noctx
-  - nolintlint
-  - nosprintfhostport
-  - prealloc
-  - predeclared
-  - revive
-  - rowserrcheck
-  - staticcheck
-  - stylecheck
-  - tenv
-  - thelper
-  - typecheck
-  - unconvert
-  - unparam
-  - unused
-  - usestdlibvars
-  - whitespace
+    - asasalint # warns about passing []any to func(...any) without expanding it
+    - asciicheck # non ascii symbols
+    - bidichk # dangerous unicode sequences
+    - bodyclose # unclosed http bodies
+    - containedctx # context.Context nested in a struct
+    - copyloopvar # copying loop variables
+    - dogsled # too many blank identifiers in assignments
+    - dupword # duplicate words
+    - durationcheck # multiplying two durations
+    - errcheck # unchecked errors
+    - errchkjson # invalid types passed to json encoder
+    - gci # ensures imports are organized
+    - ginkgolinter # ginkgo and gomega
+    - goconst # strings that can be replaced by constants
+    - gocritic # bugs, performance, style (we could add custom ones to this one)
+    - godot # checks that comments end in a period
+    - gofmt # warns about incorrect use of fmt functions
+    - goimports # import formatting
+    - goprintffuncname # printft-like functions should be named with f at the end
+    - gosec # potential security problems
+    - gosimple # simplify code
+    - govet # basically 'go vet'
+    - importas # consistent import aliases
+    - ineffassign # ineffectual assignments
+    - intrange # suggest using integer range in for loops
+    - loggercheck # check for even key/value pairs in logger calls
+    - misspell # spelling
+    - nakedret # naked returns (named return parameters and an empty return)
+    - nilerr # returning nil after checking err is not nil
+    - noctx # http requests without context.Context
+    - nolintlint # badly formatted nolint directives
+    - nosprintfhostport # using sprintf to construct host:port in a URL
+    - prealloc # suggest preallocating slices
+    - predeclared # shadowing predeclared identifiers
+    - revive # better version of golint
+    - staticcheck # some of staticcheck's rules
+    - stylecheck # another replacement for golint
+    - tenv # using os.Setenv instead of t.Setenv in tests
+    - thelper # test helpers not starting with t.Helper()
+    - unconvert # unnecessary type conversions
+    - unparam # unused function parameters
+    - unused # unused constants, variables,functions, types
+    - usestdlibvars # using variables/constants from the standard library
+    - whitespace # unnecessary newlines
 
 linters-settings:
   gci:
@@ -187,7 +180,6 @@ linters-settings:
         alias: infraexpv1
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     require-specific: true
   revive:
     rules:
@@ -224,6 +216,12 @@ linters-settings:
   goconst:
     ignore-tests: true
 issues:
+  exclude-files:
+    - "zz_generated.*\\.go$"
+    - "vendored_openapi\\.go$"
+    # We don't want to invest time to fix new linter findings in old API types.
+    - "internal/apis/.*"
+
   max-same-issues: 0
   max-issues-per-linter: 0
   # We are disabling default golangci exclusions because we want to help reviewers to focus on reviewing the most relevant


### PR DESCRIPTION
**What this PR does / why we need it**:
We're using an adapted version of CAPI's golangci-lint config. I've recently updated the linter list with comments summarising what each linter does, since it's quite cumbersome to look it up in case you want to know.
This should also make it easier for other projects to adopt this configuration.

I've also removed two linters:
- typecheck - it's no longer listed in the documentation
- rowserrcheck - it's for the `sql` package, and I hope we're not using that anywhere

I also removed one deprecated parameter and moved file exclusions to the new location.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci