### PR TITLE
🌱 Refine v1beta2 UpToDate and Rollout conditions

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -979,7 +979,10 @@ func reconcileMachineUpToDateCondition(_ context.Context, controlPlane *internal
 		if machinesNotUptoDateNames.Has(machine.Name) {
 			message := ""
 			if reasons, ok := machinesNotUptoDateConditionMessages[machine.Name]; ok {
-				message = strings.Join(reasons, "; ")
+				for i := range reasons {
+					reasons[i] = fmt.Sprintf("* %s", reasons[i])
+				}
+				message = strings.Join(reasons, "\n")
 			}
 
 			v1beta2conditions.Set(machine, metav1.Condition{

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2134,7 +2134,7 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 					Type:    clusterv1.MachineUpToDateV1Beta2Condition,
 					Status:  metav1.ConditionFalse,
 					Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-					Message: "Version v1.30.0, v1.31.0 required",
+					Message: "* Version v1.30.0, v1.31.0 required",
 				},
 			},
 		},

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -226,7 +226,7 @@ func setRollingOutCondition(_ context.Context, kcp *controlplanev1.KubeadmContro
 		}
 		rollingOutReplicas++
 		if upToDateCondition.Message != "" {
-			rolloutReasons.Insert(strings.Split(upToDateCondition.Message, "; ")...)
+			rolloutReasons.Insert(strings.Split(upToDateCondition.Message, "\n")...)
 		}
 	}
 
@@ -247,17 +247,14 @@ func setRollingOutCondition(_ context.Context, kcp *controlplanev1.KubeadmContro
 		// Surface rollout reasons ensuring that if there is a version change, it goes first.
 		reasons := rolloutReasons.UnsortedList()
 		sort.Slice(reasons, func(i, j int) bool {
-			if strings.HasPrefix(reasons[i], "Version") && !strings.HasPrefix(reasons[j], "Version") {
+			if strings.HasPrefix(reasons[i], "* Version") && !strings.HasPrefix(reasons[j], "* Version") {
 				return true
 			}
-			if !strings.HasPrefix(reasons[i], "Version") && strings.HasPrefix(reasons[j], "Version") {
+			if !strings.HasPrefix(reasons[i], "* Version") && strings.HasPrefix(reasons[j], "* Version") {
 				return false
 			}
 			return reasons[i] < reasons[j]
 		})
-		for i := range reasons {
-			reasons[i] = fmt.Sprintf("* %s", reasons[i])
-		}
 		message += fmt.Sprintf("\n%s", strings.Join(reasons, "\n"))
 	}
 	v1beta2conditions.Set(kcp, metav1.Condition{

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -169,20 +169,21 @@ func Test_setRollingOutCondition(t *testing.T) {
 						Reason: clusterv1.InternalErrorV1Beta2Reason,
 					},
 				}}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "m4"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{
+					{
+						Type:   clusterv1.MachineUpToDateV1Beta2Condition,
+						Status: metav1.ConditionFalse,
+						Reason: clusterv1.MachineNotUpToDateV1Beta2Reason,
+						Message: "* Failure domain failure-domain1, failure-domain2 required\n" +
+							"* InfrastructureMachine is not up-to-date",
+					},
+				}}}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "m3"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{
 					{
 						Type:    clusterv1.MachineUpToDateV1Beta2Condition,
 						Status:  metav1.ConditionFalse,
 						Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-						Message: "Version v1.25.0, v1.26.0 required",
-					},
-				}}}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "m4"}, Status: clusterv1.MachineStatus{V1Beta2: &clusterv1.MachineV1Beta2Status{Conditions: []metav1.Condition{
-					{
-						Type:    clusterv1.MachineUpToDateV1Beta2Condition,
-						Status:  metav1.ConditionFalse,
-						Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-						Message: "Failure domain failure-domain1, failure-domain2 required; InfrastructureMachine is not up-to-date",
+						Message: "* Version v1.25.0, v1.26.0 required",
 					},
 				}}}},
 			},

--- a/internal/controllers/machinedeployment/machinedeployment_status.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status.go
@@ -175,7 +175,7 @@ func setRollingOutCondition(_ context.Context, machineDeployment *clusterv1.Mach
 		}
 		rollingOutReplicas++
 		if upToDateCondition.Message != "" {
-			rolloutReasons.Insert(strings.Split(upToDateCondition.Message, "; ")...)
+			rolloutReasons.Insert(strings.Split(upToDateCondition.Message, "\n")...)
 		}
 	}
 
