### PR TITLE
✨ Support `DockerCluster` without load balancer

### DIFF
--- a/test/infrastructure/docker/api/v1alpha4/zz_generated.conversion.go
+++ b/test/infrastructure/docker/api/v1alpha4/zz_generated.conversion.go
@@ -518,6 +518,7 @@ func autoConvert_v1beta1_DockerLoadBalancer_To_v1alpha4_DockerLoadBalancer(in *v
 		return err
 	}
 	// WARNING: in.CustomHAProxyConfigTemplateRef requires manual conversion: does not exist in peer-type
+	// WARNING: in.Disable requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
@@ -65,6 +65,9 @@ type DockerLoadBalancer struct {
 	// node is added or removed. The template will also support the JoinHostPort function to join the host and port of the backend server.
 	// +optional
 	CustomHAProxyConfigTemplateRef *corev1.LocalObjectReference `json:"customHAProxyConfigTemplateRef,omitempty"`
+
+	// Disable allows skipping the creation of the cluster load balancer.
+	Disable bool `json:"disable,omitempty"`
 }
 
 // ImageMeta allows customizing the image used for components that are not

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -429,6 +429,10 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  disable:
+                    description: Disable allows skipping the creation of the cluster
+                      load balancer.
+                    type: boolean
                   imageRepository:
                     description: |-
                       ImageRepository sets the container registry to pull the haproxy image from.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -250,6 +250,10 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          disable:
+                            description: Disable allows skipping the creation of the
+                              cluster load balancer.
+                            type: boolean
                           imageRepository:
                             description: |-
                               ImageRepository sets the container registry to pull the haproxy image from.

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -93,6 +93,7 @@ var (
 	// CAPD specific flags.
 	concurrency             int
 	clusterCacheConcurrency int
+	skipLoadBalancer        bool
 )
 
 func init() {


### PR DESCRIPTION

**What this PR does / why we need it**:

In certain scenarios it may be desirable to deploy CAPD machines without a load-balancer. 

For example, in the case of a hosted control plane such as a Kamaji the load-balancer will be fulfilled by the control plane provider (indirectly at least).

This change introduces a new field to the `DockerCluster` API that when `true` will skip the steps involved in creating and managing the load balancer container.

```yaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: DockerCluster
...
spec:
  loadBalancer:
    disable: true
```

This change is opt-in and has no impact otherwise.

/area provider/infrastructure-docker