### PR TITLE
:warning: Fix object logging in predicates

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -130,7 +130,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		&clusterv1.Cluster{},
 		handler.EnqueueRequestsFromMapFunc(r.ClusterToKubeadmConfigs),
 		builder.WithPredicates(
-			predicates.All(predicateLog,
+			predicates.All(mgr.GetScheme(), predicateLog,
 				predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 				predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 			),

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -131,7 +131,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		handler.EnqueueRequestsFromMapFunc(r.ClusterToKubeadmConfigs),
 		builder.WithPredicates(
 			predicates.All(predicateLog,
-				predicates.ClusterUnpausedAndInfrastructureReady(predicateLog),
+				predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 				predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 			),
 		),

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -103,7 +103,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(r.ClusterToKubeadmControlPlane),
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 					predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 				),

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -105,7 +105,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 			builder.WithPredicates(
 				predicates.All(predicateLog,
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
-					predicates.ClusterUnpausedAndInfrastructureReady(predicateLog),
+					predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 				),
 			),
 		).Build(r)

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -115,7 +115,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 			builder.WithPredicates(
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),
 			),

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -114,7 +114,7 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			handler.EnqueueRequestsFromMapFunc(clusterToMachinePools),
 			// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -125,8 +125,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachines),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-				predicates.All(predicateLog,
-					predicates.Any(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
+					predicates.Any(mgr.GetScheme(), predicateLog,
 						predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 						predicates.ClusterControlPlaneInitialized(mgr.GetScheme(), predicateLog),
 					),

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -127,8 +127,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(predicateLog,
 					predicates.Any(predicateLog,
-						predicates.ClusterUnpaused(predicateLog),
-						predicates.ClusterControlPlaneInitialized(predicateLog),
+						predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
+						predicates.ClusterControlPlaneInitialized(mgr.GetScheme(), predicateLog),
 					),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -99,7 +99,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 				),
 			),

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -100,7 +100,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 				),
 			),
 		).Complete(r)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -100,7 +100,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),
 			),

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -99,7 +99,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -122,7 +122,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -123,7 +123,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			builder.WithPredicates(
 				// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 				),
 			),

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -67,7 +67,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.MachineDeployment{},
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ResourceIsTopologyOwned(mgr.GetScheme(), predicateLog),
 					predicates.ResourceNotPaused(mgr.GetScheme(), predicateLog)),
 			),
@@ -79,7 +79,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 				),

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -68,7 +68,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		For(&clusterv1.MachineDeployment{},
 			builder.WithPredicates(
 				predicates.All(predicateLog,
-					predicates.ResourceIsTopologyOwned(predicateLog),
+					predicates.ResourceIsTopologyOwned(mgr.GetScheme(), predicateLog),
 					predicates.ResourceNotPaused(mgr.GetScheme(), predicateLog)),
 			),
 		).
@@ -80,8 +80,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			builder.WithPredicates(
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
-					predicates.ClusterHasTopology(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
+					predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 				),
 			),
 		).

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -70,7 +70,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		For(&clusterv1.MachineSet{},
 			builder.WithPredicates(
 				predicates.All(predicateLog,
-					predicates.ResourceIsTopologyOwned(predicateLog),
+					predicates.ResourceIsTopologyOwned(mgr.GetScheme(), predicateLog),
 					predicates.ResourceNotPaused(mgr.GetScheme(), predicateLog)),
 			),
 		).
@@ -82,8 +82,8 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
 			builder.WithPredicates(
 				predicates.All(predicateLog,
-					predicates.ClusterUnpaused(predicateLog),
-					predicates.ClusterHasTopology(predicateLog),
+					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
+					predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 				),
 			),
 		).

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -69,7 +69,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.MachineSet{},
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ResourceIsTopologyOwned(mgr.GetScheme(), predicateLog),
 					predicates.ResourceNotPaused(mgr.GetScheme(), predicateLog)),
 			),
@@ -81,7 +81,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineSets),
 			builder.WithPredicates(
-				predicates.All(predicateLog,
+				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 					predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 				),

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -190,7 +190,7 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr 
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToDockerMachinePools),
 			builder.WithPredicates(
-				predicates.ClusterUnpausedAndInfrastructureReady(predicateLog),
+				predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 			),
 		).Build(r)
 	if err != nil {

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -207,7 +207,7 @@ func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("DockerCluster"), mgr.GetClient(), &infrav1.DockerCluster{})),
 			builder.WithPredicates(
-				predicates.ClusterUnpaused(predicateLog),
+				predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 			),
 		).Complete(r)
 	if err != nil {

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -501,7 +501,7 @@ func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToDockerMachines),
 			builder.WithPredicates(
-				predicates.ClusterUnpausedAndInfrastructureReady(predicateLog),
+				predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 			),
 		).Complete(r)
 	if err != nil {

--- a/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorycluster_controller.go
@@ -217,7 +217,7 @@ func (r *InMemoryClusterReconciler) SetupWithManager(ctx context.Context, mgr ct
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("InMemoryCluster"), mgr.GetClient(), &infrav1.InMemoryCluster{})),
 			builder.WithPredicates(
-				predicates.ClusterUnpaused(predicateLog),
+				predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 			),
 		).Complete(r)
 	if err != nil {

--- a/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
+++ b/test/infrastructure/inmemory/internal/controllers/inmemorymachine_controller.go
@@ -1160,7 +1160,7 @@ func (r *InMemoryMachineReconciler) SetupWithManager(ctx context.Context, mgr ct
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToInMemoryMachines),
 			builder.WithPredicates(
-				predicates.ClusterUnpausedAndInfrastructureReady(predicateLog),
+				predicates.ClusterUnpausedAndInfrastructureReady(mgr.GetScheme(), predicateLog),
 			),
 		).Complete(r)
 	if err != nil {

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -175,7 +175,7 @@ func ClusterUnpaused(scheme *runtime.Scheme, logger logr.Logger) predicate.Funcs
 	log := logger.WithValues("predicate", "ClusterUnpaused")
 
 	// Use any to ensure we process either create or update events we care about
-	return Any(log, ClusterCreateNotPaused(scheme, log), ClusterUpdateUnpaused(scheme, log))
+	return Any(scheme, log, ClusterCreateNotPaused(scheme, log), ClusterUpdateUnpaused(scheme, log))
 }
 
 // ClusterControlPlaneInitialized returns a Predicate that returns true on Update events
