### PR TITLE
🌱 Refine v1beta2 ControlPlaneHealthy condition

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2019,10 +2019,7 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 					Status: metav1.ConditionUnknown,
 					Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 					Message: "* Machine machine1-test:\n" +
-						"  * APIServerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * ControllerManagerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * SchedulerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * EtcdPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID",
+						"  * Control plane components: Waiting for GenericInfrastructureMachine to report spec.providerID",
 				},
 			},
 			expectMachineConditions: []metav1.Condition{
@@ -2099,10 +2096,7 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 					Status: metav1.ConditionUnknown,
 					Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 					Message: "* Machine machine1-test:\n" +
-						"  * APIServerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * ControllerManagerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * SchedulerPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID\n" +
-						"  * EtcdPodHealthy: Waiting for GenericInfrastructureMachine to report spec.providerID",
+						"  * Control plane components: Waiting for GenericInfrastructureMachine to report spec.providerID",
 				},
 			},
 			expectMachineConditions: []metav1.Condition{

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -804,10 +804,7 @@ func TestUpdateStaticPodConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * APIServerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * ControllerManagerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * SchedulerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * EtcdPodHealthy: Waiting for GenericInfraMachine to report spec.providerID",
+					"  * Control plane components: Waiting for GenericInfraMachine to report spec.providerID",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
@@ -837,10 +834,7 @@ func TestUpdateStaticPodConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * APIServerPodHealthy: Waiting for a Node with spec.providerID dummy-provider-id to exist\n" +
-					"  * ControllerManagerPodHealthy: Waiting for a Node with spec.providerID dummy-provider-id to exist\n" +
-					"  * SchedulerPodHealthy: Waiting for a Node with spec.providerID dummy-provider-id to exist\n" +
-					"  * EtcdPodHealthy: Waiting for a Node with spec.providerID dummy-provider-id to exist",
+					"  * Control plane components: Waiting for a Node with spec.providerID dummy-provider-id to exist",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
@@ -891,10 +885,7 @@ func TestUpdateStaticPodConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * APIServerPodHealthy: Node n1 is unreachable\n" +
-					"  * ControllerManagerPodHealthy: Node n1 is unreachable\n" +
-					"  * SchedulerPodHealthy: Node n1 is unreachable\n" +
-					"  * EtcdPodHealthy: Node n1 is unreachable",
+					"  * Control plane components: Node n1 is unreachable",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
@@ -922,10 +913,7 @@ func TestUpdateStaticPodConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * APIServerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * ControllerManagerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * SchedulerPodHealthy: Waiting for GenericInfraMachine to report spec.providerID\n" +
-					"  * EtcdPodHealthy: Waiting for GenericInfraMachine to report spec.providerID",
+					"  * Control plane components: Waiting for GenericInfraMachine to report spec.providerID",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
@@ -958,10 +946,7 @@ func TestUpdateStaticPodConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * APIServerPodHealthy: Node n1 does not exist\n" +
-					"  * ControllerManagerPodHealthy: Node n1 does not exist\n" +
-					"  * SchedulerPodHealthy: Node n1 does not exist\n" +
-					"  * EtcdPodHealthy: Node n1 does not exist",
+					"  * Control plane components: Node n1 does not exist",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {


### PR DESCRIPTION
**What this PR does / why we need it**:
Refine KCP's ControlPlaneHealthy condition by grouping conditions when they all have the same message
/area provider/control-plane-kubeadm

Part of https://github.com/kubernetes-sigs/cluster-api/issues/11105