### PR TITLE
🌱 Foreground deletion for MachineDeployments and MachineSets

### DIFF
--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -27,7 +27,7 @@ const (
 	MachineDeploymentTopologyFinalizer = "machinedeployment.topology.cluster.x-k8s.io"
 
 	// MachineDeploymentFinalizer is the finalizer used by the MachineDeployment controller to
-	// cleanup the MachineDeployment descendant MachineSets when a MachineDeployment is being deleted.
+	// ensure ordered cleanup of corresponding MachineSets when a MachineDeployment is being deleted.
 	MachineDeploymentFinalizer = "cluster.x-k8s.io/machinedeployment"
 )
 

--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -25,6 +25,10 @@ const (
 	// MachineDeploymentTopologyFinalizer is the finalizer used by the topology MachineDeployment controller to
 	// clean up referenced template resources if necessary when a MachineDeployment is being deleted.
 	MachineDeploymentTopologyFinalizer = "machinedeployment.topology.cluster.x-k8s.io"
+
+	// MachineDeploymentFinalizer is the finalizer used by the MachineDeployment controller to
+	// cleanup the MachineDeployment descendant MachineSets when a MachineDeployment is being deleted.
+	MachineDeploymentFinalizer = "machinedeployment.cluster.x-k8s.io"
 )
 
 // MachineDeploymentStrategyType defines the type of MachineDeployment rollout strategies.

--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -28,7 +28,7 @@ const (
 
 	// MachineDeploymentFinalizer is the finalizer used by the MachineDeployment controller to
 	// cleanup the MachineDeployment descendant MachineSets when a MachineDeployment is being deleted.
-	MachineDeploymentFinalizer = "machinedeployment.cluster.x-k8s.io"
+	MachineDeploymentFinalizer = "cluster.x-k8s.io/machinedeployment"
 )
 
 // MachineDeploymentStrategyType defines the type of MachineDeployment rollout strategies.

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -32,7 +32,7 @@ const (
 
 	// MachineSetFinalizer is the finalizer used by the MachineSet controller to
 	// cleanup the MachineSet descendant Machines when a Machineset is being deleted.
-	MachineSetFinalizer = "machineset.cluster.x-k8s.io"
+	MachineSetFinalizer = "cluster.x-k8s.io/machineset"
 )
 
 // ANCHOR: MachineSetSpec

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -31,7 +31,7 @@ const (
 	MachineSetTopologyFinalizer = "machineset.topology.cluster.x-k8s.io"
 
 	// MachineSetFinalizer is the finalizer used by the MachineSet controller to
-	// cleanup the MachineSet descendant Machines when a Machineset is being deleted.
+	// ensure ordered cleanup of corresponding Machines when a Machineset is being deleted.
 	MachineSetFinalizer = "cluster.x-k8s.io/machineset"
 )
 

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -29,6 +29,10 @@ const (
 	// MachineSetTopologyFinalizer is the finalizer used by the topology MachineDeployment controller to
 	// clean up referenced template resources if necessary when a MachineSet is being deleted.
 	MachineSetTopologyFinalizer = "machineset.topology.cluster.x-k8s.io"
+
+	// MachineSetFinalizer is the finalizer used by the MachineSet controller to
+	// cleanup the MachineSet descendant Machines when a Machineset is being deleted.
+	MachineSetFinalizer = "machineset.cluster.x-k8s.io"
 )
 
 // ANCHOR: MachineSetSpec

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -50,6 +53,10 @@ var (
 	// machineDeploymentKind contains the schema.GroupVersionKind for the MachineDeployment type.
 	machineDeploymentKind = clusterv1.GroupVersion.WithKind("MachineDeployment")
 )
+
+// deleteRequeueAfter is how long to wait before checking again to see if the MachineDeployment
+// still has owned MachineSets.
+const deleteRequeueAfter = 5 * time.Second
 
 // machineDeploymentManagerName is the manager name used for Server-Side-Apply (SSA) operations
 // in the MachineDeployment controller.
@@ -158,9 +165,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		}
 	}()
 
-	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
-	// is enabled
+	// Handle deletion reconciliation loop.
 	if !deployment.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, deployment)
+	}
+
+	// Add finalizer first if not set to avoid the race condition between init and delete.
+	// Note: Finalizers in general can only be added when the deletionTimestamp is not set.
+	if !controllerutil.ContainsFinalizer(deployment, clusterv1.MachineDeploymentFinalizer) {
+		controllerutil.AddFinalizer(deployment, clusterv1.MachineDeploymentFinalizer)
 		return ctrl.Result{}, nil
 	}
 
@@ -284,6 +297,33 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	}
 
 	return errors.Errorf("unexpected deployment strategy type: %s", md.Spec.Strategy.Type)
+}
+
+func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineDeployment) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	msList, err := r.getMachineSetsForDeployment(ctx, md)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If all the descendant machinesets are deleted, then remove the machinedeployment's finalizer.
+	if len(msList) == 0 {
+		controllerutil.RemoveFinalizer(md, clusterv1.MachineDeploymentFinalizer)
+		return ctrl.Result{}, nil
+	}
+
+	// else delete owned machinesets.
+	log.Info("MachineDeployment still has owned MachineSets, deleting them first")
+	for _, ms := range msList {
+		if ms.DeletionTimestamp.IsZero() {
+			log.Info("Deleting MachineSet", "MachineSet", klog.KObj(ms))
+			if err := r.Client.Delete(ctx, ms); err != nil {
+				return ctrl.Result{}, errors.Wrapf(err, "failed to delete MachineSet %s", klog.KObj(ms))
+			}
+		}
+	}
+
+	return ctrl.Result{RequeueAfter: deleteRequeueAfter}, nil
 }
 
 // getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -232,7 +232,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 		}
 	}
 
-	msList, err := r.getMachineSetsForDeployment(ctx, md)
+	msList, err := r.getAndAdoptMachineSetsForDeployment(ctx, md)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 
 func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineDeployment) error {
 	log := ctrl.LoggerFrom(ctx)
-	msList, err := r.getMachineSetsForDeployment(ctx, md)
+	msList, err := r.getAndAdoptMachineSetsForDeployment(ctx, md)
 	if err != nil {
 		return err
 	}
@@ -321,8 +321,8 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineD
 	return nil
 }
 
-// getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
-func (r *Reconciler) getMachineSetsForDeployment(ctx context.Context, md *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
+// getAndAdoptMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
+func (r *Reconciler) getAndAdoptMachineSetsForDeployment(ctx context.Context, md *clusterv1.MachineDeployment) ([]*clusterv1.MachineSet, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// List all MachineSets to find those we own but that no longer match our selector.

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	clog "sigs.k8s.io/cluster-api/util/log"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -306,7 +307,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineD
 		return nil
 	}
 
-	log.Info("MachineDeployment still has descendant MachineSets - deleting them first", "count", len(msList), "descendants", descendantMachineSets(msList))
+	log.Info("Waiting for MachineSets to be deleted", "MachineSets", clog.ObjNamesString(msList))
 
 	// else delete owned machinesets.
 	for _, ms := range msList {
@@ -473,17 +474,4 @@ func reconcileExternalTemplateReference(ctx context.Context, c client.Client, cl
 	}))
 
 	return patchHelper.Patch(ctx, obj)
-}
-
-func descendantMachineSets(objs []*clusterv1.MachineSet) string {
-	objNames := make([]string, len(objs))
-	for _, obj := range objs {
-		objNames = append(objNames, obj.GetName())
-	}
-
-	if len(objNames) > 10 {
-		objNames = append(objNames[:10], "...")
-	}
-
-	return strings.Join(objNames, ",")
 }

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -18,6 +18,7 @@ package machinedeployment
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -992,4 +994,97 @@ func updateMachineDeployment(ctx context.Context, c client.Client, md *clusterv1
 		modify(md)
 		return patchHelper.Patch(ctx, md)
 	})
+}
+
+func TestReconciler_reconcileDelete(t *testing.T) {
+	labels := map[string]string{
+		"some": "labelselector",
+	}
+	md := builder.MachineDeployment("default", "md0").WithClusterName("test").Build()
+	md.DeletionTimestamp = ptr.To(metav1.Now())
+	md.Spec.Selector = metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+	mdWithoutFinalizer := md.DeepCopy()
+	mdWithoutFinalizer.Finalizers = nil
+	tests := []struct {
+		name              string
+		machineDeployment *clusterv1.MachineDeployment
+		want              *clusterv1.MachineDeployment
+		objs              []client.Object
+		wantMachineSets   []clusterv1.MachineSet
+		expectError       bool
+	}{
+		{
+			name:              "Should do nothing when no descendant MachineSets exist and finalizer is already gone",
+			machineDeployment: mdWithoutFinalizer.DeepCopy(),
+			want:              mdWithoutFinalizer.DeepCopy(),
+			objs:              nil,
+			wantMachineSets:   nil,
+			expectError:       false,
+		},
+		{
+			name:              "Should remove finalizer when no descendant MachineSets exist",
+			machineDeployment: md.DeepCopy(),
+			want:              mdWithoutFinalizer.DeepCopy(),
+			objs:              nil,
+			wantMachineSets:   nil,
+			expectError:       false,
+		},
+		{
+			name:              "Should keep finalizer when descendant MachineSets exist and trigger deletion only for descendant MachineSets",
+			machineDeployment: md.DeepCopy(),
+			want:              md.DeepCopy(),
+			objs: []client.Object{
+				builder.MachineSet("default", "ms0").WithClusterName("test").WithLabels(labels).Build(),
+				builder.MachineSet("default", "ms1").WithClusterName("test").WithLabels(labels).Build(),
+				builder.MachineSet("default", "ms2-not-part-of-md").WithClusterName("test").Build(),
+				builder.MachineSet("default", "ms3-not-part-of-md").WithClusterName("test").Build(),
+			},
+			wantMachineSets: []clusterv1.MachineSet{
+				*builder.MachineSet("default", "ms2-not-part-of-md").WithClusterName("test").Build(),
+				*builder.MachineSet("default", "ms3-not-part-of-md").WithClusterName("test").Build(),
+			},
+			expectError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
+			r := &Reconciler{
+				Client:   c,
+				recorder: record.NewFakeRecorder(32),
+			}
+			// Mark machineDeployment to be in deletion.
+
+			err := r.reconcileDelete(ctx, tt.machineDeployment)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			g.Expect(tt.machineDeployment).To(BeComparableTo(tt.want))
+
+			machineSetList := &clusterv1.MachineSetList{}
+			g.Expect(c.List(ctx, machineSetList, client.InNamespace("default"))).ToNot(HaveOccurred())
+
+			// Remove ResourceVersion so we can actually compare.
+			for i, m := range machineSetList.Items {
+				m.ResourceVersion = ""
+				machineSetList.Items[i] = m
+			}
+
+			sort.Slice(machineSetList.Items, func(i, j int) bool {
+				return machineSetList.Items[i].GetName() < machineSetList.Items[j].GetName()
+			})
+			sort.Slice(tt.wantMachineSets, func(i, j int) bool {
+				return tt.wantMachineSets[i].GetName() < tt.wantMachineSets[j].GetName()
+			})
+
+			g.Expect(machineSetList.Items).To(BeComparableTo(tt.wantMachineSets))
+		})
+	}
 }

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -962,7 +962,7 @@ func TestGetMachineSetsForDeployment(t *testing.T) {
 				recorder: record.NewFakeRecorder(32),
 			}
 
-			got, err := r.getMachineSetsForDeployment(ctx, &tc.machineDeployment)
+			got, err := r.getAndAdoptMachineSetsForDeployment(ctx, &tc.machineDeployment)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(got).To(HaveLen(len(tc.expected)))
 

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -342,7 +342,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, machineSet *clusterv1.
 		return nil
 	}
 
-	log.Info("MachineSet still has descendant Machines - deleting them first", "count", len(machineList), "descendants", descendantMachines(machineList))
+	log.Info("Waiting for Machines to be deleted", "Machines", clog.ObjNamesString(machineList))
 
 	// else delete owned machines.
 	for _, machine := range machineList {
@@ -1226,17 +1226,4 @@ func (r *Reconciler) reconcileExternalTemplateReference(ctx context.Context, clu
 	}))
 
 	return patchHelper.Patch(ctx, obj)
-}
-
-func descendantMachines(objs []*clusterv1.Machine) string {
-	objNames := make([]string, len(objs))
-	for _, obj := range objs {
-		objNames = append(objNames, obj.GetName())
-	}
-
-	if len(objNames) > 10 {
-		objNames = append(objNames[:10], "...")
-	}
-
-	return strings.Join(objNames, ",")
 }

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -41,7 +41,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -72,6 +74,10 @@ var (
 	// The polling is against a local memory cache.
 	stateConfirmationInterval = 100 * time.Millisecond
 )
