### PR TITLE
🌱 Refine order for v1beta2 summary util

### DIFF
--- a/util/conditions/v1beta2/merge_strategies.go
+++ b/util/conditions/v1beta2/merge_strategies.go
@@ -259,7 +259,9 @@ func (d *defaultMergeStrategy) Merge(conditions []ConditionWithOwnerInfo, condit
 	// provided by the user (it is considered as order of relevance).
 	if isSummaryOperation {
 		messages := []string{}
-		for _, condition := range append(issueConditions, append(unknownConditions, infoConditions...)...) {
+
+		// Note: use conditions because we want to preserve the order of relevance defined by the users (the order of condition types).
+		for _, condition := range conditions {
 			priority := d.getPriorityFunc(condition.Condition)
 			if priority == InfoMergePriority {
 				// Drop info messages when we are surfacing issues or unknown.

--- a/util/conditions/v1beta2/summary_test.go
+++ b/util/conditions/v1beta2/summary_test.go
@@ -116,9 +116,9 @@ func TestSummary(t *testing.T) {
 				Type:   clusterv1.AvailableV1Beta2Condition,
 				Status: metav1.ConditionFalse, // False because there are many issues
 				Reason: issuesReportedReason,  // Using a generic reason
-				Message: "* B: Message-B\n" +
-					"* !C: Message-!C\n" +
-					"* A: Message-A", // messages from all the issues & unknown conditions (info dropped)
+				Message: "* A: Message-A\n" +
+					"* B: Message-B\n" +
+					"* !C: Message-!C", // messages from all the issues & unknown conditions (info dropped); also, the order defined in ForConditionTypes must be preserved.
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Preserve the order of relevance defined by the users (the order of condition types) when computing the summary

/area util

Part of https://github.com/kubernetes-sigs/cluster-api/issues/11105