### PR TITLE
✨ util: Warning handler that discards messages that match a regular expression

### DIFF
--- a/util/apiwarnings/doc.go
+++ b/util/apiwarnings/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package apiwarnings defines warning handlers used with API clients.
+package apiwarnings

--- a/util/apiwarnings/handler.go
+++ b/util/apiwarnings/handler.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiwarnings
+
+import (
+	"regexp"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+// DiscardMatchingHandlerOptions configures the handler created with
+// NewDiscardMatchingHandler.
+type DiscardMatchingHandlerOptions struct {
+	// Deduplicate indicates a given warning message should only be written once.
+	// Setting this to true in a long-running process handling many warnings can
+	// result in increased memory use.
+	Deduplicate bool
+
+	// Expressions is a slice of regular expressions used to discard warnings.
+	// If the warning message matches any expression, it is not logged.
+	Expressions []regexp.Regexp
+}
+
+// NewDiscardMatchingHandler initializes and returns a new DiscardMatchingHandler.
+func NewDiscardMatchingHandler(l logr.Logger, opts DiscardMatchingHandlerOptions) *DiscardMatchingHandler {
+	h := &DiscardMatchingHandler{logger: l, opts: opts}
+	if opts.Deduplicate {
+		h.logged = map[string]struct{}{}
+	}
+	return h
+}
+
+// DiscardMatchingHandler is a handler that discards API server warnings
+// whose message matches any user-defined regular expressions.
+type DiscardMatchingHandler struct {
+	// logger is used to log responses with the warning header
+	logger logr.Logger
+	// opts contain options controlling warning output
+	opts DiscardMatchingHandlerOptions
+	// loggedLock guards logged
+	loggedLock sync.Mutex
+	// used to keep track of already logged messages
+	// and help in de-duplication.
+	logged map[string]struct{}
+}
+
+// HandleWarningHeader handles logging for responses from API server that are
+// warnings with code being 299 and uses a logr.Logger for its logging purposes.
+func (h *DiscardMatchingHandler) HandleWarningHeader(code int, _, message string) {
+	if code != 299 || message == "" {
+		return
+	}
+
+	for _, exp := range h.opts.Expressions {
+		if exp.MatchString(message) {
+			return
+		}
+	}
+
+	if h.opts.Deduplicate {
+		h.loggedLock.Lock()
+		defer h.loggedLock.Unlock()
+
+		if _, alreadyLogged := h.logged[message]; alreadyLogged {
+			return
+		}
+		h.logged[message] = struct{}{}
+	}
+	h.logger.Info(message)
+}

--- a/util/apiwarnings/handler_test.go
+++ b/util/apiwarnings/handler_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiwarnings
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/gomega"
+)
+
+func TestDiscardMatchingHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       DiscardMatchingHandlerOptions
+		code       int
+		message    string
+		wantLogged bool
+	}{
+		{
+			name:    "log, if warning does not match any expression",
+			code:    299,
+			message: "non-matching warning",
+			opts: DiscardMatchingHandlerOptions{
+				Expressions: []regexp.Regexp{},
+			},
+			wantLogged: true,
+		},
+		{
+			name:    "do not log, if warning matches at least one expression",
+			code:    299,
+			message: "matching warning",
+			opts: DiscardMatchingHandlerOptions{
+				Expressions: []regexp.Regexp{
+					*regexp.MustCompile("^matching.*"),
+				},
+			},
+			wantLogged: false,
+		},
+		{
+			name:    "do not log, if code is not 299",
+			code:    0,
+			message: "",
+			opts: DiscardMatchingHandlerOptions{
+				Expressions: []regexp.Regexp{},
+			},
+			wantLogged: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			logged := false
+			h := NewDiscardMatchingHandler(
+				funcr.New(func(_, _ string) {
+					logged = true
+				},
+					funcr.Options{},
+				),
+				tt.opts,
+			)
+			h.HandleWarningHeader(tt.code, "", tt.message)
+			g.Expect(logged).To(Equal(tt.wantLogged))
+		})
+	}
+}
+
+func TestDiscardMatchingHandler_uninitialized(t *testing.T) {
+	g := NewWithT(t)
+	h := DiscardMatchingHandler{}
+	g.Expect(func() {
+		h.HandleWarningHeader(0, "", "")
+	}).ToNot(Panic())
+}

--- a/util/apiwarnings/handler_test.go
+++ b/util/apiwarnings/handler_test.go
@@ -80,12 +80,11 @@ func TestDiscardMatchingHandler(t *testing.T) {
 	}
 }
 
-func TestDiscardMatchingHandler_NilLogger(t *testing.T) {
+func TestDiscardMatchingHandler_uninitialized(t *testing.T) {
 	g := NewWithT(t)
-	h := DiscardMatchingHandler{
-		// Logger is nil
-	}
+	h := DiscardMatchingHandler{}
 	g.Expect(func() {
-		h.HandleWarningHeader(0, "", "")
+		// Together, the code and message value ensure that the handler logs the message.
+		h.HandleWarningHeader(299, "", "example")
 	}).ToNot(Panic())
 }

--- a/util/apiwarnings/handler_test.go
+++ b/util/apiwarnings/handler_test.go
@@ -57,6 +57,13 @@ func TestDiscardMatchingHandler(t *testing.T) {
 		{
 			name:        "do not log, if code is not 299",
 			code:        0,
+			message:     "warning",
+			expressions: []regexp.Regexp{},
+			wantLogged:  false,
+		},
+		{
+			name:        "do not log, if message is empty",
+			code:        299,
 			message:     "",
 			expressions: []regexp.Regexp{},
 			wantLogged:  false,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
As described in #10932 and #11065, users see API server warnings from run `clusterctl move`, and in controller logs. We want to offer users the option of hiding these warnings. The warning handler available in client-go allows us to hide all warnings, but we want to hide only specific warnings.

This PR implements a handler that we can customize to our needs. Because Cluster API providers are affected by this issue, we define the handler in a new `util/apiwarnings` package that can be used by providers, which are typically consumers of the `cluster-api` go module.

Future PRs will use this handler to hide warnings in the `clusterctl move` command, and controller logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area util