+
+// deleteRequeueAfter is how long to wait before checking again to see if the MachineDeployment
+// still has owned MachineSets.
+const deleteRequeueAfter = 5 * time.Second
 
 const machineSetManagerName = "capi-machineset"
 
@@ -182,9 +188,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		}
 	}()
 
-	// Ignore deleted MachineSets, this can happen when foregroundDeletion
-	// is enabled
+	// Handle deletion reconciliation loop.
 	if !machineSet.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, machineSet)
+	}
+
+	// Add finalizer first if not set to avoid the race condition between init and delete.
+	// Note: Finalizers in general can only be added when the deletionTimestamp is not set.
+	if !controllerutil.ContainsFinalizer(machineSet, clusterv1.MachineSetFinalizer) {
+		controllerutil.AddFinalizer(machineSet, clusterv1.MachineSetFinalizer)
 		return ctrl.Result{}, nil
 	}
 
@@ -224,8 +236,6 @@ func patchMachineSet(ctx context.Context, patchHelper *patch.Helper, machineSet 
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, machineSet *clusterv1.MachineSet) (ctrl.Result, error) {
-	log := ctrl.LoggerFrom(ctx)
-
 	// Reconcile and retrieve the Cluster object.
 	if machineSet.Labels == nil {
 		machineSet.Labels = make(map[string]string)
@@ -266,63 +276,28 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	machineSet.Spec.Selector.MatchLabels[clusterv1.ClusterNameLabel] = machineSet.Spec.ClusterName
 	machineSet.Spec.Template.Labels[clusterv1.ClusterNameLabel] = machineSet.Spec.ClusterName
 
-	selectorMap, err := metav1.LabelSelectorAsMap(&machineSet.Spec.Selector)
+	machines, err := r.getMachinesForMachineSet(ctx, machineSet)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to convert MachineSet %q label selector to a map", machineSet.Name)
-	}
-
-	// Get all Machines linked to this MachineSet.
-	allMachines := &clusterv1.MachineList{}
-	err = r.Client.List(ctx,
-		allMachines,
-		client.InNamespace(machineSet.Namespace),
-		client.MatchingLabels(selectorMap),
-	)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to list machines")
-	}
-
-	// Filter out irrelevant machines (i.e. IsControlledBy something else) and claim orphaned machines.
-	// Machines in deleted state are deliberately not excluded https://github.com/kubernetes-sigs/cluster-api/pull/3434.
-	filteredMachines := make([]*clusterv1.Machine, 0, len(allMachines.Items))
-	for idx := range allMachines.Items {
-		machine := &allMachines.Items[idx]
-		log := log.WithValues("Machine", klog.KObj(machine))
-		if shouldExcludeMachine(machineSet, machine) {
-			continue
-		}
-
-		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
-		if metav1.GetControllerOf(machine) == nil {
-			if err := r.adoptOrphan(ctx, machineSet, machine); err != nil {
-				log.Error(err, "Failed to adopt Machine")
-				r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedAdopt", "Failed to adopt Machine %q: %v", machine.Name, err)
-				continue
-			}
-			log.Info("Adopted Machine")
-			r.recorder.Eventf(machineSet, corev1.EventTypeNormal, "SuccessfulAdopt", "Adopted Machine %q", machine.Name)
-		}
-
-		filteredMachines = append(filteredMachines, machine)
+		return ctrl.Result{}, errors.Wrap(err, "failed to list Machines")
 	}
 
 	result := ctrl.Result{}
 
-	reconcileUnhealthyMachinesResult, err := r.reconcileUnhealthyMachines(ctx, cluster, machineSet, filteredMachines)
+	reconcileUnhealthyMachinesResult, err := r.reconcileUnhealthyMachines(ctx, cluster, machineSet, machines)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile unhealthy machines")
 	}
 	result = util.LowestNonZeroResult(result, reconcileUnhealthyMachinesResult)
 
-	if err := r.syncMachines(ctx, machineSet, filteredMachines); err != nil {
+	if err := r.syncMachines(ctx, machineSet, machines); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to update Machines")
 	}
 
-	syncReplicasResult, syncErr := r.syncReplicas(ctx, cluster, machineSet, filteredMachines)
+	syncReplicasResult, syncErr := r.syncReplicas(ctx, cluster, machineSet, machines)
 	result = util.LowestNonZeroResult(result, syncReplicasResult)
 
 	// Always updates status as machines come up or die.
-	if err := r.updateStatus(ctx, cluster, machineSet, filteredMachines); err != nil {
+	if err := r.updateStatus(ctx, cluster, machineSet, machines); err != nil {
 		return ctrl.Result{}, errors.Wrapf(kerrors.NewAggregate([]error{err, syncErr}), "failed to update MachineSet's Status")
 	}
 
@@ -357,6 +332,77 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	}
 
 	return result, nil
