### PR TITLE
🐛 fix: incorrect name used in kustomize path

### DIFF
--- a/test/framework/kubernetesversions/data/kustomization.yaml
+++ b/test/framework/kubernetesversions/data/kustomization.yaml
@@ -16,4 +16,4 @@ patches:
     kind: KubeadmConfigTemplate
     name: .*-md-0
     version: v1beta1
-- patch: platform-kustomization.yaml
+- path: platform-kustomization.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

A kustomization file used in the test framework is using an incorrect field name after its change to kustomize v5. Specifically it was using `patch` instead of `path` which cause kustomize to fail when building.

You would only see this if you do something like this in your tests:

```go

import (
   "sigs.k8s.io/cluster-api/test/framework/kubernetesversions"
)

		ciTemplateForUpgradePath, err := kubernetesversions.GenerateCIArtifactsInjectedTemplateForDebian(
			kubernetesversions.GenerateCIArtifactsInjectedTemplateForDebianInput{
				ArtifactsDirectory:    e2eCtx.Settings.ArtifactFolder,
				SourceTemplate:        sourceTemplateForUpgrade,
				PlatformKustomization: platformKustomization,
			},
		)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area testing
