### PR TITLE
🌱 Update conditions.Set function to set LastTransitionTime only when status of condition changes

### DIFF
--- a/util/conditions/setter_test.go
+++ b/util/conditions/setter_test.go
@@ -158,6 +158,9 @@ func TestSetLastTransitionTime(t *testing.T) {
 	fooWithBarMessage := FalseCondition("foo", "reason foo", clusterv1.ConditionSeverityInfo, "message bar")
 	fooWithLastTransitionTime := FalseCondition("foo", "reason foo", clusterv1.ConditionSeverityInfo, "message foo")
 	fooWithLastTransitionTime.LastTransitionTime = x
+	fooWithLastTransitionTimeWithBarMessage := FalseCondition("foo", "reason foo", clusterv1.ConditionSeverityInfo, "message bar")
+	fooWithLastTransitionTimeWithBarMessage.LastTransitionTime = y
+
 	fooWithAnotherState := TrueCondition("foo")
 	fooWithAnotherStateWithLastTransitionTime := TrueCondition("foo")
 	fooWithAnotherStateWithLastTransitionTime.LastTransitionTime = y
@@ -212,6 +215,14 @@ func TestSetLastTransitionTime(t *testing.T) {
 			name: "Set a condition that already exists but with different Message should preserve the last transition time",
 			to:   setterWithConditions(fooWithLastTransitionTime),
 			new:  fooWithBarMessage,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).To(Equal(x))
+			},
+		},
+		{
+			name: "Set a condition that already exists, with different state but same Status should ignore the last transition even if defined",
+			to:   setterWithConditions(fooWithLastTransitionTime),
+			new:  fooWithLastTransitionTimeWithBarMessage,
 			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
 				g.Expect(lastTransitionTime).To(Equal(x))
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR existing behavior of Set condition function as follows

Existing behavior

1. Update condition.LastTransitionTime to current time whenever any one of the fields(Status, Reason, Severity, Message) changes in new condition.
2. Sets the condition.LastTransitionTime to newConidtion.LastTransitionTime if defined only when the newCondition does not exist.

Proposed behavior

1.  Update condition.LastTransitionTime to current time only when Status field of new condition differ from existing condition status.
2. Sets the condition.LastTransitionTime to newCondition.LastTransitionTime  if defined whether the newCondition already exist or new.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11033

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->