### PR TITLE
🐛 [release-1.8] kcp: consider all machines for setting .status.version

### DIFF
--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -56,8 +56,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, contro
 		return nil
 	}
 
-	machinesWithHealthyAPIServer := controlPlane.Machines.Filter(collections.HealthyAPIServer())
-	lowestVersion := machinesWithHealthyAPIServer.LowestVersion()
+	lowestVersion := controlPlane.Machines.LowestVersion()
 	if lowestVersion != nil {
 		controlPlane.KCP.Status.Version = lowestVersion
 	}


### PR DESCRIPTION
manual cherry-pick of:

- #11304

/hold