### PR TITLE
🌱 Improve Cluster RemoteConnectionProbe condition

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -269,10 +269,10 @@ const (
 	ClusterRemoteConnectionProbeV1Beta2Condition = "RemoteConnectionProbe"
 
 	// ClusterRemoteConnectionProbeFailedV1Beta2Reason surfaces issues with the connection to the workload cluster.
-	ClusterRemoteConnectionProbeFailedV1Beta2Reason = "RemoteConnectionProbeFailed"
+	ClusterRemoteConnectionProbeFailedV1Beta2Reason = "ProbeFailed"
 
 	// ClusterRemoteConnectionProbeSucceededV1Beta2Reason is used to report a working connection with the workload cluster.
-	ClusterRemoteConnectionProbeSucceededV1Beta2Reason = "RemoteConnectionProbeSucceeded"
+	ClusterRemoteConnectionProbeSucceededV1Beta2Reason = "ProbeSucceeded"
 )
 
 // Cluster's ScalingUp condition and corresponding reasons that will be used in v1Beta2 API version.

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -63,9 +63,6 @@ const (
 	// deleteRequeueAfter is how long to wait before checking again to see if the cluster still has children during
 	// deletion.
 	deleteRequeueAfter = 5 * time.Second
-
-	// remoteConnectionProbeSucceededMessage is the message to be used when remote connection probe succeeded.
-	remoteConnectionProbeSucceededMessage = "Remote connection probe succeeded"
 )
 
 // Update permissions on /finalizers subresrouce is required on management clusters with 'OwnerReferencesPermissionEnforcement' plugin enabled.
@@ -203,10 +200,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (retRes ct
 		})
 	} else {
 		v1beta2conditions.Set(cluster, metav1.Condition{
-			Type:    clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
-			Status:  metav1.ConditionTrue,
-			Reason:  clusterv1.ClusterRemoteConnectionProbeSucceededV1Beta2Reason,
-			Message: remoteConnectionProbeSucceededMessage,
+			Type:   clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: clusterv1.ClusterRemoteConnectionProbeSucceededV1Beta2Reason,
 		})
 	}
 

--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -969,10 +969,6 @@ func setAvailableCondition(ctx context.Context, cluster *clusterv1.Cluster) {
 		overrideConditions = append(overrideConditions, *controlPlaneAvailableCondition)
 	}
 
-	if remoteConnectionProbeCondition := calculateRemoteConnectionProbeForSummary(cluster); remoteConnectionProbeCondition != nil {
-		overrideConditions = append(overrideConditions, *remoteConnectionProbeCondition)
-	}
-
 	if len(overrideConditions) > 0 {
 		summaryOpts = append(summaryOpts, overrideConditions)
 	}
@@ -1048,31 +1044,6 @@ func calculateControlPlaneAvailableForSummary(cluster *clusterv1.Cluster) *v1bet
 			Type:    controlPlaneAvailableCondition.Type,
 			Status:  controlPlaneAvailableCondition.Status,
 			Reason:  controlPlaneAvailableCondition.Reason,
-			Message: message,
-		},
-	}
-}
-
-func calculateRemoteConnectionProbeForSummary(cluster *clusterv1.Cluster) *v1beta2conditions.ConditionWithOwnerInfo {
-	remoteConnectionProbeCondition := v1beta2conditions.Get(cluster, clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition)
-	if remoteConnectionProbeCondition == nil {
-		return nil
-	}
-
-	message := remoteConnectionProbeCondition.Message
-	if remoteConnectionProbeCondition.Status == metav1.ConditionTrue && remoteConnectionProbeCondition.Message == remoteConnectionProbeSucceededMessage {
-		message = ""
-	}
-
-	return &v1beta2conditions.ConditionWithOwnerInfo{
-		OwnerResource: v1beta2conditions.ConditionOwnerInfo{
-			Kind: "Cluster",
-			Name: cluster.Name,
-		},
-		Condition: metav1.Condition{
-			Type:    remoteConnectionProbeCondition.Type,
-			Status:  remoteConnectionProbeCondition.Status,
-			Reason:  remoteConnectionProbeCondition.Reason,
 			Message: message,
 		},
 	}

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -1980,7 +1980,7 @@ func TestSetAvailableCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "Drops messages from InfraCluster and ControlPlane when using fallback to fields; drop message from RemoteConnectionProbe when true",
+			name: "Drops messages from InfraCluster and ControlPlane when using fallback to fields",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "machine-test",
@@ -2013,10 +2013,9 @@ func TestSetAvailableCondition(t *testing.T) {
 								Reason: "Foo",
 							},
 							{
-								Type:    clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
-								Status:  metav1.ConditionTrue,
-								Reason:  clusterv1.ClusterRemoteConnectionProbeSucceededV1Beta2Reason,
-								Message: remoteConnectionProbeSucceededMessage,
+								Type:   clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
+								Status: metav1.ConditionTrue,
+								Reason: clusterv1.ClusterRemoteConnectionProbeSucceededV1Beta2Reason,
 							},
 							{
 								Type:   clusterv1.ClusterDeletingV1Beta2Condition,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We don't need a message in the success case. The reason is good enough. Also the reasons could be shorter


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11105 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->