### PR TITLE
✨ Add e2e tests & clusterctl changes for cross-ns CC ref

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -344,7 +344,7 @@ func (c *clusterctlClient) getTemplateFromRepository(ctx context.Context, cluste
 
 	clusterClassClient := repo.ClusterClasses(version)
 
-	template, err = addClusterClassIfMissing(ctx, template, clusterClassClient, cluster, targetNamespace, listVariablesOnly)
+	template, err = addClusterClassIfMissing(ctx, template, clusterClassClient, cluster, listVariablesOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -17,8 +17,6 @@ limitations under the License.
 package repository
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -144,7 +142,7 @@ func NewTemplate(input TemplateInput) (Template, error) {
 
 // MergeTemplates merges the provided Templates into one Template.
 // Notes on the merge operation:
-//   - The merge operation returns an error if all the templates do not have the same TargetNamespace.
+//   - The merge operation sets targetNamespace empty if all the templates do not share the same TargetNamespace.
 //   - The Variables of the resulting template is a union of all Variables in the templates.
 //   - The default value is picked from the first template that defines it.
 //     The defaults of the same variable in the subsequent templates will be ignored.
@@ -173,7 +171,7 @@ func MergeTemplates(templates ...Template) (Template, error) {
 		}
 
 		if merged.targetNamespace != tmpl.TargetNamespace() {
-			return nil, fmt.Errorf("cannot merge templates with different targetNamespaces")
+			merged.targetNamespace = ""
 		}
 
 		merged.objs = append(merged.objs, tmpl.Objs()...)

--- a/docs/book/src/developer/providers/contracts/clusterctl.md
+++ b/docs/book/src/developer/providers/contracts/clusterctl.md
@@ -416,6 +416,12 @@ ClusterClass definitions MUST be stored in the same location as the component YA
 in the Cluster template; Cluster template files using a ClusterClass are usually simpler because they are no longer
 required to have all the templates.
 
+Additionally, namespace of the ClusterClass can differ from the Cluster. This requires specifying
+Cluster.spec.topology.classNamespace field in the Cluster template;
+Cluster template may define classNamespace as `classNamespace: ${CLUSTER_CLASS_NAMESPACE:=""}`, which would allow to
+optionally specify namespace of the referred ClusterClass via env. Empty or missing value is uses Cluster namespace
+by default.
+
 Each provider should create user facing documentation with the list of available ClusterClass definitions.
 
 #### Target namespace

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -60,3 +60,31 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 		}
 	})
 })
+
+var _ = Describe("When upgrading a workload cluster using ClusterClass in a different NS with RuntimeSDK [ClusterClass]", Label("ClusterClass"), func() {
+	ClusterUpgradeWithRuntimeSDKSpec(ctx, func() ClusterUpgradeWithRuntimeSDKSpecInput {
+		return ClusterUpgradeWithRuntimeSDKSpecInput{
+			E2EConfig:              e2eConfig,
+			ClusterctlConfigPath:   clusterctlConfigPath,
+			BootstrapClusterProxy:  bootstrapClusterProxy,
+			ArtifactFolder:         artifactFolder,
+			SkipCleanup:            skipCleanup,
+			InfrastructureProvider: ptr.To("docker"),
+			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
+				// continuous reconciles when everything should be stable.
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+			},
+			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
+			Flavor:                                ptr.To("upgrades-runtimesdk"),
+			DeployClusterClassInSeparateNamespace: true,
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
+			ExtensionConfigName:       "k8s-upgrade-with-runtimesdk-cross-ns",
+		}
+	})
+})

--- a/test/e2e/clusterclass_changes.go
+++ b/test/e2e/clusterclass_changes.go
@@ -135,11 +135,11 @@ type ClusterClassChangesSpecInput struct {
 // indirect test coverage of this from other tests as well.
 func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClassChangesSpecInput) {
 	var (
-		specName         = "clusterclass-changes"
-		input            ClusterClassChangesSpecInput
-		namespace        *corev1.Namespace
-		cancelWatches    context.CancelFunc
-		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		specName                         = "clusterclass-changes"
+		input                            ClusterClassChangesSpecInput
+		namespace, clusterClassNamespace *corev1.Namespace
+		cancelWatches                    context.CancelFunc
+		clusterResources                 *clusterctl.ApplyClusterTemplateAndWaitResult
 	)
 
 	BeforeEach(func() {
@@ -155,6 +155,8 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 
 		// Set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)
+		clusterClassNamespace = framework.CreateNamespace(ctx, framework.CreateNamespaceInput{Creator: input.BootstrapClusterProxy.GetClient(), Name: fmt.Sprintf("%s-clusterclass", namespace.Name)}, "40s", "10s")
+		Expect(clusterClassNamespace).ToNot(BeNil(), "Failed to create namespace")
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 	})
 
@@ -184,10 +186,21 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, clusterResources)
 
+		originalClusterClassState := clusterResources.ClusterClass.DeepCopy()
+
+		By("Rebasing the Cluster to a ClusterClass with a modified label for MachineDeployments and wait for changes to be applied to the MachineDeployment objects")
+		rebasedClusterClass := rebaseClusterClassAndWait(ctx, rebaseClusterClassAndWaitInput{
+			ClusterProxy:                 input.BootstrapClusterProxy,
+			ClusterClass:                 clusterResources.ClusterClass,
+			Cluster:                      clusterResources.Cluster,
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+		})
+
 		By("Modifying the control plane configuration in ClusterClass and wait for changes to be applied to the control plane object")
 		modifyControlPlaneViaClusterClassAndWait(ctx, modifyClusterClassControlPlaneAndWaitInput{
 			ClusterProxy:             input.BootstrapClusterProxy,
-			ClusterClass:             clusterResources.ClusterClass,
+			ClusterClass:             rebasedClusterClass,
 			Cluster:                  clusterResources.Cluster,
 			ModifyControlPlaneFields: input.ModifyControlPlaneFields,
 			WaitForControlPlane:      input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
@@ -196,7 +209,7 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 		By("Modifying the MachineDeployment configuration in ClusterClass and wait for changes to be applied to the MachineDeployment objects")
 		modifyMachineDeploymentViaClusterClassAndWait(ctx, modifyMachineDeploymentViaClusterClassAndWaitInput{
 			ClusterProxy:                        input.BootstrapClusterProxy,
-			ClusterClass:                        clusterResources.ClusterClass,
+			ClusterClass:                        rebasedClusterClass,
 			Cluster:                             clusterResources.Cluster,
 			ModifyBootstrapConfigTemplateFields: input.ModifyMachineDeploymentBootstrapConfigTemplateFields,
 			ModifyInfrastructureMachineTemplateFields: input.ModifyMachineDeploymentInfrastructureMachineTemplateFields,
@@ -206,19 +219,55 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 		By("Modifying the MachinePool configuration in ClusterClass and wait for changes to be applied to the MachinePool objects")
 		modifyMachinePoolViaClusterClassAndWait(ctx, modifyMachinePoolViaClusterClassAndWaitInput{
 			ClusterProxy:                        input.BootstrapClusterProxy,
-			ClusterClass:                        clusterResources.ClusterClass,
+			ClusterClass:                        rebasedClusterClass,
 			Cluster:                             clusterResources.Cluster,
 			ModifyBootstrapConfigTemplateFields: input.ModifyMachinePoolBootstrapConfigTemplateFields,
 			ModifyInfrastructureMachinePoolTemplateFields: input.ModifyMachinePoolInfrastructureMachinePoolTemplateFields,
 			WaitForMachinePools:                           input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 
-		By("Rebasing the Cluster to a ClusterClass with a modified label for MachineDeployments and wait for changes to be applied to the MachineDeployment objects")
-		rebaseClusterClassAndWait(ctx, rebaseClusterClassAndWaitInput{
-			ClusterProxy:              input.BootstrapClusterProxy,
-			ClusterClass:              clusterResources.ClusterClass,
-			Cluster:                   clusterResources.Cluster,
-			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		By("Rebasing the Cluster to a copy of original ClusterClass in a different namespace")
+		rebasedClusterClass = rebaseClusterClassAndWait(ctx, rebaseClusterClassAndWaitInput{
+			ClusterProxy:          input.BootstrapClusterProxy,
+			ClusterClassNamespace: clusterClassNamespace.Name,
+			ClusterClass:          originalClusterClassState,
+			Cluster:               clusterResources.Cluster,
+			// This rebase will revert the CP back to the original state. If we modified CP fields via
+			// modifyControlPlaneViaClusterClassAndWait this rebase will leads to changes in the CP.
+			ControlPlaneChanged:          input.ModifyControlPlaneFields != nil,
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+		})
+
+		By("Performing modifications on the referenced ClusterClass templates in a different namespace")
+
+		By("Modifying the control plane configuration in second ClusterClass and wait for changes to be applied to the control plane object")
+		modifyControlPlaneViaClusterClassAndWait(ctx, modifyClusterClassControlPlaneAndWaitInput{
+			ClusterProxy:             input.BootstrapClusterProxy,
+			ClusterClass:             rebasedClusterClass,
+			Cluster:                  clusterResources.Cluster,
+			ModifyControlPlaneFields: input.ModifyControlPlaneFields,
+			WaitForControlPlane:      input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+		})
+
+		By("Modifying the MachineDeployment configuration in ClusterClass and wait for changes to be applied to the MachineDeployment objects")
+		modifyMachineDeploymentViaClusterClassAndWait(ctx, modifyMachineDeploymentViaClusterClassAndWaitInput{
+			ClusterProxy:                        input.BootstrapClusterProxy,
+			ClusterClass:                        rebasedClusterClass,
+			Cluster:                             clusterResources.Cluster,
+			ModifyBootstrapConfigTemplateFields: input.ModifyMachineDeploymentBootstrapConfigTemplateFields,
+			ModifyInfrastructureMachineTemplateFields: input.ModifyMachineDeploymentInfrastructureMachineTemplateFields,
+			WaitForMachineDeployments:                 input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+
+		By("Modifying the MachinePool configuration in ClusterClass and wait for changes to be applied to the MachinePool objects")
+		modifyMachinePoolViaClusterClassAndWait(ctx, modifyMachinePoolViaClusterClassAndWaitInput{
+			ClusterProxy:                        input.BootstrapClusterProxy,
+			ClusterClass:                        rebasedClusterClass,
+			Cluster:                             clusterResources.Cluster,
+			ModifyBootstrapConfigTemplateFields: input.ModifyMachinePoolBootstrapConfigTemplateFields,
+			ModifyInfrastructureMachinePoolTemplateFields: input.ModifyMachinePoolInfrastructureMachinePoolTemplateFields,
+			WaitForMachinePools:                           input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 
 		By("Deleting a MachineDeploymentTopology in the Cluster Topology and wait for associated MachineDeployment to be deleted")
@@ -233,6 +282,14 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 	AfterEach(func() {
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		framework.DumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+
+		if !input.SkipCleanup {
+			Byf("Deleting namespace used for hosting the %q test spec ClusterClass", specName)
+			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+				Deleter: input.BootstrapClusterProxy.GetClient(),
+				Name:    clusterClassNamespace.Name,
+			})
+		}
 	})
 }
 
@@ -300,6 +357,18 @@ func modifyControlPlaneViaClusterClassAndWait(ctx context.Context, input modifyC
 			g.Expect(ok).To(BeTrue(), fmt.Sprintf("failed to get field %q", fieldPath))
 			g.Expect(currentValue).To(Equal(expectedValue), fmt.Sprintf("field %q should be equal", fieldPath))
 		}
+
+		// Ensure KCP recognized the change and finished scaling.
+		// Note: This is to ensure to not hit https://github.com/kubernetes-sigs/cluster-api/issues/11772
+		observedGeneration, ok, err := unstructured.NestedInt64(controlPlane.Object, "status", "observedGeneration")
+		g.Expect(err).ToNot(HaveOccurred())
+		if ok {
+			g.Expect(controlPlane.GetGeneration()).To(BeComparableTo(observedGeneration))
+		}
+		scaling, err := contract.ControlPlane().IsScaling(controlPlane)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(scaling).To(BeFalse())
+
 		return nil
 	}, input.WaitForControlPlane...).Should(Succeed())
 }
@@ -660,16 +729,19 @@ func assertMachinePoolTopologyFields(g Gomega, mp expv1.MachinePool, mpTopology 
 
 // rebaseClusterClassAndWaitInput is the input type for rebaseClusterClassAndWait.
 type rebaseClusterClassAndWaitInput struct {
-	ClusterProxy              framework.ClusterProxy
-	ClusterClass              *clusterv1.ClusterClass
-	Cluster                   *clusterv1.Cluster
-	WaitForMachineDeployments []interface{}
+	ClusterProxy                 framework.ClusterProxy
+	ClusterClass                 *clusterv1.ClusterClass
+	ClusterClassNamespace        string
+	Cluster                      *clusterv1.Cluster
+	ControlPlaneChanged          bool
+	WaitForMachineDeployments    []interface{}
+	WaitForControlPlaneIntervals []interface{}
 }
 
 // rebaseClusterClassAndWait rebases the cluster to a copy of the ClusterClass with different worker labels
 // and waits until the changes are rolled out to the MachineDeployments of the Cluster.
 // NOTE: This helper is really specific to this test, so we are keeping this private vs. adding it to the framework.
-func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndWaitInput) {
+func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndWaitInput) *clusterv1.ClusterClass {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for RebaseClusterClassAndWait")
 	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling RebaseClusterClassAndWait")
 	Expect(input.ClusterClass).ToNot(BeNil(), "Invalid argument. input.ClusterClass can't be nil when calling RebaseClusterClassAndWait")
@@ -679,11 +751,18 @@ func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndW
 
 	var testWorkerLabelName = "rebase-diff"
 
+	sourceClusterClass := input.ClusterClass.DeepCopy()
+	Expect(mgmtClient.Get(ctx, client.ObjectKeyFromObject(sourceClusterClass), sourceClusterClass)).To(Succeed())
+
 	// Create a new ClusterClass with a new name and the new worker label set.
-	newClusterClass := input.ClusterClass.DeepCopy()
+	newClusterClass := sourceClusterClass.DeepCopy()
 	newClusterClassName := fmt.Sprintf("%s-%s", input.ClusterClass.Name, util.RandomString(6))
 	newClusterClass.SetName(newClusterClassName)
+	if input.ClusterClassNamespace != "" {
+		newClusterClass.SetNamespace(input.ClusterClassNamespace)
+	}
 	newClusterClass.SetResourceVersion("")
+
 	for i, mdClass := range newClusterClass.Spec.Workers.MachineDeployments {
 		if mdClass.Template.Metadata.Labels == nil {
 			mdClass.Template.Metadata.Labels = map[string]string{}
@@ -691,6 +770,24 @@ func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndW
 		mdClass.Template.Metadata.Labels[testWorkerLabelName] = mdClass.Class
 		newClusterClass.Spec.Workers.MachineDeployments[i] = mdClass
 	}
+
+	// Copy ClusterClass templates to the new namespace
+	for i, mdClass := range newClusterClass.Spec.Workers.MachineDeployments {
+		cloneRef(ctx, mgmtClient, mdClass.Template.Infrastructure.Ref, input.ClusterClassNamespace)
+		cloneRef(ctx, mgmtClient, mdClass.Template.Bootstrap.Ref, input.ClusterClassNamespace)
+		newClusterClass.Spec.Workers.MachineDeployments[i] = mdClass
+	}
+
+	for i, mpClass := range newClusterClass.Spec.Workers.MachinePools {
+		cloneRef(ctx, mgmtClient, mpClass.Template.Infrastructure.Ref, input.ClusterClassNamespace)
+		cloneRef(ctx, mgmtClient, mpClass.Template.Bootstrap.Ref, input.ClusterClassNamespace)
+		newClusterClass.Spec.Workers.MachinePools[i] = mpClass
+	}
+
+	cloneRef(ctx, mgmtClient, newClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref, input.ClusterClassNamespace)
+	cloneRef(ctx, mgmtClient, newClusterClass.Spec.ControlPlane.Ref, input.ClusterClassNamespace)
+	cloneRef(ctx, mgmtClient, newClusterClass.Spec.Infrastructure.Ref, input.ClusterClassNamespace)
+
 	Expect(mgmtClient.Create(ctx, newClusterClass)).To(Succeed())
 
 	// Get the current ControlPlane, we will later verify that it has not changed.
@@ -702,6 +799,7 @@ func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndW
 	patchHelper, err := patch.NewHelper(input.Cluster, mgmtClient)
 	Expect(err).ToNot(HaveOccurred())
 	input.Cluster.Spec.Topology.Class = newClusterClassName
+	input.Cluster.Spec.Topology.ClassNamespace = input.ClusterClassNamespace
 	// We have to retry the patch. The ClusterClass was just created so the client cache in the
 	// controller/webhook might not be aware of it yet. If the webhook is not aware of the ClusterClass
 	// we get a "Cluster ... can't be validated. ClusterClass ... can not be retrieved" error.
@@ -714,10 +812,10 @@ func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndW
 		// NOTE: We only wait until the change is rolled out to the MachineDeployment objects and not to the worker machines
 		// to speed up the test and focus the test on the ClusterClass feature.
 		log.Logf("Waiting for MachineDeployment rollout for MachineDeploymentTopology %q (class %q) to complete.", mdTopology.Name, mdTopology.Class)
-		Eventually(func() error {
+		Eventually(func(g Gomega) error {
 			// Get MachineDeployment for the current MachineDeploymentTopology.
 			mdList := &clusterv1.MachineDeploymentList{}
-			Expect(mgmtClient.List(ctx, mdList, client.InNamespace(input.Cluster.Namespace), client.MatchingLabels{
+			g.Expect(mgmtClient.List(ctx, mdList, client.InNamespace(input.Cluster.Namespace), client.MatchingLabels{
 				clusterv1.ClusterTopologyMachineDeploymentNameLabel: mdTopology.Name,
 			})).To(Succeed())
 			if len(mdList.Items) != 1 {
@@ -738,13 +836,59 @@ func rebaseClusterClassAndWait(ctx context.Context, input rebaseClusterClassAndW
 		}, input.WaitForMachineDeployments...).Should(Succeed())
 	}
 
-	// Verify that the ControlPlane has not been changed.
-	// NOTE: MachineDeployments are rolled out before the ControlPlane. Thus, we know that the
-	// ControlPlane would have been updated by now, if there have been any changes.
-	afterControlPlane, err := external.Get(ctx, mgmtClient, controlPlaneRef)
+	if input.ControlPlaneChanged {
+		Eventually(func(g Gomega) {
+			controlPlane, err := external.Get(ctx, mgmtClient, controlPlaneRef)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(controlPlane.GetGeneration()).ToNot(Equal(beforeControlPlane.GetGeneration()),
+				"ControlPlane generation should be incremented during the rebase because ControlPlane expected to be changed.")
+
+			// Ensure KCP recognized the change and finished scaling.
+			// Note: This is to ensure to not hit https://github.com/kubernetes-sigs/cluster-api/issues/11772
+			observedGeneration, ok, err := unstructured.NestedInt64(controlPlane.Object, "status", "observedGeneration")
+			g.Expect(err).ToNot(HaveOccurred())
+			if ok {
+				g.Expect(controlPlane.GetGeneration()).To(BeComparableTo(observedGeneration))
+			}
+
+			scaling, err := contract.ControlPlane().IsScaling(controlPlane)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(scaling).To(BeFalse())
+		}, input.WaitForControlPlaneIntervals...).Should(Succeed())
+	} else {
+		Consistently(func(g Gomega) {
+			// Verify that the ControlPlane has not been changed.
+			// NOTE: MachineDeployments are rolled out before the ControlPlane. Thus, we know that the
+			// ControlPlane would have been updated by now, if there have been any changes.
+			afterControlPlane, err := external.Get(ctx, mgmtClient, controlPlaneRef)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(afterControlPlane.GetGeneration()).To(Equal(beforeControlPlane.GetGeneration()),
+				"ControlPlane generation should not be incremented during the rebase because ControlPlane should not be affected.")
+		}, "5s", "100ms").Should(Succeed())
+	}
+
+	return newClusterClass
+}
+
+// cloneRef performs required modifications to avoid conflict, and create a copy of the referenced object, updating the ref in-place.
+func cloneRef(ctx context.Context, cl client.Client, ref *corev1.ObjectReference, namespace string) {
+	if ref == nil {
+		return
+	}
+
+	template, err := external.Get(ctx, cl, ref)
 	Expect(err).ToNot(HaveOccurred())
-	Expect(afterControlPlane.GetGeneration()).To(Equal(beforeControlPlane.GetGeneration()),
-		"ControlPlane generation should not be incremented during the rebase because ControlPlane should not be affected.")
+	if namespace != "" {
+		template.SetNamespace(namespace)
+	} else {
+		template.SetGenerateName(template.GetName() + "-")
+		template.SetName("")
+	}
+	template.SetResourceVersion("")
+	template.SetOwnerReferences(nil)
+	Expect(cl.Create(ctx, template)).To(Succeed())
+
+	*ref = *external.GetObjectReference(template)
 }
 
 // deleteMachineDeploymentTopologyAndWaitInput is the input type for deleteMachineDeploymentTopologyAndWaitInput.

--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
@@ -14,6 +14,7 @@ spec:
     serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
   topology:
     class: "quick-start"
+    classNamespace: '${CLUSTER_CLASS_NAMESPACE:-""}'
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       metadata:

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
@@ -14,6 +14,7 @@ spec:
     serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
   topology:
     class: "quick-start-runtimesdk"
+    classNamespace: '${CLUSTER_CLASS_NAMESPACE:-""}'
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       metadata: {}

--- a/test/e2e/quick_start.go
+++ b/test/e2e/quick_start.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -43,6 +44,9 @@ type QuickStartSpecInput struct {
 	// Cluster name allows to specify a deterministic clusterName.
 	// If not set, a random one will be generated.
 	ClusterName *string
+
+	// DeployClusterClassInSeparateNamespace defines if the ClusterClass should be deployed in a separate namespace.
+	DeployClusterClassInSeparateNamespace bool
 
 	// InfrastructureProvider allows to specify the infrastructure provider to be used when looking for
 	// cluster templates.
@@ -85,11 +89,12 @@ type QuickStartSpecInput struct {
 // NOTE: This test works with Clusters with and without ClusterClass.
 func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput) {
 	var (
-		specName         = "quick-start"
-		input            QuickStartSpecInput
-		namespace        *corev1.Namespace
-		cancelWatches    context.CancelFunc
-		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+		specName              = "quick-start"
+		input                 QuickStartSpecInput
+		namespace             *corev1.Namespace
+		clusterClassNamespace *corev1.Namespace
+		cancelWatches         context.CancelFunc
+		clusterResources      *clusterctl.ApplyClusterTemplateAndWaitResult
 	)
 
 	BeforeEach(func() {
@@ -104,6 +109,12 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)
+
+		if input.DeployClusterClassInSeparateNamespace {
+			clusterClassNamespace = framework.CreateNamespace(ctx, framework.CreateNamespaceInput{Creator: input.BootstrapClusterProxy.GetClient(), Name: fmt.Sprintf("%s-clusterclass", namespace.Name)}, "40s", "10s")
+			Expect(clusterClassNamespace).ToNot(BeNil(), "Failed to create namespace")
+		}
+
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 	})
 
@@ -134,11 +145,21 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 		if input.ClusterName != nil {
 			clusterName = *input.ClusterName
 		}
+
+		variables := map[string]string{}
+		maps.Copy(variables, input.ClusterctlVariables)
+
+		if input.DeployClusterClassInSeparateNamespace {
+			variables["CLUSTER_CLASS_NAMESPACE"] = clusterClassNamespace.Name
+			By("Creating a cluster referencing a ClusterClass from another namespace")
+		}
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
 				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
 				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				ClusterctlVariables:      variables,
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   infrastructureProvider,
 				Flavor:                   flavor,
@@ -147,7 +168,6 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
 				ControlPlaneMachineCount: controlPlaneMachineCount,
 				WorkerMachineCount:       workerMachineCount,
-				ClusterctlVariables:      input.ClusterctlVariables,
 			},
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
@@ -159,11 +179,18 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 				}
 			},
 		}, clusterResources)
+
 		By("PASSED!")
 	})
 
 	AfterEach(func() {
 		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
 		framework.DumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+		if input.DeployClusterClassInSeparateNamespace && !input.SkipCleanup {
+			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+				Deleter: input.BootstrapClusterProxy.GetClient(),
+				Name:    clusterClassNamespace.Name,
+			})
+		}
 	})
 }

--- a/test/extension/handlers/topologymutation/testdata/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/extension/handlers/topologymutation/testdata/clusterclass-quick-start-runtimesdk.yaml
@@ -54,9 +54,9 @@ spec:
   patches:
   - name: test-patch
     external:
-      generateExtension: generate-patches.k8s-upgrade-with-runtimesdk
-      validateExtension: validate-topology.k8s-upgrade-with-runtimesdk
-      discoverVariablesExtension: discover-variables.k8s-upgrade-with-runtimesdk
+      generateExtension: generate-patches.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
+      validateExtension: validate-topology.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
+      discoverVariablesExtension: discover-variables.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -394,7 +394,7 @@ func forceClusterClassReconcile(ctx context.Context, cli client.Client, clusterK
 
 	if cluster.Spec.Topology != nil {
 		class := &clusterv1.ClusterClass{}
-		Expect(cli.Get(ctx, client.ObjectKey{Namespace: clusterKey.Namespace, Name: cluster.Spec.Topology.Class}, class)).To(Succeed())
+		Expect(cli.Get(ctx, cluster.GetClassKey(), class)).To(Succeed())
 		annotationPatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"metadata\":{\"annotations\":{\"cluster.x-k8s.io/modifiedAt\":\"%v\"}}}", time.Now().Format(time.RFC3339))))
 		Expect(cli.Patch(ctx, class, annotationPatch)).To(Succeed())
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR allows `clusterctl` to create a template with a reference to CC located in a different namespace.
This change allows to perform e2e tests in a multi-ns environment.

Added e2e tests to verify cluster-class quick-start scenario and runtime extension scenario in a cross-namespaced context.

The PR is built on top of:
- https://github.com/kubernetes-sigs/cluster-api/pull/11361
- https://github.com/kubernetes-sigs/cluster-api/pull/11352

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5673 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->