### PR TITLE
:seedling: Remove json logging replacement in e2e test config

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -100,9 +100,6 @@ providers:
       - sourcePath: "../data/shared/v1.8/metadata.yaml"
   - name: v1.9.99 # next; use manifest from source files
     value: ../../../config/default
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
     files:
     - sourcePath: "../data/shared/main/metadata.yaml"
 
@@ -174,9 +171,6 @@ providers:
       - sourcePath: "../data/shared/v1.8/metadata.yaml"
   - name: v1.9.99 # next; use manifest from source files
     value: ../../../bootstrap/kubeadm/config/default
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
     files:
     - sourcePath: "../data/shared/main/metadata.yaml"
 
@@ -248,9 +242,6 @@ providers:
       - sourcePath: "../data/shared/v1.8/metadata.yaml"
   - name: v1.9.99 # next; use manifest from source files
     value: ../../../controlplane/kubeadm/config/default
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
     files:
     - sourcePath: "../data/shared/main/metadata.yaml"
 
@@ -337,9 +328,6 @@ providers:
       - sourcePath: "../data/infrastructure-docker/v1.8/clusterclass-quick-start.yaml"
   - name: v1.9.99 # next; use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
     files:
     # Add cluster templates
     - sourcePath: "../data/infrastructure-docker/main/cluster-template.yaml"
@@ -369,9 +357,6 @@ providers:
   versions:
   - name: v1.9.99 # next; use manifest from source files
     value: ../../../test/infrastructure/inmemory/config/default
-    replacements:
-    - old: "--leader-elect"
-      new: "--leader-elect\n        - --logging-format=json"
     files:
     # Add cluster templates
     - sourcePath: "../data/infrastructure-inmemory/main/clusterclass-in-memory.yaml"
@@ -383,9 +368,6 @@ providers:
   versions:
     - name: v1.9.99 # next; use manifest from source files
       value: ../../../test/extension/config/default
-      replacements:
-      - old: "--leader-elect"
-        new: "--leader-elect\n        - --logging-format=json"
       files:
       - sourcePath: "../data/shared/main/metadata.yaml"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
removes JSON logging from built from main e2e components to improve ease of troubleshooting per conversation here: https://github.com/kubernetes-sigs/cluster-api/issues/11133#issuecomment-2428586507

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing