### PR TITLE
🌱 test: add options for additional resources and verify volume detach to node drain test

### DIFF
--- a/test/e2e/node_drain_test.go
+++ b/test/e2e/node_drain_test.go
@@ -20,8 +20,18 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/framework"
 )
 
 var _ = Describe("When testing Node drain", func() {
@@ -34,6 +44,40 @@ var _ = Describe("When testing Node drain", func() {
 			SkipCleanup:            skipCleanup,
 			Flavor:                 ptr.To("topology"),
 			InfrastructureProvider: ptr.To("docker"),
+			VerifyNodeVolumeDetach: true,
+			CreateAdditionalResources: func(ctx context.Context, clusterProxy framework.ClusterProxy, cluster *clusterv1.Cluster) {
+				workloadClusterClient := clusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name).GetClient()
+
+				nodeList := &corev1.NodeList{}
+				Expect(workloadClusterClient.List(ctx, nodeList)).To(Succeed())
+
+				// Create a fake VolumeAttachment object for each Node without having a real backing csi driver.
+				for _, node := range nodeList.Items {
+					va := generateVolumeAttachment(node)
+					Expect(workloadClusterClient.Create(ctx, va)).To(Succeed())
+					// Set .Status.Attached to true to make the VolumeAttachment blocking for machine deletions.
+					va.Status.Attached = true
+					Expect(workloadClusterClient.Status().Update(ctx, va)).To(Succeed())
+				}
+			},
 		}
 	})
 })
+
+func generateVolumeAttachment(node corev1.Node) *storagev1.VolumeAttachment {
+	return &storagev1.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("va-%s", node.GetName()),
+			Finalizers: []string{
+				"test.cluster.x-k8s.io/block",
+			},
+		},
+		Spec: storagev1.VolumeAttachmentSpec{
+			Attacher: "manual",
+			NodeName: node.GetName(),
+			Source: storagev1.VolumeAttachmentSource{
+				PersistentVolumeName: ptr.To("foo"),
+			},
+		},
+	}
+}

--- a/test/framework/convenience.go
+++ b/test/framework/convenience.go
@@ -24,6 +24,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +89,9 @@ func TryAddDefaultSchemes(scheme *runtime.Scheme) {
 	// Add coordination to the schema
 	// Note: This is e.g. used to trigger kube-controller-manager restarts by stealing its lease.
 	_ = coordinationv1.AddToScheme(scheme)
+
+	// Add storagev1 to the scheme
+	_ = storagev1.AddToScheme(scheme)
 }
 
 // ObjectToKind returns the Kind without the package prefix. Pass in a pointer to a struct


### PR DESCRIPTION
…o node drain test

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adds options to the node drain test to check for volume detachments to be blocking as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing