### PR TITLE
✨ update the --namespace <namespace> option to accept a comma-separated list for watching multiple selected namespaces

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -69,7 +69,7 @@ var (
 	leaderElectionRenewDeadline time.Duration
 	leaderElectionRetryPeriod   time.Duration
 	watchFilterValue            string
-	watchNamespace              string
+	watchNamespacesList         []string
 	profilerAddress             string
 	enableContentionProfiling   bool
 	syncPeriod                  time.Duration
@@ -116,8 +116,8 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
-	fs.StringVar(&watchNamespace, "namespace", "",
-		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
+	fs.StringSliceVar(&watchNamespacesList, "namespace", nil,
+		"Comma-separated list of namespaces that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
@@ -212,9 +212,10 @@ func main() {
 	}
 
 	var watchNamespaces map[string]cache.Config
-	if watchNamespace != "" {
-		watchNamespaces = map[string]cache.Config{
-			watchNamespace: {},
+	if watchNamespacesList != nil {
+		watchNamespaces = map[string]cache.Config{}
+		for _, watchNamespace := range watchNamespacesList {
+			watchNamespaces[watchNamespace] = cache.Config{}
 		}
 	}
 

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -74,7 +74,7 @@ var (
 	leaderElectionRenewDeadline time.Duration
 	leaderElectionRetryPeriod   time.Duration
 	watchFilterValue            string
-	watchNamespace              string
+	watchNamespacesList         []string
 	profilerAddress             string
 	enableContentionProfiling   bool
 	syncPeriod                  time.Duration
@@ -125,8 +125,8 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 5*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
-	fs.StringVar(&watchNamespace, "namespace", "",
-		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
+	fs.StringSliceVar(&watchNamespacesList, "namespace", nil,
+		"Comma-separated list of namespaces that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
@@ -237,9 +237,10 @@ func main() {
 	}
 
 	var watchNamespaces map[string]cache.Config
-	if watchNamespace != "" {
-		watchNamespaces = map[string]cache.Config{
-			watchNamespace: {},
+	if watchNamespacesList != nil {
+		watchNamespaces = map[string]cache.Config{}
+		for _, watchNamespace := range watchNamespacesList {
+			watchNamespaces[watchNamespace] = cache.Config{}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ var (
 	leaderElectionRenewDeadline time.Duration
 	leaderElectionRetryPeriod   time.Duration
 	watchFilterValue            string
-	watchNamespace              string
+	watchNamespacesList         []string
 	profilerAddress             string
 	enableContentionProfiling   bool
 	syncPeriod                  time.Duration
@@ -166,8 +166,8 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
-	fs.StringVar(&watchNamespace, "namespace", "",
-		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
+	fs.StringSliceVar(&watchNamespacesList, "namespace", nil,
+		"Comma-separated list of namespaces that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
@@ -317,9 +317,10 @@ func main() {
 	}
 
 	var watchNamespaces map[string]cache.Config
-	if watchNamespace != "" {
-		watchNamespaces = map[string]cache.Config{
-			watchNamespace: {},
+	if watchNamespacesList != nil {
+		watchNamespaces = map[string]cache.Config{}
+		for _, watchNamespace := range watchNamespacesList {
+			watchNamespaces[watchNamespace] = cache.Config{}
 		}
 	}
 

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -75,7 +75,7 @@ var (
 	leaderElectionRenewDeadline time.Duration
 	leaderElectionRetryPeriod   time.Duration
 	watchFilterValue            string
-	watchNamespace              string
+	watchNamespacesList         []string
 	profilerAddress             string
 	enableContentionProfiling   bool
 	syncPeriod                  time.Duration
@@ -123,8 +123,8 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
-	fs.StringVar(&watchNamespace, "namespace", "",
-		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
+	fs.StringSliceVar(&watchNamespacesList, "namespace", nil,
+		"Comma-separated list of namespaces that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 
 	fs.StringVar(&watchFilterValue, "watch-filter", "",
 		fmt.Sprintf("Label value that the controller watches to reconcile cluster-api objects. Label key is always %s. If unspecified, the controller watches for all cluster-api objects.", clusterv1.WatchLabel))
@@ -216,9 +216,10 @@ func main() {
 	}
 
 	var watchNamespaces map[string]cache.Config
-	if watchNamespace != "" {
-		watchNamespaces = map[string]cache.Config{
-			watchNamespace: {},
+	if watchNamespacesList != nil {
+		watchNamespaces = map[string]cache.Config{}
+		for _, watchNamespace := range watchNamespacesList {
+			watchNamespaces[watchNamespace] = cache.Config{}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* watching multiple selected namespaces

**Which issue(s) this PR fixes** 
Fixes #11192

/area/clusterresourceset