+}
+
+func (r *Reconciler) reconcileDelete(ctx context.Context, machineSet *clusterv1.MachineSet) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	machineList, err := r.getMachinesForMachineSet(ctx, machineSet)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If all the descendant machines are deleted, then remove the machinedeployment's finalizer.
+	if len(machineList) == 0 {
+		controllerutil.RemoveFinalizer(machineSet, clusterv1.MachineSetFinalizer)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("MachineSet still has owned Machines, deleting them first")
+	for _, machine := range machineList {
+		if machine.DeletionTimestamp.IsZero() {
+			log.Info("Deleting Machine", "Machine", klog.KObj(machine))
+			if err := r.Client.Delete(ctx, machine); err != nil {
+				return ctrl.Result{}, errors.Wrapf(err, "failed to delete Machine %s", klog.KObj(machine))
+			}
+		}
+	}
+
+	return ctrl.Result{RequeueAfter: deleteRequeueAfter}, nil
+}
+
+func (r *Reconciler) getMachinesForMachineSet(ctx context.Context, machineSet *clusterv1.MachineSet) ([]*clusterv1.Machine, error) {
+	log := ctrl.LoggerFrom(ctx)
+	selectorMap, err := metav1.LabelSelectorAsMap(&machineSet.Spec.Selector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to convert MachineSet %q label selector to a map", machineSet.Name)
+	}
+
+	// Get all Machines linked to this MachineSet.
+	allMachines := &clusterv1.MachineList{}
+	err = r.Client.List(ctx,
+		allMachines,
+		client.InNamespace(machineSet.Namespace),
+		client.MatchingLabels(selectorMap),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list machines")
+	}
+
+	// Filter out irrelevant machines (i.e. IsControlledBy something else) and claim orphaned machines.
+	// Machines in deleted state are deliberately not excluded https://github.com/kubernetes-sigs/cluster-api/pull/3434.
+	filteredMachines := make([]*clusterv1.Machine, 0, len(allMachines.Items))
+	for idx := range allMachines.Items {
+		machine := &allMachines.Items[idx]
+		log := log.WithValues("Machine", klog.KObj(machine))
+		if shouldExcludeMachine(machineSet, machine) {
+			continue
+		}
+
+		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
+		if metav1.GetControllerOf(machine) == nil {
+			if err := r.adoptOrphan(ctx, machineSet, machine); err != nil {
+				log.Error(err, "Failed to adopt Machine")
+				r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedAdopt", "Failed to adopt Machine %q: %v", machine.Name, err)
+				continue
+			}
+			log.Info("Adopted Machine")
+			r.recorder.Eventf(machineSet, corev1.EventTypeNormal, "SuccessfulAdopt", "Adopted Machine %q", machine.Name)
+		}
+
+		filteredMachines = append(filteredMachines, machine)
+	}
+
+	return filteredMachines, nil
 }
 
 // syncMachines updates Machines, InfrastructureMachine and BootstrapConfig to propagate in-place mutable fields

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -348,7 +348,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, machineSet *clusterv1.
 	for _, machine := range machineList {
 		if machine.DeletionTimestamp.IsZero() {
 			log.Info("Deleting Machine", "Machine", klog.KObj(machine))
-			if err := r.Client.Delete(ctx, machine); err != nil {
+			if err := r.Client.Delete(ctx, machine); err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "failed to delete Machine %s", klog.KObj(machine))
 			}
 		}
