### PR TITLE
🌱 KCP: handle members without name in MemberNames

### DIFF
--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -18,6 +18,8 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
@@ -34,9 +36,15 @@ func MemberForName(members []*etcd.Member, name string) *etcd.Member {
 }
 
 // MemberNames returns a list of all the etcd member names.
+// Note: this function is specificially designed for MemberEqual and setting condition messages.
 func MemberNames(members []*etcd.Member) []string {
 	names := make([]string, 0, len(members))
 	for _, m := range members {
+		// When adding a member the name may not yet be set.
+		if m.Name == "" {
+			names = append(names, fmt.Sprintf("name not set yet for member with id %d", m.ID))
+			continue
+		}
 		names = append(names, m.Name)
 	}
 	return names


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
When reading etcd members, it might happen that a member doesn't have yet the name set. 

This PR makes sure the comparison between etcd members list read from different machines takes into account members without name properly.

Note: this is usually a temporary issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area conditions