### PR TITLE
KCP: Change Pod does not exist message to allow aggregation

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -655,7 +655,7 @@ func (w *Workload) updateStaticPodCondition(ctx context.Context, machine *cluste
 				Type:    staticPodV1beta2Condition,
 				Status:  metav1.ConditionFalse,
 				Reason:  controlplanev1.KubeadmControlPlaneMachinePodDoesNotExistV1Beta2Reason,
-				Message: fmt.Sprintf("Pod %s does not exist", podKey.Name),
+				Message: "Pod does not exist",
 			})
 			return
 		}

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -1193,7 +1193,7 @@ func TestUpdateStaticPodCondition(t *testing.T) {
 				Type:    v1beta2Condition,
 				Status:  metav1.ConditionFalse,
 				Reason:  controlplanev1.KubeadmControlPlaneMachinePodDoesNotExistV1Beta2Reason,
-				Message: "Pod kube-component-node does not exist",
+				Message: "Pod does not exist",
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR slightly changes the error message that is surfaced when a control plane Pod does not exist. As the condition name already contains the affected Pod we don't have to add the full pod name to the message. If the messages are constant accross various Pods they can be aggregated into just one "Control plane components" message

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11105 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->