### PR TITLE
🐛Fix conditions hasSameState nil pointer dereference

### DIFF
--- a/util/conditions/setter.go
+++ b/util/conditions/setter.go
@@ -203,6 +203,9 @@ func lexicographicLess(i, j *clusterv1.Condition) bool {
 // HasSameState returns true if a condition has the same state of another; state is defined
 // by the union of following fields: Type, Status, Reason, Severity and Message (it excludes LastTransitionTime).
 func HasSameState(i, j *clusterv1.Condition) bool {
+	if i == nil || j == nil {
+		return i == j
+	}
 	return i.Type == j.Type &&
 		i.Status == j.Status &&
 		i.Reason == j.Reason &&

--- a/util/conditions/setter_test.go
+++ b/util/conditions/setter_test.go
@@ -33,6 +33,16 @@ import (
 func TestHasSameState(t *testing.T) {
 	g := NewWithT(t)
 
+	// two nils
+	var nil2 *clusterv1.Condition
+	g.Expect(HasSameState(nil1, nil2)).To(BeTrue())
+
+	// nil condition 1
+	g.Expect(HasSameState(nil1, true1)).To(BeFalse())
+
+	// nil condition 2
+	g.Expect(HasSameState(true1, nil2)).To(BeFalse())
+
 	// same condition
 	falseInfo2 := falseInfo1.DeepCopy()
 	g.Expect(HasSameState(falseInfo1, falseInfo2)).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:

conditions hasSameState method accepts two pointers, but does dereference without any additional checks, resulting in nil-pointer panic:

```console
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```

The PR adds according tests to proof (that fail with the said above panic) and simple nil-check, that marks two nil conditions as being the same.

/area util