### PR TITLE
🌱 Ignore new Machines when calculating MachinesUpToDate condition

### DIFF
--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -476,19 +476,22 @@ func Test_setMachinesReadyAndMachinesUpToDateConditions(t *testing.T) {
 					&clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "m1"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{readyTrue, upToDateTrue}}}},
 					&clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "m2"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{readyTrue, upToDateFalse}}}},
 					&clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "m3"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{readyFalse, upToDateFalse}}}},
+					&clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "m4"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{readyFalse}}}},                                                                         // Machine without UpToDate condition
+					&clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "m5", CreationTimestamp: metav1.Time{Time: time.Now().Add(-5 * time.Second)}}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{readyFalse}}}}, // New Machine without UpToDate condition (should be ignored)
 				),
 			},
 			expectMachinesReadyCondition: metav1.Condition{
 				Type:    controlplanev1.KubeadmControlPlaneMachinesReadyV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
 				Reason:  controlplanev1.KubeadmControlPlaneMachinesNotReadyV1Beta2Reason,
-				Message: "* Machine m3: NotReady",
+				Message: "* Machines m3, m4, m5: NotReady",
 			},
 			expectMachinesUpToDateCondition: metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachinesUpToDateV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachinesNotUpToDateV1Beta2Reason,
-				Message: "* Machines m2, m3: NotUpToDate",
+				Type:   controlplanev1.KubeadmControlPlaneMachinesUpToDateV1Beta2Condition,
+				Status: metav1.ConditionFalse,
+				Reason: controlplanev1.KubeadmControlPlaneMachinesNotUpToDateV1Beta2Reason,
+				Message: "* Machines m2, m3: NotUpToDate\n" +
+					"* Machine m4: Condition UpToDate not yet reported",
 			},
 		},
 	}

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -1005,10 +1005,11 @@ func TestSetMachinesUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
-			name:    "One machine without up-to-date condition",
+			name:    "One machine without up-to-date condition, one new Machines without up-to-date condition",
 			cluster: fakeCluster("c"),
 			machines: []*clusterv1.Machine{
 				fakeMachine("no-condition-machine-1"),
+				fakeMachine("no-condition-machine-2-new", creationTimestamp{Time: time.Now().Add(-5 * time.Second)}), // ignored because it's new
 			},
 			getDescendantsSucceeded: true,
 			expectCondition: metav1.Condition{
@@ -2648,6 +2649,12 @@ type initialized bool
 
 func (r initialized) ApplyToControlPlane(cp *unstructured.Unstructured) {
 	_ = contract.ControlPlane().Initialized().Set(cp, bool(r))
+}
+
+type creationTimestamp metav1.Time
+
+func (t creationTimestamp) ApplyToMachine(m *clusterv1.Machine) {
+	m.CreationTimestamp = metav1.Time(t)
 }
 
 type nodeRef corev1.ObjectReference

--- a/internal/controllers/machinedeployment/machinedeployment_status_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status_test.go
@@ -814,10 +814,11 @@ func Test_setMachinesUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
-			name:              "One machine without up-to-date condition",
+			name:              "One machine without up-to-date condition, one new Machines without up-to-date condition",
 			machineDeployment: &clusterv1.MachineDeployment{},
 			machines: []*clusterv1.Machine{
 				fakeMachine("no-condition-machine-1"),
+				fakeMachine("no-condition-machine-2-new", withCreationTimestamp(time.Now().Add(-5*time.Second))), // ignored because it's new
 			},
 			getMachinesSucceeded: true,
 			expectCondition: metav1.Condition{
@@ -1170,6 +1171,12 @@ func fakeMachine(name string, options ...fakeMachinesOption) *clusterv1.Machine 
 		opt(p)
 	}
 	return p
+}
+
+func withCreationTimestamp(t time.Time) fakeMachinesOption {
+	return func(m *clusterv1.Machine) {
+		m.CreationTimestamp = metav1.Time{Time: t}
+	}
 }
 
 func withStaleDeletion() fakeMachinesOption {

--- a/internal/controllers/machineset/machineset_controller_status_test.go
+++ b/internal/controllers/machineset/machineset_controller_status_test.go
@@ -727,10 +727,11 @@ func Test_setMachinesUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
-			name:       "One machine without up-to-date condition",
+			name:       "One machine without up-to-date condition, one new Machines without up-to-date condition",
 			machineSet: machineSet,
 			machines: []*clusterv1.Machine{
 				newMachine("no-condition-machine-1"),
+				fakeMachine("no-condition-machine-2-new", withCreationTimestamp(time.Now().Add(-5*time.Second))), // ignored because it's new
 			},
 			getAndAdoptMachinesForMachineSetSucceeded: true,
 			expectCondition: metav1.Condition{
@@ -1026,6 +1027,12 @@ func fakeMachine(name string, options ...fakeMachinesOption) *clusterv1.Machine 
 		opt(p)
 	}
 	return p
+}
+
+func withCreationTimestamp(t time.Time) fakeMachinesOption {
+	return func(m *clusterv1.Machine) {
+		m.CreationTimestamp = metav1.Time{Time: t}
+	}
 }
 
 func withV1Beta2Condition(c metav1.Condition) fakeMachinesOption {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11105

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->