### PR TITLE
🌱 v1beta2 conditions: make NewAggregate use generics

### DIFF
--- a/util/conditions/v1beta2/aggregate.go
+++ b/util/conditions/v1beta2/aggregate.go
@@ -51,7 +51,7 @@ func (o *AggregateOptions) ApplyOptions(opts []AggregateOption) *AggregateOption
 // the TargetConditionType option.
 //
 // Additionally, it is possible to inject custom merge strategies using the CustomMergeStrategy option.
-func NewAggregateCondition(sourceObjs []Getter, sourceConditionType string, opts ...AggregateOption) (*metav1.Condition, error) {
+func NewAggregateCondition[T Getter](sourceObjs []T, sourceConditionType string, opts ...AggregateOption) (*metav1.Condition, error) {
 	if len(sourceObjs) == 0 {
 		return nil, errors.New("sourceObjs can't be empty")
 	}
@@ -118,7 +118,7 @@ func NewAggregateCondition(sourceObjs []Getter, sourceConditionType string, opts
 
 // SetAggregateCondition is a convenience method that calls NewAggregateCondition to create an aggregate condition from the source objects,
 // and then calls Set to add the new condition to the target object.
-func SetAggregateCondition(sourceObjs []Getter, targetObj Setter, conditionType string, opts ...AggregateOption) error {
+func SetAggregateCondition[T Getter](sourceObjs []T, targetObj Setter, conditionType string, opts ...AggregateOption) error {
 	aggregateCondition, err := NewAggregateCondition(sourceObjs, conditionType, opts...)
 	if err != nil {
 		return err

--- a/util/conditions/v1beta2/aggregate_test.go
+++ b/util/conditions/v1beta2/aggregate_test.go
@@ -271,8 +271,9 @@ func TestAggregate(t *testing.T) {
 	}
 
 	t.Run("Fails if source objects are empty", func(t *testing.T) {
+		var objs []*builder.Phase3Obj
 		g := NewWithT(t)
-		_, err := NewAggregateCondition(nil, AvailableCondition)
+		_, err := NewAggregateCondition(objs, AvailableCondition)
 		g.Expect(err).To(HaveOccurred())
 	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This allows to pass in slices like `[]*clusterv1.Machine`.

Otherwise we have to repack them into a `[]Getter` slice via e.g.:

```
getters := []Getter{}
for _, machine := range []*clusterv1.Machine{...} {
  getters = append(getters, machine)
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->