### PR TITLE
🌱  use latest atomic variable instead of old one

### DIFF
--- a/test/infrastructure/inmemory/pkg/runtime/cache/cache_test.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/cache_test.go
@@ -132,7 +132,7 @@ func Test_cache_scale(t *testing.T) {
 
 	time.Sleep(testDuration)
 
-	t.Log("createCount", createCount, "getCount", getCount, "listCount", listCount, "deleteCount", deleteCount)
+	t.Log("createCount", createCount.Load(), "getCount", getCount.Load(), "listCount", listCount.Load(), "deleteCount", deleteCount.Load())
 
 	cancel()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I replace atomic.AddXX function to atomic variable and receiver method itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->