### PR TITLE
🌱 Fix flake in TestClusterReconciler

### DIFF
--- a/internal/controllers/cluster/suite_test.go
+++ b/internal/controllers/cluster/suite_test.go
@@ -84,6 +84,11 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("Failed to create ClusterCache: %v", err))
 		}
 
+		// Setting ConnectionCreationRetryInterval to 2 seconds, otherwise client creation is
+		// only retried every 30s. If we get unlucky tests are then failing with timeout.
+		clusterCache.(interface{ SetConnectionCreationRetryInterval(time.Duration) }).
+			SetConnectionCreationRetryInterval(2 * time.Second)
+
 		if err := (&Reconciler{
 			Client:                      mgr.GetClient(),
 			APIReader:                   mgr.GetClient(),


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Flakes: https://storage.googleapis.com/k8s-triage/index.html?job=periodic-cluster-api-test-.*main

e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/1846587606641414144

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to #11247 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->