### PR TITLE
🌱 test/framework: allow to include arbitrary types when dumping resources

### DIFF
--- a/test/framework/alltypes_helpers.go
+++ b/test/framework/alltypes_helpers.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,8 +46,9 @@ import (
 
 // GetCAPIResourcesInput is the input for GetCAPIResources.
 type GetCAPIResourcesInput struct {
-	Lister    Lister
-	Namespace string
+	Lister       Lister
+	Namespace    string
+	IncludeTypes []metav1.TypeMeta
 }
 
 // GetCAPIResources reads all the CAPI resources in a namespace.
@@ -57,13 +59,13 @@ func GetCAPIResources(ctx context.Context, input GetCAPIResourcesInput) []*unstr
 	Expect(input.Namespace).NotTo(BeEmpty(), "input.Namespace is required for GetCAPIResources")
 
 	types := getClusterAPITypes(ctx, input.Lister)
+	types.Insert(input.IncludeTypes...)
 
 	objList := []*unstructured.Unstructured{}
-	for i := range types {
-		typeMeta := types[i]
+	for _, typ := range types.UnsortedList() {
 		typeList := new(unstructured.UnstructuredList)
-		typeList.SetAPIVersion(typeMeta.APIVersion)
-		typeList.SetKind(typeMeta.Kind)
+		typeList.SetAPIVersion(typ.APIVersion)
+		typeList.SetKind(typ.Kind)
 
 		if err := input.Lister.List(ctx, typeList, client.InNamespace(input.Namespace)); err != nil {
 			if apierrors.IsNotFound(err) {
@@ -86,8 +88,8 @@ func GetCAPIResources(ctx context.Context, input GetCAPIResourcesInput) []*unstr
 
 // getClusterAPITypes returns the list of TypeMeta to be considered for the move discovery phase.
 // This list includes all the types belonging to CAPI providers.
-func getClusterAPITypes(ctx context.Context, lister Lister) []metav1.TypeMeta {
-	discoveredTypes := []metav1.TypeMeta{}
+func getClusterAPITypes(ctx context.Context, lister Lister) sets.Set[metav1.TypeMeta] {
+	discoveredTypes := sets.New[metav1.TypeMeta]()
 
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
 	Eventually(func() error {
@@ -100,7 +102,7 @@ func getClusterAPITypes(ctx context.Context, lister Lister) []metav1.TypeMeta {
 				continue
 			}
 
-			discoveredTypes = append(discoveredTypes, metav1.TypeMeta{
+			discoveredTypes.Insert(metav1.TypeMeta{
 				Kind: crd.Spec.Names.Kind,
 				APIVersion: metav1.GroupVersion{
 					Group:   crd.Spec.Group,
@@ -114,9 +116,10 @@ func getClusterAPITypes(ctx context.Context, lister Lister) []metav1.TypeMeta {
 
 // DumpAllResourcesInput is the input for DumpAllResources.
 type DumpAllResourcesInput struct {
-	Lister    Lister
-	Namespace string
-	LogPath   string
+	Lister       Lister
+	Namespace    string
+	LogPath      string
+	IncludeTypes []metav1.TypeMeta
 }
 
 // DumpAllResources dumps Cluster API related resources to YAML
@@ -127,8 +130,9 @@ func DumpAllResources(ctx context.Context, input DumpAllResourcesInput) {
 	Expect(input.Namespace).NotTo(BeEmpty(), "input.Namespace is required for DumpAllResources")
 
 	resources := GetCAPIResources(ctx, GetCAPIResourcesInput{
-		Lister:    input.Lister,
-		Namespace: input.Namespace,
+		Lister:       input.Lister,
+		Namespace:    input.Namespace,
+		IncludeTypes: input.IncludeTypes,
 	})
 
 	for i := range resources {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area testing