### PR TITLE
✨ Update MHC with v1Beta2 status

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -200,22 +200,71 @@ const (
 	// Note: this could happen when creating the machine. However, this state should be treated as an error if it lasts indefinitely.
 	MachineNodeDoesNotExistV1Beta2Reason = ObjectDoesNotExistV1Beta2Reason
 
-	// MachineNodeDeletedV1Beta2Reason surfaces when  the node hosted on the machine has been deleted.
+	// MachineNodeDeletedV1Beta2Reason surfaces when the node hosted on the machine has been deleted.
 	// Note: controllers can't identify if the Node was deleted by the controller itself, e.g.
 	// during the deletion workflow, or by a users.
 	MachineNodeDeletedV1Beta2Reason = ObjectDeletedV1Beta2Reason
 )
 
-// Machine's HealthCheckSucceeded and OwnerRemediated conditions and corresponding reasons that will be used in v1Beta2 API version.
-// Note: HealthCheckSucceeded and OwnerRemediated condition are set by the MachineHealthCheck controller.
+// Machine's HealthCheckSucceeded condition and corresponding reasons that will be used in v1Beta2 API version.
+// Note: HealthCheckSucceeded condition is set by the MachineHealthCheck controller.
 const (
 	// MachineHealthCheckSucceededV1Beta2Condition is true if MHC instances targeting this machine report the Machine
 	// is healthy according to the definition of healthy present in the spec of the MachineHealthCheck object.
 	MachineHealthCheckSucceededV1Beta2Condition = "HealthCheckSucceeded"
 
+	// MachineHealthCheckSucceededV1Beta2Reason surfaces when a machine passes all the health checks defined by a MachineHealthCheck object.
+	MachineHealthCheckSucceededV1Beta2Reason = "HealthCheckSucceeded"
+
+	// MachineHealthCheckUnhealthyNodeV1Beta2Reason surfaces when the node hosted on the machine does not pass the health checks
+	// defined by a MachineHealthCheck object.
+	MachineHealthCheckUnhealthyNodeV1Beta2Reason = "UnhealthyNode"
+
+	// MachineHealthCheckNodeStartupTimeoutV1Beta2Reason surfaces when the node hosted on the machine does not appear within
+	// the timeout defined by a MachineHealthCheck object.
+	MachineHealthCheckNodeStartupTimeoutV1Beta2Reason = "NodeStartupTimeout"
+
+	// MachineHealthCheckNodeDeletedV1Beta2Reason surfaces when a MachineHealthCheck detect that the node hosted on the
+	// machine has been deleted while the Machine is still running.
+	MachineHealthCheckNodeDeletedV1Beta2Reason = "NodeDeleted"
+
+	// MachineHealthCheckHasRemediateAnnotationV1Beta2Reason surfaces a MachineHealthCheck detects a machine manually remediated
+	// via the remediate-machine annotation.
+	MachineHealthCheckHasRemediateAnnotationV1Beta2Reason = "HasRemediateAnnotation"
+)
+
+// Machine's OwnerRemediated conditions and corresponding reasons that will be used in v1Beta2 API version.
+// Note: OwnerRemediated condition is initially set by the MachineHealthCheck controller; then it is up to the Machine's
+// owner controller to update or delete this condition.
+const (
 	// MachineOwnerRemediatedV1Beta2Condition is only present if MHC instances targeting this machine
 	// determine that the controller owning this machine should perform remediation.
 	MachineOwnerRemediatedV1Beta2Condition = "OwnerRemediated"
+
+	// MachineOwnerRemediatedWaitingForRemediationV1Beta2Reason surfaces the machine is waiting for the owner controller
+	// to start remediation.
+	MachineOwnerRemediatedWaitingForRemediationV1Beta2Reason = "WaitingForRemediation"
+)
+
+// Machine's ExternallyRemediated conditions and corresponding reasons that will be used in v1Beta2 API version.
+// Note: ExternallyRemediated condition is initially set by the MachineHealthCheck controller; then it is up to the external
+// remediation controller to update or delete this condition.
+const (
+	// MachineExternallyRemediatedV1Beta2Condition is only present if MHC instances targeting this machine
+	// determine that an external controller should perform remediation.
+	MachineExternallyRemediatedV1Beta2Condition = "ExternallyRemediated"
+
+	// MachineExternallyRemediatedWaitingForRemediationV1Beta2Reason surfaces the machine is waiting for the
+	// external remediation controller to start remediation.
+	MachineExternallyRemediatedWaitingForRemediationV1Beta2Reason = "WaitingForRemediation"
+
+	// MachineExternallyRemediatedRemediationTemplateNotFoundV1Beta2Reason surfaces that the MachineHealthCheck cannot
+	// find the template for a external remediation request.
+	MachineExternallyRemediatedRemediationTemplateNotFoundV1Beta2Reason = "RemediationTemplateNotFound"
+
+	// MachineExternallyRemediatedRemediationRequestCreationFailedV1Beta2Reason surfaces that the MachineHealthCheck cannot
+	// create a request for the external remediation controller.
+	MachineExternallyRemediatedRemediationRequestCreationFailedV1Beta2Reason = "RemediationRequestCreationFailed"
 )
 
 // Machine's Deleting condition and corresponding reasons that will be used in v1Beta2 API version.

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -24,6 +24,27 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// MachineHealthCheck's RemediationAllowed condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// MachineHealthCheckRemediationAllowedV1Beta2Condition surfaces whether the MachineHealthCheck is
+	// allowed to remediate any Machines or whether it is blocked from remediating any further.
+	MachineHealthCheckRemediationAllowedV1Beta2Condition = "RemediationAllowed"
+
+	// MachineHealthCheckTooManyUnhealthyV1Beta2Reason is the reason used when too many Machines are unhealthy and
+	// the MachineHealthCheck is blocked from making any further remediation.
+	MachineHealthCheckTooManyUnhealthyV1Beta2Reason = "TooManyUnhealthy"
+
+	// MachineHealthCheckRemediationAllowedV1Beta2Reason is the reason used when the number of unhealthy machine
+	// is within the limits defined by the MachineHealthCheck, and thus remediation is allowed.
+	MachineHealthCheckRemediationAllowedV1Beta2Reason = "RemediationAllowed"
+)
+
+// MachineHealthCheck's Paused condition and corresponding reasons that will be used in v1Beta2 API version.
+const (
+	// MachineHealthCheckPausedV1Beta2Condition is true if this MachineHealthCheck or the Cluster it belongs to are paused.
+	MachineHealthCheckPausedV1Beta2Condition = PausedV1Beta2Condition
+)
+
 var (
 	// DefaultNodeStartupTimeout is the time allowed for a node to start up.
 	// Can be made longer as part of spec if required for particular provider.

--- a/api/v1beta1/v1beta2_condition_consts.go
+++ b/api/v1beta1/v1beta2_condition_consts.go
@@ -225,16 +225,6 @@ const (
 	ClusterPausedV1Beta2Condition = PausedV1Beta2Condition
 )
 
-// Conditions that will be used for the MachineHealthCheck object in v1Beta2 API version.
-const (
-	// MachineHealthCheckRemediationAllowedV1Beta2Condition surfaces whether the MachineHealthCheck is
-	// allowed to remediate any Machines or whether it is blocked from remediating any further.
-	MachineHealthCheckRemediationAllowedV1Beta2Condition = "RemediationAllowed"
-
-	// MachineHealthCheckPausedV1Beta2Condition is true if this MachineHealthCheck or the Cluster it belongs to are paused.
-	MachineHealthCheckPausedV1Beta2Condition = PausedV1Beta2Condition
-)
-
 // Conditions that will be used for the ClusterClass object in v1Beta2 API version.
 const (
 	// ClusterClassVariablesReadyV1Beta2Condition is true if the ClusterClass variables, including both inline and external

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -97,6 +98,13 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 	if annotations.HasRemediateMachine(t.Machine) {
 		conditions.MarkFalse(t.Machine, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.HasRemediateMachineAnnotationReason, clusterv1.ConditionSeverityWarning, "Marked for remediation via remediate-machine annotation")
 		logger.V(3).Info("Target is marked for remediation via remediate-machine annotation")
+
+		v1beta2conditions.Set(t.Machine, metav1.Condition{
+			Type:    clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  clusterv1.MachineHealthCheckHasRemediateAnnotationV1Beta2Reason,
+			Message: "Marked for remediation via cluster.x-k8s.io/remediate-machine annotation",
+		})
 		return true, time.Duration(0)
 	}
 
@@ -116,6 +124,13 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 	if t.nodeMissing {
 		logger.V(3).Info("Target is unhealthy: node is missing")
 		conditions.MarkFalse(t.Machine, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.NodeNotFoundReason, clusterv1.ConditionSeverityWarning, "")
+
+		v1beta2conditions.Set(t.Machine, metav1.Condition{
+			Type:    clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  clusterv1.MachineHealthCheckNodeDeletedV1Beta2Reason,
+			Message: fmt.Sprintf("Node %s has been deleted", t.Machine.Status.NodeRef.Name),
+		})
 		return true, time.Duration(0)
 	}
 
@@ -170,6 +185,13 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 		if comparisonTime.Add(timeoutForMachineToHaveNode.Duration).Before(now) {
 			conditions.MarkFalse(t.Machine, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.NodeStartupTimeoutReason, clusterv1.ConditionSeverityWarning, "Node failed to report startup in %s", timeoutDuration)
 			logger.V(3).Info("Target is unhealthy: machine has no node", "duration", timeoutDuration)
+
+			v1beta2conditions.Set(t.Machine, metav1.Condition{
+				Type:    clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineHealthCheckNodeStartupTimeoutV1Beta2Reason,
+				Message: fmt.Sprintf("Node failed to report startup in %s", timeoutDuration),
+			})
 			return true, time.Duration(0)
 		}
 
@@ -194,6 +216,13 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 		if nodeCondition.LastTransitionTime.Add(c.Timeout.Duration).Before(now) {
 			conditions.MarkFalse(t.Machine, clusterv1.MachineHealthCheckSucceededCondition, clusterv1.UnhealthyNodeConditionReason, clusterv1.ConditionSeverityWarning, "Condition %s on node is reporting status %s for more than %s", c.Type, c.Status, c.Timeout.Duration.String())
 			logger.V(3).Info("Target is unhealthy: condition is in state longer than allowed timeout", "condition", c.Type, "state", c.Status, "timeout", c.Timeout.Duration.String())
+
+			v1beta2conditions.Set(t.Machine, metav1.Condition{
+				Type:    clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineHealthCheckUnhealthyNodeV1Beta2Reason,
+				Message: fmt.Sprintf("Condition %s on Node is reporting status %s for more than %s", c.Type, c.Status, c.Timeout.Duration.String()),
+			})
 			return true, time.Duration(0)
 		}
 
@@ -327,6 +356,12 @@ func (r *Reconciler) healthCheckTargets(targets []healthCheckTarget, logger logr
 
 		if t.Machine.DeletionTimestamp.IsZero() && t.Node != nil {
 			conditions.MarkTrue(t.Machine, clusterv1.MachineHealthCheckSucceededCondition)
+
+			v1beta2conditions.Set(t.Machine, metav1.Condition{
+				Type:   clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachineHealthCheckSucceededV1Beta2Reason,
+			})
 			healthy = append(healthy, t)
 		}
 	}

--- a/util/conditions/v1beta2/getter.go
+++ b/util/conditions/v1beta2/getter.go
@@ -55,6 +55,38 @@ func Get(sourceObj Getter, sourceConditionType string) *metav1.Condition {
 	return meta.FindStatusCondition(sourceObj.GetV1Beta2Conditions(), sourceConditionType)
 }
 
+// Has returns true if a condition with the given type exists.
+func Has(from Getter, conditionType string) bool {
+	return Get(from, conditionType) != nil
+}
+
+// IsTrue is true if the condition with the given type is True, otherwise it returns false
+// if the condition is not True or if the condition does not exist (is nil).
+func IsTrue(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionTrue
+	}
+	return false
+}
+
+// IsFalse is true if the condition with the given type is False, otherwise it returns false
+// if the condition is not False or if the condition does not exist (is nil).
+func IsFalse(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionFalse
+	}
+	return false
+}
+
+// IsUnknown is true if the condition with the given type is Unknown or if the condition
+// does not exist (is nil).
+func IsUnknown(from Getter, conditionType string) bool {
+	if c := Get(from, conditionType); c != nil {
+		return c.Status == metav1.ConditionUnknown
+	}
+	return true
+}
+
 // UnstructuredGet returns a condition from an Unstructured object.
 //
 // UnstructuredGet supports retrieving conditions from objects at different stages of the transition from

