### PR TITLE
:seedling: Add dry-run CreateOrUpdate call in clusterctl upgrade e2e tests

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -447,6 +447,12 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		})
 		Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
 
+		// Applying the cluster template in dry-run to ensure mgmt cluster webhooks are up and available
+		log.Logf("Applying the cluster template yaml to the cluster in dry-run")
+		Eventually(func() error {
+			return managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate, framework.WithCreateOpts([]client.CreateOption{client.DryRunAll}...), framework.WithUpdateOpts([]client.UpdateOption{client.DryRunAll}...))
+		}, "1m", "10s").ShouldNot(HaveOccurred())
+
 		log.Logf("Applying the cluster template yaml to the cluster")
 		Expect(managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)).To(Succeed())
 

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -109,6 +109,8 @@ type ClusterProxy interface {
 // createOrUpdateConfig contains options for use with CreateOrUpdate.
 type createOrUpdateConfig struct {
 	labelSelector labels.Selector
+	createOpts    []client.CreateOption
+	updateOpts    []client.UpdateOption
 }
 
 // CreateOrUpdateOption is a configuration option supplied to CreateOrUpdate.
@@ -118,6 +120,20 @@ type CreateOrUpdateOption func(*createOrUpdateConfig)
 func WithLabelSelector(labelSelector labels.Selector) CreateOrUpdateOption {
 	return func(c *createOrUpdateConfig) {
 		c.labelSelector = labelSelector
+	}
+}
+
+// WithCreateOpts allows definition of the Create options to be used in resource Create.
+func WithCreateOpts(createOpts ...client.CreateOption) CreateOrUpdateOption {
+	return func(c *createOrUpdateConfig) {
+		c.createOpts = createOpts
+	}
+}
+
+// WithUpdateOpts allows definition of the Update options to be used in resource Update.
+func WithUpdateOpts(updateOpts ...client.UpdateOption) CreateOrUpdateOption {
+	return func(c *createOrUpdateConfig) {
+		c.updateOpts = updateOpts
 	}
 }
 
@@ -320,7 +336,7 @@ func (p *clusterProxy) CreateOrUpdate(ctx context.Context, resources []byte, opt
 			if err := p.GetClient().Get(ctx, objectKey, existingObject); err != nil {
 				// Expected error -- if the object does not exist, create it
 				if apierrors.IsNotFound(err) {
-					if err := p.GetClient().Create(ctx, &o); err != nil {
+					if err := p.GetClient().Create(ctx, &o, config.createOpts...); err != nil {
 						retErrs = append(retErrs, err)
 					}
 				} else {
@@ -328,7 +344,7 @@ func (p *clusterProxy) CreateOrUpdate(ctx context.Context, resources []byte, opt
 				}
 			} else {
 				o.SetResourceVersion(existingObject.GetResourceVersion())
-				if err := p.GetClient().Update(ctx, &o); err != nil {
+				if err := p.GetClient().Update(ctx, &o, config.updateOpts...); err != nil {
 					retErrs = append(retErrs, err)
 				}
 			}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Ensures that applying the cluster template in clusterctl upgrade e2e tests succeeds in dry-run before actually creating/updating

as discussed here: https://github.com/kubernetes-sigs/cluster-api/issues/11133#issuecomment-2432255732
<!-- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
-->

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing