### PR TITLE
📖 Add warning note about hook invocation in SDK

### DIFF
--- a/docs/book/src/tasks/experimental-features/runtime-sdk/index.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/index.md
@@ -5,6 +5,7 @@ The Runtime SDK feature provides an extensibility mechanism that allows systems,
 <aside class="note warning">
 
 All currently implemented hooks require to also enable the [ClusterClass](../cluster-class/index.md) feature.
+Please note that hooks are only invoked for Clusters created using ClusterClass.
 
 </aside>
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:


This PR adds a caution note to the documentation indicating that hooks are only invoked for Clusters created using ClusterClass. This clarification is necessary because, despite enabling the RuntimeSDK feature, hooks will not be delivered to clusters not created with ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->