### PR TITLE
🐛 kcp: consider all machines for setting .status.version

### DIFF
--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -56,8 +56,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, contro
 		return nil
 	}
 
-	machinesWithHealthyAPIServer := controlPlane.Machines.Filter(collections.HealthyAPIServer())
-	lowestVersion := machinesWithHealthyAPIServer.LowestVersion()
+	lowestVersion := controlPlane.Machines.LowestVersion()
 	if lowestVersion != nil {
 		controlPlane.KCP.Status.Version = lowestVersion
 	}

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -290,17 +290,6 @@ func WithVersion() Func {
 	}
 }
 
-// HealthyAPIServer returns a filter to find all machines that have a MachineAPIServerPodHealthyCondition
-// set to true.
-func HealthyAPIServer() Func {
-	return func(machine *clusterv1.Machine) bool {
-		if machine == nil {
-			return false
-		}
-		return conditions.IsTrue(machine, controlplanev1.MachineAPIServerPodHealthyCondition)
-	}
-}
-
 // HasNode returns a filter to find all machines that have a corresponding Kubernetes node.
 func HasNode() Func {
 	return func(machine *clusterv1.Machine) bool {

--- a/util/collections/machine_filters_test.go
+++ b/util/collections/machine_filters_test.go
@@ -378,26 +378,6 @@ func TestWithVersion(t *testing.T) {
 	})
 }
 
-func TestHealthyAPIServer(t *testing.T) {
-	t.Run("nil machine returns false", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(collections.HealthyAPIServer()(nil)).To(BeFalse())
-	})
-
-	t.Run("unhealthy machine returns false", func(t *testing.T) {
-		g := NewWithT(t)
-		machine := &clusterv1.Machine{}
-		g.Expect(collections.HealthyAPIServer()(machine)).To(BeFalse())
-	})
-
-	t.Run("healthy machine returns true", func(t *testing.T) {
-		g := NewWithT(t)
-		machine := &clusterv1.Machine{}
-		conditions.Set(machine, conditions.TrueCondition(controlplanev1.MachineAPIServerPodHealthyCondition))
-		g.Expect(collections.HealthyAPIServer()(machine)).To(BeTrue())
-	})
-}
-
 func TestGetFilteredMachinesForCluster(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Uses the lowest version of *all* machines when calculating .status.version for KCP.

Otherwise there may still exist CP machines in an old version which still serve the kube-apiserver (as e.g. in #11296).

Before this could have lead to version skew violations, because coming up new worker machines may still have been able to connect to the old apiserver. Altough except for CAPD this is unlikely, because provisioning also takes some time. In the failing test-case though we block the deletion of the old CP machine which increases the propability to hit this race.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Via: #11296

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
-->