### PR TITLE
🌱 Add basic validation for time duration

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -153,17 +153,23 @@ type ControlPlaneTopology struct {
 	// NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
 	// The default value is 0, meaning that the node can be drained without any time limitations.
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
 	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// Defaults to 10 seconds.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDeletionTimeout *metav1.Duration `json:"nodeDeletionTimeout,omitempty"`
 
@@ -226,17 +232,23 @@ type MachineDeploymentTopology struct {
 	// NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
 	// The default value is 0, meaning that the node can be drained without any time limitations.
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
 	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// Defaults to 10 seconds.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDeletionTimeout *metav1.Duration `json:"nodeDeletionTimeout,omitempty"`
 
@@ -303,17 +315,23 @@ type MachinePoolTopology struct {
 	// NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
 	// The default value is 0, meaning that the node can be drained without any time limitations.
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
 	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
 	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
 	// hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// Defaults to 10 seconds.
+	// +kubebuilder:validation:Pattern="^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Type:=string
 	// +optional
 	NodeDeletionTimeout *metav1.Duration `json:"nodeDeletionTimeout,omitempty"`
 

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1086,17 +1086,20 @@ spec:
                           NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
                           hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
                           Defaults to 10 seconds.
+                        pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                         type: string
                       nodeDrainTimeout:
                         description: |-
                           NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
                           The default value is 0, meaning that the node can be drained without any time limitations.
                           NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                         type: string
                       nodeVolumeDetachTimeout:
                         description: |-
                           NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                           to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                         type: string
                       replicas:
                         description: |-
@@ -1387,17 +1390,20 @@ spec:
                                 NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
                                 hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
                                 Defaults to 10 seconds.
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             nodeDrainTimeout:
                               description: |-
                                 NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
                                 The default value is 0, meaning that the node can be drained without any time limitations.
                                 NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             nodeVolumeDetachTimeout:
                               description: |-
                                 NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                                 to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             replicas:
                               description: |-
@@ -1613,17 +1619,20 @@ spec:
                                 NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
                                 hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
                                 Defaults to 10 seconds.
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             nodeDrainTimeout:
                               description: |-
                                 NodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
                                 The default value is 0, meaning that the node can be drained without any time limitations.
                                 NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             nodeVolumeDetachTimeout:
                               description: |-
                                 NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
                                 to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              pattern: ^(([1-9][0-9]*(\.[0-9]+)?|0?\.[0-9]+)(ns|us|µs|ms|s|m|h))+$
                               type: string
                             replicas:
                               description: |-


### PR DESCRIPTION
Basic validation for time duration can be done using kubebuilder markers to match the pattern "^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$",

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Basic validation for time duration can be done using kubebuilder markers to match the pattern "^(([1-9][0-9]*(\\.[0-9]+)?|0?\\.[0-9]+)(ns|us|µs|ms|s|m|h))+$"

Examples of valid matches:
- 1s
- 23ms
- 0.123us
- 456.789µs
- 1m30s
- 2h15m

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7104 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->