### PR TITLE
✨ Add classNamespace to topology

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"cmp"
 	"fmt"
 	"net"
 	"strings"
@@ -516,6 +517,15 @@ type ClusterAvailabilityGate struct {
 type Topology struct {
 	// The name of the ClusterClass object to create the topology.
 	Class string `json:"class"`
+
+	// classNamespace is the namespace of the ClusterClass object to create the topology.
+	// If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
+	// Value must follow the DNS1123Subdomain syntax.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$`
+	ClassNamespace string `json:"classNamespace,omitempty"`
 
 	// The Kubernetes version of the cluster.
 	Version string `json:"version"`
@@ -1045,7 +1055,9 @@ func (c *Cluster) GetClassKey() types.NamespacedName {
 	if c.Spec.Topology == nil {
 		return types.NamespacedName{}
 	}
-	return types.NamespacedName{Namespace: c.GetNamespace(), Name: c.Spec.Topology.Class}
+
+	namespace := cmp.Or(c.Spec.Topology.ClassNamespace, c.Namespace)
+	return types.NamespacedName{Namespace: namespace, Name: c.Spec.Topology.Class}
 }
 
 // GetConditions returns the set of conditions for this object.

--- a/api/v1beta1/index/index.go
+++ b/api/v1beta1/index/index.go
@@ -36,7 +36,7 @@ func AddDefaultIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}
 
 	if feature.Gates.Enabled(feature.ClusterTopology) {
-		if err := ByClusterClassName(ctx, mgr); err != nil {
+		if err := ByClusterClassRef(ctx, mgr); err != nil {
 			return err
 		}
 	}

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -4461,6 +4461,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_Topology(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"classNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "classNamespace is the namespace of the ClusterClass object to create the topology. If the namespace is empty or not set, it is defaulted to the namespace of the cluster object. Value must follow the DNS1123Subdomain syntax.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Kubernetes version of the cluster.",

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -928,6 +928,15 @@ spec:
                     description: The name of the ClusterClass object to create the
                       topology.
                     type: string
+                  classNamespace:
+                    description: |-
+                      classNamespace is the namespace of the ClusterClass object to create the topology.
+                      If the namespace is empty or not set, it is defaulted to the namespace of the cluster object.
+                      Value must follow the DNS1123Subdomain syntax.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?(?:\.[a-z0-9](?:[-a-z0-9]*[a-z0-9])?)*$
+                    type: string
                   controlPlane:
                     description: controlPlane describes the cluster control plane.
                     properties:

--- a/internal/apis/core/v1alpha4/conversion.go
+++ b/internal/apis/core/v1alpha4/conversion.go
@@ -42,6 +42,7 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 		if dst.Spec.Topology == nil {
 			dst.Spec.Topology = &clusterv1.Topology{}
 		}
+		dst.Spec.Topology.ClassNamespace = restored.Spec.Topology.ClassNamespace
 		dst.Spec.Topology.Variables = restored.Spec.Topology.Variables
 		dst.Spec.Topology.ControlPlane.Variables = restored.Spec.Topology.ControlPlane.Variables
 

--- a/internal/apis/core/v1alpha4/zz_generated.conversion.go
+++ b/internal/apis/core/v1alpha4/zz_generated.conversion.go
@@ -1757,6 +1757,7 @@ func Convert_v1alpha4_Topology_To_v1beta1_Topology(in *Topology, out *v1beta1.To
 
 func autoConvert_v1beta1_Topology_To_v1alpha4_Topology(in *v1beta1.Topology, out *Topology, s conversion.Scope) error {
 	out.Class = in.Class
+	// WARNING: in.ClassNamespace requires manual conversion: does not exist in peer-type
 	out.Version = in.Version
 	out.RolloutAfter = (*metav1.Time)(unsafe.Pointer(in.RolloutAfter))
 	if err := Convert_v1beta1_ControlPlaneTopology_To_v1alpha4_ControlPlaneTopology(&in.ControlPlane, &out.ControlPlane, s); err != nil {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -492,8 +492,9 @@ func (r *Reconciler) clusterClassToCluster(ctx context.Context, o client.Object)
 	if err := r.Client.List(
 		ctx,
 		clusterList,
-		client.MatchingFields{index.ClusterClassNameField: clusterClass.Name},
-		client.InNamespace(clusterClass.Namespace),
+		client.MatchingFields{
+			index.ClusterClassRefPath: index.ClusterClassRef(clusterClass),
+		},
 	); err != nil {
 		return nil
 	}

--- a/internal/controllers/topology/cluster/suite_test.go
+++ b/internal/controllers/topology/cluster/suite_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 		}
 		// Set up the ClusterClassName index explicitly here. This index is ordinarily created in
 		// index.AddDefaultIndexes. That doesn't happen here because the ClusterClass feature flag is not set.
-		if err := index.ByClusterClassName(ctx, mgr); err != nil {
+		if err := index.ByClusterClassRef(ctx, mgr); err != nil {
 			panic(fmt.Sprintf("unable to setup index: %v", err))
 		}
 	}

--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -107,20 +107,6 @@ func LocalObjectTemplatesAreCompatible(current, desired clusterv1.LocalObjectTem
 				currentGK.Kind, desiredGK.Kind),
 		))
 	}
-	allErrs = append(allErrs, LocalObjectTemplatesAreInSameNamespace(current, desired, pathPrefix)...)
-	return allErrs
-}
-
-// LocalObjectTemplatesAreInSameNamespace checks if two referenced objects are in the same namespace.
-func LocalObjectTemplatesAreInSameNamespace(current, desired clusterv1.LocalObjectTemplate, pathPrefix *field.Path) field.ErrorList {
-	var allErrs field.ErrorList
-	if current.Ref.Namespace != desired.Ref.Namespace {
-		allErrs = append(allErrs, field.Forbidden(
-			pathPrefix.Child("ref", "namespace"),
-			fmt.Sprintf("templates must be in the same namespace as the ClusterClass (%s)",
-				current.Ref.Namespace),
-		))
-	}
 	return allErrs
 }
 

--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -379,12 +379,14 @@ func (webhook *ClusterClass) classNamesFromMPWorkerClass(w clusterv1.WorkersClas
 func (webhook *ClusterClass) getClustersUsingClusterClass(ctx context.Context, clusterClass *clusterv1.ClusterClass) ([]clusterv1.Cluster, error) {
 	clusters := &clusterv1.ClusterList{}
 	err := webhook.Client.List(ctx, clusters,
-		client.MatchingFields{index.ClusterClassNameField: clusterClass.Name},
-		client.InNamespace(clusterClass.Namespace),
+		client.MatchingFields{
+			index.ClusterClassRefPath: index.ClusterClassRef(clusterClass),
+		},
 	)
 	if err != nil {
 		return nil, err
 	}
+
 	return clusters.Items, nil
 }
 

--- a/util/test/builder/builders.go
+++ b/util/test/builder/builders.go
@@ -114,7 +114,7 @@ func (c *ClusterBuilder) Build() *clusterv1.Cluster {
 
 // ClusterTopologyBuilder contains the fields needed to build a testable ClusterTopology.
 type ClusterTopologyBuilder struct {
-	class                 string
+	class, classNamespace string
 	workers               *clusterv1.WorkersTopology
 	version               string
 	controlPlaneReplicas  int32
@@ -133,6 +133,12 @@ func ClusterTopology() *ClusterTopologyBuilder {
 // WithClass adds the passed ClusterClass name to the ClusterTopologyBuilder.
 func (c *ClusterTopologyBuilder) WithClass(class string) *ClusterTopologyBuilder {
 	c.class = class
+	return c
+}
+
+// WithClassNamespace adds the passed classNamespace to the ClusterTopologyBuilder.
+func (c *ClusterTopologyBuilder) WithClassNamespace(ns string) *ClusterTopologyBuilder {
+	c.classNamespace = ns
 	return c
 }
 
@@ -181,9 +187,10 @@ func (c *ClusterTopologyBuilder) WithVariables(vars ...clusterv1.ClusterVariable
 // Build returns a testable cluster Topology object with any values passed to the builder.
 func (c *ClusterTopologyBuilder) Build() *clusterv1.Topology {
 	t := &clusterv1.Topology{
-		Class:   c.class,
-		Workers: c.workers,
-		Version: c.version,
+		Class:          c.class,
+		ClassNamespace: c.classNamespace,
+		Workers:        c.workers,
+		Version:        c.version,
 		ControlPlane: clusterv1.ControlPlaneTopology{
 			Replicas:           &c.controlPlaneReplicas,
 			MachineHealthCheck: c.controlPlaneMHC,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adding `classNamespace` variable to the cluster topology, which allows to point to a ClusterClass in a different namespace. This field is dormant, and is used for differentiation only.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #5673

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterclass