### PR TITLE
🐛 Fix RuntimeClient nil check in Cluster controller

### DIFF
--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -94,8 +94,12 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	if r.Client == nil || r.APIReader == nil || r.ClusterCache == nil || r.RuntimeClient == nil {
-		return errors.New("Client, APIReader, ClusterCache and RuntimeClient must not be nil")
+	if r.Client == nil || r.APIReader == nil || r.ClusterCache == nil {
+		return errors.New("Client, APIReader and ClusterCache must not be nil")
+	}
+
+	if feature.Gates.Enabled(feature.RuntimeSDK) && r.RuntimeClient == nil {
+		return errors.New("RuntimeClient must not be nil")
 	}
 
 	r.predicateLog = ctrl.LoggerFrom(ctx).WithValues("controller", "topology/cluster")


### PR DESCRIPTION
**What this PR does / why we need it**:

RuntimeClient is only mandatory if RuntimeSDK feature gate is enabled

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