@@ -234,13 +234,13 @@ func ClusterUnpausedAndInfrastructureReady(scheme *runtime.Scheme, logger logr.L
 	log := logger.WithValues("predicate", "ClusterUnpausedAndInfrastructureReady")
 
 	// Only continue processing create events if both not paused and infrastructure is ready
-	createPredicates := All(log, ClusterCreateNotPaused(scheme, log), ClusterCreateInfraReady(scheme, log))
+	createPredicates := All(scheme, log, ClusterCreateNotPaused(scheme, log), ClusterCreateInfraReady(scheme, log))
 
 	// Process update events if either Cluster is unpaused or infrastructure becomes ready
-	updatePredicates := Any(log, ClusterUpdateUnpaused(scheme, log), ClusterUpdateInfraReady(scheme, log))
+	updatePredicates := Any(scheme, log, ClusterUpdateUnpaused(scheme, log), ClusterUpdateInfraReady(scheme, log))
 
 	// Use any to ensure we process either create or update events we care about
-	return Any(log, createPredicates, updatePredicates)
+	return Any(scheme, log, createPredicates, updatePredicates)
 }
 
 // ClusterHasTopology returns a Predicate that returns true when cluster.Spec.Topology

--- a/util/predicates/cluster_predicates_test.go
+++ b/util/predicates/cluster_predicates_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -31,7 +32,7 @@ import (
 
 func TestClusterControlplaneInitializedPredicate(t *testing.T) {
 	g := NewWithT(t)
-	predicate := predicates.ClusterControlPlaneInitialized(logr.New(log.NullLogSink{}))
+	predicate := predicates.ClusterControlPlaneInitialized(runtime.NewScheme(), logr.New(log.NullLogSink{}))
 
 	markedFalse := clusterv1.Cluster{}
 	conditions.MarkFalse(&markedFalse, clusterv1.ControlPlaneInitializedCondition, clusterv1.MissingNodeRefReason, clusterv1.ConditionSeverityWarning, "")

--- a/util/predicates/generic_predicates.go
+++ b/util/predicates/generic_predicates.go
@@ -30,10 +30,13 @@ import (
 )
 
 // All returns a predicate that returns true only if all given predicates return true.
-func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
+func All(scheme *runtime.Scheme, logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
+			if gvk, err := apiutil.GVKForObject(e.ObjectNew, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.ObjectNew))
+			}
 			for _, p := range predicates {
 				if !p.UpdateFunc(e) {
 					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
@@ -45,6 +48,9 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if !p.CreateFunc(e) {
 					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
@@ -56,6 +62,9 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if !p.DeleteFunc(e) {
 					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
@@ -67,6 +76,9 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if !p.GenericFunc(e) {
 					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
@@ -80,10 +92,13 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 }
 
 // Any returns a predicate that returns true only if any given predicate returns true.
-func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
+func Any(scheme *runtime.Scheme, logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
+			if gvk, err := apiutil.GVKForObject(e.ObjectNew, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.ObjectNew))
+			}
 			for _, p := range predicates {
 				if p.UpdateFunc(e) {
 					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
@@ -95,6 +110,9 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if p.CreateFunc(e) {
 					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
@@ -106,6 +124,9 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if p.DeleteFunc(e) {
 					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
@@ -117,6 +138,9 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
+			if gvk, err := apiutil.GVKForObject(e.Object, scheme); err == nil {
+				log = log.WithValues(gvk.Kind, klog.KObj(e.Object))
+			}
 			for _, p := range predicates {
 				if p.GenericFunc(e) {
 					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
@@ -182,7 +206,7 @@ func ResourceNotPaused(scheme *runtime.Scheme, logger logr.Logger) predicate.Fun
 // ResourceNotPausedAndHasFilterLabel returns a predicate that returns true only if the
 // ResourceNotPaused and ResourceHasFilterLabel predicates return true.
 func ResourceNotPausedAndHasFilterLabel(scheme *runtime.Scheme, logger logr.Logger, labelValue string) predicate.Funcs {
-	return All(logger, ResourceNotPaused(scheme, logger), ResourceHasFilterLabel(scheme, logger, labelValue))
+	return All(scheme, logger, ResourceNotPaused(scheme, logger), ResourceHasFilterLabel(scheme, logger, labelValue))
 }
 
 func processIfNotPaused(scheme *runtime.Scheme, logger logr.Logger, obj client.Object) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR logs objects kind predicates for easier debugging.

Related PR with same changes for few predicates: https://github.com/kubernetes-sigs/cluster-api/pull/11188

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10818

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area utils