### PR TITLE
 📖 Drop k8s.gcr.io deprecation notice

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -4,17 +4,6 @@ Cluster API is a Kubernetes sub-project focused on providing declarative APIs an
 
 Started by the Kubernetes Special Interest Group (SIG) [Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#readme), the Cluster API project uses Kubernetes-style APIs and patterns to automate cluster lifecycle management for platform operators. The supporting infrastructure, like virtual machines, networks, load balancers, and VPCs, as well as the Kubernetes cluster configuration are all defined in the same way that application developers operate deploying and managing their workloads. This enables consistent and repeatable cluster deployments across a wide variety of infrastructure environments.
 
-## ⚠️ Breaking Changes ⚠️
-
-<aside class="note">
-<h1>Legacy k8s.gcr.io container image registry will be redirected to registry.k8s.io</h1>
-
-k8s.gcr.io image registry will be redirected to registry.k8s.io on Monday March 20th.
-All images available in k8s.gcr.io are available at registry.k8s.io.
-Please read the [announcement](https://kubernetes.io/blog/2023/03/10/image-registry-redirect/) for more details.
-
-Also, this [guide](https://github.com/kubernetes/registry.k8s.io/tree/main/docs/mirroring) provide instructions about how to identify images to mirror and how to use mirrored images.
-
 ## Getting started
 
 * [Quick Start](./user/quick-start.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
k8s.gcr.io happened some time ago now, also, there is a formatting issue (lacks of /aside 😅 )

/area documentation