### PR TITLE
🌱 Handle finalizers early in Reconciles

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -317,6 +317,9 @@ func TestReconcileNoCluster(t *testing.T) {
 					Name:       "foo",
 				},
 			},
+			Finalizers: []string{
+				controlplanev1.KubeadmControlPlaneFinalizer,
+			},
 		},
 		Spec: controlplanev1.KubeadmControlPlaneSpec{
 			Version: "v1.16.6",

--- a/util/finalizers/finalizers.go
+++ b/util/finalizers/finalizers.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package finalizers implements finalizer helper functions.
+package finalizers
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+// EnsureFinalizer adds a finalizer if the object doesn't have a deletionTimestamp set
+// and if the finalizer is not already set.
+// This util is usually used in reconcilers directly after the reconciled object was retrieved
+// and before pause is handled or "defer patch" with the patch helper.
+func EnsureFinalizer(ctx context.Context, c client.Client, o client.Object, finalizer string) (finalizerAdded bool, err error) {
+	// Finalizers can only be added when the deletionTimestamp is not set.
+	if !o.GetDeletionTimestamp().IsZero() {
+		return false, nil
+	}
+
+	if controllerutil.ContainsFinalizer(o, finalizer) {
+		return false, nil
+	}
+
+	patchHelper, err := patch.NewHelper(o, c)
+	if err != nil {
+		return false, err
+	}
+
+	controllerutil.AddFinalizer(o, finalizer)
+
+	if err := patchHelper.Patch(ctx, o); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/util/finalizers/finalizers_test.go
+++ b/util/finalizers/finalizers_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package finalizers implements finalizer helper functions.
+package finalizers
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	ctx = ctrl.SetupSignalHandler()
+)
+
+func TestEnsureFinalizer(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+
+	testFinalizer := "cluster.x-k8s.io/test-finalizer"
+
+	tests := []struct {
+		name                  string
+		obj                   client.Object
+		wantErr               bool
+		wantFinalizersUpdated bool
+		wantFinalizer         bool
+	}{
+		{
+			name: "should not add finalizer if object has deletionTimestamp",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"some-other-finalizer"},
+				},
+			},
+			wantErr:               false,
+			wantFinalizersUpdated: false,
+			wantFinalizer:         false,
+		},
+		{
+			name: "should not add finalizer if finalizer is already set",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Finalizers: []string{testFinalizer},
+				},
+			},
+			wantErr:               false,
+			wantFinalizersUpdated: false,
+			wantFinalizer:         true,
+		},
+		{
+			name: "should add finalizer if finalizer is not already set",
+			obj: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster",
+					Finalizers: []string{"some-other-finalizer"},
+				},
+			},
+			wantErr:               false,
+			wantFinalizersUpdated: true,
+			wantFinalizer:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.obj).Build()
+
+			gotFinalizersUpdated, gotErr := EnsureFinalizer(ctx, c, tt.obj, testFinalizer)
+			g.Expect(gotErr != nil).To(Equal(tt.wantErr))
+			g.Expect(gotFinalizersUpdated).To(Equal(tt.wantFinalizersUpdated))
+
+			gotObj := tt.obj.DeepCopyObject().(client.Object)
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(gotObj), gotObj)).To(Succeed())
+			g.Expect(controllerutil.ContainsFinalizer(gotObj, testFinalizer)).To(Equal(tt.wantFinalizer))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11105

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->