### PR TITLE
🐛 Try to fix TestClusterCacheHealthCheck test

### DIFF
--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -95,7 +95,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 					Namespace: ns.GetName(),
 				},
 			}
-			g.Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
 			conditions.MarkTrue(testCluster, clusterv1.ControlPlaneInitializedCondition)
 			testCluster.Status.InfrastructureReady = true
 			g.Expect(k8sClient.Status().Update(ctx, testCluster)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Not sure why this test suddenly became flaky without any code changes (as far as I can tell).

(Maybe it was also flaky since a while, not sure)

Let's see if this somehow improves the situation.

Failed runs:
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api/11339/pull-cluster-api-test-main/1850888969013694464
* https://storage.googleapis.com/k8s-triage/index.html?job=.*cluster-api.*main&test=TestClusterCacheHealthCheck&xjob=.*-e2e-.*%7C.*-provider-.*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->