### PR TITLE
:seedling: Update RKE2 provider URL

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -348,7 +348,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         RKE2BootstrapProviderName,
-			url:          "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/bootstrap-components.yaml",
+			url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
 		&provider{
@@ -395,7 +395,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         RKE2ControlPlaneProviderName,
-			url:          "https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/control-plane-components.yaml",
+			url:          "https://github.com/rancher/cluster-api-provider-rke2/releases/latest/control-plane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -110,7 +110,7 @@ kubeadm                 BootstrapProvider        https://github.com/kubernetes-s
 kubekey-k3s             BootstrapProvider        https://github.com/kubesphere/kubekey/releases/latest/                                      bootstrap-components.yaml
 microk8s                BootstrapProvider        https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/releases/latest/       bootstrap-components.yaml
 ocne                    BootstrapProvider        https://github.com/verrazzano/cluster-api-provider-ocne/releases/latest/                    bootstrap-components.yaml
-rke2                    BootstrapProvider        https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/               bootstrap-components.yaml
+rke2                    BootstrapProvider        https://github.com/rancher/cluster-api-provider-rke2/releases/latest/                       bootstrap-components.yaml
 talos                   BootstrapProvider        https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/         bootstrap-components.yaml
 k0sproject-k0smotron    ControlPlaneProvider     https://github.com/k0sproject/k0smotron/releases/latest/                                    control-plane-components.yaml
 kamaji                  ControlPlaneProvider     https://github.com/clastix/cluster-api-control-plane-provider-kamaji/releases/latest/       control-plane-components.yaml
@@ -119,7 +119,7 @@ kubekey-k3s             ControlPlaneProvider     https://github.com/kubesphere/k
 microk8s                ControlPlaneProvider     https://github.com/canonical/cluster-api-control-plane-provider-microk8s/releases/latest/   control-plane-components.yaml
 nested                  ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/             control-plane-components.yaml
 ocne                    ControlPlaneProvider     https://github.com/verrazzano/cluster-api-provider-ocne/releases/latest/                    control-plane-components.yaml
-rke2                    ControlPlaneProvider     https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/               control-plane-components.yaml
+rke2                    ControlPlaneProvider     https://github.com/rancher/cluster-api-provider-rke2/releases/latest/                       control-plane-components.yaml
 talos                   ControlPlaneProvider     https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/     control-plane-components.yaml
 aws                     InfrastructureProvider                                                                                               my-aws-infrastructure-components.yaml
 azure                   InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest/              infrastructure-components.yaml
@@ -190,7 +190,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: bootstrap-components.yaml
   Name: rke2
   ProviderType: BootstrapProvider
-  URL: https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/
+  URL: https://github.com/rancher/cluster-api-provider-rke2/releases/latest/
 - File: bootstrap-components.yaml
   Name: talos
   ProviderType: BootstrapProvider
@@ -226,7 +226,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: control-plane-components.yaml
   Name: rke2
   ProviderType: ControlPlaneProvider
-  URL: https://github.com/rancher-sandbox/cluster-api-provider-rke2/releases/latest/
+  URL: https://github.com/rancher/cluster-api-provider-rke2/releases/latest/
 - File: control-plane-components.yaml
   Name: talos
   ProviderType: ControlPlaneProvider


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/guide.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The CAPRKE2 repository was recently moved from https://github.com/rancher-sandbox/cluster-api-provider-rke2 to https://github.com/rancher/cluster-api-provider-rke2 so GitHub redirects any requests to the old repo URL, to the new repo URL. This change simply updates the CAPRKE2 provider URL to point to the new repo .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl