### PR TITLE
📖 Update SIG Cluster Lifecycle mailing list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,8 +233,8 @@ The [template](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/pro
   - Issues can be placed on the roadmap during planning if there is one or more folks
     that can dedicate time to writing a CAEP and/or implementing it after approval.
 - A proposal SHOULD be introduced and discussed during the weekly community meetings or on the
- [Kubernetes SIG Cluster Lifecycle mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle).
-  - Submit and discuss proposals using a collaborative writing platform, preferably Google Docs, share documents with edit permissions with the [Kubernetes SIG Cluster Lifecycle mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle).
+ [SIG Cluster Lifecycle mailing list](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle).
+  - Submit and discuss proposals using a collaborative writing platform, preferably Google Docs, share documents with edit permissions with the [SIG Cluster Lifecycle mailing list](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle).
 - A proposal in a Google Doc MUST turn into a [Pull Request](https://github.com/kubernetes-sigs/cluster-api/pulls).
 - Proposals MUST be merged and in `implementable` state to be considered part of a major or minor release.
 
@@ -509,8 +509,7 @@ quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1           
 
 To gain viewing permissions to google docs in this project, please join either the
 [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) or
-[kubernetes-sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) google
-group.
+[sig-cluster-lifecycle](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle) google group.
 
 ## Issue and Pull Request Management
 

--- a/docs/release/release-team.md
+++ b/docs/release/release-team.md
@@ -98,7 +98,7 @@ When assembling a release team, the release team lead should look for volunteers
 - Have some prior experience with contributing to CAPI releases (such having been in the release team for a prior release)
 - Have diverse company affiliations (i.e. not all from the same company)
 - Are members of the Kubernetes slack community (register if you are not!)
-- Are members of the Cluster Lifecycle SIG mailing list (subscribe to the [SIG Cluster Lifecycle Google Group](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) if you are not!)
+- Are members of the Cluster Lifecycle SIG mailing list (subscribe to the [SIG Cluster Lifecycle Google Group](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle) if you are not!)
 
 ## Time Commitment
 

--- a/docs/release/release-templates.md
+++ b/docs/release/release-templates.md
@@ -4,7 +4,7 @@ This document contains a collection of announcement templates for the release te
 
 ## Email Release Announcement Template
 
-To use this template, send an email using the following template to the `kubernetes-sig-cluster-lifecycle@googlegroups.com` mailing list. The person sending out the email should ensure that they are first part of the mailing list.
+To use this template, send an email using the following template to the `sig-cluster-lifecycle@kubernetes.io` mailing list. The person sending out the email should ensure that they are first part of the mailing list.
 
 ```
 Hello everyone,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR update SIG Cluster Lifecycle mailing list from [old one](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)  to [new one](https://groups.google.com/a/kubernetes.io/g/sig-cluster-lifecycle).


/area documentation
