### PR TITLE
🌱 Use TODO instead of FIXME consistently

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -963,7 +963,7 @@ func (o *objectMover) createTargetObject(ctx context.Context, nodeToCreate *node
 	// Rebuild the owner reference chain
 	o.buildOwnerChain(obj, nodeToCreate)
 
-	// FIXME Workaround for https://github.com/kubernetes/kubernetes/issues/32220. Remove when the issue is fixed.
+	// TODO Workaround for https://github.com/kubernetes/kubernetes/issues/32220. Remove when the issue is fixed.
 	// If the resource already exists, the API server ordinarily returns an AlreadyExists error. Due to the above issue, if the resource has a non-empty metadata.generateName field, the API server returns a ServerTimeoutError. To ensure that the API server returns an AlreadyExists error, we set the metadata.generateName field to an empty string.
 	if obj.GetName() != "" && obj.GetGenerateName() != "" {
 		obj.SetGenerateName("")

--- a/cmd/clusterctl/client/repository/repository_gitlab.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab.go
@@ -118,7 +118,7 @@ func (g *gitLabRepository) DefaultVersion() string {
 
 // GetVersions returns the list of versions that are available in a provider repository.
 func (g *gitLabRepository) GetVersions(_ context.Context) ([]string, error) {
-	// FIXME Get versions from GitLab API
+	// TODO Get versions from GitLab API
 	return []string{g.defaultVersion}, nil
 }
 

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -1420,7 +1420,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 	})
 
 	t.Run("when a machine is paused", func(t *testing.T) {
-		// FIXME: Resolve flaky/failing test
+		// TODO: Resolve flaky/failing test
 		t.Skip("skipping until made stable")
 		g := NewWithT(t)
 		cluster := createCluster(g, ns.Name)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Let's use TODO consistently. I don't see a benefit in using FIXME in a small amount of cases instead


(I'm personally using FIXME when I'm working on a PR to track TODOs that I have to resolve before I open the PR, those few occurences of FIXME are annoying in that situation)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->