### PR TITLE
🐛 clusterclass: fix nil pointer for empty workers in webhook

### DIFF
--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -772,17 +772,19 @@ func DefaultAndValidateVariables(ctx context.Context, cluster, oldCluster *clust
 			oldCPOverrides = oldCluster.Spec.Topology.ControlPlane.Variables.Overrides
 		}
 
-		oldMDVariables = make(map[string][]clusterv1.ClusterVariable, len(oldCluster.Spec.Topology.Workers.MachineDeployments))
-		for _, md := range oldCluster.Spec.Topology.Workers.MachineDeployments {
-			if md.Variables != nil {
-				oldMDVariables[md.Name] = md.Variables.Overrides
+		if oldCluster.Spec.Topology.Workers != nil {
+			oldMDVariables = make(map[string][]clusterv1.ClusterVariable, len(oldCluster.Spec.Topology.Workers.MachineDeployments))
+			for _, md := range oldCluster.Spec.Topology.Workers.MachineDeployments {
+				if md.Variables != nil {
+					oldMDVariables[md.Name] = md.Variables.Overrides
+				}
 			}
-		}
 
-		oldMPVariables = make(map[string][]clusterv1.ClusterVariable, len(oldCluster.Spec.Topology.Workers.MachinePools))
-		for _, mp := range oldCluster.Spec.Topology.Workers.MachinePools {
-			if mp.Variables != nil {
-				oldMPVariables[mp.Name] = mp.Variables.Overrides
+			oldMPVariables = make(map[string][]clusterv1.ClusterVariable, len(oldCluster.Spec.Topology.Workers.MachinePools))
+			for _, mp := range oldCluster.Spec.Topology.Workers.MachinePools {
+				if mp.Variables != nil {
+					oldMPVariables[mp.Name] = mp.Variables.Overrides
+				}
 			}
 		}
 	}

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -165,6 +165,18 @@ func TestClusterDefaultAndValidateVariables(t *testing.T) {
 			},
 		},
 		{
+			name: "should pass with empty oldTopology",
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				Build(),
+			topology:    &clusterv1.Topology{},
+			oldTopology: &clusterv1.Topology{},
+			expect: &clusterv1.Topology{
+				Class:     "class1",
+				Version:   "v1.22.2",
+				Variables: []clusterv1.ClusterVariable{},
+			},
+		},
+		{
 			name: "don't change a variable if it is already set",
 			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithStatusVariables(clusterv1.ClusterClassStatusVariable{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

When creating a cluster without defining any workers:

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: test
  namespace: default
spec:
  topology:
    class: quick-start
    controlPlane:
      metadata: {}
      replicas: 1
    variables:
    version: v1.31.0
    # workers:
```

The reconciliation fails because the cluster cannot be patched anymore because the webhook panic's. This is visible in the cluster's status condition and when trying to patch the cluster (e.g. adding workers):

```yaml
...
status:
  conditions:
  - lastTransitionTime: "2024-09-19T06:57:27Z"
    message: 'error reconciling the Cluster topology: failed to mark "AfterControlPlaneInitialized"
      hook(s) as pending: failed to patch Cluster default/test: admission webhook
      "default.cluster.cluster.x-k8s.io" denied the request: panic: runtime error:
      invalid memory address or nil pointer dereference [recovered]'
```

```bash
❯ k apply -f cluster.yaml
Error from server: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"cluster.x-k8s.io/v1beta1\",\"kind\":\"Cluster\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"default\"},\"spec\":{\"topology\":{\"class\":\"quick-start\",\"controlPlane\":{\"metadata\":{},\"replicas\":1},\"variables\":null,\"version\":\"v1.31.0\",\"workers\":{\"machineDeployments\":[{\"class\":\"default-worker\",\"metadata\":{},\"name\":\"md-0\",\"replicas\":0}]}}}}\n"}},"spec":{"topology":{"workers":{"machineDeployments":[{"class":"default-worker","metadata":{},"name":"md-0","replicas":0}]}}}}
to:
Resource: "cluster.x-k8s.io/v1beta1, Resource=clusters", GroupVersionKind: "cluster.x-k8s.io/v1beta1, Kind=Cluster"
Name: "test", Namespace: "default"
for: "cluster.yaml": error when patching "cluster.yaml": admission webhook "default.cluster.cluster.x-k8s.io" denied the request: panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

The detailed stacktrace from the logs:
```
E0919 06:58:49.341383      20 signal_unix.go:881] "Observed a panic" logger="admission" webhookGroup="cluster.x-k8s.io" webhookKind="Cluster" Cluster="default/test" namespace="default" name="test" resource={"group":"cluster.x-k8s.io","version":"v1beta1","resource":"clusters"} user="system:serviceaccount:capi-system:capi-manager" requestID="1141264c-8de3-4b31-9b9e-d328162a593e" panic="runtime error: invalid memory address or nil pointer dereference" panicGoValue="\"invalid memory addres
s or nil pointer dereference\"" stacktrace=<                                                                                                                                                                                                                 goroutine 2160 [running]:
        k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2aafdd0, 0x400071d860}, {0x24dde00, 0x3c525a0})                                                                                                                                                             /Users/schlotterc/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/runtime/runtime.go:107 +0xe4
        sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle.func1()                                                                                                                                                                               /Users/schlotterc/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/webhook/admission/webhook.go:163 +0x158
        panic({0x24dde00?, 0x3c525a0?})                                                                                                                                                                                                                              /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/runtime/panic.go:770 +0xf0
        sigs.k8s.io/cluster-api/internal/webhooks.DefaultAndValidateVariables({0x2aafdd0, 0x400071d890}, 0x40013d41a0, 0x40013d4ea0, 0x400085d600)                                                                                                                   /Users/schlotterc/go/src/sigs.k8s.io/cluster-api/internal/webhooks/cluster.go:775 +0x1dc
        sigs.k8s.io/cluster-api/internal/webhooks.(*Cluster).Default(0x400085aab0, {0x2aafdd0, 0x400071d890}, {0x2a96340, 0x40013d41a0})                                                                                                                             /Users/schlotterc/go/src/sigs.k8s.io/cluster-api/internal/webhooks/cluster.go:162 +0xbd8
        sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*defaulterForType).Handle(_, {_, _}, {{{0x4000fd98c0, 0x24}, {{0x40010aac50, 0x10}, {0x40010aac28, 0x7}, {0x40010aac60, ...}}, ...}})                                                                  /Users/schlotterc/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/webhook/admission/defaulter_custom.go:80 +0x3e0
        sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0x4000fd98c0, 0x24}, {{0x40010aac50, 0x10}, {0x40010aac28, 0x7}, {0x40010aac60, ...}}, ...}})                                                                           /Users/schlotterc/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/webhook/admission/webhook.go:181 +0x264
        sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0x4000858870, {0xe14f5da398f0, 0x40016b1810}, 0x4000e98360)                                                                                                                        /Users/schlotterc/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/webhook/admission/http.go:119 +0xeb0
        github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1({0xe14f5da398f0, 0x40016b1810}, 0x4000e98360)                                                                                                                        /Users/schlotterc/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:60 +0x104
        net/http.HandlerFunc.ServeHTTP(0x400085b080, {0xe14f5da398f0, 0x40016b1810}, 0x4000e98360)                                                                                                                                                                   /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:2166 +0x40
        github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                              /Users/schlotterc/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:147 +0xd0
        net/http.HandlerFunc.ServeHTTP(0x400085b290, {0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                                                                        /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:2166 +0x40
        github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                             /Users/schlotterc/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:109 +0x9c
        net/http.HandlerFunc.ServeHTTP(0x4000857e80, {0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                                                                        /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:2166 +0x40
        net/http.(*ServeMux).ServeHTTP(0x40004c6ea0, {0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                                                                        /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:2683 +0x29c
        net/http.serverHandler.ServeHTTP({0x40005ec000}, {0x2aac8a0, 0x4000cb4fc0}, 0x4000e98360)                                                                                                                                                                    /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:3137 +0x2a0
        net/http.(*conn).serve(0x40013baea0, {0x2aafe08, 0x4001a892c0})
                /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:2039 +0x15f8
        created by net/http.(*Server).Serve in goroutine 210
                /Users/schlotterc/.bin/go-archive/go1.22.1.darwin-arm64/src/net/http/server.go:3285 +0x88c
 >
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterclass