### PR TITLE
📖 Add more documentation about the KCP pre-terminate hook

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -61,6 +61,15 @@ const (
 	// search each annotation for during the pre-terminate.delete lifecycle hook
 	// to pause reconciliation of deletion. These hooks will prevent removal of
 	// an instance from an infrastructure provider until all are removed.
+	//
+	// Notes for Machines managed by KCP (starting with Cluster API v1.8.2):
+	// * KCP adds its own pre-terminate hook on all Machines it controls. This is done to ensure it can later remove
+	//   the etcd member right before Machine termination (i.e. before InfraMachine deletion).
+	// * Starting with Kubernetes v1.31 the KCP pre-terminate hook will wait for all other pre-terminate hooks to finish to
+	//   ensure it runs last (thus ensuring that kubelet is still working while other pre-terminate hooks run). This is only done
+	//   for v1.31 or above because the kubeadm ControlPlaneKubeletLocalMode was introduced with kubeadm 1.31. This feature configures
+	//   the kubelet to communicate with the local apiserver. Only because of that the kubelet immediately starts failing after the etcd
+	//   member is removed. We need the ControlPlaneKubeletLocalMode feature with 1.31 to adhere to the kubelet skew policy.
 	PreTerminateDeleteHookAnnotationPrefix = "pre-terminate.delete.hook.machine.cluster.x-k8s.io"
 
 	// MachineCertificatesExpiryDateAnnotation annotation specifies the expiry date of the machine certificates in RFC3339 format.

--- a/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
+++ b/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
@@ -17,6 +17,15 @@ maintainers of providers and consumers of our Go API.
 
 ### Other
 
+- Notes for Machines managed by KCP (starting with Cluster API v1.8.2):
+  - KCP adds its own pre-terminate hook on all Machines it controls. This is done to ensure it can later remove
+    the etcd member right before Machine termination (i.e. before InfraMachine deletion).
+  - Starting with Kubernetes v1.31 the KCP pre-terminate hook will wait for all other pre-terminate hooks to finish to
+    ensure it runs last (thus ensuring that kubelet is still working while other pre-terminate hooks run). This is only done
+    for v1.31 or above because the kubeadm ControlPlaneKubeletLocalMode was introduced with kubeadm 1.31. This feature configures
+    the kubelet to communicate with the local apiserver. Only because of that the kubelet immediately starts failing after the etcd
+    member is removed. We need the ControlPlaneKubeletLocalMode feature with 1.31 to adhere to the kubelet skew policy.
+
 ### Suggested changes for providers
 
 - The Errors package was created when capi provider implementation was running as machineActuators that needed to vendor core capi to function. There is no usage recommendations today and its value is questionable since we moved to CRDs that inter-operate mostly via conditions. Instead we plan to drop the dedicated semantic for terminal failure and keep improving Machine lifecycle signal through conditions. Therefore the Errors package [has been deprecated in v1.8](https://github.com/kubernetes-sigs/cluster-api/issues/10784). It's recommented to remove any usage of the currently exported variables.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/11137

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->