### PR TITLE
🌱 Fix parsing of `config.live_reload_deps` from Tilt provider config file

### DIFF
--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -388,6 +388,7 @@ func loadTiltProvider(providerRepository string) (map[string]tiltProviderConfig,
 		ret[p.Name] = tiltProviderConfig{
 			Context:           &contextPath,
 			Version:           p.Config.Version,
+			LiveReloadDeps:    p.Config.LiveReloadDeps,
 			ApplyProviderYaml: p.Config.ApplyProviderYaml,
 			KustomizeFolder:   p.Config.KustomizeFolder,
 			KustomizeOptions:  p.Config.KustomizeOptions,


### PR DESCRIPTION
**What this PR does / why we need it**:

My local clone of `cluster-api-provider-aws`, configured in CAPI via `tilt-settings.yaml` ...

```
provider_repos:
  - /Users/asommer/dev/e/cluster-api-provider-aws
enable_providers:
  - aws
  - kubeadm-bootstrap
  - kubeadm-control-plane
# [...]
```

... failed to reload on code changes because `start.sh` wasn't used. It is only used if, for instance, `live_reload_deps` is non-empty. That property was parsed from the config file, but not passed on to the function which fixes up the `Deployment` command.

/area devtools