### PR TITLE
🐛 Fix sorting of v1beta2 conditions when patching

### DIFF
--- a/util/conditions/v1beta2/options.go
+++ b/util/conditions/v1beta2/options.go
@@ -26,6 +26,11 @@ func (f ConditionSortFunc) ApplyToSet(opts *SetOptions) {
 	opts.conditionSortFunc = f
 }
 
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ConditionSortFunc) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.conditionSortFunc = f
+}
+
 // TargetConditionType allows to specify the type of new mirror or aggregate conditions.
 type TargetConditionType string
 
@@ -105,15 +110,17 @@ func (t CustomMergeStrategy) ApplyToAggregate(opts *AggregateOptions) {
 
 // OwnedConditionTypes allows to define condition types owned by the controller when performing patch apply.
 // In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
-func OwnedConditionTypes(conditionTypes ...string) ApplyOption {
-	return func(c *applyOptions) {
-		c.ownedConditionTypes = conditionTypes
-	}
+type OwnedConditionTypes []string
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (o OwnedConditionTypes) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.ownedConditionTypes = o
 }
 
 // ForceOverwrite instructs patch apply to always use the value provided by the controller (no matter of what value exists currently).
-func ForceOverwrite(v bool) ApplyOption {
-	return func(c *applyOptions) {
-		c.forceOverwrite = v
-	}
+type ForceOverwrite bool
+
+// ApplyToPatchApply applies this configuration to the given patch apply options.
+func (f ForceOverwrite) ApplyToPatchApply(opts *PatchApplyOptions) {
+	opts.forceOverwrite = bool(f)
 }

--- a/util/conditions/v1beta2/patch_test.go
+++ b/util/conditions/v1beta2/patch_test.go
@@ -138,7 +138,7 @@ func TestApply(t *testing.T) {
 		before  Setter
 		after   Setter
 		latest  Setter
-		options []ApplyOption
+		options []PatchApplyOption
 		want    []metav1.Condition
 		wantErr bool
 	}{
@@ -195,7 +195,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(),
 			after:   objectWithConditions(fooTrue),
 			latest:  objectWithConditions(fooFalse),
-			options: []ApplyOption{ForceOverwrite(true)},
+			options: []PatchApplyOption{ForceOverwrite(true)},
 			want:    []metav1.Condition{fooTrue}, // after condition should be kept in case of error
 			wantErr: false,
 		},
@@ -204,7 +204,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(),
 			after:   objectWithConditions(fooTrue),
 			latest:  objectWithConditions(fooFalse),
-			options: []ApplyOption{OwnedConditionTypes("foo")},
+			options: []PatchApplyOption{OwnedConditionTypes{"foo"}},
 			want:    []metav1.Condition{fooTrue}, // after condition should be kept in case of error
 			wantErr: false,
 		},
@@ -237,7 +237,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooTrue),
 			after:   objectWithConditions(),
 			latest:  objectWithConditions(fooFalse),
-			options: []ApplyOption{ForceOverwrite(true)},
+			options: []PatchApplyOption{ForceOverwrite(true)},
 			want:    []metav1.Condition{},
 			wantErr: false,
 		},
@@ -246,7 +246,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooTrue),
 			after:   objectWithConditions(),
 			latest:  objectWithConditions(fooFalse),
-			options: []ApplyOption{OwnedConditionTypes("foo")},
+			options: []PatchApplyOption{OwnedConditionTypes{"foo"}},
 			want:    []metav1.Condition{},
 			wantErr: false,
 		},
@@ -279,7 +279,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooFalse),
 			after:   objectWithConditions(fooFalse2),
 			latest:  objectWithConditions(fooTrue),
-			options: []ApplyOption{ForceOverwrite(true)},
+			options: []PatchApplyOption{ForceOverwrite(true)},
 			want:    []metav1.Condition{fooFalse2},
 			wantErr: false,
 		},
@@ -288,7 +288,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooFalse),
 			after:   objectWithConditions(fooFalse2),
 			latest:  objectWithConditions(fooTrue),
-			options: []ApplyOption{OwnedConditionTypes("foo")},
+			options: []PatchApplyOption{OwnedConditionTypes{"foo"}},
 			want:    []metav1.Condition{fooFalse2},
 			wantErr: false,
 		},
@@ -305,7 +305,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooTrue),
 			after:   objectWithConditions(fooFalse),
 			latest:  objectWithConditions(),
-			options: []ApplyOption{ForceOverwrite(true)},
+			options: []PatchApplyOption{ForceOverwrite(true)},
 			want:    []metav1.Condition{fooFalse},
 			wantErr: false,
 		},
@@ -314,7 +314,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooTrue),
 			after:   objectWithConditions(fooFalse),
 			latest:  objectWithConditions(),
-			options: []ApplyOption{OwnedConditionTypes("foo")},
+			options: []PatchApplyOption{OwnedConditionTypes{"foo"}},
 			want:    []metav1.Condition{fooFalse},
 			wantErr: false,
 		},
@@ -323,7 +323,7 @@ func TestApply(t *testing.T) {
 			before:  objectWithConditions(fooTrue),
 			after:   objectWithConditions(fooFalse),
 			latest:  objectWithConditions(),
-			options: []ApplyOption{nil},
+			options: []PatchApplyOption{nil},
 			wantErr: true,
 		},
 	}

--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -297,7 +297,7 @@ func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, f
 					return errors.Errorf("%s %s doesn't satisfy conditions.Setter, cannot apply patch", h.gvk.Kind, klog.KObj(latest))
 				}
 
-				return diff.Apply(latestSetter, v1beta2conditions.ForceOverwrite(forceOverwrite), v1beta2conditions.OwnedConditionTypes(ownedV1beta2Conditions...))
+				return diff.Apply(latestSetter, v1beta2conditions.ForceOverwrite(forceOverwrite), v1beta2conditions.OwnedConditionTypes(ownedV1beta2Conditions))
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enforce sorting of v1beta2 conditions when patching

/area util
