### PR TITLE
🌱 Enable race detector for main module unit tests

### DIFF
--- a/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -26,6 +28,8 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -26,6 +28,8 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -28,6 +30,8 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion_no_fuzz_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion_no_fuzz_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upstreamv1beta4
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+)
+
+// This test case has been moved out of conversion_test.go because it should be run with the race detector.
+// Note: The tests in conversion_test.go are disabled when the race detector is enabled (via "//go:build !race") because otherwise the fuzz tests would just time out.
+
+func TestTimeoutForControlPlaneMigration(t *testing.T) {
+	timeout := metav1.Duration{Duration: 10 * time.Second}
+	t.Run("from ClusterConfiguration to InitConfiguration and back", func(t *testing.T) {
+		g := NewWithT(t)
+
+		clusterConfiguration := &bootstrapv1.ClusterConfiguration{
+			APIServer: bootstrapv1.APIServer{TimeoutForControlPlane: &timeout},
+		}
+
+		initConfiguration := &InitConfiguration{}
+		err := initConfiguration.ConvertFromClusterConfiguration(clusterConfiguration)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(initConfiguration.Timeouts.ControlPlaneComponentHealthCheck).To(Equal(&timeout))
+
+		clusterConfiguration = &bootstrapv1.ClusterConfiguration{}
+		err = initConfiguration.ConvertToClusterConfiguration(clusterConfiguration)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(clusterConfiguration.APIServer.TimeoutForControlPlane).To(Equal(&timeout))
+	})
+	t.Run("from ClusterConfiguration to JoinConfiguration and back", func(t *testing.T) {
+		g := NewWithT(t)
+
+		clusterConfiguration := &bootstrapv1.ClusterConfiguration{
+			APIServer: bootstrapv1.APIServer{TimeoutForControlPlane: &timeout},
+		}
+
+		joinConfiguration := &JoinConfiguration{}
+		err := joinConfiguration.ConvertFromClusterConfiguration(clusterConfiguration)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(joinConfiguration.Timeouts.ControlPlaneComponentHealthCheck).To(Equal(&timeout))
+
+		clusterConfiguration = &bootstrapv1.ClusterConfiguration{}
+		err = joinConfiguration.ConvertToClusterConfiguration(clusterConfiguration)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(clusterConfiguration.APIServer.TimeoutForControlPlane).To(Equal(&timeout))
+	})
+}

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -18,18 +20,18 @@ package upstreamv1beta4
 
 import (
 	"testing"
-	"time"
 
 	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)
@@ -143,42 +145,4 @@ func bootstrapv1JoinConfigurationFuzzer(obj *bootstrapv1.JoinConfiguration, c fu
 	if obj.Discovery.File != nil {
 		obj.Discovery.File.KubeConfig = nil
 	}
-}
-
-func TestTimeoutForControlPlaneMigration(t *testing.T) {
-	timeout := metav1.Duration{Duration: 10 * time.Second}
-	t.Run("from ClusterConfiguration to InitConfiguration and back", func(t *testing.T) {
-		g := NewWithT(t)
-
-		clusterConfiguration := &bootstrapv1.ClusterConfiguration{
-			APIServer: bootstrapv1.APIServer{TimeoutForControlPlane: &timeout},
-		}
-
-		initConfiguration := &InitConfiguration{}
-		err := initConfiguration.ConvertFromClusterConfiguration(clusterConfiguration)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(initConfiguration.Timeouts.ControlPlaneComponentHealthCheck).To(Equal(&timeout))
-
-		clusterConfiguration = &bootstrapv1.ClusterConfiguration{}
-		err = initConfiguration.ConvertToClusterConfiguration(clusterConfiguration)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(clusterConfiguration.APIServer.TimeoutForControlPlane).To(Equal(&timeout))
-	})
-	t.Run("from ClusterConfiguration to JoinConfiguration and back", func(t *testing.T) {
-		g := NewWithT(t)
-
-		clusterConfiguration := &bootstrapv1.ClusterConfiguration{
-			APIServer: bootstrapv1.APIServer{TimeoutForControlPlane: &timeout},
-		}
-
-		joinConfiguration := &JoinConfiguration{}
-		err := joinConfiguration.ConvertFromClusterConfiguration(clusterConfiguration)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(joinConfiguration.Timeouts.ControlPlaneComponentHealthCheck).To(Equal(&timeout))
-
-		clusterConfiguration = &bootstrapv1.ClusterConfiguration{}
-		err = joinConfiguration.ConvertToClusterConfiguration(clusterConfiguration)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(clusterConfiguration.APIServer.TimeoutForControlPlane).To(Equal(&timeout))
-	})
 }

--- a/exp/ipam/api/v1alpha1/conversion_test.go
+++ b/exp/ipam/api/v1alpha1/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -24,6 +26,8 @@ import (
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for IPAddress", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/bootstrap/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -27,6 +29,8 @@ import (
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/upstreamv1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/bootstrap/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -31,6 +33,8 @@ const (
 	fakeID     = "abcdef"
 	fakeSecret = "abcdef0123456789"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/controlplane/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -28,6 +30,8 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/controlplane/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -35,6 +37,8 @@ const (
 	fakeID     = "abcdef"
 	fakeSecret = "abcdef0123456789"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/addons/v1alpha3/conversion_test.go
+++ b/internal/apis/core/exp/addons/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/addons/v1alpha4/conversion_test.go
+++ b/internal/apis/core/exp/addons/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/v1alpha3/conversion_test.go
+++ b/internal/apis/core/exp/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -27,6 +29,8 @@ import (
 	clusterv1alpha3 "sigs.k8s.io/cluster-api/internal/apis/core/v1alpha3"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for MachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/v1alpha4/conversion_test.go
+++ b/internal/apis/core/exp/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -24,6 +26,8 @@ import (
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for MachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/v1alpha3/conversion_test.go
+++ b/internal/apis/core/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -28,6 +30,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for Cluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/v1alpha4/conversion_test.go
+++ b/internal/apis/core/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -29,6 +31,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for Cluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/exp/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	infraexpv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/exp/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,6 +24,8 @@ import (
 	infraexpv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Took the part for the unit tests of the main module from https://github.com/kubernetes-sigs/cluster-api/pull/10899.
I want to get the race detector for this part of our code base ASAP.

This PR:
* enables the race detector for `make test` & `make junit-test`
* `make junit-test` uses `-json`, because of that I had to make sure a proper logger is used in envtest unit tests, otherwise we hit a race condition when writing/reading os.Stderr
* Fuzz tests time out after 10m when run with the race detector, because of that all test files with fuzz tests have been flagged with `go build !race`. Additional test executions have been added to `make test` and `make test-junit` to ensure the tests in these files are still executed (the `!race` tag means that these files are entirely ignored when running tests with `-race`)
* The race detector slows down the test job. It now takes around 18m instead of 10m. But I think it's worth it. Also we usually have to wait for the e2e-blocking test anyway and that one takes ~17m.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->