### PR TITLE
🌱 Fixing TestClusterCacheHealthCheck flake

### DIFF
--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -19,6 +19,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -158,7 +159,8 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			ns := setup(t, g)
 			defer teardown(t, g, ns)
 			// Create a context with a timeout to cancel the healthcheck after some time
-			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			contextTimeout := time.Second
+			ctx, cancel := context.WithTimeout(ctx, contextTimeout)
 			defer cancel()
 			// Delete the cluster accessor and lock the cluster to simulate creation of a new cluster accessor
 			cct.deleteAccessor(ctx, testClusterKey)
@@ -177,8 +179,9 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 				path:               "/",
 			})
 			timeElapsedForHealthCheck := time.Since(startHealthCheck)
+			timeElapsedForHealthCheckRounded := int(math.Round(timeElapsedForHealthCheck.Seconds()))
 			// If the duration is shorter than the timeout, we know that the healthcheck wasn't requeued properly.
-			g.Expect(timeElapsedForHealthCheck).Should(BeNumerically(">=", time.Second))
+			g.Expect(timeElapsedForHealthCheckRounded).Should(BeNumerically(">=", int(contextTimeout.Seconds())))
 			// The healthcheck should be aborted by the timout of the context
 			g.Expect(ctx.Done()).Should(BeClosed())
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR is a followup of this one: https://github.com/kubernetes-sigs/cluster-api/pull/11343. We're comparing durations with nanosecond precision, which is causing test flakiness. This PR resolves the issue by rounding durations to seconds instead of checking at the nanosecond level.

Failed runs:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api/11339/pull-cluster-api-test-main/1850888969013694464

https://storage.googleapis.com/k8s-triage/index.html?job=.*cluster-api.*main&test=TestClusterCacheHealthCheck&xjob=.*-e2e-.*%7C.*-provider-.*


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->