### PR TITLE
:seedling: Make controller mandatory param for external object tracker

### DIFF
--- a/controllers/external/fake/controller.go
+++ b/controllers/external/fake/controller.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Controller implements controller.Controller interface.
+type Controller struct {
+	controller.Controller
+}
+
+// Watch helps in testing and does nothing but returns nil.
+func (c Controller) Watch(_ source.Source) error {
+	return nil
+}

--- a/controllers/external/fake/doc.go
+++ b/controllers/external/fake/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fake provides a fake controllers for testing.
+package fake

--- a/controllers/external/tracker.go
+++ b/controllers/external/tracker.go
@@ -44,13 +44,8 @@ type ObjectTracker struct {
 
 // Watch uses the controller to issue a Watch only if the object hasn't been seen before.
 func (o *ObjectTracker) Watch(log logr.Logger, obj client.Object, handler handler.EventHandler, p ...predicate.Predicate) error {
-	// Consider this a no-op if the controller isn't present.
-	if o.Controller == nil {
-		return nil
-	}
-
-	if o.Cache == nil || o.Scheme == nil {
-		return errors.New("both scheme and cache must be set for object tracker")
+	if o.Controller == nil || o.Cache == nil || o.Scheme == nil {
+		return errors.New("all of controller, cache and scheme must be set for object tracker")
 	}
 
 	gvk := obj.GetObjectKind().GroupVersionKind()

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -26,7 +26,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -38,7 +37,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
@@ -132,9 +131,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -174,9 +173,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -213,9 +212,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -268,9 +267,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -335,9 +334,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -380,9 +379,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -432,9 +431,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -497,9 +496,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -568,9 +567,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -637,9 +636,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -728,9 +727,9 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -1046,12 +1045,13 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			}
 
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
+			fakeClient := fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
 			r := &MachinePoolReconciler{
-				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
+				Client: fakeClient,
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     fakeClient.Scheme(),
 				},
 			}
 
@@ -1349,9 +1349,9 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				Client:       fakeClient,
 				ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     fakeClient.Scheme(),
 				},
 			}
 
@@ -1437,9 +1437,9 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 				Client:   env,
 				ssaCache: ssa.NewCache(),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     env.Scheme(),
 				},
 			}
 			scope := &scope{
@@ -1505,9 +1505,9 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 				Client:   env,
 				ssaCache: ssa.NewCache(),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     env.Scheme(),
 				},
 			}
 
@@ -1868,9 +1868,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -1935,9 +1935,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -1985,9 +1985,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -2031,9 +2031,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 
@@ -2099,9 +2099,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: fakeController.Controller{},
+				Controller: externalfake.Controller{},
 				Cache:      &informertest.FakeInformers{},
