### PR TITLE
🌱 Deprecate ClusterCacheTracker

### DIFF
--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -32,6 +32,8 @@ import (
 
 // ClusterCacheReconciler is responsible for stopping remote cluster caches when
 // the cluster for the remote cache is being deleted.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.ClusterCache instead.
 type ClusterCacheReconciler struct {
 	Client  client.Client
 	Tracker *ClusterCacheTracker

--- a/controllers/remote/cluster_cache_tracker.go
+++ b/controllers/remote/cluster_cache_tracker.go
@@ -66,6 +66,8 @@ const (
 var ErrClusterLocked = errors.New("cluster is locked already")
 
 // ClusterCacheTracker manages client caches for workload clusters.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.ClusterCache instead.
 type ClusterCacheTracker struct {
 	log logr.Logger
 
@@ -108,6 +110,8 @@ type ClusterCacheTracker struct {
 
 // ClusterCacheTrackerOptions defines options to configure
 // a ClusterCacheTracker.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.ClusterCache instead.
 type ClusterCacheTrackerOptions struct {
 	// SecretCachingClient is a client which caches secrets.
 	// If set it will be used to read the kubeconfig secret.
@@ -172,6 +176,8 @@ func setDefaultOptions(opts *ClusterCacheTrackerOptions) {
 }
 
 // NewClusterCacheTracker creates a new ClusterCacheTracker.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.SetupWithManager instead.
 func NewClusterCacheTracker(manager ctrl.Manager, options ClusterCacheTrackerOptions) (*ClusterCacheTracker, error) {
 	setDefaultOptions(&options)
 

--- a/controllers/remote/cluster_cache_tracker_fake.go
+++ b/controllers/remote/cluster_cache_tracker_fake.go
@@ -24,6 +24,8 @@ import (
 )
 
 // NewTestClusterCacheTracker creates a new fake ClusterCacheTracker that can be used by unit tests with fake client.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.NewTestClusterCacheTracker instead.
 func NewTestClusterCacheTracker(log logr.Logger, cl client.Client, remoteClient client.Client, scheme *runtime.Scheme, objKey client.ObjectKey, watchObjects ...string) *ClusterCacheTracker {
 	testCacheTracker := &ClusterCacheTracker{
 		log:              log,

--- a/controllers/remote/index.go
+++ b/controllers/remote/index.go
@@ -24,6 +24,8 @@ import (
 )
 
 // Index is a helper to model the info passed to cache.IndexField.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.CacheOptionsIndex instead.
 type Index struct {
 	Object       client.Object
 	Field        string
@@ -31,6 +33,8 @@ type Index struct {
 }
 
 // NodeProviderIDIndex is used to index Nodes by ProviderID.
+//
+// Deprecated: This will be removed in Cluster API v1.10, use clustercache.NodeProviderIDIndex instead.
 var NodeProviderIDIndex = Index{
 	Object:       &corev1.Node{},
 	Field:        index.NodeProviderIDField,

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -121,9 +121,6 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 	r.ssaCache = ssa.NewCache()
 
 	if r.managementCluster == nil {
-		if r.ClusterCache == nil {
-			return errors.New("cluster cache tracker is nil, cannot create the internal management cluster resource")
-		}
 		r.managementCluster = &internal.Management{
 			Client:              r.Client,
 			SecretCachingClient: r.SecretCachingClient,

--- a/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
+++ b/docs/book/src/developer/providers/migrations/v1.8-to-v1.9.md
@@ -29,3 +29,9 @@ maintainers of providers and consumers of our Go API.
 ### Suggested changes for providers
 
 - The Errors package was created when capi provider implementation was running as machineActuators that needed to vendor core capi to function. There is no usage recommendations today and its value is questionable since we moved to CRDs that inter-operate mostly via conditions. Instead we plan to drop the dedicated semantic for terminal failure and keep improving Machine lifecycle signal through conditions. Therefore the Errors package [has been deprecated in v1.8](https://github.com/kubernetes-sigs/cluster-api/issues/10784). It's recommended to remove any usage of the currently exported variables.
+- The `ClusterCacheTracker` component has been deprecated, please use the new `ClusterCache` instead. For more context and examples for 
+  how to use it, see [PR: Introduce new ClusterCache](https://github.com/kubernetes-sigs/cluster-api/pull/11247) and the corresponding
+  [issue](https://github.com/kubernetes-sigs/cluster-api/issues/11272). Some notes:
+  - The `DisabledFor` option (previously `ClientUncachedObjects`) is not defaulted to `&corev1.ConfigMap` & `&corev1.Secret` anymore, 
+    thus it's now necessary to explicitly set `DisabledFor` to avoid caching ConfigMaps and Secrets.
+  - `SecretClient` and `UserAgent` are now mandatory options, please take a look at the corresponding godoc.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11272

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->