### PR TITLE
🐛 Align "random" deletion policy behavior regarding deletion annotations

### DIFF
--- a/internal/controllers/machineset/machineset_delete_policy.go
+++ b/internal/controllers/machineset/machineset_delete_policy.go
@@ -82,7 +82,7 @@ func randomDeletePolicy(machine *clusterv1.Machine) deletePriority {
 		return mustDelete
 	}
 	if _, ok := machine.ObjectMeta.Annotations[clusterv1.DeleteMachineAnnotation]; ok {
-		return betterDelete
+		return shouldDelete
 	}
 	if !isMachineHealthy(machine) {
 		return betterDelete

--- a/internal/controllers/machineset/machineset_delete_policy_test.go
+++ b/internal/controllers/machineset/machineset_delete_policy_test.go
@@ -200,9 +200,9 @@ func TestMachineToDelete(t *testing.T) {
 			desc: "func=randomDeletePolicy, DeleteMachineAnnotation, diff=1",
 			diff: 1,
 			machines: []*clusterv1.Machine{
-				healthyMachine,
+				betterDeleteMachine,
 				deleteMachineWithMachineAnnotation,
-				healthyMachine,
+				betterDeleteMachine,
 			},
 			expect: []*clusterv1.Machine{
 				deleteMachineWithMachineAnnotation,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Right now, the `oldest` and `newest` deletion policies prioritize machines that have the `cluster.x-k8s.io/delete-machine` annotation over unhealthy machines when deciding which machines need to be deleted. This wasn't the case with the `random` deletion policy. This change aligns the latter to the rest, making it honor the deletion annotation.

The unit tests for that part of the code have also been modified to be more strict when comparing machines with this annotation, always comparing them with unhealthy machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11387 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machineset