### PR TITLE
📖 Add Cluster API release-1.10 timeline document

### DIFF
--- a/docs/release/releases/release-1.10.md
+++ b/docs/release/releases/release-1.10.md
@@ -1,0 +1,37 @@
+# Cluster API v1.10
+
+## Timeline
+
+The following table shows the preliminary dates for the `v1.10` release cycle.
+
+| **What**                                             | **Who**      | **When**                    | **Week** |
+|------------------------------------------------------|--------------|-----------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 6 January 2025       | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 10 January 2025      | week 1   |
+| Team finalized                                       | Release Lead | Friday 10 January 2025      | week 1   |
+| *v1.8.x & v1.9.x released*                           | Release Lead | Tuesday 21th January 2025   | week 3   |
+| *v1.8.x & v1.9.x released*                           | Release Lead | Tuesday 18th February 2025  | week 7   |
+| v1.10.0-beta.0 released                              | Release Lead | Tuesday 18th March 2025     | week 11  |
+| Communicate beta to providers                        | Comms Manager| Tuesday 18th March 2025     | week 11  |
+| *v1.8.x & v1.9.x released*                           | Release Lead | Tuesday 18th March 2025     | week 11  |
+| v1.10.0-beta.x released                              | Release Lead | Tuesday 25th March 2025     | week 12  |
+| KubeCon idle week                                    |      -       | 1st - 4th April 2025        | week 13  |
+| release-1.10 branch created (**Begin [Code Freeze]**)| Release Lead | Tuesday 8nd April 2025      | week 14  |
+| v1.10.0-rc.0 released                                | Release Lead | Tuesday 8nd April 2025      | week 14  |
+| release-1.10 jobs created                            | CI Manager   | Tuesday 8nd April 2025      | week 14  |
+| v1.10.0-rc.x released                                | Release Lead | Tuesday 15th April 2025     | week 15  |
+| **v1.10.0 released**                                 | Release Lead | Tuesday 22th April 2025     | week 16  |
+| *v1.8.x & v1.9.x released*                           | Release Lead | Tuesday 22th April 2025     | week 16  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 16  |
+| *v1.10.1 released (tentative)*                       | Release Lead | Tuesday 29th April 2025     | week 17  |
+
+After the .0 the .1 release will be created to ensure faster Kubernetes support after K8s 1.33.0 will be available. After the .1 we expect to release monthly patch release (more details will be provided in the 1.11 release schedule).
+
+## Release team
+
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
+| Release Lead                              | TBD | TBD                                    |
+| Communications/Docs/Release Notes Manager | TBD | TBD                                    |
+| CI Signal/Bug Triage/Automation Manager   | TBD | TBD                                    |
+| Maintainer                                | TBD | TBD                                    |


### PR DESCRIPTION
This PR adds release-1.10 cycle schedule document with preliminary dates taking into account [Kubecon Europe 2025](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) between April 1-4, 2025 on week 16th in the schedule.

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/11092

/area release
/kind documentation