### PR TITLE
🐛 kind: downgrade binary to v0.24.0 to fix building node images for <= v1.30

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -30,7 +30,8 @@ goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 
 # Note: When updating the MINIMUM_KIND_VERSION new shas MUST be added in `preBuiltMappings` at `test/infrastructure/kind/mapper.go`
-MINIMUM_KIND_VERSION=v0.25.0
+# Note: The kind version here is out of sync with our go dependency which is 0.25.0 due to issues building images <= kubernetes v1.30.
+MINIMUM_KIND_VERSION=v0.24.0
 
 
 # Ensure the kind tool exists and is a viable version, or installs it


### PR DESCRIPTION
…v1.30

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Downgrades kind to v0.24.0 because v0.25.0 is currently broken in building images from prebuilt binaries for kubernetes < v1.31.

Partially reverts:
- https://github.com/kubernetes-sigs/cluster-api/pull/11473

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1732652928530129

/area ci