@@ -196,17 +196,14 @@ func setRollingOutCondition(_ context.Context, machineDeployment *clusterv1.Mach
 		// Surface rollout reasons ensuring that if there is a version change, it goes first.
 		reasons := rolloutReasons.UnsortedList()
 		sort.Slice(reasons, func(i, j int) bool {
-			if strings.HasPrefix(reasons[i], "Version") && !strings.HasPrefix(reasons[j], "Version") {
+			if strings.HasPrefix(reasons[i], "* Version") && !strings.HasPrefix(reasons[j], "* Version") {
 				return true
 			}
-			if !strings.HasPrefix(reasons[i], "Version") && strings.HasPrefix(reasons[j], "Version") {
+			if !strings.HasPrefix(reasons[i], "* Version") && strings.HasPrefix(reasons[j], "* Version") {
 				return false
 			}
 			return reasons[i] < reasons[j]
 		})
-		for i := range reasons {
-			reasons[i] = fmt.Sprintf("* %s", reasons[i])
-		}
 		message += fmt.Sprintf("\n%s", strings.Join(reasons, "\n"))
 	}
 	v1beta2conditions.Set(machineDeployment, metav1.Condition{

--- a/internal/controllers/machinedeployment/machinedeployment_status_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status_test.go
@@ -266,17 +266,18 @@ func Test_setRollingOutCondition(t *testing.T) {
 					Status: metav1.ConditionUnknown,
 					Reason: clusterv1.InternalErrorV1Beta2Reason,
 				})),
+				fakeMachine("machine-4", withV1Beta2Condition(metav1.Condition{
+					Type:   clusterv1.MachineUpToDateV1Beta2Condition,
+					Status: metav1.ConditionFalse,
+					Reason: clusterv1.MachineNotUpToDateV1Beta2Reason,
+					Message: "* Failure domain failure-domain1, failure-domain2 required\n" +
+						"* InfrastructureMachine is not up-to-date",
+				})),
 				fakeMachine("machine-3", withV1Beta2Condition(metav1.Condition{
 					Type:    clusterv1.MachineUpToDateV1Beta2Condition,
 					Status:  metav1.ConditionFalse,
 					Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-					Message: "Version v1.25.0, v1.26.0 required",
-				})),
-				fakeMachine("machine-4", withV1Beta2Condition(metav1.Condition{
-					Type:    clusterv1.MachineUpToDateV1Beta2Condition,
-					Status:  metav1.ConditionFalse,
-					Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-					Message: "Failure domain failure-domain1, failure-domain2 required; InfrastructureMachine is not up-to-date",
+					Message: "* Version v1.25.0, v1.26.0 required",
 				})),
 			},
 			getMachinesSucceeded: true,

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -641,11 +641,14 @@ func newMachineUpToDateCondition(s *scope) *metav1.Condition {
 	}
 
 	if !upToDate {
+		for i := range conditionMessages {
+			conditionMessages[i] = fmt.Sprintf("* %s", conditionMessages[i])
+		}
 		return &metav1.Condition{
 			Type:    clusterv1.MachineUpToDateV1Beta2Condition,
 			Status:  metav1.ConditionFalse,
 			Reason:  clusterv1.MachineNotUpToDateV1Beta2Reason,
-			Message: strings.Join(conditionMessages, "; "),
+			Message: strings.Join(conditionMessages, "\n"),
 		}
 	}
 

--- a/util/conditions/v1beta2/summary_test.go
+++ b/util/conditions/v1beta2/summary_test.go
@@ -98,9 +98,10 @@ func TestSummary(t *testing.T) {
 				{Type: "B", Status: metav1.ConditionFalse, Reason: "Reason-B", Message: "Message-B"},                     // issue
 				{Type: "A", Status: metav1.ConditionTrue, Reason: "Reason-A", Message: "Message-A"},                      // info
 				{Type: "!C", Status: metav1.ConditionTrue, Reason: "Reason-!C", Message: "* Message-!C1\n* Message-!C2"}, // issue
+				{Type: "D", Status: metav1.ConditionFalse, Reason: "Reason-D", Message: "Message-D\n* More message-D"},   // issue
 			},
 			conditionType: clusterv1.AvailableV1Beta2Condition,
-			options:       []SummaryOption{ForConditionTypes{"A", "B", "!C"}, NegativePolarityConditionTypes{"!C"}},
+			options:       []SummaryOption{ForConditionTypes{"A", "B", "!C", "D"}, NegativePolarityConditionTypes{"!C"}},
 			want: &metav1.Condition{
 				Type:   clusterv1.AvailableV1Beta2Condition,
 				Status: metav1.ConditionFalse, // False because there are many issues
@@ -108,7 +109,10 @@ func TestSummary(t *testing.T) {
 				Message: "* B: Message-B\n" +
 					"* !C:\n" +
 					"  * Message-!C1\n" +
-					"  * Message-!C2", // messages from all the issues & unknown conditions (info dropped)
+					"  * Message-!C2\n" +
+					"* D:\n" +
+					"  * Message-D\n" +
+					"    * More message-D", // messages from all the issues & unknown conditions (info dropped)
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
- Improve UpToDate condition applied by KCP/MD to Machines so it shows different reasons using a list (instead of a comma separated string)
- Improve RolloutOut condition in KCP/MD so it takes into account that now Machines's UpToDate is a list
- Improve RolloutOut condition at Cluster level so messages are indented
- Add more test for merge strategies

/area conditions