@@ -381,6 +381,7 @@ func (r *Reconciler) getAndAdoptMachinesForMachineSet(ctx context.Context, machi
 	for idx := range allMachines.Items {
 		machine := &allMachines.Items[idx]
 		log := log.WithValues("Machine", klog.KObj(machine))
+		ctx := ctrl.LoggerInto(ctx, log)
 		if shouldExcludeMachine(machineSet, machine) {
 			continue
 		}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -890,6 +890,9 @@ func newMachineSet(name, cluster string, replicas int32) *clusterv1.MachineSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
+			Finalizers: []string{
+				clusterv1.MachineSetFinalizer,
+			},
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: cluster,
 			},
@@ -930,6 +933,9 @@ func TestMachineSetReconcile_MachinesCreatedConditionFalseOnBadInfraRef(t *testi
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: cluster.Name,
+			},
+			Finalizers: []string{
+				clusterv1.MachineSetFinalizer,
 			},
 		},
 		Spec: clusterv1.MachineSetSpec{

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -2194,7 +2194,6 @@ func TestReconciler_reconcileDelete(t *testing.T) {
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
 			}
-			// Mark machineSet to be in deletion.
 
 			err := r.reconcileDelete(ctx, tt.machineSet)
 			if tt.expectError {

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -18,6 +18,7 @@ package machineset
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -2127,5 +2128,98 @@ func assertMachine(g *WithT, actualMachine *clusterv1.Machine, expectedMachine *
 	// Check Finalizer
 	if expectedMachine.Finalizers != nil {
 		g.Expect(actualMachine.Finalizers).Should(Equal(expectedMachine.Finalizers))
+	}
+}
+
+func TestReconciler_reconcileDelete(t *testing.T) {
+	labels := map[string]string{
+		"some": "labelselector",
+	}
+	ms := builder.MachineSet("default", "ms0").WithClusterName("test").Build()
+	ms.DeletionTimestamp = ptr.To(metav1.Now())
+	ms.Spec.Selector = metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+	msWithoutFinalizer := ms.DeepCopy()
+	msWithoutFinalizer.Finalizers = nil
+	tests := []struct {
+		name         string
+		machineSet   *clusterv1.MachineSet
+		want         *clusterv1.MachineSet
+		objs         []client.Object
+		wantMachines []clusterv1.Machine
+		expectError  bool
+	}{
+		{
+			name:         "Should do nothing when no descendant Machines exist and finalizer is already gone",
+			machineSet:   msWithoutFinalizer.DeepCopy(),
+			want:         msWithoutFinalizer.DeepCopy(),
+			objs:         nil,
+			wantMachines: nil,
+			expectError:  false,
+		},
+		{
+			name:         "Should remove finalizer when no descendant Machines exist",
+			machineSet:   ms.DeepCopy(),
+			want:         msWithoutFinalizer.DeepCopy(),
+			objs:         nil,
+			wantMachines: nil,
+			expectError:  false,
+		},
+		{
+			name:       "Should keep finalizer when descendant Machines exist and trigger deletion only for descendant Machines",
+			machineSet: ms.DeepCopy(),
+			want:       ms.DeepCopy(),
+			objs: []client.Object{
+				builder.Machine("default", "m0").WithClusterName("test").WithLabels(labels).Build(),
+				builder.Machine("default", "m1").WithClusterName("test").WithLabels(labels).Build(),
+				builder.Machine("default", "m2-not-part-of-ms").WithClusterName("test").Build(),
+				builder.Machine("default", "m3-not-part-of-ms").WithClusterName("test").Build(),
+			},
+			wantMachines: []clusterv1.Machine{
+				*builder.Machine("default", "m2-not-part-of-ms").WithClusterName("test").Build(),
+				*builder.Machine("default", "m3-not-part-of-ms").WithClusterName("test").Build(),
+			},
+			expectError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
+			r := &Reconciler{
+				Client:   c,
+				recorder: record.NewFakeRecorder(32),
+			}
+			// Mark machineSet to be in deletion.
+
+			err := r.reconcileDelete(ctx, tt.machineSet)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			g.Expect(tt.machineSet).To(BeComparableTo(tt.want))
+
+			machineList := &clusterv1.MachineList{}
+			g.Expect(c.List(ctx, machineList, client.InNamespace("default"))).ToNot(HaveOccurred())
+
+			// Remove ResourceVersion so we can actually compare.
+			for i, m := range machineList.Items {
+				m.ResourceVersion = ""
+				machineList.Items[i] = m
+			}
+
+			sort.Slice(machineList.Items, func(i, j int) bool {
+				return machineList.Items[i].GetName() < machineList.Items[j].GetName()
+			})
+			sort.Slice(tt.wantMachines, func(i, j int) bool {
+				return tt.wantMachines[i].GetName() < tt.wantMachines[j].GetName()
+			})
+
+			g.Expect(machineList.Items).To(BeComparableTo(tt.wantMachines))
+		})
 	}
 }

--- a/test/e2e/cluster_deletion.go
+++ b/test/e2e/cluster_deletion.go
@@ -322,7 +322,7 @@ func getDeletionPhaseObjects(ctx context.Context, bootstrapClusterProxy framewor
 
 		objectsPerPhase = append(objectsPerPhase, objects)
 	}
-	return
+	return objectsPerPhase, blockingObjects
 }
 
 func addFinalizer(ctx context.Context, c client.Client, finalizer string, objs ...client.Object) {

--- a/test/e2e/cluster_deletion.go
+++ b/test/e2e/cluster_deletion.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/test/e2e/internal/log"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+// ClusterDeletionSpecInput is the input for ClusterDeletionSpec.
+type ClusterDeletionSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+
+	// Cluster name allows to specify a deterministic clusterName.
+	// If not set, a random one will be generated.
+	ClusterName *string
+
+	// InfrastructureProvider allows to specify the infrastructure provider to be used when looking for
+	// cluster templates.
+	// If not set, clusterctl will look at the infrastructure provider installed in the management cluster;
+	// if only one infrastructure provider exists, it will be used, otherwise the operation will fail if more than one exists.
+	InfrastructureProvider *string
+
+	// Flavor, if specified is the template flavor used to create the cluster for testing.
+	// If not specified, the default flavor for the selected infrastructure provider is used.
+	Flavor *string
+
+	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	ControlPlaneMachineCount *int64
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	WorkerMachineCount *int64
+
+	// Allows to inject functions to be run while waiting for the control plane to be initialized,
+	// which unblocks CNI installation, and for the control plane machines to be ready (after CNI installation).
+	ControlPlaneWaiters clusterctl.ControlPlaneWaiters
+
+	// Allows to inject a function to be run after test namespace is created.
+	// If not specified, this is a no-op.
+	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+
+	// Allows to inject a function to be run after machines are provisioned.
+	// If not specified, this is a no-op.
+	PostMachinesProvisioned func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
+
+	// ClusterDeletionPhases define kinds which are expected to get deleted in phases.
+	ClusterDeletionPhases []ClusterDeletionPhase
+}
+
+type ClusterDeletionPhase struct {
+	// Kinds are the Kinds which are supposed to be deleted in this phase.
+	Kinds sets.Set[string]
+	// KindsWithFinalizer are the kinds which are considered to be deleted in this phase, but need to be blocking.
+	KindsWithFinalizer sets.Set[string]
+	// objects will be filled later by objects which match a kind given in one of the above sets.
+	objects []client.Object
+}
+
+// ClusterDeletionSpec implements a test that verifies that MachineDeployment rolling updates are successful.
+func ClusterDeletionSpec(ctx context.Context, inputGetter func() ClusterDeletionSpecInput) {
+	var (
+		specName             = "cluster-deletion"
+		input                ClusterDeletionSpecInput
+		namespace            *corev1.Namespace
+		cancelWatches        context.CancelFunc
+		clusterResources     *clusterctl.ApplyClusterTemplateAndWaitResult
+		finalizer            = "test.cluster.x-k8s.io/cluster-deletion"
+		objectsWithFinalizer []client.Object
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should successfully create and delete a Cluster", func() {
+		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
+		if input.InfrastructureProvider != nil {
+			infrastructureProvider = *input.InfrastructureProvider
+		}
+
+		flavor := clusterctl.DefaultFlavor
+		if input.Flavor != nil {
+			flavor = *input.Flavor
+		}
+
+		controlPlaneMachineCount := ptr.To[int64](1)
+		if input.ControlPlaneMachineCount != nil {
+			controlPlaneMachineCount = input.ControlPlaneMachineCount
+		}
+
+		workerMachineCount := ptr.To[int64](1)
+		if input.WorkerMachineCount != nil {
+			workerMachineCount = input.WorkerMachineCount
+		}
+
+		clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+		if input.ClusterName != nil {
+			clusterName = *input.ClusterName
+		}
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   infrastructureProvider,
+				Flavor:                   flavor,
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: controlPlaneMachineCount,
+				WorkerMachineCount:       workerMachineCount,
+			},
+			ControlPlaneWaiters:          input.ControlPlaneWaiters,
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostMachinesProvisioned: func() {
+				if input.PostMachinesProvisioned != nil {
+					input.PostMachinesProvisioned(input.BootstrapClusterProxy, namespace.Name, clusterName)
+				}
+			},
+		}, clusterResources)
+
+		relevantKinds := sets.Set[string]{}
+
+		for _, phaseInput := range input.ClusterDeletionPhases {
+			relevantKinds = relevantKinds.
+				Union(phaseInput.KindsWithFinalizer).
+				Union(phaseInput.Kinds)
+		}
+
+		// Get all objects relevant to the test by filtering for the kinds of the phases.
+		graph, err := clusterctlcluster.GetOwnerGraph(ctx, namespace.GetName(), input.BootstrapClusterProxy.GetKubeconfigPath(), func(u unstructured.Unstructured) bool {
+			return relevantKinds.Has(u.GetKind())
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		for i, phase := range input.ClusterDeletionPhases {
+			// Iterate over the graph and find all objects relevant for the phase.
+			// * Objects matching the kind except for Machines (see below)
+			// * Machines which are owned by one of the kinds which are part of the phase
+			allKinds := phase.KindsWithFinalizer.Union(phase.Kinds)
+			allKindsWithoutMachine := allKinds.Clone().Delete("Machine")
+
+			for _, node := range graph {
+				// Only add objects which match a defined kind for the phase.
+				if !allKinds.Has(node.Object.Kind) {
+					continue
+				}
+
+				// Special handling for machines: only add machines which are owned by one of the given kinds.
+				if node.Object.Kind == "Machine" {
+					isOwnedByKind := false
+					for _, owner := range node.Owners {
+						if allKindsWithoutMachine.Has(owner.Kind) {
+							isOwnedByKind = true
+							break
+						}
+					}
+					// Ignore Machines which are not owned by one of the given kinds.
+					if !isOwnedByKind {
+						continue
+					}
+				}
+
+				obj := new(unstructured.Unstructured)
+				obj.SetAPIVersion(node.Object.APIVersion)
+				obj.SetKind(node.Object.Kind)
+				obj.SetName(node.Object.Name)
+				obj.SetNamespace(namespace.GetName())
+
+				phase.objects = append(phase.objects, obj)
+
+				// If the object's kind is part of kindsWithFinalizer, then additionally the object to the finalizedObjs slice.
+				if phase.KindsWithFinalizer.Has(obj.GetKind()) {
+					objectsWithFinalizer = append(objectsWithFinalizer, obj)
+				}
+			}
+
+			// Update the phase in input.ClusterDeletionPhases
+			input.ClusterDeletionPhases[i] = phase
+		}
+
+		// Update all objects in objectsWithFinalizers and add the finalizer for this test to control when these objects vanish.
+		addFinalizer(ctx, input.BootstrapClusterProxy.GetClient(), finalizer, objectsWithFinalizer...)
+
+		// Trigger the deletion of the Cluster.
+		framework.DeleteCluster(ctx, framework.DeleteClusterInput{
+			Cluster: clusterResources.Cluster,
+			Deleter: input.BootstrapClusterProxy.GetClient(),
+		})
+
+		var objectsDeleted, objectsInDeletion []client.Object
+
+		for i, phase := range input.ClusterDeletionPhases {
+			// Objects which previously were in deletion because they waited for our finalizer being removed are now checked to actually had been removed.
+			objectsDeleted = objectsInDeletion
+			// All objects for this phase are expected to get into deletion (still exist and have deletionTimestamp set).
+			objectsInDeletion = phase.objects
+			// All objects which are part of future phases are expected to not yet be in deletion.
+			objectsNotInDeletion := []client.Object{}
+			for j := i + 1; j < len(input.ClusterDeletionPhases); j++ {
+				objectsNotInDeletion = append(objectsNotInDeletion, input.ClusterDeletionPhases[j].objects...)
+			}
+
+			Eventually(func(g Gomega) {
+				// Ensure expected objects are in deletion
+				for _, obj := range objectsInDeletion {
+					g.Expect(input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(obj), obj)).ToNot(HaveOccurred())
+					g.Expect(obj.GetDeletionTimestamp().IsZero()).To(BeFalse())
+				}
+
+				// Ensure deleted objects are gone
+				for _, obj := range objectsDeleted {
+					err := input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(obj), obj)
+					g.Expect(err).To(HaveOccurred())
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				}
+
+				// Ensure other objects are not in deletion.
+				for _, obj := range objectsNotInDeletion {
+					g.Expect(input.BootstrapClusterProxy.GetClient().Get(ctx, client.ObjectKeyFromObject(obj), obj)).ToNot(HaveOccurred())
+					g.Expect(obj.GetDeletionTimestamp().IsZero()).To(BeTrue())
+				}
+			}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
+
+			// Remove the test's finalizer from all objects which had been expected to be in deletion to unblock the next phase.
+			removeFinalizer(ctx, input.BootstrapClusterProxy.GetClient(), finalizer, objectsInDeletion...)
+		}
+
+		// The last phase should unblock the cluster to actually have been removed.
+		log.Logf("Waiting for the Cluster %s to be deleted", klog.KObj(clusterResources.Cluster))
+		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
+			Client:         input.BootstrapClusterProxy.GetClient(),
+			Cluster:        clusterResources.Cluster,
+			ArtifactFolder: input.ArtifactFolder,
+		}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dump all the resources in the spec namespace and the workload cluster.
+		framework.DumpAllResourcesAndLogs(ctx, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, clusterResources.Cluster)
+
+		if !input.SkipCleanup {
+			// Remove finalizers we added to block normal deletion.
+			removeFinalizer(ctx, input.BootstrapClusterProxy.GetClient(), finalizer, objectsWithFinalizer...)
+
+			By(fmt.Sprintf("Deleting cluster %s", klog.KObj(clusterResources.Cluster)))
+			// While https://github.com/kubernetes-sigs/cluster-api/issues/2955 is addressed in future iterations, there is a chance
+			// that cluster variable is not set even if the cluster exists, so we are calling DeleteAllClustersAndWait
+			// instead of DeleteClusterAndWait
+			framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
+				Client:         input.BootstrapClusterProxy.GetClient(),
+				Namespace:      namespace.Name,
+				ArtifactFolder: input.ArtifactFolder,
+			}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
+
+			By(fmt.Sprintf("Deleting namespace used for hosting the %q test spec", specName))
+			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+				Deleter: input.BootstrapClusterProxy.GetClient(),
+				Name:    namespace.Name,
+			})
+		}
+		cancelWatches()
+	})
+}
+
+func addFinalizer(ctx context.Context, c client.Client, finalizer string, objs ...client.Object) {
+	for _, obj := range objs {
+		Expect(c.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+
+		helper, err := patch.NewHelper(obj, c)
+		Expect(err).ToNot(HaveOccurred())
+
+		obj.SetFinalizers(append(obj.GetFinalizers(), finalizer))
+
+		Expect(helper.Patch(ctx, obj)).ToNot(HaveOccurred())
+	}
+}
+
+func removeFinalizer(ctx context.Context, c client.Client, finalizer string, objs ...client.Object) {
+	for _, obj := range objs {
+		err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		helper, err := patch.NewHelper(obj, c)
+		Expect(err).ToNot(HaveOccurred())
+
+		var finalizers []string
+		for _, f := range obj.GetFinalizers() {
+			if f == finalizer {
+				continue
+			}
+			finalizers = append(finalizers, f)
+		}
+
+		obj.SetFinalizers(finalizers)
+		Expect(helper.Patch(ctx, obj)).ToNot(HaveOccurred())
+	}
+}

--- a/test/e2e/cluster_deletion.go
+++ b/test/e2e/cluster_deletion.go
@@ -417,7 +417,3 @@ func assertDeletionPhase(ctx context.Context, c client.Client, finalizer string,
 		return kerrors.NewAggregate(errs)
 	}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(Succeed())
 }