--- a/util/conditions/v1beta2/getter_test.go
+++ b/util/conditions/v1beta2/getter_test.go
@@ -593,6 +593,34 @@ func TestConvertFromUnstructuredConditions(t *testing.T) {
 	}
 }
 
+func TestIsMethods(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := objectWithValueGetter{
+		Status: objectWithValueGetterStatus{
+			Conditions: []metav1.Condition{
+				{Type: "trueCondition", Status: metav1.ConditionTrue},
+				{Type: "falseCondition", Status: metav1.ConditionFalse},
+				{Type: "unknownCondition", Status: metav1.ConditionUnknown},
+			},
+		},
+	}
+
+	// test isTrue
+	g.Expect(IsTrue(obj, "trueCondition")).To(BeTrue())
+	g.Expect(IsTrue(obj, "falseCondition")).To(BeFalse())
+	g.Expect(IsTrue(obj, "unknownCondition")).To(BeFalse())
+	// test isFalse
+	g.Expect(IsFalse(obj, "trueCondition")).To(BeFalse())
+	g.Expect(IsFalse(obj, "falseCondition")).To(BeTrue())
+	g.Expect(IsFalse(obj, "unknownCondition")).To(BeFalse())
+
+	// test isUnknown
+	g.Expect(IsUnknown(obj, "trueCondition")).To(BeFalse())
+	g.Expect(IsUnknown(obj, "falseCondition")).To(BeFalse())
+	g.Expect(IsUnknown(obj, "unknownCondition")).To(BeTrue())
+}
+
 type objectWithValueGetter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/util/conditions/v1beta2/setter.go
