### PR TITLE
🌱 Refine v1beta2 summary

### DIFF
--- a/util/conditions/v1beta2/merge_strategies.go
+++ b/util/conditions/v1beta2/merge_strategies.go
@@ -285,7 +285,7 @@ func (d *defaultMergeStrategy) Merge(conditions []ConditionWithOwnerInfo, condit
 			if condition.Message != "" {
 				m += indentIfMultiline(condition.Message)
 			} else {
-				m += " No additional info provided"
+				m += fmt.Sprintf(" %s", condition.Reason)
 			}
 			messages = append(messages, m)
 		}

--- a/util/conditions/v1beta2/summary_test.go
+++ b/util/conditions/v1beta2/summary_test.go
@@ -70,9 +70,9 @@ func TestSummary(t *testing.T) {
 			options:       []SummaryOption{ForConditionTypes{"A", "B", "!C"}, NegativePolarityConditionTypes{"!C"}},
 			want: &metav1.Condition{
 				Type:    clusterv1.AvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,               // False because there is one issue
-				Reason:  issuesReportedReason,                // Using a generic reason
-				Message: "* !C: No additional info provided", // messages from all the issues & unknown conditions (info dropped); since message is empty, a default one is added
+				Status:  metav1.ConditionFalse, // False because there is one issue
+				Reason:  issuesReportedReason,  // Using a generic reason
+				Message: "* !C: Reason-!C",     // messages from all the issues & unknown conditions (info dropped); since message is empty, a default one is added
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
When computing summary conditions, if a condition is not reporting a message surface reason (it should be more informative than the current generic message)

/area conditions
