### PR TITLE
🌱 Truncate lastTransitionTime for v1beta2 conditions

### DIFF
--- a/util/conditions/v1beta2/patch.go
+++ b/util/conditions/v1beta2/patch.go
@@ -148,7 +148,7 @@ func (p Patch) Apply(latest Setter, opts ...PatchApplyOption) error {
 		case AddConditionPatch:
 			// If the condition is owned, always keep the after value.
 			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
-				meta.SetStatusCondition(&latestConditions, *conditionPatch.After)
+				setStatusCondition(&latestConditions, *conditionPatch.After)
 				continue
 			}
 
@@ -163,12 +163,12 @@ func (p Patch) Apply(latest Setter, opts ...PatchApplyOption) error {
 				continue
 			}
 			// If the condition does not exists on the latest, add the new after condition.
-			meta.SetStatusCondition(&latestConditions, *conditionPatch.After)
+			setStatusCondition(&latestConditions, *conditionPatch.After)
 
 		case ChangeConditionPatch:
 			// If the conditions is owned, always keep the after value.
 			if applyOpt.forceOverwrite || applyOpt.isOwnedConditionType(conditionPatch.After.Type) {
-				meta.SetStatusCondition(&latestConditions, *conditionPatch.After)
+				setStatusCondition(&latestConditions, *conditionPatch.After)
 				continue
 			}
 
@@ -190,7 +190,7 @@ func (p Patch) Apply(latest Setter, opts ...PatchApplyOption) error {
 				continue
 			}
 			// Otherwise apply the new after condition.
-			meta.SetStatusCondition(&latestConditions, *conditionPatch.After)
+			setStatusCondition(&latestConditions, *conditionPatch.After)
 
 		case RemoveConditionPatch:
 			// If latestConditions is nil or empty, nothing to remove.

--- a/util/conditions/v1beta2/setter_test.go
+++ b/util/conditions/v1beta2/setter_test.go
@@ -18,6 +18,7 @@ package v1beta2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -175,6 +176,42 @@ func TestSet(t *testing.T) {
 		condition.ObservedGeneration = foo.Generation
 		expected := []metav1.Condition{condition}
 		g.Expect(foo.Status.Conditions).To(Equal(expected), cmp.Diff(foo.Status.Conditions, expected))
+	})
+
+	t.Run("Set drops milliseconds", func(t *testing.T) {
+		g := NewWithT(t)
+		foo := &builder.Phase3Obj{
+			ObjectMeta: metav1.ObjectMeta{Generation: 123},
+			Status: builder.Phase3ObjStatus{
+				Conditions: nil,
+			},
+		}
+
+		condition := metav1.Condition{
+			Type:    "fooCondition",
+			Status:  metav1.ConditionTrue,
+			Reason:  "FooReason",
+			Message: "FooMessage",
+		}
+
+		// Check LastTransitionTime after setting a condition for the first time
+		Set(foo, condition)
+		ltt1 := foo.Status.Conditions[0].LastTransitionTime.Time
+		g.Expect(ltt1).To(Equal(ltt1.Truncate(1*time.Second)), cmp.Diff(ltt1, ltt1.Truncate(1*time.Second)))
+
+		// Check LastTransitionTime after changing an existing condition
+		condition.Status = metav1.ConditionFalse     // this will force set to change the LastTransitionTime
+		condition.LastTransitionTime = metav1.Time{} // this will force set to compute a new LastTransitionTime
+		Set(foo, condition)
+		ltt2 := foo.Status.Conditions[0].LastTransitionTime.Time
+		g.Expect(ltt2).To(Equal(ltt2.Truncate(1*time.Second)), cmp.Diff(ltt2, ltt2.Truncate(1*time.Second)))
+
+		// Check LastTransitionTime after setting a Time with milliseconds
+		condition.Status = metav1.ConditionTrue     // this will force set to change the LastTransitionTime
+		condition.LastTransitionTime = metav1.Now() // this will force set to not default LastTransitionTime
+		Set(foo, condition)
+		ltt3 := foo.Status.Conditions[0].LastTransitionTime.Time
+		g.Expect(ltt3).To(Equal(ltt3.Truncate(1*time.Second)), cmp.Diff(ltt3, ltt3.Truncate(1*time.Second)))
 	})
 }
 


### PR DESCRIPTION
This PR ensures lastTransitionTime for v1beta2 conditions is rounded down to second, thus making it consistent what we have in memory with what Marshal/Unmarshal will do while the data is sent to/read from the API server.
(this makes writing our tests simpler)