### PR TITLE
🌱 kcp: ensure ReadinessGates for v1beta2 conditions get set

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1567,6 +1567,7 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 			NodeDrainTimeout:        duration5s,
 			NodeVolumeDetachTimeout: duration5s,
 			NodeDeletionTimeout:     duration5s,
+			ReadinessGates:          mandatoryMachineReadinessGates,
 		},
 	}
 	g.Expect(env.Create(ctx, deletingMachine, client.FieldOwner(classicManager))).To(Succeed())

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -49,11 +49,11 @@ import (
 
 // mandatoryMachineReadinessGates are readinessGates KCP enforces to be set on machine it owns.
 var mandatoryMachineReadinessGates = []clusterv1.MachineReadinessGate{
-	{ConditionType: string(controlplanev1.MachineAPIServerPodHealthyCondition)},
-	{ConditionType: string(controlplanev1.MachineControllerManagerPodHealthyCondition)},
-	{ConditionType: string(controlplanev1.MachineSchedulerPodHealthyCondition)},
-	{ConditionType: string(controlplanev1.MachineEtcdPodHealthyCondition)},
-	{ConditionType: string(controlplanev1.MachineEtcdMemberHealthyCondition)},
+	{ConditionType: string(controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyV1Beta2Condition)},
+	{ConditionType: string(controlplanev1.KubeadmControlPlaneMachineControllerManagerPodHealthyV1Beta2Condition)},
+	{ConditionType: string(controlplanev1.KubeadmControlPlaneMachineSchedulerPodHealthyV1Beta2Condition)},
+	{ConditionType: string(controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyV1Beta2Condition)},
+	{ConditionType: string(controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition)},
 }
 
 func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, controlPlane *internal.ControlPlane) (ctrl.Result, error) {
@@ -465,8 +465,6 @@ func ensureMandatoryReadinessGates(m *clusterv1.Machine) {
 		return
 	}
 
-	additionalConditions := []clusterv1.MachineReadinessGate{}
-
 	for _, want := range mandatoryMachineReadinessGates {
 		found := false
 		for _, got := range m.Spec.ReadinessGates {
@@ -476,9 +474,7 @@ func ensureMandatoryReadinessGates(m *clusterv1.Machine) {
 			}
 		}
 		if !found {
-			additionalConditions = append(additionalConditions, want)
+			m.Spec.ReadinessGates = append(m.Spec.ReadinessGates, want)
 		}
 	}
-
-	m.Spec.ReadinessGates = append(m.Spec.ReadinessGates, additionalConditions...)
 }

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -539,6 +539,7 @@ func TestKubeadmControlPlaneReconciler_computeDesiredMachine(t *testing.T) {
 			NodeDrainTimeout:        kcp.Spec.MachineTemplate.NodeDrainTimeout,
 			NodeDeletionTimeout:     kcp.Spec.MachineTemplate.NodeDeletionTimeout,
 			NodeVolumeDetachTimeout: kcp.Spec.MachineTemplate.NodeVolumeDetachTimeout,
+			ReadinessGates:          mandatoryMachineReadinessGates,
 		}
 		g.Expect(createdMachine.Name).To(HavePrefix(kcp.Name))
 		g.Expect(createdMachine.Namespace).To(Equal(kcp.Namespace))
@@ -601,6 +602,7 @@ func TestKubeadmControlPlaneReconciler_computeDesiredMachine(t *testing.T) {
 					ConfigRef: bootstrapRef,
 				},
 				InfrastructureRef: *infraRef,
+				ReadinessGates:    []clusterv1.MachineReadinessGate{{ConditionType: "Foo"}},
 			},
 		}
 
@@ -621,6 +623,7 @@ func TestKubeadmControlPlaneReconciler_computeDesiredMachine(t *testing.T) {
 			NodeDrainTimeout:        kcp.Spec.MachineTemplate.NodeDrainTimeout,
 			NodeDeletionTimeout:     kcp.Spec.MachineTemplate.NodeDeletionTimeout,
 			NodeVolumeDetachTimeout: kcp.Spec.MachineTemplate.NodeVolumeDetachTimeout,
+			ReadinessGates:          append([]clusterv1.MachineReadinessGate{{ConditionType: "Foo"}}, mandatoryMachineReadinessGates...),
 		}
 		g.Expect(updatedMachine.Namespace).To(Equal(kcp.Namespace))
 		g.Expect(updatedMachine.OwnerReferences).To(HaveLen(1))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Ensures KCP sets the following conditions at its owned Machine's .spec.readinessGates:

- controlplanev1.MachineAPIServerPodHealthyCondition
- controlplanev1.MachineControllerManagerPodHealthyCondition
- controlplanev1.MachineSchedulerPodHealthyCondition
- controlplanev1.MachineEtcdPodHealthyCondition
- controlplanev1.MachineEtcdMemberHealthyCondition

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of 
- #11105

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->