### PR TITLE
🐛 machine: use correct APIVersion for KCP related exclude

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -634,11 +634,17 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 	return ctrl.Result{}, nil
 }
 
-// KubeadmControlPlanePreTerminateHookCleanupAnnotation inlined from KCP (we want to avoid importing the KCP API package).
-const KubeadmControlPlanePreTerminateHookCleanupAnnotation = clusterv1.PreTerminateDeleteHookAnnotationPrefix + "/kcp-cleanup"
+const (
+	// KubeadmControlPlaneAPIVersion inlined from KCP (we want to avoid importing the KCP API package).
+	KubeadmControlPlaneAPIVersion = "controlplane.cluster.x-k8s.io/v1beta1"
+
+	// KubeadmControlPlanePreTerminateHookCleanupAnnotation inlined from KCP (we want to avoid importing the KCP API package).
+	KubeadmControlPlanePreTerminateHookCleanupAnnotation = clusterv1.PreTerminateDeleteHookAnnotationPrefix + "/kcp-cleanup"
+)
 
 func (r *Reconciler) isNodeDrainAllowed(m *clusterv1.Machine) bool {
-	if util.IsControlPlaneMachine(m) && util.HasOwner(m.GetOwnerReferences(), clusterv1.GroupVersion.String(), []string{"KubeadmControlPlane"}) {
+	// TODO(chrischdi) check why this does not work
+	if util.IsControlPlaneMachine(m) && util.HasOwner(m.GetOwnerReferences(), KubeadmControlPlaneAPIVersion, []string{"KubeadmControlPlane"}) {
 		if _, exists := m.Annotations[KubeadmControlPlanePreTerminateHookCleanupAnnotation]; !exists {
 			return false
 		}
@@ -658,7 +664,7 @@ func (r *Reconciler) isNodeDrainAllowed(m *clusterv1.Machine) bool {
 // isNodeVolumeDetachingAllowed returns False if either ExcludeWaitForNodeVolumeDetachAnnotation annotation is set OR
 // nodeVolumeDetachTimeoutExceeded timeout is exceeded, otherwise returns True.
 func (r *Reconciler) isNodeVolumeDetachingAllowed(m *clusterv1.Machine) bool {
-	if util.IsControlPlaneMachine(m) && util.HasOwner(m.GetOwnerReferences(), clusterv1.GroupVersion.String(), []string{"KubeadmControlPlane"}) {
+	if util.IsControlPlaneMachine(m) && util.HasOwner(m.GetOwnerReferences(), KubeadmControlPlaneAPIVersion, []string{"KubeadmControlPlane"}) {
 		if _, exists := m.Annotations[KubeadmControlPlanePreTerminateHookCleanupAnnotation]; !exists {
 			return false
 		}

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -1366,7 +1366,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 					Annotations: map[string]string{KubeadmControlPlanePreTerminateHookCleanupAnnotation: ""},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: clusterv1.GroupVersion.String(),
+							APIVersion: KubeadmControlPlaneAPIVersion,
 							Kind:       "KubeadmControlPlane",
 							Name:       "Foo",
 						},
@@ -1390,7 +1390,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 					Labels:    map[string]string{clusterv1.MachineControlPlaneLabel: ""},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: clusterv1.GroupVersion.String(),
+							APIVersion: KubeadmControlPlaneAPIVersion,
 							Kind:       "KubeadmControlPlane",
 							Name:       "Foo",
 						},
@@ -1927,7 +1927,7 @@ func TestIsNodeVolumeDetachingAllowed(t *testing.T) {
 					Annotations: map[string]string{KubeadmControlPlanePreTerminateHookCleanupAnnotation: ""},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: clusterv1.GroupVersion.String(),
+							APIVersion: KubeadmControlPlaneAPIVersion,
 							Kind:       "KubeadmControlPlane",
 							Name:       "Foo",
 						},
@@ -1951,7 +1951,7 @@ func TestIsNodeVolumeDetachingAllowed(t *testing.T) {
 					Labels:    map[string]string{clusterv1.MachineControlPlaneLabel: ""},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: clusterv1.GroupVersion.String(),
+							APIVersion: KubeadmControlPlaneAPIVersion,
 							Kind:       "KubeadmControlPlane",
 							Name:       "Foo",
 						},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Uses the correct APIVersion when checking ownerreference for KCP for excluding machines from drain & wait for volumes after the pre-terminate hook was removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area machine