### PR TITLE
:sparkles: ClusterClass: ensure templates are created in the Cluster namespace

### DIFF
--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -1347,6 +1347,7 @@ func templateToTemplate(in templateToInput) (*unstructured.Unstructured, error) 
 	if in.currentObjectRef != nil && in.currentObjectRef.Name != "" {
 		template.SetName(in.currentObjectRef.Name)
 	}
+	template.SetNamespace(in.cluster.Namespace)
 
 	return template, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Creation of the infrastructure template in desired state for the `Cluster` is always using namespace of the template, while `Cluster` object namespace is ignored. This changes behavior to use `Cluster` namespace for the generated template, which allows referencing `ClusterClass` from a `Cluster` resource located in different namespace, if validating policy allows it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #5673

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterclass