### PR TITLE
🌱  Refine v1beta2 machine ready

### DIFF
--- a/util/conditions/v1beta2/options.go
+++ b/util/conditions/v1beta2/options.go
@@ -154,3 +154,11 @@ type ComputeReasonFunc func(issueConditions []ConditionWithOwnerInfo, unknownCon
 func (f ComputeReasonFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
 	opts.computeReasonFunc = f
 }
+
+// SummaryMessageTransformFunc defines a function to be used when computing the message for a summary condition returned by the DefaultMergeStrategy.
+type SummaryMessageTransformFunc func([]string) []string
+
+// ApplyToDefaultMergeStrategy applies this configuration to the given DefaultMergeStrategy options.
+func (f SummaryMessageTransformFunc) ApplyToDefaultMergeStrategy(opts *DefaultMergeStrategyOptions) {
+	opts.summaryMessageTransformFunc = f
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refine machine's ready condition by grouping control plane and etcd conditions when they all have the same message
/area machine

Part of https://github.com/kubernetes-sigs/cluster-api/issues/11105