+++ b/util/conditions/v1beta2/setter.go
@@ -97,3 +97,19 @@ func Set(targetObj Setter, condition metav1.Condition, opts ...SetOption) {
 
 	targetObj.SetV1Beta2Conditions(conditions)
 }
+
+// Delete deletes the condition with the given type.
+func Delete(to Setter, conditionType string) {
+	if to == nil {
+		return
+	}
+
+	conditions := to.GetV1Beta2Conditions()
+	newConditions := make([]metav1.Condition, 0, len(conditions)-1)
+	for _, condition := range conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+	to.SetV1Beta2Conditions(newConditions)
+}

--- a/util/conditions/v1beta2/setter_test.go
+++ b/util/conditions/v1beta2/setter_test.go
@@ -177,3 +177,22 @@ func TestSet(t *testing.T) {
 		g.Expect(foo.Status.Conditions).To(Equal(expected), cmp.Diff(foo.Status.Conditions, expected))
 	})
 }
+
+func TestDelete(t *testing.T) {
+	g := NewWithT(t)
+
+	obj := &builder.Phase2Obj{
+		Status: builder.Phase2ObjStatus{
+			Conditions: []metav1.Condition{
+				{Type: "trueCondition", Status: metav1.ConditionTrue},
+				{Type: "falseCondition", Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	Delete(nil, "foo") // no-op
+	Delete(obj, "trueCondition")
+	Delete(obj, "trueCondition") // no-op
+
+	g.Expect(obj.GetV1Beta2Conditions()).To(MatchConditions([]metav1.Condition{{Type: "falseCondition", Status: metav1.ConditionFalse}}, IgnoreLastTransitionTime(true)))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds code for updating MachineHealthCheck with v1beta2 status.
Also MachineHealthCheck now updates targeted Machines with v1beta2 status too.

**Which issue(s) this PR fixes**:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/11105

/area machinehealthcheck