### PR TITLE
Fixing TestClusterResourceSetReconciler flaky test

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -996,7 +996,7 @@ metadata:
 		}, timeout).Should(BeTrue())
 
 		t.Log("Create Kubernetes API Server Service")
-		g.Expect(env.Delete(ctx, fakeService)).Should(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, fakeService)).Should(Succeed())
 		kubernetesAPIServerService.ResourceVersion = ""
 		g.Expect(env.Create(ctx, kubernetesAPIServerService)).Should(Succeed())
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR is changing Delete to CleanupAndWait so we can make sure that `fakeService` is deleted before we start creating `kubernetesAPIServerService`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This PR is fixing this flake:

https://storage.googleapis.com/k8s-triage/index.html?job=.*-cluster-api-.*&xjob=.*-provider-.*%7C.*-operator-.*#1dd40f6a601b864b9511

Failure is:
`Service "kubernetes" is invalid: spec.clusterIPs: Invalid value: []string{"10.0.0.1"}: failed to allocate IP 10.0.0.1: provided IP is already allocated`
Can be seen here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/1853481305933615104

/area test
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area test
-->