### PR TITLE
🐛 hack: fix the shell used when running pr-verify

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -12,5 +12,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
 
       - name: Check if PR title is valid
-        run: sh hack/verify-pr-title.sh "${{ github.event.pull_request.title }}"
+        run: |
+          ./hack/verify-pr-title.sh "${{ github.event.pull_request.title }}"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The action did use sh instead of bash.

Tested here: https://github.com/chrischdi/cluster-api/actions/runs/10808759886/job/29982425599?pr=204

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fix for #11062

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->