### PR TITLE
✨  add typed watcher to ClusterCache

### DIFF
--- a/controllers/clustercache/cluster_accessor_test.go
+++ b/controllers/clustercache/cluster_accessor_test.go
@@ -327,7 +327,7 @@ func TestWatch(t *testing.T) {
 	accessor := newClusterAccessor(clusterKey, config)
 
 	tw := &testWatcher{}
-	wi := WatchInput{
+	wi := WatcherOptions{
 		Name:         "test-watch",
 		Watcher:      tw,
 		Kind:         &corev1.Node{},
@@ -335,7 +335,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	// Add watch when not connected (fails)
-	err := accessor.Watch(ctx, wi)
+	err := accessor.Watch(ctx, NewWatcher(wi))
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(errors.Is(err, ErrClusterNotConnected)).To(BeTrue())
 
@@ -346,12 +346,12 @@ func TestWatch(t *testing.T) {
 	g.Expect(accessor.lockedState.connection.watches).To(BeEmpty())
 
 	// Add watch
-	g.Expect(accessor.Watch(ctx, wi)).To(Succeed())
+	g.Expect(accessor.Watch(ctx, NewWatcher(wi))).To(Succeed())
 	g.Expect(accessor.lockedState.connection.watches.Has("test-watch")).To(BeTrue())
 	g.Expect(accessor.lockedState.connection.watches.Len()).To(Equal(1))
 
 	// Add watch again (no-op as watch already exists)
-	g.Expect(accessor.Watch(ctx, wi)).To(Succeed())
+	g.Expect(accessor.Watch(ctx, NewWatcher(wi))).To(Succeed())
 	g.Expect(accessor.lockedState.connection.watches.Has("test-watch")).To(BeTrue())
 	g.Expect(accessor.lockedState.connection.watches.Len()).To(Equal(1))
 

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -371,12 +371,12 @@ func (r *MachinePoolReconciler) watchClusterNodes(ctx context.Context, cluster *
 		return nil
 	}
 
-	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.WatchInput{
+	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.NewWatcher(clustercache.WatcherOptions{
 		Name:         "machinepool-watchNodes",
 		Watcher:      r.controller,
 		Kind:         &corev1.Node{},
 		EventHandler: handler.EnqueueRequestsFromMapFunc(r.nodeToMachinePool),
-	})
+	}))
 }
 
 func (r *MachinePoolReconciler) nodeToMachinePool(ctx context.Context, o client.Object) []reconcile.Request {

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -1045,12 +1045,12 @@ func (r *Reconciler) watchClusterNodes(ctx context.Context, cluster *clusterv1.C
 		return nil
 	}
 
-	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.WatchInput{
+	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.NewWatcher(clustercache.WatcherOptions{
 		Name:         "machine-watchNodes",
 		Watcher:      r.controller,
 		Kind:         &corev1.Node{},
 		EventHandler: handler.EnqueueRequestsFromMapFunc(r.nodeToMachine),
-	})
+	}))
 }
 
 func (r *Reconciler) nodeToMachine(ctx context.Context, o client.Object) []reconcile.Request {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -351,14 +351,14 @@ func TestGetNode(t *testing.T) {
 
 	// Retry because the ClusterCache might not have immediately created the clusterAccessor.
 	g.Eventually(func(g Gomega) {
-		g.Expect(clusterCache.Watch(ctx, util.ObjectKey(testCluster), clustercache.WatchInput{
+		g.Expect(clusterCache.Watch(ctx, util.ObjectKey(testCluster), clustercache.NewWatcher(clustercache.WatcherOptions{
 			Name:    "TestGetNode",
 			Watcher: w,
 			Kind:    &corev1.Node{},
 			EventHandler: handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
 				return nil
 			}),
-		})).To(Succeed())
+		}))).To(Succeed())
 	}, 1*time.Minute, 5*time.Second).Should(Succeed())
 
 	for _, tc := range testCases {

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -571,12 +571,12 @@ func (r *Reconciler) nodeToMachineHealthCheck(ctx context.Context, o client.Obje
 }
 
 func (r *Reconciler) watchClusterNodes(ctx context.Context, cluster *clusterv1.Cluster) error {
-	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.WatchInput{
+	return r.ClusterCache.Watch(ctx, util.ObjectKey(cluster), clustercache.NewWatcher(clustercache.WatcherOptions{
 		Name:         "machinehealthcheck-watchClusterNodes",
 		Watcher:      r.controller,
 		Kind:         &corev1.Node{},
 		EventHandler: handler.EnqueueRequestsFromMapFunc(r.nodeToMachineHealthCheck),
-	})
+	}))
 }
 
 // getMachineFromNode retrieves the machine with a nodeRef to nodeName


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds support for typed watched to ClusterCache.

This will be specially useful when you want to reconcile a single object on the workload cluster.

With the current API to reconcile a single object on the workload cluster we need to reconcile an object on the mgt cluster that inturn reconciles all objects on the workload cluster. 

An example use case when the new API would be useful:
Reconciling a single workload cluster node instead of queueing the CAPI Cluster to then reconciler all workload cluster nodes.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clustercachetracker