### PR TITLE
🌱 Refine v1beta2 condition order

### DIFF
--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -960,12 +960,12 @@ func setAvailableCondition(ctx context.Context, cluster *clusterv1.Cluster) {
 	log := ctrl.LoggerFrom(ctx)
 
 	forConditionTypes := v1beta2conditions.ForConditionTypes{
+		clusterv1.ClusterDeletingV1Beta2Condition,
+		clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
 		clusterv1.ClusterInfrastructureReadyV1Beta2Condition,
 		clusterv1.ClusterControlPlaneAvailableV1Beta2Condition,
 		clusterv1.ClusterWorkersAvailableV1Beta2Condition,
-		clusterv1.ClusterRemoteConnectionProbeV1Beta2Condition,
 		clusterv1.ClusterTopologyReconciledV1Beta2Condition,
-		clusterv1.ClusterDeletingV1Beta2Condition,
 	}
 	for _, g := range cluster.Spec.AvailabilityGates {
 		forConditionTypes = append(forConditionTypes, g.ConditionType)

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -1730,11 +1730,11 @@ func TestSetAvailableCondition(t *testing.T) {
 				Type:   clusterv1.ClusterAvailableV1Beta2Condition,
 				Status: metav1.ConditionUnknown,
 				Reason: clusterv1.ClusterAvailableUnknownV1Beta2Reason,
-				Message: "* InfrastructureReady: Condition not yet reported\n" +
-					"* ControlPlaneAvailable: Condition not yet reported\n" +
-					"* WorkersAvailable: Condition not yet reported\n" +
+				Message: "* Deleting: Condition not yet reported\n" +
 					"* RemoteConnectionProbe: Condition not yet reported\n" +
-					"* Deleting: Condition not yet reported",
+					"* InfrastructureReady: Condition not yet reported\n" +
+					"* ControlPlaneAvailable: Condition not yet reported\n" +
+					"* WorkersAvailable: Condition not yet reported",
 			},
 		},
 		{

--- a/util/conditions/v1beta2/sort_test.go
+++ b/util/conditions/v1beta2/sort_test.go
@@ -46,10 +46,10 @@ func TestDefaultSortLessFunc(t *testing.T) {
 	g.Expect(conditions).To(Equal([]metav1.Condition{
 		{Type: clusterv1.AvailableV1Beta2Condition},
 		{Type: clusterv1.ReadyV1Beta2Condition},
-		{Type: clusterv1.PausedV1Beta2Condition},
-		{Type: clusterv1.DeletingV1Beta2Condition},
 		{Type: "A"},
 		{Type: "B"},
 		{Type: "C!"},
+		{Type: clusterv1.PausedV1Beta2Condition},
+		{Type: clusterv1.DeletingV1Beta2Condition},
 	}))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve condition sort so that Readiness/Availability gates shows up before paused/deleting
Align condition order in Cluster Available condition to condition sort order

/area util

Part of https://github.com/kubernetes-sigs/cluster-api/issues/11105