### PR TITLE
🐛Fix conditions lexicographicLess nil pointer dereference

### DIFF
--- a/util/conditions/setter.go
+++ b/util/conditions/setter.go
@@ -186,11 +186,17 @@ func Delete(to Setter, t clusterv1.ConditionType) {
 	to.SetConditions(newConditions)
 }
 
-// lexicographicLess returns true if a condition is less than another with regards to the
-// to order of conditions designed for convenience of the consumer, i.e. kubectl.
+// lexicographicLess returns true if a condition is less than another in regard to
+// the order of conditions designed for convenience of the consumer, i.e. kubectl.
 // According to this order the Ready condition always goes first, followed by all the other
 // conditions sorted by Type.
 func lexicographicLess(i, j *clusterv1.Condition) bool {
+	if i == nil {
+		return true
+	}
+	if j == nil {
+		return false
+	}
 	return (i.Type == clusterv1.ReadyCondition || i.Type < j.Type) && j.Type != clusterv1.ReadyCondition
 }
 

--- a/util/conditions/setter_test.go
+++ b/util/conditions/setter_test.go
@@ -84,6 +84,12 @@ func TestLexicographicLess(t *testing.T) {
 	a = TrueCondition("A")
 	b = TrueCondition(clusterv1.ReadyCondition)
 	g.Expect(lexicographicLess(a, b)).To(BeFalse())
+
+	a = TrueCondition("A")
+	g.Expect(lexicographicLess(a, nil1)).To(BeFalse())
+
+	b = TrueCondition("A")
+	g.Expect(lexicographicLess(nil1, b)).To(BeTrue())
 }
 
 func TestSet(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

similar to https://github.com/kubernetes-sigs/cluster-api/pull/11254 conditions lexicographicLess method accepts two pointers, but does dereference without any additional checks, resulting in nil-pointer panic:

```console
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```

The PR adds according tests to proof (that fail with the said above panic) and simple nil-check, that sets nil-condition less than any other

/area util