### PR TITLE
🌱 clusterctl: properly indent multiline lists in clusterctl describe

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -780,6 +780,10 @@ func formatParagraph(text string, maxWidth int) string {
 			}
 			break
 		}
+		indent := tmp
+		if strings.HasPrefix(strings.TrimSpace(l), "* ") {
+			indent += "  "
+		}
 		for _, w := range re.Split(l, -1) {
 			if len(tmp)+len(w) < maxWidth {
 				if strings.TrimSpace(tmp) != "" {
@@ -789,7 +793,7 @@ func formatParagraph(text string, maxWidth int) string {
 				continue
 			}
 			lines = append(lines, tmp)
-			tmp = w
+			tmp = indent + w
 		}
 		lines = append(lines, tmp)
 	}

--- a/cmd/clusterctl/cmd/describe_cluster_test.go
+++ b/cmd/clusterctl/cmd/describe_cluster_test.go
@@ -365,3 +365,41 @@ func (t *Table) NegatedFailureMessage(actual interface{}) string {
 	actualTable := strings.Split(actual.(string), "\n")
 	return fmt.Sprintf("Expected %v and received %v", t.tableData, actualTable)
 }
+
+func Test_formatParagraph(t *testing.T) {
+	tests := []struct {
+		text     string
+		maxWidth int
+		want     string
+	}{
+		{
+			text:     "",
+			maxWidth: 254,
+			want:     "",
+		},
+		{
+			text:     "* a b c d e f",
+			maxWidth: 5,
+			want:     "* a b\n  c d\n  e f",
+		},
+		{
+			text: "* a b c d e f\n" +
+				"  * g h\n" +
+				"  * i j",
+			maxWidth: 5,
+			want: "* a b\n" +
+				"  c d\n" +
+				"  e f\n" +
+				"  * g\n" +
+				"    h\n" +
+				"  * i\n" +
+				"    j",
+		},
+	}
+	for ti, tt := range tests {
+		t.Run(fmt.Sprintf("%d", ti), func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect("\n" + formatParagraph(tt.text, tt.maxWidth)).To(BeEquivalentTo("\n" + tt.want))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Example:

Before:

![image](https://github.com/user-attachments/assets/72966426-23cb-4d75-8393-8ef5685da36b)

After:

![image](https://github.com/user-attachments/assets/3f3be324-94ad-4035-bc9d-07975d37e36b)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterctl