### PR TITLE
🌱 machine: prevent error spamming for NodeOutdatedTaint if objects are not found

### DIFF
--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -311,10 +311,10 @@ func (r *Reconciler) patchNode(ctx context.Context, remoteClient client.Client, 
 		} else {
 			hasTaintChanges = taints.RemoveNodeTaint(newNode, clusterv1.NodeOutdatedRevisionTaint) || hasTaintChanges
 		}
+	}
 
-		if !hasAnnotationChanges && !hasLabelChanges && !hasTaintChanges {
-			return nil
-		}
+	if !hasAnnotationChanges && !hasLabelChanges && !hasTaintChanges {
+		return nil
 	}
 
 	return remoteClient.Patch(ctx, newNode, client.StrategicMergeFrom(node))

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -774,7 +774,7 @@ func TestPatchNode(t *testing.T) {
 			md:      newFakeMachineDeployment(metav1.NamespaceDefault, clusterName),
 		},
 		{
-			name: "Ensure Labels and Annotations still get patched if MachineSet cannot be found",
+			name: "Ensure Labels and Annotations still get patched if MachineSet and Machinedeployment cannot be found",
 			oldNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("node-%s", util.RandomString(6)),
@@ -814,21 +814,7 @@ func TestPatchNode(t *testing.T) {
 				Spec: newFakeMachineSpec(metav1.NamespaceDefault, clusterName),
 			},
 			ms: nil,
-			md: &clusterv1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-md",
-					Namespace: metav1.NamespaceDefault,
-					Annotations: map[string]string{
-						clusterv1.RevisionAnnotation: "1",
-					},
-				},
-				Spec: clusterv1.MachineDeploymentSpec{
-					ClusterName: clusterName,
-					Template: clusterv1.MachineTemplateSpec{
-						Spec: newFakeMachineSpec(metav1.NamespaceDefault, clusterName),
-					},
-				},
-			},
+			md: nil,
 		},
 		{
 			name: "Ensure NodeOutdatedRevisionTaint to be set if a node is associated to an outdated machineset",
@@ -976,7 +962,9 @@ func TestPatchNode(t *testing.T) {
 			if ms != nil {
 				g.Expect(env.CreateAndWait(ctx, ms)).To(Succeed())
 			}
-			g.Expect(env.CreateAndWait(ctx, md)).To(Succeed())
+			if md != nil {
+				g.Expect(env.CreateAndWait(ctx, md)).To(Succeed())
+			}
 			t.Cleanup(func() {
 				_ = env.CleanupAndWait(ctx, oldNode, machine, ms, md)
 			})

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -780,8 +780,18 @@ func TestPatchNode(t *testing.T) {
 					Name: fmt.Sprintf("node-%s", util.RandomString(6)),
 				},
 			},
+			newLabels: map[string]string{
+				"label-from-machine": "foo",
+			},
+			newAnnotations: map[string]string{
+				"annotation-from-machine": "foo",
+			},
+			expectedLabels: map[string]string{
+				"label-from-machine": "foo",
+			},
 			expectedAnnotations: map[string]string{
-				clusterv1.LabelsFromMachineAnnotation: "",
+				"annotation-from-machine":             "foo",
+				clusterv1.LabelsFromMachineAnnotation: "label-from-machine",
 			},
 			expectedTaints: []corev1.Taint{
 				{Key: "node.kubernetes.io/not-ready", Effect: "NoSchedule"}, // Added by the API server

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -27,17 +27,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/internal/topology/ownerrefs"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestGetNode(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR reduces spammy output especially during background deletion of objects like a whole cluster.

Example from https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/11146/pull-cluster-api-e2e-blocking-main/1832066840088547328/artifacts/clusters/bootstrap/logs/capi-system/capi-controller-manager/capi-controller-manager-5f5f6bcf4c-4zpjc/manager.log :

Example: owner reference is gone:
```
{"ts":1725634615581.657,"caller":"controller/controller.go:316","msg":"Reconciler error","controller":"machine","controllerGroup":"cluster.x-k8s.io","controllerKind":"Machine","Machine":{"name":"quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","namespace":"quick-start-ev3dh5"},"namespace":"quick-start-ev3dh5","name":"quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","reconcileID":"5a5d16c2-944d-4bbb-ae38-670497f71998","err":"failed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt: failed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated: failed to find MachineSet owner reference for Machine quick-start-ev3dh5/quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","errCauses":[{"error":"failed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt: failed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated: failed to find MachineSet owner reference for Machine quick-start-ev3dh5/quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","errorVerbose":"failed to find MachineSet owner reference for Machine quick-start-ev3dh5/quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt\nsigs.k8s.io/cluster-api/internal/controllers/machine.getOwnerMachineSetObjectKey\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:363\nsigs.k8s.io/cluster-api/internal/controllers/machine.shouldNodeHaveOutdatedTaint\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:323\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).patchNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:299\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcileNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:139\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:316\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).Reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:240\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\truntime/asm_amd64.s:1695\nfailed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).patchNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:301\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcileNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:139\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:316\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).Reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:240\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\truntime/asm_amd64.s:1695\nfailed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcileNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:140\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:316\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).Reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:240\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\truntime/asm_amd64.s:1695"}]}
```

Example MachineDeployment gone:

```
{"ts":1725634762385.2092,"caller":"controller/controller.go:316","msg":"Reconciler error","controller":"machine","controllerGroup":"cluster.x-k8s.io","controllerKind":"Machine","Machine":{"name":"quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","namespace":"quick-start-ev3dh5"},"namespace":"quick-start-ev3dh5","name":"quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt","reconcileID":"42367c14-daab-42f7-9a3f-df199c620093","err":"failed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt: failed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated: MachineDeployment.cluster.x-k8s.io \"quick-start-0qi0bi-md-0-kskml\" not found","errCauses":[{"error":"failed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt: failed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated: MachineDeployment.cluster.x-k8s.io \"quick-start-0qi0bi-md-0-kskml\" not found","errorVerbose":"MachineDeployment.cluster.x-k8s.io \"quick-start-0qi0bi-md-0-kskml\" not found\nfailed to check if Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt is outdated\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).patchNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:301\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcileNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:139\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:316\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).Reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:240\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\truntime/asm_amd64.s:1695\nfailed to reconcile Node quick-start-0qi0bi-md-0-kskml-96tqh-jg4tt\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcileNode\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller_noderef.go:140\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:316\nsigs.k8s.io/cluster-api/internal/controllers/machine.(*Reconciler).Reconcile\n\tsigs.k8s.io/cluster-api/internal/controllers/machine/machine_controller.go:240\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:303\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224\nruntime.goexit\n\truntime/asm_amd64.s:1695"}]}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area machine