### PR TITLE
:seedling:  Add Canonical Kubernetes providers

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -74,26 +74,28 @@ const (
 
 // Bootstrap providers.
 const (
-	KubeadmBootstrapProviderName           = "kubeadm"
-	TalosBootstrapProviderName             = "talos"
-	MicroK8sBootstrapProviderName          = "microk8s"
-	OracleCloudNativeBootstrapProviderName = "ocne"
-	KubeKeyK3sBootstrapProviderName        = "kubekey-k3s"
-	RKE2BootstrapProviderName              = "rke2"
-	K0smotronBootstrapProviderName         = "k0sproject-k0smotron"
+	KubeadmBootstrapProviderName             = "kubeadm"
+	TalosBootstrapProviderName               = "talos"
+	MicroK8sBootstrapProviderName            = "microk8s"
+	OracleCloudNativeBootstrapProviderName   = "ocne"
+	KubeKeyK3sBootstrapProviderName          = "kubekey-k3s"
+	RKE2BootstrapProviderName                = "rke2"
+	K0smotronBootstrapProviderName           = "k0sproject-k0smotron"
+	CanonicalKubernetesBootstrapProviderName = "canonical-kubernetes"
 )
 
 // ControlPlane providers.
 const (
-	KubeadmControlPlaneProviderName           = "kubeadm"
-	TalosControlPlaneProviderName             = "talos"
-	MicroK8sControlPlaneProviderName          = "microk8s"
-	NestedControlPlaneProviderName            = "nested"
-	OracleCloudNativeControlPlaneProviderName = "ocne"
-	KubeKeyK3sControlPlaneProviderName        = "kubekey-k3s"
-	KamajiControlPlaneProviderName            = "kamaji"
-	RKE2ControlPlaneProviderName              = "rke2"
-	K0smotronControlPlaneProviderName         = "k0sproject-k0smotron"
+	KubeadmControlPlaneProviderName             = "kubeadm"
+	TalosControlPlaneProviderName               = "talos"
+	MicroK8sControlPlaneProviderName            = "microk8s"
+	NestedControlPlaneProviderName              = "nested"
+	OracleCloudNativeControlPlaneProviderName   = "ocne"
+	KubeKeyK3sControlPlaneProviderName          = "kubekey-k3s"
+	KamajiControlPlaneProviderName              = "kamaji"
+	RKE2ControlPlaneProviderName                = "rke2"
+	K0smotronControlPlaneProviderName           = "k0sproject-k0smotron"
+	CanonicalKubernetesControlPlaneProviderName = "canonical-kubernetes"
 )
 
 // IPAM providers.
@@ -356,6 +358,11 @@ func (p *providersClient) defaults() []Provider {
 			url:          "https://github.com/k0sproject/k0smotron/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
+		&provider{
+			name:         CanonicalKubernetesBootstrapProviderName,
+			url:          "https://github.com/canonical/cluster-api-k8s/releases/latest/bootstrap-components.yaml",
+			providerType: clusterctlv1.BootstrapProviderType,
+		},
 
 		// ControlPlane providers
 		&provider{
@@ -401,6 +408,11 @@ func (p *providersClient) defaults() []Provider {
 		&provider{
 			name:         K0smotronControlPlaneProviderName,
 			url:          "https://github.com/k0sproject/k0smotron/releases/latest/control-plane-components.yaml",
+			providerType: clusterctlv1.ControlPlaneProviderType,
+		},
+		&provider{
+			name:         CanonicalKubernetesControlPlaneProviderName,
+			url:          "https://github.com/canonical/cluster-api-k8s/releases/latest/control-plane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -57,6 +57,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
+				config.CanonicalKubernetesBootstrapProviderName,
 				config.K0smotronBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.KubeKeyK3sBootstrapProviderName,
@@ -64,6 +65,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 				config.OracleCloudNativeBootstrapProviderName,
 				config.RKE2BootstrapProviderName,
 				config.TalosBootstrapProviderName,
+				config.CanonicalKubernetesControlPlaneProviderName,
 				config.K0smotronControlPlaneProviderName,
 				config.KamajiControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,
@@ -119,6 +121,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
+				config.CanonicalKubernetesBootstrapProviderName,
 				customProviderConfig.Name(),
 				config.K0smotronBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
@@ -127,6 +130,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 				config.OracleCloudNativeBootstrapProviderName,
 				config.RKE2BootstrapProviderName,
 				config.TalosBootstrapProviderName,
+				config.CanonicalKubernetesControlPlaneProviderName,
 				config.K0smotronControlPlaneProviderName,
 				config.KamajiControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -105,6 +105,7 @@ providers:
 var expectedOutputText = `NAME                    TYPE                     URL                                                                                         FILE
 cluster-api             CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                                core_components.yaml
 another-provider        BootstrapProvider        ./                                                                                          bootstrap-components.yaml
+canonical-kubernetes    BootstrapProvider        https://github.com/canonical/cluster-api-k8s/releases/latest/                               bootstrap-components.yaml
 k0sproject-k0smotron    BootstrapProvider        https://github.com/k0sproject/k0smotron/releases/latest/                                    bootstrap-components.yaml
 kubeadm                 BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                             bootstrap-components.yaml
 kubekey-k3s             BootstrapProvider        https://github.com/kubesphere/kubekey/releases/latest/                                      bootstrap-components.yaml
@@ -112,6 +113,7 @@ microk8s                BootstrapProvider        https://github.com/canonical/cl
 ocne                    BootstrapProvider        https://github.com/verrazzano/cluster-api-provider-ocne/releases/latest/                    bootstrap-components.yaml
 rke2                    BootstrapProvider        https://github.com/rancher/cluster-api-provider-rke2/releases/latest/                       bootstrap-components.yaml
 talos                   BootstrapProvider        https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/         bootstrap-components.yaml
+canonical-kubernetes    ControlPlaneProvider     https://github.com/canonical/cluster-api-k8s/releases/latest/                               control-plane-components.yaml
 k0sproject-k0smotron    ControlPlaneProvider     https://github.com/k0sproject/k0smotron/releases/latest/                                    control-plane-components.yaml
 kamaji                  ControlPlaneProvider     https://github.com/clastix/cluster-api-control-plane-provider-kamaji/releases/latest/       control-plane-components.yaml
 kubeadm                 ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                             control-plane-components.yaml
@@ -168,6 +170,10 @@ var expectedOutputYaml = `- File: core_components.yaml
   ProviderType: BootstrapProvider
   URL: ./
 - File: bootstrap-components.yaml
+  Name: canonical-kubernetes
+  ProviderType: BootstrapProvider
+  URL: https://github.com/canonical/cluster-api-k8s/releases/latest/
+- File: bootstrap-components.yaml
   Name: k0sproject-k0smotron
   ProviderType: BootstrapProvider
   URL: https://github.com/k0sproject/k0smotron/releases/latest/
@@ -195,6 +201,10 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: talos
   ProviderType: BootstrapProvider
   URL: https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/
+- File: control-plane-components.yaml
+  Name: canonical-kubernetes
+  ProviderType: ControlPlaneProvider
+  URL: https://github.com/canonical/cluster-api-k8s/releases/latest/
 - File: control-plane-components.yaml
   Name: k0sproject-k0smotron
   ProviderType: ControlPlaneProvider

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -7,6 +7,7 @@ updated info about which API version they are supporting.
 
 ## Bootstrap
 - [Amazon Elastic Kubernetes Service (EKS)](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/main/bootstrap/eks)
+- [Canonical Kubernetes](https://github.com/canonical/cluster-api-k8s)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/bootstrap/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-bootstrap-provider-microk8s)
 - [Oracle Cloud Native Environment (OCNE)](https://github.com/verrazzano/cluster-api-provider-ocne)
@@ -15,6 +16,7 @@ updated info about which API version they are supporting.
 - [k0smotron/k0s](https://github.com/k0sproject/k0smotron)
 
 ## Control Plane
+- [Canonical Kubernetes](https://github.com/canonical/cluster-api-k8s)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-control-plane-provider-microk8s)
 - [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the Canonical Kubernetes bootstrap and control-plane providers to the `clusterctl` default providers and updates the provider reference accordingly in the documentation.

https://github.com/canonical/cluster-api-k8s

/area clusterctl
