### PR TITLE
🌱 Drop retry when computing KCP conditions

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -67,8 +67,11 @@ func (w *Workload) UpdateEtcdConditions(ctx context.Context, controlPlane *Contr
 	if controlPlane.IsEtcdManaged() {
 		// Update etcd conditions.
 		// In case of well known temporary errors + control plane scaling up/down or rolling out, retry a few times.
-		// Note: this is required because there isn't a watch mechanism on etcd.
-		maxRetry := 3
+		// Note: it seems that reducing the number of them during every reconciles also improves stability,
+		// thus we are stopping doing retries (we only try once).
+		// However, we keep the code implementing retry support so we can easily revert this decision in a patch
+		// release if we need to.
+		maxRetry := 1
 		for i := range maxRetry {
 			retryableError := w.updateManagedEtcdConditions(ctx, controlPlane)
 			// if we should retry and there is a retry left, wait a bit.

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -154,8 +154,9 @@ func TestUpdateEtcdConditions(t *testing.T) {
 			callCount = 0
 			w.UpdateEtcdConditions(ctx, controlPane)
 			if tt.expectedRetry {
-				g.Expect(callCount).To(Equal(3))
-			} else {
+				// Note we keep the code implementing retry support so we can easily re-activate it if we need to.
+				//	g.Expect(callCount).To(Equal(3))
+				// } else {
 				g.Expect(callCount).To(Equal(1))
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems that this is now unnecessary after recent changes to avoid unnecessary release calls

/area provider/control-plane-kubeadm