### PR TITLE
🌱 KCP: Skip validation if CoreDNS migration library supports an upgrade if the library is not used

### DIFF
--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -620,6 +620,12 @@ func (webhook *KubeadmControlPlane) validateCoreDNSVersion(oldK, newK *controlpl
 	if toVersion.Equals(fromVersion) {
 		return allErrs
 	}
+
+	// Skip validating if the skip CoreDNS annotation is set. If set, KCP doesn't use the migration library.
+	if _, ok := newK.Annotations[controlplanev1.SkipCoreDNSAnnotation]; ok {
+		return allErrs
+	}
+
 	if err := migration.ValidUpMigration(fromVersion.String(), toVersion.String()); err != nil {
 		allErrs = append(
 			allErrs,

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
@@ -554,6 +554,17 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		},
 	}
 
+	validUnsupportedCoreDNSVersionWithSkipAnnotation := dns.DeepCopy()
+	validUnsupportedCoreDNSVersionWithSkipAnnotation.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = bootstrapv1.DNS{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: "gcr.io/capi-test",
+			ImageTag:        "v99.99.99",
+		},
+	}
+	validUnsupportedCoreDNSVersionWithSkipAnnotation.Annotations = map[string]string{
+		controlplanev1.SkipCoreDNSAnnotation: "",
+	}
+
 	unsetCoreDNSToVersion := dns.DeepCopy()
 	unsetCoreDNSToVersion.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = bootstrapv1.DNS{
 		ImageMeta: bootstrapv1.ImageMeta{
@@ -859,6 +870,17 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			name:   "should succeed when using the same CoreDNS version - not supported",
 			before: validUnsupportedCoreDNSVersion,
 			kcp:    validUnsupportedCoreDNSVersion,
+		},
+		{
+			name:      "should fail when upgrading to an unsupported version",
+			before:    dns,
+			kcp:       validUnsupportedCoreDNSVersion,
+			expectErr: true,
+		},
+		{
+			name:   "should succeed when upgrading to an unsupported version and KCP has skip annotation set",
+			before: dns,
+			kcp:    validUnsupportedCoreDNSVersionWithSkipAnnotation,
 		},
 		{
 			name:      "should fail when using an invalid DNS build",


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
It doesn't make sense to check if the migratoin library supports an upgrade if the code doing the CoreDNS upgrade is skipped. So let's get rid of it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->