### PR TITLE
🐛 Fix predicate logging

### DIFF
--- a/controllers/external/tracker_test.go
+++ b/controllers/external/tracker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,7 +67,7 @@ func (c *watchCountController) Watch(_ source.Source) error {
 func TestRetryWatch(t *testing.T) {
 	g := NewWithT(t)
 	ctrl := newWatchCountController(true)
-	tracker := ObjectTracker{Controller: ctrl, Scheme: runtime.NewScheme(), Cache: &informertest.FakeInformers{}}
+	tracker := ObjectTracker{Controller: ctrl, Scheme: runtime.NewScheme(), Cache: &informertest.FakeInformers{}, PredicateLogger: ptr.To(logr.New(log.NullLogSink{}))}
 
 	err := tracker.Watch(logger, &clusterv1.Cluster{}, nil)
 	g.Expect(err).To(HaveOccurred())
@@ -80,7 +81,7 @@ func TestRetryWatch(t *testing.T) {
 func TestWatchMultipleTimes(t *testing.T) {
 	g := NewWithT(t)
 	ctrl := &watchCountController{}
-	tracker := ObjectTracker{Controller: ctrl, Scheme: runtime.NewScheme(), Cache: &informertest.FakeInformers{}}
+	tracker := ObjectTracker{Controller: ctrl, Scheme: runtime.NewScheme(), Cache: &informertest.FakeInformers{}, PredicateLogger: ptr.To(logr.New(log.NullLogSink{}))}
 
 	obj := &clusterv1.Cluster{
 		TypeMeta: metav1.TypeMeta{

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -134,9 +134,10 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machinepool-controller")
 	r.externalTracker = external.ObjectTracker{
-		Controller: c,
-		Cache:      mgr.GetCache(),
-		Scheme:     mgr.GetScheme(),
+		Controller:      c,
+		Cache:           mgr.GetCache(),
+		Scheme:          mgr.GetScheme(),
+		PredicateLogger: &predicateLog,
 	}
 	r.ssaCache = ssa.NewCache()
 

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
@@ -131,9 +133,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -173,9 +176,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -212,9 +216,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -267,9 +272,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -334,9 +340,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -379,9 +386,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -431,9 +439,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -496,9 +505,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -567,9 +577,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -636,9 +647,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -727,9 +739,10 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -1049,9 +1062,10 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			r := &MachinePoolReconciler{
 				Client: fakeClient,
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     fakeClient.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          fakeClient.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -1349,9 +1363,10 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				Client:       fakeClient,
 				ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     fakeClient.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          fakeClient.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -1437,9 +1452,10 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 				Client:   env,
 				ssaCache: ssa.NewCache(),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     env.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          env.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 			scope := &scope{
@@ -1505,9 +1521,10 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 				Client:   env,
 				ssaCache: ssa.NewCache(),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     env.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          env.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -1868,9 +1885,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -1935,9 +1953,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -1985,9 +2004,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -2031,9 +2051,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 
@@ -2099,9 +2120,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
 			externalTracker: external.ObjectTracker{
-				Controller: externalfake.Controller{},
-				Cache:      &informertest.FakeInformers{},
-				Scheme:     fakeClient.Scheme(),
+				Controller:      externalfake.Controller{},
+				Cache:           &informertest.FakeInformers{},
+				Scheme:          fakeClient.Scheme(),
+				PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 			},
 		}
 

--- a/exp/internal/controllers/machinepool_controller_test.go
+++ b/exp/internal/controllers/machinepool_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -601,9 +603,10 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(trackerClientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     clientFake.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          clientFake.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -1165,9 +1168,10 @@ func TestMachinePoolConditions(t *testing.T) {
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     clientFake.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          clientFake.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -116,9 +116,10 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 
 	r.recorder = mgr.GetEventRecorderFor("cluster-controller")
 	r.externalTracker = external.ObjectTracker{
-		Controller: c,
-		Cache:      mgr.GetCache(),
-		Scheme:     mgr.GetScheme(),
+		Controller:      c,
+		Cache:           mgr.GetCache(),
+		Scheme:          mgr.GetScheme(),
+		PredicateLogger: &predicateLog,
 	}
 	return nil
 }

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -20,15 +20,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -259,9 +262,10 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     c.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          c.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -541,9 +545,10 @@ func TestClusterReconcileControlPlane(t *testing.T) {
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     c.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          c.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -924,9 +929,10 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 				Client:   c,
 				recorder: record.NewFakeRecorder(32),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     c.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          c.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -171,9 +171,10 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
 	r.externalTracker = external.ObjectTracker{
-		Controller: c,
-		Cache:      mgr.GetCache(),
-		Scheme:     mgr.GetScheme(),
+		Controller:      c,
+		Cache:           mgr.GetCache(),
+		Scheme:          mgr.GetScheme(),
+		PredicateLogger: &predicateLog,
 	}
 	r.ssaCache = ssa.NewCache()
 	r.reconcileDeleteCache = cache.New[cache.ReconcileEntry]()

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -304,9 +306,10 @@ func TestReconcileBootstrap(t *testing.T) {
 			r := &Reconciler{
 				Client: c,
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     runtime.NewScheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          runtime.NewScheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 			s := &scope{cluster: defaultCluster, machine: tc.machine}
@@ -861,9 +864,10 @@ func TestReconcileInfrastructure(t *testing.T) {
 			r := &Reconciler{
 				Client: c,
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     c.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          c.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 			s := &scope{cluster: defaultCluster, machine: tc.machine}

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -951,9 +953,10 @@ func TestReconcileRequest(t *testing.T) {
 				recorder:             record.NewFakeRecorder(10),
 				reconcileDeleteCache: cache.New[cache.ReconcileEntry](),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     clientFake.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          clientFake.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 
@@ -1242,9 +1245,10 @@ func TestMachineConditions(t *testing.T) {
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 				ssaCache:     ssa.NewCache(),
 				externalTracker: external.ObjectTracker{
-					Controller: externalfake.Controller{},
-					Cache:      &informertest.FakeInformers{},
-					Scheme:     clientFake.Scheme(),
+					Controller:      externalfake.Controller{},
+					Cache:           &informertest.FakeInformers{},
+					Scheme:          clientFake.Scheme(),
+					PredicateLogger: ptr.To(logr.New(log.NullLogSink{})),
 				},
 			}
 

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -192,9 +192,10 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr 
 
 	r.recorder = mgr.GetEventRecorderFor(dockerMachinePoolControllerName)
 	r.externalTracker = external.ObjectTracker{
-		Controller: c,
-		Cache:      mgr.GetCache(),
-		Scheme:     mgr.GetScheme(),
+		Controller:      c,
+		Cache:           mgr.GetCache(),
+		Scheme:          mgr.GetScheme(),
+		PredicateLogger: &predicateLog,
 	}
 	r.ssaCache = ssa.NewCache()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We had a few places where we used the logger from the Reconcile ctx in predicates. The predicate logs than contained a specific object and reconcileID even though the execution of the Predicate was entirely independent of this reconcile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->