### PR TITLE
🌱 Drop ReconcileError events

### DIFF
--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -182,7 +182,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			log.V(5).Info("Requeuing because connection to the workload cluster is down")
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
-		r.recorder.Eventf(m, corev1.EventTypeWarning, "ReconcileError", "%v", err)
 
 		// Requeue immediately if any errors occurred
 		return ctrl.Result{}, err

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -256,7 +256,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (retres ct
 			return ctrl.Result{RequeueAfter: time.Minute}, nil
 		}
 		err = kerr
-		r.recorder.Eventf(s.machineSet, corev1.EventTypeWarning, "ReconcileError", "%v", kerr)
 	}
 	return result, err
 }

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -613,30 +613,6 @@ func TestMachineSetReconcile(t *testing.T) {
 		g.Expect(result).To(BeComparableTo(reconcile.Result{}))
 	})
 
-	t.Run("records event if reconcile fails", func(t *testing.T) {
-		g := NewWithT(t)
-
-		ms := newMachineSet("machineset1", testClusterName, int32(0))
-		ms.Spec.Template.Spec.Bootstrap.ConfigRef = &corev1.ObjectReference{
-			Kind:      "FooTemplate",
-			Namespace: ms.GetNamespace(),
-			Name:      "doesnotexist",
-		}
-
-		request := reconcile.Request{
-			NamespacedName: util.ObjectKey(ms),
-		}
-
-		rec := record.NewFakeRecorder(32)
-		c := fake.NewClientBuilder().WithObjects(testCluster, ms).WithStatusSubresource(&clusterv1.MachineSet{}).Build()
-		msr := &Reconciler{
-			Client:   c,
-			recorder: rec,
-		}
-		_, _ = msr.Reconcile(ctx, request)
-		g.Eventually(rec.Events).Should(Receive())
-	})
-
 	t.Run("reconcile successfully when labels are missing", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I think we should not publish events every time we get a reconcile errors. This can be very very spamy

Note: We have exponential backoff, but Reconcile will still be additionally triggered by updates on watched events.

P.S. There's another occurence of this, but Fabrizio will take care of that one in #11338

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->