### PR TITLE
✨ clusterctl: Allow user to suppress API warnings

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -200,7 +200,7 @@ func newClusterClient(kubeconfig Kubeconfig, configClient config.Client, options
 
 	// if there is an injected proxy, use it, otherwise use a default one
 	if client.proxy == nil {
-		client.proxy = newProxy(client.kubeconfig)
+		client.proxy = NewProxy(client.kubeconfig)
 	}
 
 	// if there is an injected repositoryClientFactory, use it, otherwise use the default one

--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -68,7 +68,7 @@ func FilterClusterObjectsWithNameFilter(s string) func(u unstructured.Unstructur
 // own owner references; there is no guarantee about the stability of this API. Using this test with providers may require
 // a custom implementation of this function, or the OwnerGraph it returns.
 func GetOwnerGraph(ctx context.Context, namespace, kubeconfigPath string, filterFn GetOwnerGraphFilterFunction) (OwnerGraph, error) {
-	p := newProxy(Kubeconfig{Path: kubeconfigPath, Context: ""})
+	p := NewProxy(Kubeconfig{Path: kubeconfigPath, Context: ""})
 	invClient := newInventoryClient(p, nil)
 
 	graph := newObjectGraph(p, invClient)

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -83,6 +83,7 @@ type proxy struct {
 	kubeconfig         Kubeconfig
 	timeout            time.Duration
 	configLoadingRules *clientcmd.ClientConfigLoadingRules
+	warningHandler     rest.WarningHandler
 }
 
 var _ Proxy = &proxy{}
@@ -154,6 +155,8 @@ func (k *proxy) GetConfig() (*rest.Config, error) {
 	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go doesn't generate throttling log messages
 	restConfig.QPS = 20
 	restConfig.Burst = 100
+
+	restConfig.WarningHandler = k.warningHandler
 
 	return restConfig, nil
 }
@@ -376,7 +379,15 @@ func InjectKubeconfigPaths(paths []string) ProxyOption {
 	}
 }
 
-func newProxy(kubeconfig Kubeconfig, opts ...ProxyOption) Proxy {
+// InjectWarningHandler sets the handler for warnings returned by the Kubernetes API server.
+func InjectWarningHandler(handler rest.WarningHandler) ProxyOption {
+	return func(p *proxy) {
+		p.warningHandler = handler
+	}
+}
+
+// NewProxy returns a proxy used for operating objects in a cluster.
+func NewProxy(kubeconfig Kubeconfig, opts ...ProxyOption) Proxy {
 	// If a kubeconfig file isn't provided, find one in the standard locations.
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if kubeconfig.Path != "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Allows the clusterctl user to configure the API client warning handler.

The warning handler is configured by the Proxy. If a user only wants to configure the warning handler, we should not require them to implement their own Proxy. This PR, therefore, exports our Proxy constructor, and adds an option that allows the user to construct a Proxy with their own warning handler.

The PR does not change the existing warning handling behavior. As before, the default warning handler is provided by the controller-runtime client. Its default warning warning handler has not changed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10932

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->