### PR TITLE
🌱 Make Type in ClusterClass variable schema properly optional

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -450,7 +450,8 @@ type JSONSchemaProps struct {
 
 	// Type is the type of the variable.
 	// Valid values are: object, array, string, integer, number or boolean.
-	Type string `json:"type"`
+	// +optional
+	Type string `json:"type,omitempty"`
 
 	// Properties specifies fields of an object.
 	// NOTE: Can only be set if type is object.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1551,7 +1551,6 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_JSONSchemaProps(ref common.Referen
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type is the type of the variable. Valid values are: object, array, string, integer, number or boolean.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1799,7 +1798,6 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_JSONSchemaProps(ref common.Referen
 						},
 					},
 				},
-				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -1336,8 +1336,6 @@ spec:
                                     (scope and select) variables.
                                   type: object
                               type: object
-                          required:
-                          - type
                           type: object
                       required:
                       - openAPIV3Schema
@@ -2500,8 +2498,6 @@ spec:
                                           (scope and select) variables.
                                         type: object
                                     type: object
-                                required:
-                                - type
                                 type: object
                             required:
                             - openAPIV3Schema


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to: #10637 

Effectively `Type` was already optional as it was possible to set `Type` to "".
But since #10637 we actually want this field to be optional to allow schemas like this:
```yaml
            testQuantityField:
              anyOf:
              - type: integer
              - type: string
              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
              x-kubernetes-int-or-string: true
 ```

Without this PR the schema would look like this:
```yaml
            testQuantityField:
              anyOf:
              - type: integer
              - type: string
              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
              type: "" # << this is not intended
              x-kubernetes-int-or-string: true
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->