### PR TITLE
🌱 Fix messages of conditions used for summaries and aggregations

### DIFF
--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -212,9 +212,10 @@ func setInitializedCondition(_ context.Context, kcp *controlplanev1.KubeadmContr
 func setScalingUpCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, infrastructureObjectNotFound bool, preflightChecks internal.PreflightCheckResults) {
 	if kcp.Spec.Replicas == nil {
 		v1beta2conditions.Set(kcp, metav1.Condition{
-			Type:   controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: controlplanev1.KubeadmControlPlaneScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Type:    controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  controlplanev1.KubeadmControlPlaneScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}
@@ -263,9 +264,10 @@ func setScalingUpCondition(_ context.Context, kcp *controlplanev1.KubeadmControl
 func setScalingDownCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, preflightChecks internal.PreflightCheckResults) {
 	if kcp.Spec.Replicas == nil {
 		v1beta2conditions.Set(kcp, metav1.Condition{
-			Type:   controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: controlplanev1.KubeadmControlPlaneScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Type:    controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  controlplanev1.KubeadmControlPlaneScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}
@@ -685,11 +687,11 @@ func getPreflightMessages(preflightChecks internal.PreflightCheckResults) []stri
 	}
 
 	if preflightChecks.ControlPlaneComponentsNotHealthy {
-		additionalMessages = append(additionalMessages, "* waiting for control plane components to be healthy")
+		additionalMessages = append(additionalMessages, "* waiting for control plane components to become healthy")
 	}
 
 	if preflightChecks.EtcdClusterNotHealthy {
-		additionalMessages = append(additionalMessages, "* waiting for etcd cluster to be healthy")
+		additionalMessages = append(additionalMessages, "* waiting for etcd cluster to become healthy")
 	}
 	return additionalMessages
 }

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -133,9 +133,10 @@ func Test_setScalingUpCondition(t *testing.T) {
 				KCP: &controlplanev1.KubeadmControlPlane{},
 			},
 			expectCondition: metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: controlplanev1.KubeadmControlPlaneScalingUpWaitingForReplicasSetV1Beta2Reason,
+				Type:    controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  controlplanev1.KubeadmControlPlaneScalingUpWaitingForReplicasSetV1Beta2Reason,
+				Message: "Waiting for spec.replicas set",
 			},
 		},
 		{
@@ -264,8 +265,8 @@ func Test_setScalingUpCondition(t *testing.T) {
 				Reason: controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Reason,
 				Message: "Scaling up from 3 to 5 replicas is blocked because:\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
-					"* waiting for control plane components to be healthy\n" +
-					"* waiting for etcd cluster to be healthy",
+					"* waiting for control plane components to become healthy\n" +
+					"* waiting for etcd cluster to become healthy",
 			},
 		},
 	}
@@ -294,9 +295,10 @@ func Test_setScalingDownCondition(t *testing.T) {
 				KCP: &controlplanev1.KubeadmControlPlane{},
 			},
 			expectCondition: metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: controlplanev1.KubeadmControlPlaneScalingDownWaitingForReplicasSetV1Beta2Reason,
+				Type:    controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  controlplanev1.KubeadmControlPlaneScalingDownWaitingForReplicasSetV1Beta2Reason,
+				Message: "Waiting for spec.replicas set",
 			},
 		},
 		{
@@ -429,8 +431,8 @@ func Test_setScalingDownCondition(t *testing.T) {
 				Reason: controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Reason,
 				Message: "Scaling down from 3 to 1 replicas is blocked because:\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
-					"* waiting for control plane components to be healthy\n" +
-					"* waiting for etcd cluster to be healthy",
+					"* waiting for control plane components to become healthy\n" +
+					"* waiting for etcd cluster to become healthy",
 			},
 		},
 	}