-
-func hasFinalizer(wantFinalizer string, finalizers []string) bool {
-	return sets.New[string](finalizers...).Has(wantFinalizer)
-}

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -41,12 +41,12 @@ var _ = Describe("When performing cluster deletion with ClusterClass [ClusterCla
 
 			ClusterDeletionPhases: []ClusterDeletionPhase{
 				{
-					// All Machines owned by MachineDeployments or MachineSets and themselves should be deleted in this phase.
+					// All Machines owned by MachineDeployments or MachineSets, MachineDeployments and MachineSets should be deleted in this phase.
 					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
 						if objectReference.Kind == "Machine" && hasOwner(objectOwnerReferences, "MachineDeployment", "MachineSet") {
 							return true
 						}
-						return sets.New[string]("MachineDeployment", "MachineSet").Has(objectReference.Kind)
+						return objectReference.Kind == "MachineDeployment" || objectReference.Kind == "MachineSet"
 					},
 					// Of the above, only Machines should be considered to be blocking to test foreground deletion.
 					BlockingObjectFilter: func(objectReference corev1.ObjectReference, _ []metav1.OwnerReference) bool {
@@ -54,7 +54,7 @@ var _ = Describe("When performing cluster deletion with ClusterClass [ClusterCla
 					},
 				},
 				{
-					// All Machines owned by KubeadmControlPlane and itself should be deleted in this phase.
+					// All Machines owned by KubeadmControlPlane and KubeadmControlPlane should be deleted in this phase.
 					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
 						if objectReference.Kind == "Machine" && hasOwner(objectOwnerReferences, "KubeadmControlPlane") {
 							return true

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -21,11 +21,10 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
-
-	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
 
 var _ = Describe("When performing cluster deletion with ClusterClass [ClusterClass]", func() {
@@ -41,43 +40,40 @@ var _ = Describe("When performing cluster deletion with ClusterClass [ClusterCla
 			InfrastructureProvider:   ptr.To("docker"),
 
 			ClusterDeletionPhases: []ClusterDeletionPhase{
-				// The first phase deletes all worker related machines.
 				{
 					// All Machines owned by MachineDeployments or MachineSets and themselves should be deleted in this phase.
-					DeletionSelector: func(node clusterctlcluster.OwnerGraphNode) bool {
-						if node.Object.Kind == "Machine" && hasOwner(node.Owners, "MachineDeployment", "MachineSet") {
+					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						if objectReference.Kind == "Machine" && hasOwner(objectOwnerReferences, "MachineDeployment", "MachineSet") {
 							return true
 						}
-						return sets.New[string]("MachineDeployment", "MachineSet").Has(node.Object.Kind)
+						return sets.New[string]("MachineDeployment", "MachineSet").Has(objectReference.Kind)
 					},
 					// Of the above, only Machines should be considered to be blocking to test foreground deletion.
-					IsBlocking: func(node clusterctlcluster.OwnerGraphNode) bool {
-						return node.Object.Kind == "Machine"
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						return objectReference.Kind == "Machine"
 					},
 				},
-				// The second phase deletes all control plane related machines.
 				{
-					// All Machines owned by KubeadmControlPlane and themselves should be deleted in this phase.
-					DeletionSelector: func(node clusterctlcluster.OwnerGraphNode) bool {
-						if node.Object.Kind == "Machine" && hasOwner(node.Owners, "KubeadmControlPlane") {
+					// All Machines owned by KubeadmControlPlane and itself should be deleted in this phase.
+					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						if objectReference.Kind == "Machine" && hasOwner(objectOwnerReferences, "KubeadmControlPlane") {
 							return true
 						}
-						return node.Object.Kind == "KubeadmControlPlane"
+						return objectReference.Kind == "KubeadmControlPlane"
 					},
 					// Of the above, only Machines should be considered to be blocking to test foreground deletion.
-					IsBlocking: func(node clusterctlcluster.OwnerGraphNode) bool {
-						return node.Object.Kind == "Machine"
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						return objectReference.Kind == "Machine"
 					},
 				},
-				// The third phase deletes the infrastructure cluster.
 				{
 					// The DockerCluster should be deleted in this phase.
-					DeletionSelector: func(node clusterctlcluster.OwnerGraphNode) bool {
-						return node.Object.Kind == "DockerCluster"
+					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						return objectReference.Kind == "DockerCluster"
 					},
 					// Of the above, the DockerCluster should be considered to be blocking.
-					IsBlocking: func(node clusterctlcluster.OwnerGraphNode) bool {
-						return node.Object.Kind == "DockerCluster"
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+						return objectReference.Kind == "DockerCluster"
 					},
 				},
 			},

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", func() {
+var _ = Describe("When performing cluster deletion with ClusterClass [PR-Blocking] [ClusterClass]", func() {
 	ClusterDeletionSpec(ctx, func() ClusterDeletionSpecInput {
 		return ClusterDeletionSpecInput{
 			E2EConfig:                e2eConfig,
@@ -41,19 +41,19 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				// The first phase deletes all worker related machines.
 				// Note: only setting the finalizer on Machines results in properly testing foreground deletion.
 				{
-					Kinds:              sets.New[string]("MachineDeployment", "MachineSet"),
-					KindsWithFinalizer: sets.New[string]("Machine"),
+					DeleteKinds:      sets.New[string]("MachineDeployment", "MachineSet"),
+					DeleteBlockKinds: sets.New[string]("Machine"),
 				},
 				// The second phase deletes all control plane related machines.
 				// Note: only setting the finalizer on Machines results in properly testing foreground deletion.
 				{
-					Kinds:              sets.New[string]("KubeadmControlPlane"),
-					KindsWithFinalizer: sets.New[string]("Machine"),
+					DeleteKinds:      sets.New[string]("KubeadmControlPlane"),
+					DeleteBlockKinds: sets.New[string]("Machine"),
 				},
 				// The third phase deletes the infrastructure cluster.
 				{
-					Kinds:              sets.New[string](),
-					KindsWithFinalizer: sets.New[string]("DockerCluster"),
+					DeleteKinds:      sets.New[string](),
+					DeleteBlockKinds: sets.New[string]("DockerCluster"),
 				},
 			},
 		}

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -49,7 +49,7 @@ var _ = Describe("When performing cluster deletion with ClusterClass [ClusterCla
 						return sets.New[string]("MachineDeployment", "MachineSet").Has(objectReference.Kind)
 					},
 					// Of the above, only Machines should be considered to be blocking to test foreground deletion.
-					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, _ []metav1.OwnerReference) bool {
 						return objectReference.Kind == "Machine"
 					},
 				},
@@ -62,17 +62,17 @@ var _ = Describe("When performing cluster deletion with ClusterClass [ClusterCla
 						return objectReference.Kind == "KubeadmControlPlane"
 					},
 					// Of the above, only Machines should be considered to be blocking to test foreground deletion.
-					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, _ []metav1.OwnerReference) bool {
 						return objectReference.Kind == "Machine"
 					},
 				},
 				{
 					// The DockerCluster should be deleted in this phase.
-					ObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+					ObjectFilter: func(objectReference corev1.ObjectReference, _ []metav1.OwnerReference) bool {
 						return objectReference.Kind == "DockerCluster"
 					},
 					// Of the above, the DockerCluster should be considered to be blocking.
-					BlockingObjectFilter: func(objectReference corev1.ObjectReference, objectOwnerReferences []metav1.OwnerReference) bool {
+					BlockingObjectFilter: func(objectReference corev1.ObjectReference, _ []metav1.OwnerReference) bool {
 						return objectReference.Kind == "DockerCluster"
 					},
 				},

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -1,0 +1,61 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", func() {
+	ClusterDeletionSpec(ctx, func() ClusterDeletionSpecInput {
+		return ClusterDeletionSpecInput{
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			ControlPlaneMachineCount: ptr.To[int64](3),
+			Flavor:                   ptr.To("topology"),
+			InfrastructureProvider:   ptr.To("docker"),
+
+			ClusterDeletionPhases: []ClusterDeletionPhase{
+				// The first phase deletes all worker related machines.
+				// Note: only setting the finalizer on Machines results in properly testing foreground deletion.
+				{
+					Kinds:              sets.New[string]("MachineDeployment", "MachineSet"),
+					KindsWithFinalizer: sets.New[string]("Machine"),
+				},
+				// The second phase deletes all control plane related machines.
+				// Note: only setting the finalizer on Machines results in properly testing foreground deletion.
+				{
+					Kinds:              sets.New[string]("KubeadmControlPlane"),
+					KindsWithFinalizer: sets.New[string]("Machine"),
+				},
+				// The third phase deletes the infrastructure cluster.
+				{
+					Kinds:              sets.New[string](),
+					KindsWithFinalizer: sets.New[string]("DockerCluster"),
+				},
+			},
+		}
+	})
+})

--- a/test/framework/finalizers_helpers.go
+++ b/test/framework/finalizers_helpers.go
@@ -42,8 +42,10 @@ import (
 
 // CoreFinalizersAssertionWithLegacyClusters maps Cluster API core types to their expected finalizers for legacy Clusters.
 var CoreFinalizersAssertionWithLegacyClusters = map[string]func(types.NamespacedName) []string{
-	clusterKind: func(_ types.NamespacedName) []string { return []string{clusterv1.ClusterFinalizer} },
-	machineKind: func(_ types.NamespacedName) []string { return []string{clusterv1.MachineFinalizer} },
+	clusterKind:           func(_ types.NamespacedName) []string { return []string{clusterv1.ClusterFinalizer} },
+	machineKind:           func(_ types.NamespacedName) []string { return []string{clusterv1.MachineFinalizer} },
+	machineSetKind:        func(_ types.NamespacedName) []string { return []string{clusterv1.MachineSetFinalizer} },
+	machineDeploymentKind: func(_ types.NamespacedName) []string { return []string{clusterv1.MachineDeploymentFinalizer} },
 }
 
 // CoreFinalizersAssertionWithClassyClusters maps Cluster API core types to their expected finalizers for classy Clusters.
@@ -52,8 +54,12 @@ var CoreFinalizersAssertionWithClassyClusters = func() map[string]func(types.Nam
 	for k, v := range CoreFinalizersAssertionWithLegacyClusters {
 		r[k] = v
 	}
-	r[machineSetKind] = func(_ types.NamespacedName) []string { return []string{clusterv1.MachineSetTopologyFinalizer} }
-	r[machineDeploymentKind] = func(_ types.NamespacedName) []string { return []string{clusterv1.MachineDeploymentTopologyFinalizer} }
+	r[machineSetKind] = func(_ types.NamespacedName) []string {
+		return []string{clusterv1.MachineSetTopologyFinalizer, clusterv1.MachineSetFinalizer}
+	}
+	r[machineDeploymentKind] = func(_ types.NamespacedName) []string {
+		return []string{clusterv1.MachineDeploymentTopologyFinalizer, clusterv1.MachineDeploymentFinalizer}
+	}
 	return r
 }()
 

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -111,14 +111,20 @@ func getOwners(ctx context.Context, c client.Client, obj metav1.Object) ([]owner
 // five objects. On more than five objects it outputs the first five objects and
 // adds information about how much more are in the given list.
 func ObjNamesString[T client.Object](objs []T) string {
-	objNames := make([]string, len(objs))
+	shortenedBy := 0
+	if len(objs) > 5 {
+		shortenedBy = len(objs) - 5
+		objs = objs[:5]
+	}
+
+	stringList := []string{}
 	for _, obj := range objs {
-		objNames = append(objNames, obj.GetName())
+		stringList = append(stringList, obj.GetName())
 	}
 
-	if len(objNames) <= 5 {
-		return strings.Join(objNames, ", ")
+	if shortenedBy > 0 {
+		stringList = append(stringList, fmt.Sprintf("... (%d more)", shortenedBy))
 	}
 
-	return fmt.Sprintf("%s and %d more", strings.Join(objNames[:5], ", "), len(objNames)-5)
+	return strings.Join(stringList, ", ")
 }

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -19,6 +19,8 @@ package log
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -103,4 +105,20 @@ func getOwners(ctx context.Context, c client.Client, obj metav1.Object) ([]owner
 	}
 
 	return owners, nil
+}
+
+// ObjNamesString returns a comma separated list of the object names, limited to
+// five objects. On more than five objects it outputs the first five objects and
+// adds information about how much more are in the given list.
+func ObjNamesString[T client.Object](objs []T) string {
+	objNames := make([]string, len(objs))
+	for _, obj := range objs {
+		objNames = append(objNames, obj.GetName())
+	}
+
+	if len(objNames) <= 5 {
+		return strings.Join(objNames, ", ")
+	}
+
+	return fmt.Sprintf("%s and %d more", strings.Join(objNames[:5], ", "), len(objNames)-5)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Supersedes #10791

This PR implements foreground deletion in the machinedeployment and machineset controllers using a finalizer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10710

/area machinedeployment
/area machineset