### PR TITLE
🐛 Log errors on specific log levels correctly

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -135,7 +135,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 	for _, nodeRef := range nodeRefs {
 		node := &corev1.Node{}
 		if err := c.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
-			log.V(2).Error(err, "Failed to get Node, skipping", "Node", klog.KRef("", nodeRef.Name))
+			log.Error(err, "Failed to get Node, skipping", "Node", klog.KRef("", nodeRef.Name))
 			continue
 		}
 
@@ -200,7 +200,7 @@ func (r *MachinePoolReconciler) patchNodes(ctx context.Context, c client.Client,
 	for _, nodeRef := range references {
 		node := &corev1.Node{}
 		if err := c.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
-			log.V(2).Error(err, "Failed to get Node, skipping setting annotations", "Node", klog.KRef("", nodeRef.Name))
+			log.Error(err, "Failed to get Node, skipping setting annotations", "Node", klog.KRef("", nodeRef.Name))
 			continue
 		}
 		patchHelper, err := patch.NewHelper(node, c)
@@ -219,7 +219,7 @@ func (r *MachinePoolReconciler) patchNodes(ctx context.Context, c client.Client,
 		// Patch the node if needed.
 		if hasAnnotationChanges || hasTaintChanges {
 			if err := patchHelper.Patch(ctx, node); err != nil {
-				log.V(2).Error(err, "Failed patch Node to set annotations and drop taints", "Node", klog.KObj(node))
+				log.Error(err, "Failed patch Node to set annotations and drop taints", "Node", klog.KObj(node))
 				return err
 			}
 		}

--- a/internal/controllers/machine/drain/drain.go
+++ b/internal/controllers/machine/drain/drain.go
@@ -215,7 +215,7 @@ evictionLoop:
 		case <-ctx.Done():
 			// Skip eviction if the eviction timeout is reached.
 			err := fmt.Errorf("eviction timeout of %s reached, eviction will be retried", evictionTimeout)
-			log.V(4).Error(err, "Error when evicting Pod")
+			log.V(4).Info("Error when evicting Pod", "err", err)
 			res.PodsFailedEviction[err.Error()] = append(res.PodsFailedEviction[err.Error()], pd.Pod)
 			continue evictionLoop
 		default:
@@ -250,17 +250,17 @@ evictionLoop:
 				err = errors.New(errorMessage)
 			}
 
-			log.V(4).Error(err, "Error when evicting Pod")
+			log.V(4).Info("Error when evicting Pod", "err", err)
 			res.PodsFailedEviction[err.Error()] = append(res.PodsFailedEviction[err.Error()], pd.Pod)
 		case apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause):
 			// Creating an eviction resource in a terminating namespace will throw a forbidden error, e.g.:
 			// "pods "pod-6-to-trigger-eviction-namespace-terminating" is forbidden: unable to create new content in namespace test-namespace because it is being terminated"
 			// The kube-controller-manager is supposed to set the deletionTimestamp on the Pod and then this error will go away.
 			msg := "Cannot evict pod from terminating namespace: unable to create eviction (kube-controller-manager should set deletionTimestamp)"
-			log.V(4).Error(err, msg)
+			log.V(4).Info(msg, "err", err)
 			res.PodsFailedEviction[msg] = append(res.PodsFailedEviction[msg], pd.Pod)
 		default:
-			log.V(4).Error(err, "Error when evicting Pod")
+			log.V(4).Info("Error when evicting Pod", "err", err)
 			res.PodsFailedEviction[err.Error()] = append(res.PodsFailedEviction[err.Error()], pd.Pod)
 		}
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
@@ -106,7 +106,7 @@ func (r *Reconciler) reconcileOldMachineSetsOnDelete(ctx context.Context, oldMSs
 		}
 		selectorMap, err := metav1.LabelSelectorAsMap(&oldMS.Spec.Selector)
 		if err != nil {
-			log.V(4).Error(err, "failed to convert MachineSet label selector to a map")
+			log.V(4).Info("Failed to convert MachineSet label selector to a map", "err", err)
 			continue
 		}
 		log.V(4).Info("Fetching Machines associated with MachineSet")
@@ -127,7 +127,7 @@ func (r *Reconciler) reconcileOldMachineSetsOnDelete(ctx context.Context, oldMSs
 		}
 		machineSetScaleDownAmountDueToMachineDeletion := *oldMS.Spec.Replicas - updatedReplicaCount
 		if machineSetScaleDownAmountDueToMachineDeletion < 0 {
-			log.V(4).Error(errors.Errorf("Unexpected negative scale down amount: %d", machineSetScaleDownAmountDueToMachineDeletion), fmt.Sprintf("Error reconciling MachineSet %s", oldMS.Name))
+			log.V(4).Info(fmt.Sprintf("Error reconciling MachineSet %s", oldMS.Name), "err", errors.Errorf("Unexpected negative scale down amount: %d", machineSetScaleDownAmountDueToMachineDeletion))
 		}
 		scaleDownAmount -= machineSetScaleDownAmountDueToMachineDeletion
 		log.V(4).Info("Adjusting replica count for deleted machines", "oldReplicas", oldMS.Spec.Replicas, "newReplicas", updatedReplicaCount)

--- a/util/util.go
+++ b/util/util.go
@@ -219,7 +219,7 @@ func ClusterToInfrastructureMapFunc(ctx context.Context, gvk schema.GroupVersion
 		key := types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}
 
 		if err := c.Get(ctx, key, providerCluster); err != nil {
-			log.V(4).Error(err, fmt.Sprintf("Failed to get %T", providerCluster))
+			log.V(4).Info(fmt.Sprintf("Failed to get %T", providerCluster), "err", err)
 			return nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Was working on something new and realized that Errors are always logged independent of the configured log level.
So using `log.V(4).Error(err, )`, doesn't make sense as the errors are always logged...

godoc of the Error func:

> // Error logs an error, with the given message and key/value pairs as context.
> // It functions similarly to Info, but may have unique behavior, and should be
> // preferred for logging errors (see the package documentations for more
> // information). **The log message will always be emitted, regardless of
> // verbosity level.**


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->