### PR TITLE
:bug: Properly display the namespace name in scale test

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -637,7 +637,7 @@ func createClusterWorker(ctx context.Context, clusterProxy framework.ClusterProx
 				// If every cluster should be deployed in a separate namespace:
 				// * Deploy ClusterClass in new namespace.
 				if deployClusterInSeparateNamespaces {
-					log.Logf("Apply ClusterClass in namespace %", namespaceName)
+					log.Logf("Apply ClusterClass in namespace %s", namespaceName)
 					clusterClassYAML := bytes.Replace(customizedClusterClassYAML, []byte(scaleClusterNamespacePlaceholder), []byte(namespaceName), -1)
 					Eventually(func() error {
 						return clusterProxy.CreateOrUpdate(ctx, clusterClassYAML)


### PR DESCRIPTION
Minor fix for the scale test log, which helps properly displaying the namespace name.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->