-				Scheme:     runtime.NewScheme(),
+				Scheme:     fakeClient.Scheme(),
 			},
 		}
 

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -26,16 +26,19 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
@@ -128,6 +131,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -165,6 +173,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -199,6 +212,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -249,6 +267,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -311,6 +334,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -351,6 +379,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -398,6 +431,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -458,6 +496,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -524,6 +567,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -588,6 +636,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -674,6 +727,11 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		r := &MachinePoolReconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -990,6 +1048,11 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
 			r := &MachinePoolReconciler{
 				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			scope := &scope{
@@ -1285,6 +1348,11 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 			r := &MachinePoolReconciler{
 				Client:       fakeClient,
 				ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			scope := &scope{
@@ -1368,6 +1436,11 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 			r := &MachinePoolReconciler{
 				Client:   env,
 				ssaCache: ssa.NewCache(),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 			scope := &scope{
 				machinePool: &machinePool,
@@ -1431,6 +1504,11 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 			r := &MachinePoolReconciler{
 				Client:   env,
 				ssaCache: ssa.NewCache(),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			scope := &scope{
@@ -1789,6 +1867,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -1851,6 +1934,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -1896,6 +1984,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Client:       fakeClient,
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -1937,6 +2030,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Client:       fakeClient,
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{
@@ -2000,6 +2098,11 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
+			externalTracker: external.ObjectTracker{
+				Controller: fakeController.Controller{},
+				Cache:      &informertest.FakeInformers{},
+				Scheme:     runtime.NewScheme(),
+			},
 		}
 
 		scope := &scope{

--- a/exp/internal/controllers/machinepool_controller_test.go
+++ b/exp/internal/controllers/machinepool_controller_test.go
@@ -41,7 +41,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util"
@@ -601,9 +601,9 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(trackerClientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     clientFake.Scheme(),
 				},
 			}
 
@@ -1165,9 +1165,9 @@ func TestMachinePoolConditions(t *testing.T) {
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     clientFake.Scheme(),
 				},
 			}
 

--- a/exp/internal/controllers/machinepool_controller_test.go
+++ b/exp/internal/controllers/machinepool_controller_test.go
@@ -32,6 +32,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -39,6 +40,8 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util"
@@ -597,6 +600,11 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 				Client:       clientFake,
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(trackerClientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&tc.machinePool)})
@@ -1156,6 +1164,11 @@ func TestMachinePoolConditions(t *testing.T) {
 				Client:       clientFake,
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(machinePool)})

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -24,12 +24,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -205,6 +209,11 @@ func TestClusterReconcilePhases(t *testing.T) {
 				r := &Reconciler{
 					Client:   c,
 					recorder: record.NewFakeRecorder(32),
+					externalTracker: external.ObjectTracker{
+						Controller: fakeController.Controller{},
+						Cache:      &informertest.FakeInformers{},
+						Scheme:     runtime.NewScheme(),
+					},
 				}
 
 				res, err := r.reconcileInfrastructure(ctx, tt.cluster)
@@ -396,6 +405,11 @@ func TestClusterReconcilePhases(t *testing.T) {
 				r := &Reconciler{
 					Client:   c,
 					recorder: record.NewFakeRecorder(32),
+					externalTracker: external.ObjectTracker{
+						Controller: fakeController.Controller{},
+						Cache:      &informertest.FakeInformers{},
+						Scheme:     runtime.NewScheme(),
+					},
 				}
 
 				res, err := r.reconcileControlPlane(ctx, tt.cluster)
@@ -768,6 +782,11 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 			r := &Reconciler{
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 
 			_, err := r.reconcileInfrastructure(ctx, tt.cluster)

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
@@ -33,7 +32,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -210,9 +209,9 @@ func TestClusterReconcilePhases(t *testing.T) {
 					Client:   c,
 					recorder: record.NewFakeRecorder(32),
 					externalTracker: external.ObjectTracker{
-						Controller: fakeController.Controller{},
+						Controller: externalfake.Controller{},
 						Cache:      &informertest.FakeInformers{},
-						Scheme:     runtime.NewScheme(),
+						Scheme:     c.Scheme(),
 					},
 				}
 
@@ -406,9 +405,9 @@ func TestClusterReconcilePhases(t *testing.T) {
 					Client:   c,
 					recorder: record.NewFakeRecorder(32),
 					externalTracker: external.ObjectTracker{
-						Controller: fakeController.Controller{},
+						Controller: externalfake.Controller{},
 						Cache:      &informertest.FakeInformers{},
-						Scheme:     runtime.NewScheme(),
+						Scheme:     c.Scheme(),
 					},
 				}
 
@@ -783,9 +782,9 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     c.Scheme(),
 				},
 			}
 

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -33,7 +33,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 )
 
@@ -304,7 +304,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			r := &Reconciler{
 				Client: c,
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
 					Scheme:     runtime.NewScheme(),
 				},
@@ -861,9 +861,9 @@ func TestReconcileInfrastructure(t *testing.T) {
 			r := &Reconciler{
 				Client: c,
 				externalTracker: external.ObjectTracker{
-					Controller: fakeController.Controller{},
+					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Scheme:     c.Scheme(),
 				},
 			}
 			s := &scope{cluster: defaultCluster, machine: tc.machine}

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -25,11 +25,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 )
 
@@ -299,6 +303,11 @@ func TestReconcileBootstrap(t *testing.T) {
 
 			r := &Reconciler{
 				Client: c,
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 			s := &scope{cluster: defaultCluster, machine: tc.machine}
 			res, err := r.reconcileBootstrap(ctx, s)
@@ -851,6 +860,11 @@ func TestReconcileInfrastructure(t *testing.T) {
 
 			r := &Reconciler{
 				Client: c,
+				externalTracker: external.ObjectTracker{
+					Controller: fakeController.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     runtime.NewScheme(),
+				},
 			}
 			s := &scope{cluster: defaultCluster, machine: tc.machine}
 			result, err := r.reconcileInfrastructure(ctx, s)

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -1241,7 +1241,8 @@ func TestMachineConditions(t *testing.T) {
 					Controller: externalfake.Controller{},
 					Cache:      &informertest.FakeInformers{},
 					Scheme:     clientFake.Scheme(),
-				}}
+				},
+			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&machine)})
 			if tt.wantErr {

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -40,6 +41,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/internal/util/cache"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
@@ -944,6 +947,11 @@ func TestReconcileRequest(t *testing.T) {
 				ssaCache:             ssa.NewCache(),
 				recorder:             record.NewFakeRecorder(10),
 				reconcileDeleteCache: cache.New[cache.ReconcileEntry](),
+				externalTracker: external.ObjectTracker{
+					Controller: externalfake.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     clientFake.Scheme(),
+				},
 			}
 
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&tc.machine)})
@@ -1229,7 +1237,11 @@ func TestMachineConditions(t *testing.T) {
 				recorder:     record.NewFakeRecorder(10),
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				ssaCache:     ssa.NewCache(),
-			}
+				externalTracker: external.ObjectTracker{
+					Controller: externalfake.Controller{},
+					Cache:      &informertest.FakeInformers{},
+					Scheme:     clientFake.Scheme(),
+				}}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&machine)})
 			if tt.wantErr {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
@@ -39,7 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
+	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -142,9 +141,9 @@ func (r *Reconciler) SetupForDryRun(recorder record.EventRecorder) {
 	r.desiredStateGenerator = desiredstate.NewGenerator(r.Client, r.ClusterCache, r.RuntimeClient)
 	r.recorder = recorder
 	r.externalTracker = external.ObjectTracker{
-		Controller: fakeController.Controller{},
+		Controller: externalfake.Controller{},
 		Cache:      &informertest.FakeInformers{},
-		Scheme:     runtime.NewScheme(),
+		Scheme:     r.Client.Scheme(),
 	}
 	r.patchHelperFactory = dryRunPatchHelperFactory(r.Client)
 }

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -37,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	fakeController "sigs.k8s.io/cluster-api/controllers/external/fake"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
@@ -138,6 +141,11 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 func (r *Reconciler) SetupForDryRun(recorder record.EventRecorder) {
 	r.desiredStateGenerator = desiredstate.NewGenerator(r.Client, r.ClusterCache, r.RuntimeClient)
 	r.recorder = recorder
+	r.externalTracker = external.ObjectTracker{
+		Controller: fakeController.Controller{},
+		Cache:      &informertest.FakeInformers{},
+		Scheme:     runtime.NewScheme(),
+	}
 	r.patchHelperFactory = dryRunPatchHelperFactory(r.Client)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR makes changes to make controller param in object tracker a mandatory one, Till today function was behaving as no-op. This mandate make few test files to be updated to set the controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Follow up of discssion https://github.com/kubernetes-sigs/cluster-api/pull/11188#discussion_r1763202390

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->