--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -508,7 +508,7 @@ func setControlPlaneInitializedCondition(ctx context.Context, cluster *clusterv1
 			Type:    clusterv1.ClusterControlPlaneInitializedV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
 			Reason:  clusterv1.ClusterControlPlaneNotInitializedV1Beta2Reason,
-			Message: fmt.Sprintf("Waiting for the %s to have status.initialized set to true", cluster.Spec.ControlPlaneRef.Kind),
+			Message: "Control plane not yet initialized",
 		})
 		return
 	}

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -603,7 +603,7 @@ func TestSetControlPlaneInitialized(t *testing.T) {
 				Type:    clusterv1.ClusterControlPlaneInitializedV1Beta2Condition,
 				Status:  metav1.ConditionFalse,
 				Reason:  clusterv1.ClusterControlPlaneNotInitializedV1Beta2Reason,
-				Message: "Waiting for the FakeControlPlane to have status.initialized set to true",
+				Message: "Control plane not yet initialized",
 			},
 		},
 		{

--- a/internal/controllers/machinedeployment/machinedeployment_status.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status.go
@@ -104,9 +104,10 @@ func setAvailableCondition(_ context.Context, machineDeployment *clusterv1.Machi
 	// Surface if .spec.replicas is not yet set (this should never happen).
 	if machineDeployment.Spec.Replicas == nil {
 		v1beta2conditions.Set(machineDeployment, metav1.Condition{
-			Type:   clusterv1.MachineDeploymentAvailableV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineDeploymentAvailableWaitingForReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineDeploymentAvailableV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineDeploymentAvailableWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}
@@ -114,9 +115,10 @@ func setAvailableCondition(_ context.Context, machineDeployment *clusterv1.Machi
 	// Surface if .status.v1beta2.availableReplicas is not yet set.
 	if machineDeployment.Status.V1Beta2 == nil || machineDeployment.Status.V1Beta2.AvailableReplicas == nil {
 		v1beta2conditions.Set(machineDeployment, metav1.Condition{
-			Type:   clusterv1.MachineDeploymentAvailableV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineDeploymentAvailableV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetV1Beta2Reason,
+			Message: "Waiting for status.v1beta2.availableReplicas set",
 		})
 		return
 	}
@@ -160,9 +162,10 @@ func setScalingUpCondition(_ context.Context, machineDeployment *clusterv1.Machi
 	// Surface if .spec.replicas is not yet set (this should never happen).
 	if machineDeployment.Spec.Replicas == nil {
 		v1beta2conditions.Set(machineDeployment, metav1.Condition{
-			Type:   clusterv1.MachineDeploymentScalingUpV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineDeploymentScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineDeploymentScalingUpV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineDeploymentScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}
@@ -218,9 +221,10 @@ func setScalingDownCondition(_ context.Context, machineDeployment *clusterv1.Mac
 	// Surface if .spec.replicas is not yet set (this should never happen).
 	if machineDeployment.Spec.Replicas == nil {
 		v1beta2conditions.Set(machineDeployment, metav1.Condition{
-			Type:   clusterv1.MachineDeploymentScalingDownV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineDeploymentScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineDeploymentScalingDownV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineDeploymentScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_status_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status_test.go
@@ -105,9 +105,10 @@ func Test_setAvailableCondition(t *testing.T) {
 			machineDeployment: &clusterv1.MachineDeployment{},
 			getAndAdoptMachineSetsForDeploymentSucceeded: true,
 			expectCondition: metav1.Condition{
-				Type:   clusterv1.MachineDeploymentAvailableV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: clusterv1.MachineDeploymentAvailableWaitingForReplicasSetV1Beta2Reason,
+				Type:    clusterv1.MachineDeploymentAvailableV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachineDeploymentAvailableWaitingForReplicasSetV1Beta2Reason,
+				Message: "Waiting for spec.replicas set",
 			},
 		},
 		{
@@ -117,9 +118,10 @@ func Test_setAvailableCondition(t *testing.T) {
 			},
 			getAndAdoptMachineSetsForDeploymentSucceeded: true,
 			expectCondition: metav1.Condition{
-				Type:   clusterv1.MachineDeploymentAvailableV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetV1Beta2Reason,
+				Type:    clusterv1.MachineDeploymentAvailableV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetV1Beta2Reason,
+				Message: "Waiting for status.v1beta2.availableReplicas set",
 			},
 		},
 		{
@@ -266,9 +268,10 @@ func Test_setScalingUpCondition(t *testing.T) {
 			infrastructureTemplateNotFound:               false,
 			getAndAdoptMachineSetsForDeploymentSucceeded: true,
 			expectCondition: metav1.Condition{
-				Type:   clusterv1.MachineDeploymentScalingUpV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: clusterv1.MachineDeploymentScalingUpWaitingForReplicasSetV1Beta2Reason,
+				Type:    clusterv1.MachineDeploymentScalingUpV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachineDeploymentScalingUpWaitingForReplicasSetV1Beta2Reason,
+				Message: "Waiting for spec.replicas set",
 			},
 		},
 		{
@@ -464,9 +467,10 @@ func Test_setScalingDownCondition(t *testing.T) {
 			}(),
 			getAndAdoptMachineSetsForDeploymentSucceeded: true,
 			expectCondition: metav1.Condition{
-				Type:   clusterv1.MachineDeploymentScalingDownV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: clusterv1.MachineDeploymentScalingDownWaitingForReplicasSetV1Beta2Reason,
+				Type:    clusterv1.MachineDeploymentScalingDownV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachineDeploymentScalingDownWaitingForReplicasSetV1Beta2Reason,
+				Message: "Waiting for spec.replicas set",
 			},
 		},
 		{

--- a/internal/controllers/machineset/machineset_controller_status.go
+++ b/internal/controllers/machineset/machineset_controller_status.go
@@ -107,9 +107,10 @@ func setScalingUpCondition(_ context.Context, ms *clusterv1.MachineSet, machines
 	// Surface if .spec.replicas is not yet set (this should never happen).
 	if ms.Spec.Replicas == nil {
 		v1beta2conditions.Set(ms, metav1.Condition{
-			Type:   clusterv1.MachineSetScalingUpV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineSetScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineSetScalingUpV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineSetScalingUpWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}
@@ -172,9 +173,10 @@ func setScalingDownCondition(_ context.Context, ms *clusterv1.MachineSet, machin
 	// Surface if .spec.replicas is not yet set (this should never happen).
 	if ms.Spec.Replicas == nil {
 		v1beta2conditions.Set(ms, metav1.Condition{
-			Type:   clusterv1.MachineSetScalingDownV1Beta2Condition,
-			Status: metav1.ConditionUnknown,
-			Reason: clusterv1.MachineSetScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Type:    clusterv1.MachineSetScalingDownV1Beta2Condition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachineSetScalingDownWaitingForReplicasSetV1Beta2Reason,
+			Message: "Waiting for spec.replicas set",
 		})
 		return
 	}

--- a/internal/controllers/topology/cluster/conditions.go
+++ b/internal/controllers/topology/cluster/conditions.go
@@ -84,9 +84,10 @@ func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluste
 			),
 		)
 		v1beta2conditions.Set(cluster, metav1.Condition{
-			Type:   clusterv1.ClusterTopologyReconciledV1Beta2Condition,
-			Status: metav1.ConditionFalse,
-			Reason: clusterv1.ClusterTopologyReconciledDeletingV1Beta2Reason,
+			Type:    clusterv1.ClusterTopologyReconciledV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  clusterv1.ClusterTopologyReconciledDeletingV1Beta2Reason,
+			Message: "Cluster is deleting",
 		})
 		return nil
 	}

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -1019,7 +1019,7 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			wantConditionMessage:        "",
 			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
 			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledDeletingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "",
+			wantV1Beta2ConditionMessage: "Cluster is deleting",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11105 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->