### PR TITLE
⚠️ Machine: ignore attached Volumes referred by pods ignored during drain

### DIFF
--- a/internal/controllers/machine/drain/drain.go
+++ b/internal/controllers/machine/drain/drain.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clog "sigs.k8s.io/cluster-api/util/log"
 )
 
 // Helper contains the parameters to control the behaviour of the drain helper.
@@ -351,33 +353,14 @@ func (r EvictionResult) ConditionMessage(nodeDrainStartTime *metav1.Time) string
 
 // podDeleteListToString returns a comma-separated list of the first n entries of the PodDelete list.
 func podDeleteListToString(podList []PodDelete, n int) string {
-	return listToString(podList, func(pd PodDelete) string {
+	return clog.ListToString(podList, func(pd PodDelete) string {
 		return klog.KObj(pd.Pod).String()
 	}, n)
 }
 
 // PodListToString returns a comma-separated list of the first n entries of the Pod list.
 func PodListToString(podList []*corev1.Pod, n int) string {
-	return listToString(podList, func(p *corev1.Pod) string {
+	return clog.ListToString(podList, func(p *corev1.Pod) string {
 		return klog.KObj(p).String()
 	}, n)
-}
-
-// listToString returns a comma-separated list of the first n entries of the list (strings are calculated via stringFunc).
-func listToString[T any](list []T, stringFunc func(T) string, n int) string {
-	shortenedBy := 0
-	if len(list) > n {
-		shortenedBy = len(list) - n
-		list = list[:n]
-	}
-	stringList := []string{}
-	for _, p := range list {
-		stringList = append(stringList, stringFunc(p))
-	}
-
-	if shortenedBy > 0 {
-		stringList = append(stringList, fmt.Sprintf("... (%d more)", shortenedBy))
-	}
-
-	return strings.Join(stringList, ", ")
 }

--- a/internal/controllers/machine/drain/filters.go
+++ b/internal/controllers/machine/drain/filters.go
@@ -62,6 +62,18 @@ func (l *PodDeleteList) Pods() []*corev1.Pod {
 	return pods
 }
 
+// IgnoredPods returns a list of Pods that have to be ignored before the Node can be considered completely drained.
+// Note: As of today only Pods from  DaemonSet, static Pods or if `SkipWaitForDeleteTimeoutSeconds` is set Pods in deletion get ignored.
+func (l *PodDeleteList) IgnoredPods() []*corev1.Pod {
+	pods := []*corev1.Pod{}
+	for _, i := range l.items {
+		if !i.Status.Delete {
+			pods = append(pods, i.Pod)
+		}
+	}
+	return pods
+}
+
 func (l *PodDeleteList) errors() []error {
 	failedPods := make(map[string][]string)
 	for _, i := range l.items {

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -19,16 +19,19 @@ package machine
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -61,7 +64,8 @@ import (
 )
 
 const (
-	drainRetryInterval = time.Duration(20) * time.Second
+	drainRetryInterval               = time.Duration(20) * time.Second
+	waitForVolumeDetachRetryInterval = time.Duration(20) * time.Second
 )
 
 var (
@@ -518,14 +522,15 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 			s.deletingReason = clusterv1.MachineDeletingWaitingForVolumeDetachV1Beta2Reason
 			s.deletingMessage = fmt.Sprintf("Waiting for Node volumes to be detached (started at %s)", m.Status.Deletion.WaitForNodeVolumeDetachStartTime.Format(time.RFC3339))
 
-			if ok, err := r.shouldWaitForNodeVolumes(ctx, s, m.Status.NodeRef.Name); ok || err != nil {
-				if err != nil {
-					s.deletingReason = clusterv1.MachineDeletingWaitingForVolumeDetachV1Beta2Reason
-					s.deletingMessage = "Error waiting for volumes to be detached from Node, please check controller logs for errors"
-					r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedWaitForVolumeDetach", "error waiting for node volumes detaching, Machine's node %q: %v", m.Status.NodeRef.Name, err)
-					return ctrl.Result{}, err
-				}
-				return ctrl.Result{}, nil
+			result, err := r.shouldWaitForNodeVolumes(ctx, s)
+			if err != nil {
+				s.deletingReason = clusterv1.MachineDeletingWaitingForVolumeDetachV1Beta2Reason
+				s.deletingMessage = "Error waiting for volumes to be detached from Node, please check controller logs for errors"
+				r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedWaitForVolumeDetach", "error waiting for node volumes detaching, Machine's node %q: %v", m.Status.NodeRef.Name, err)
+				return ctrl.Result{}, err
+			}
+			if !result.IsZero() {
+				return result, nil
 			}
 			conditions.MarkTrue(m, clusterv1.VolumeDetachSucceededCondition)
 			r.recorder.Eventf(m, corev1.EventTypeNormal, "NodeVolumesDetached", "success waiting for node volumes detaching Machine's node %q", m.Status.NodeRef.Name)
@@ -783,7 +788,7 @@ func (r *Reconciler) drainNode(ctx context.Context, s *scope) (ctrl.Result, erro
 	if err := remoteClient.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
 		if apierrors.IsNotFound(err) {
 			// If an admin deletes the node directly, we'll end up here.
-			log.Error(err, "Could not find node from noderef, it may have already been deleted")
+			log.Info("Could not find Node from Machine.status.nodeRef, skip waiting for volume detachment.")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, errors.Wrapf(err, "unable to get Node %s", nodeName)
@@ -866,7 +871,8 @@ func (r *Reconciler) drainNode(ctx context.Context, s *scope) (ctrl.Result, erro
 // this could cause issue for some storage provisioner, for example, vsphere-volume this is problematic
 // because if the node is deleted before detach success, then the underline VMDK will be deleted together with the Machine
 // so after node draining we need to check if all volumes are detached before deleting the node.
-func (r *Reconciler) shouldWaitForNodeVolumes(ctx context.Context, s *scope, nodeName string) (bool, error) {
+func (r *Reconciler) shouldWaitForNodeVolumes(ctx context.Context, s *scope) (ctrl.Result, error) {
+	nodeName := s.machine.Status.NodeRef.Name
 	log := ctrl.LoggerFrom(ctx, "Node", klog.KRef("", nodeName))
 	ctx = ctrl.LoggerInto(ctx, log)
 
@@ -875,16 +881,16 @@ func (r *Reconciler) shouldWaitForNodeVolumes(ctx context.Context, s *scope, nod
 
 	remoteClient, err := r.ClusterCache.GetClient(ctx, util.ObjectKey(cluster))
 	if err != nil {
-		return true, err
+		return ctrl.Result{}, err
 	}
 
 	node := &corev1.Node{}
 	if err := remoteClient.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Error(err, "Could not find node from noderef, it may have already been deleted")
-			return false, nil
+			return ctrl.Result{}, nil
 		}
-		return true, err
+		return ctrl.Result{}, err
 	}
 
 	if noderefutil.IsNodeUnreachable(node) {
@@ -892,17 +898,49 @@ func (r *Reconciler) shouldWaitForNodeVolumes(ctx context.Context, s *scope, nod
 		// We need to skip the detachment as we otherwise block deletions
 		// of unreachable nodes when a volume is attached.
 		log.Info("Node is unreachable, skip waiting for volume detachment.")
-		return false, nil
+		return ctrl.Result{}, nil
 	}
 
-	if len(node.Status.VolumesAttached) != 0 {
-		log.Info("Waiting for Node volumes to be detached")
-		s.deletingReason = clusterv1.MachineDeletingWaitingForVolumeDetachV1Beta2Reason
-		s.deletingMessage = fmt.Sprintf("Waiting for Node volumes to be detached (started at %s)", machine.Status.Deletion.WaitForNodeVolumeDetachStartTime.Format(time.RFC3339))
-		return true, nil
+	// Get two sets of information about volumes currently attached to the node:
+	// * VolumesAttached names from node.Status.VolumesAttached
+	// * PersistentVolume names from VolumeAttachments with status.Attached set to true
+	attachedNodeVolumeNames, attachedPVNames, err := getAttachedVolumeInformation(ctx, remoteClient, node)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	return false, nil
+	// Return early if there are no volumes to wait for getting detached.
+	if len(attachedNodeVolumeNames) == 0 && len(attachedPVNames) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	// Get all PVCs we want to ignore because they belong to Pods for which we skipped drain.
+	pvcsToIgnoreFromPods, err := getPersistentVolumeClaimsToIgnore(ctx, remoteClient, nodeName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// List all PersistentVolumes and return the ones we want to wait for.
+	attachedVolumeInformation, err := getPersistentVolumesWaitingForDetach(ctx, remoteClient, attachedNodeVolumeNames, attachedPVNames, pvcsToIgnoreFromPods)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// If no pvcs were found we have to wait for and there is no unmatched information, then we are finished with waiting for volumes.
+	if attachedVolumeInformation.isEmpty() {
+		return ctrl.Result{}, nil
+	}
+
+	// Add entry to the reconcileDeleteCache so we won't retry shouldWaitForNodeVolumes again before waitForVolumeDetachRetryInterval.
+	r.reconcileDeleteCache.Add(cache.NewReconcileEntry(machine, time.Now().Add(waitForVolumeDetachRetryInterval)))
+
+	s.deletingReason = clusterv1.MachineDeletingWaitingForVolumeDetachV1Beta2Reason
+	s.deletingMessage = fmt.Sprintf("Waiting for Node volumes to be detached (started at %s)", machine.Status.Deletion.WaitForNodeVolumeDetachStartTime.Format(time.RFC3339))
+
+	log.Info("Waiting for Node volumes to be detached",
+		attachedVolumeInformation.logKeys()...,
+	)
+	return ctrl.Result{RequeueAfter: waitForVolumeDetachRetryInterval}, nil
 }
 
 func (r *Reconciler) deleteNode(ctx context.Context, cluster *clusterv1.Cluster, name string) error {
@@ -1063,4 +1101,214 @@ func (r *Reconciler) nodeToMachine(ctx context.Context, o client.Object) []recon
 	}
 
 	return nil
+}
+
+// getAttachedVolumeInformation returns information about volumes attached to the node:
+// * VolumesAttached names from node.Status.VolumesAttached.
+// * PersistentVolume names from VolumeAttachments with status.Attached set to true.
+func getAttachedVolumeInformation(ctx context.Context, remoteClient client.Client, node *corev1.Node) (sets.Set[string], sets.Set[string], error) {
+	attachedVolumeName := sets.Set[string]{}
+	attachedPVNames := sets.Set[string]{}
+
+	for _, attachedVolume := range node.Status.VolumesAttached {
+		attachedVolumeName.Insert(string(attachedVolume.Name))
+	}
+
+	volumeAttachments, err := getVolumeAttachmentForNode(ctx, remoteClient, node.GetName())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to list VolumeAttachments")
+	}
+
+	for _, va := range volumeAttachments {
+		// Return an error if a VolumeAttachments does not refer a PersistentVolume.
+		if va.Spec.Source.PersistentVolumeName == nil {
+			return nil, nil, errors.Errorf("spec.source.persistentVolumeName for VolumeAttachment %s is not set", va.GetName())
+		}
+		attachedPVNames.Insert(*va.Spec.Source.PersistentVolumeName)
+	}
+
+	return attachedVolumeName, attachedPVNames, nil
+}
+
+// getPersistentVolumeClaimsToIgnore gets all pods which have been ignored by drain and returns a list of
+// NamespacedNames for all PersistentVolumeClaims referred by the pods.
+// Note: this does not require us to list PVC's directly.
+func getPersistentVolumeClaimsToIgnore(ctx context.Context, remoteClient client.Client, nodeName string) (sets.Set[string], error) {
+	drainHelper := drain.Helper{
+		Client: remoteClient,
+	}
+
+	pods, err := drainHelper.GetPodsForEviction(ctx, nodeName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find PersistentVolumeClaims from Pods ignored during drain")
+	}
+
+	ignoredPods := pods.IgnoredPods()
+
+	pvcsToIgnore := sets.Set[string]{}
+
+	for _, pod := range ignoredPods {
+		for _, volume := range pod.Spec.Volumes {
+			if volume.PersistentVolumeClaim == nil {
+				continue
+			}
+
+			key := types.NamespacedName{Namespace: pod.GetNamespace(), Name: volume.PersistentVolumeClaim.ClaimName}.String()
+			pvcsToIgnore.Insert(key)
+		}
+	}
+
+	return pvcsToIgnore, nil
+}
+
+// getVolumeAttachmentForNode does a paged list of VolumeAttachments and returns a list
+// of VolumeAttachments attached to the given node.
+func getVolumeAttachmentForNode(ctx context.Context, c client.Client, nodeName string) ([]*storagev1.VolumeAttachment, error) {
+	volumeAttachments := []*storagev1.VolumeAttachment{}
+	volumeAttachmentList := &storagev1.VolumeAttachmentList{}
+	for {
+		listOpts := []client.ListOption{
+			client.Continue(volumeAttachmentList.GetContinue()),
+			client.Limit(100),
+		}
+		if err := c.List(ctx, volumeAttachmentList, listOpts...); err != nil {
+			return nil, errors.Wrap(err, "failed to list VolumeAttachments")
+		}
+
+		for _, volumeAttachment := range volumeAttachmentList.Items {
+			// Skip VolumeAttachments which are not in attached state.
+			if !volumeAttachment.Status.Attached {
+				continue
+			}
+			// Skip VolumeAttachments which are not for the given node.
+			if volumeAttachment.Spec.NodeName != nodeName {
+				continue
+			}
+			volumeAttachments = append(volumeAttachments, &volumeAttachment)
+		}
+
+		if volumeAttachmentList.GetContinue() == "" {
+			break
+		}
+	}
+
+	return volumeAttachments, nil
+}
+
+type attachedVolumeInformation struct {
+	// Attached PersistentVolumeClaims.
+	persistentVolumeClaims []string
+
+	// Attached PersistentVolumes without a corresponding PersistentVolumeClaim.
+	persistentVolumesWithoutPVCClaimRef []string
+
+	// Entries in Node.Status.AttachedVolumes[].Name without a corresponding PersistentVolume.
+	nodeStatusVolumeNamesWithoutPV []string
+	// Names of PersistentVolumes from VolumeAttachments which don't have a corresponding PersistentVolume.
+	persistentVolumeNamesWithoutPV []string
+}
+
+func (a *attachedVolumeInformation) isEmpty() bool {
+	return len(a.persistentVolumeClaims) == 0 &&
+		len(a.persistentVolumesWithoutPVCClaimRef) == 0 &&
+		len(a.nodeStatusVolumeNamesWithoutPV) == 0 &&
+		len(a.persistentVolumeNamesWithoutPV) == 0
+}
+
+func (a *attachedVolumeInformation) logKeys() []any {
+	logKeys := []any{}
+	if len(a.persistentVolumeClaims) > 0 {
+		slices.Sort(a.persistentVolumeClaims)
+		logKeys = append(logKeys, "PersistentVolumeClaims", clog.StringListToString(a.persistentVolumeClaims))
+	}
+
+	if len(a.persistentVolumesWithoutPVCClaimRef) > 0 {
+		slices.Sort(a.persistentVolumesWithoutPVCClaimRef)
+		logKeys = append(logKeys, "PersistentVolumesWithoutPVCClaimRef", clog.StringListToString(a.persistentVolumesWithoutPVCClaimRef))
+	}
+
+	if len(a.nodeStatusVolumeNamesWithoutPV) > 0 {
+		slices.Sort(a.nodeStatusVolumeNamesWithoutPV)
+		logKeys = append(logKeys, "NodeStatusVolumeNamesWithoutPV", clog.StringListToString(a.nodeStatusVolumeNamesWithoutPV))
+	}
+
+	if len(a.persistentVolumeNamesWithoutPV) > 0 {
+		slices.Sort(a.persistentVolumeNamesWithoutPV)
+		logKeys = append(logKeys, "PersistentVolumeNamesWithoutPV", clog.StringListToString(a.persistentVolumeNamesWithoutPV))
+	}
+
+	return logKeys
+}
+
+// getPersistentVolumesWaitingForDetach returns a list of all persistentVolumes which either have
+// the calculated AttachedVolume name in attachedVolumeNames or their name in attachedPVNames.
+// PersistentVolumes which refer a PersistentVolumeClaim contained in pvcsToIgnore are filtered out.
+// If there are names in attachedVolumeNames or attachedPVNames without a corresponding PV, this returns an error.
+func getPersistentVolumesWaitingForDetach(ctx context.Context, c client.Client, attachedNodeVolumeNames, attachedPVNames, pvcsToIgnore sets.Set[string]) (*attachedVolumeInformation, error) {
+	pvcsWaitingForDetach := sets.Set[string]{}
+	persistentVolumesWithoutPVCClaimRef := []string{}
+	foundAttachedVolumeNames := sets.Set[string]{}
+	foundAttachedPVNames := sets.Set[string]{}
+
+	// List all PersistentVolumes and preserve the ones we have to wait for.
+	// Also store the found VolumeHandles and names of PersistentVolumes to check
+	// that all expected PersistentVolumes have been found.
+	// Note: pvsWaitingFor will not include PersistentVolumes we want to ignore.
+	// These are usually volumes which have a Pod which is expected to be kept.
+	persistentVolumeList := &corev1.PersistentVolumeList{}
+	for {
+		listOpts := []client.ListOption{
+			client.Continue(persistentVolumeList.GetContinue()),
+			client.Limit(100),
+		}
+		if err := c.List(ctx, persistentVolumeList, listOpts...); err != nil {
+			return nil, errors.Wrap(err, "failed to list PersistentVolumes")
+		}
+
+		for _, persistentVolume := range persistentVolumeList.Items {
+			found := false
+			// Lookup if the PersistentVolume matches an entry in attachedVolumeNames.
+			if persistentVolume.Spec.CSI != nil {
+				attachedVolumeName := fmt.Sprintf("kubernetes.io/csi/%s^%s", persistentVolume.Spec.CSI.Driver, persistentVolume.Spec.CSI.VolumeHandle)
+				if attachedNodeVolumeNames.Has(attachedVolumeName) {
+					foundAttachedVolumeNames.Insert(attachedVolumeName)
+					found = true
+				}
+			}
+
+			// Lookup if the PersistentVolume matches an entry in attachedPVNames.
+			if attachedPVNames.Has(persistentVolume.Name) {
+				foundAttachedPVNames.Insert(persistentVolume.Name)
+				found = true
+			}
+
+			// PersistentVolume which do not match an entry in attachedVolumeNames or
+			// attachedPVNames can be ignored.
+			if !found {
+				continue
+			}
+
+			// The ClaimRef should only be nil for unbound volumes and these should not be able to be attached.
+			// Also we're unable to map references which are not of Kind PersistentVolumeClaim so we record the PersistentVolume instead.
+			if persistentVolume.Spec.ClaimRef == nil || persistentVolume.Spec.ClaimRef.Kind != "PersistentVolumeClaim" {
+				persistentVolumesWithoutPVCClaimRef = append(persistentVolumesWithoutPVCClaimRef, persistentVolume.Name)
+				continue
+			}
+
+			key := types.NamespacedName{Namespace: persistentVolume.Spec.ClaimRef.Namespace, Name: persistentVolume.Spec.ClaimRef.Name}.String()
+			// Add the PersistentVolumeClaim namespaced name to the list we are waiting for being detached.
+			pvcsWaitingForDetach.Insert(key)
+		}
+
+		if persistentVolumeList.GetContinue() == "" {
+			break
+		}
+	}
+
+	return &attachedVolumeInformation{
+		persistentVolumeClaims:              pvcsWaitingForDetach.Difference(pvcsToIgnore).UnsortedList(),
+		persistentVolumesWithoutPVCClaimRef: persistentVolumesWithoutPVCClaimRef,
+		nodeStatusVolumeNamesWithoutPV:      attachedNodeVolumeNames.Difference(foundAttachedVolumeNames).UnsortedList(),
+		persistentVolumeNamesWithoutPV:      attachedPVNames.Difference(foundAttachedPVNames).UnsortedList(),
+	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -127,6 +128,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = apiextensionsv1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 
 	_ = clusterv1alpha3.AddToScheme(scheme)
 	_ = clusterv1alpha4.AddToScheme(scheme)
@@ -433,6 +435,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 					// Don't cache Pods & DaemonSets (we get/list them e.g. during drain).
 					&corev1.Pod{},
 					&appsv1.DaemonSet{},
+					// Don't cache PersistentVolumes and VolumeAttachments (we get/list them e.g. during wait for volumes to detach)
+					&storagev1.VolumeAttachment{},
+					&corev1.PersistentVolume{},
 				},
 			},
 		},

--- a/test/infrastructure/inmemory/pkg/server/api/const.go
+++ b/test/infrastructure/inmemory/pkg/server/api/const.go
@@ -25,7 +25,7 @@ var (
 		Versions: []string{"v1"},
 	}
 
-	// apiVersions is the value returned by /api/v1 discovery call.
+	// corev1APIResourceList is the value returned by /api/v1 discovery call.
 	// Note: This must contain all APIs required by CAPI.
 	corev1APIResourceList = &metav1.APIResourceList{
 		GroupVersion: "v1",
@@ -164,7 +164,7 @@ var (
 		},
 	}
 
-	// apiVersions is the value returned by /apis discovery call.
+	// apiGroupList is the value returned by /apis discovery call.
 	// Note: This must contain all APIs required by CAPI.
 	apiGroupList = &metav1.APIGroupList{
 		Groups: []metav1.APIGroup{
@@ -197,7 +197,7 @@ var (
 		},
 	}
 
-	// apiVersions is the value returned by /apis/rbac.authorization.k8s.io/v1  discovery call.
+	// rbacv1APIResourceList is the value returned by /apis/rbac.authorization.k8s.io/v1 discovery call.
 	// Note: This must contain all APIs required by CAPI.
 	rbacv1APIResourceList = &metav1.APIResourceList{
 		GroupVersion: "rbac.authorization.k8s.io/v1",
@@ -272,6 +272,9 @@ var (
 			},
 		},
 	}
+
+	// appsV1ResourceList is the value returned by /apis/apps/v1 discovery call.
+	// Note: This must contain all APIs required by CAPI.
 	appsV1ResourceList = &metav1.APIResourceList{
 		GroupVersion: "apps/v1",
 		APIResources: []metav1.APIResource{
@@ -313,6 +316,32 @@ var (
 				ShortNames: []string{
 					"deploy",
 				},
+				StorageVersionHash: "",
+			},
+		},
+	}
+
+	// storageV1ResourceList is the value returned by /apis/storage.k8s.io/v1 discovery call.
+	// Note: This must contain all APIs required by CAPI.
+	storageV1ResourceList = &metav1.APIResourceList{
+		GroupVersion: "storage.k8s.io/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name:         "volumeattachments",
+				SingularName: "volumeattachment",
+				Namespaced:   false,
+				Kind:         "VolumeAttachment",
+				Verbs: []string{
+					"create",
+					"delete",
+					"deletecollection",
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
+				ShortNames:         []string{},
 				StorageVersionHash: "",
 			},
 		},

--- a/test/infrastructure/inmemory/pkg/server/api/handler.go
+++ b/test/infrastructure/inmemory/pkg/server/api/handler.go
@@ -222,6 +222,13 @@ func (h *apiServerHandler) apisDiscovery(req *restful.Request, resp *restful.Res
 			}
 			return
 		}
+		if req.PathParameter("group") == "storage.k8s.io" && req.PathParameter("version") == "v1" {
+			if err := resp.WriteEntity(storageV1ResourceList); err != nil {
+				_ = resp.WriteErrorString(http.StatusInternalServerError, err.Error())
+				return
+			}
+			return
+		}
 
 		_ = resp.WriteErrorString(http.StatusInternalServerError, fmt.Sprintf("discovery info not defined for %s/%s", req.PathParameter("group"), req.PathParameter("version")))
 		return
@@ -666,6 +673,9 @@ func getAPIResourceList(req *restful.Request) *metav1.APIResourceList {
 		}
 		if req.PathParameter("group") == "apps" && req.PathParameter("version") == "v1" {
 			return appsV1ResourceList
+		}
+		if req.PathParameter("group") == "storage.k8s.io" && req.PathParameter("version") == "v1" {
+			return storageV1ResourceList
 		}
 		return nil
 	}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -107,19 +107,16 @@ func getOwners(ctx context.Context, c client.Client, obj metav1.Object) ([]owner
 	return owners, nil
 }
 
-// ObjNamesString returns a comma separated list of the object names, limited to
-// five objects. On more than five objects it outputs the first five objects and
-// adds information about how much more are in the given list.
-func ObjNamesString[T client.Object](objs []T) string {
+// ListToString returns a comma-separated list of the first n entries of the list (strings are calculated via stringFunc).
+func ListToString[T any](list []T, stringFunc func(T) string, n int) string {
 	shortenedBy := 0
-	if len(objs) > 5 {
-		shortenedBy = len(objs) - 5
-		objs = objs[:5]
+	if len(list) > n {
+		shortenedBy = len(list) - n
+		list = list[:n]
 	}
-
 	stringList := []string{}
-	for _, obj := range objs {
-		stringList = append(stringList, obj.GetName())
+	for _, p := range list {
+		stringList = append(stringList, stringFunc(p))
 	}
 
 	if shortenedBy > 0 {
@@ -127,4 +124,22 @@ func ObjNamesString[T client.Object](objs []T) string {
 	}
 
 	return strings.Join(stringList, ", ")
+}
+
+// StringListToString returns a comma separated list of the strings, limited to
+// five objects. On more than five objects it outputs the first five objects and
+// adds information about how much more are in the given list.
+func StringListToString(objs []string) string {
+	return ListToString(objs, func(s string) string {
+		return s
+	}, 5)
+}
+
+// ObjNamesString returns a comma separated list of the object names, limited to
+// five objects. On more than five objects it outputs the first five objects and
+// adds information about how much more are in the given list.
+func ObjNamesString[T client.Object](objs []T) string {
+	return ListToString(objs, func(obj T) string {
+		return obj.GetName()
+	}, 5)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Improves `shouldWaitForNodeVolumes` to ignore volumes referred by pods which were ignored during drain.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area machine