### PR TITLE
🌱 clusterctl: add flag to skip lagging provider check in ApplyCustomPlan

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -791,7 +791,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}
-			got, err := u.createCustomPlan(ctx, tt.args.providersToUpgrade)
+			got, err := u.createCustomPlan(ctx, UpgradeOptions{}, tt.args.providersToUpgrade)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -123,6 +123,9 @@ type ApplyUpgradeOptions struct {
 
 	// WaitProviderTimeout sets the timeout per provider upgrade.
 	WaitProviderTimeout time.Duration
+
+	// SkipLaggingProvidersCheck skips checking if other providers in the management cluster are lagging behind the target contract during upgrade planning.
+	SkipLaggingProvidersCheck bool
 }
 
 func (c *clusterctlClient) ApplyUpgrade(ctx context.Context, options ApplyUpgradeOptions) error {
@@ -171,8 +174,9 @@ func (c *clusterctlClient) ApplyUpgrade(ctx context.Context, options ApplyUpgrad
 		len(options.AddonProviders) > 0
 
 	opts := cluster.UpgradeOptions{
-		WaitProviders:       options.WaitProviders,
-		WaitProviderTimeout: options.WaitProviderTimeout,
+		WaitProviders:             options.WaitProviders,
+		WaitProviderTimeout:       options.WaitProviderTimeout,
+		SkipLaggingProvidersCheck: options.SkipLaggingProvidersCheck,
 	}
 
 	// If we are upgrading a specific set of providers only, process the providers and call ApplyCustomPlan.

--- a/cmd/clusterctl/cmd/upgrade_apply.go
+++ b/cmd/clusterctl/cmd/upgrade_apply.go
@@ -39,6 +39,7 @@ type upgradeApplyOptions struct {
 	addonProviders            []string
 	waitProviders             bool
 	waitProviderTimeout       int
+	skipLaggingProvidersCheck bool
 }
 
 var ua = &upgradeApplyOptions{}
@@ -93,6 +94,8 @@ func init() {
 		"Wait for providers to be upgraded.")
 	upgradeApplyCmd.Flags().IntVar(&ua.waitProviderTimeout, "wait-provider-timeout", 5*60,
 		"Wait timeout per provider upgrade in seconds. This value is ignored if --wait-providers is false")
+	upgradeApplyCmd.Flags().BoolVar(&ua.skipLaggingProvidersCheck, "skip-lagging-providers-check", false,
+		"Skips checking if other providers in the management cluster are lagging behind the target contract during upgrade planning")
 }
 
 func runUpgradeApply() error {
@@ -130,5 +133,6 @@ func runUpgradeApply() error {
 		AddonProviders:            ua.addonProviders,
 		WaitProviders:             ua.waitProviders,
 		WaitProviderTimeout:       time.Duration(ua.waitProviderTimeout) * time.Second,
+		SkipLaggingProvidersCheck: ua.skipLaggingProvidersCheck,
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Clusterctl runs a pre-check to see if any other providers are lagging behind the target contract before creating an upgrade plan. In the current implementation of cluster-api-operator, there are multiple controllers reconciling on each different provider type. Each one of these controllers doesn't have knowledge of the other providers, and doesn't pass in enough information to clusterctl to be able to complete this check successfully. This PR is adds a flag and `UpgradeOption` to allow us to skip this pre-check and successfully upgrade the provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This fixes [issue 570](https://github.com/kubernetes-sigs/cluster-api-operator/issues/570) in the [cluster-api-operator repo](https://github.com/kubernetes-sigs/cluster-api-operator).