### PR TITLE
:bug: MHC webhook does not default MaxUnhealthy

### DIFF
--- a/internal/webhooks/machinehealthcheck.go
+++ b/internal/webhooks/machinehealthcheck.go
@@ -78,11 +78,6 @@ func (webhook *MachineHealthCheck) Default(_ context.Context, obj runtime.Object
 	}
 	m.Labels[clusterv1.ClusterNameLabel] = m.Spec.ClusterName
 
-	if m.Spec.MaxUnhealthy == nil {
-		defaultMaxUnhealthy := intstr.FromString("100%")
-		m.Spec.MaxUnhealthy = &defaultMaxUnhealthy
-	}
-
 	if m.Spec.NodeStartupTimeout == nil {
 		m.Spec.NodeStartupTimeout = &clusterv1.DefaultNodeStartupTimeout
 	}

--- a/internal/webhooks/machinehealthcheck_test.go
+++ b/internal/webhooks/machinehealthcheck_test.go
@@ -54,7 +54,6 @@ func TestMachineHealthCheckDefault(t *testing.T) {
 	g.Expect(webhook.Default(ctx, mhc)).To(Succeed())
 
 	g.Expect(mhc.Labels[clusterv1.ClusterNameLabel]).To(Equal(mhc.Spec.ClusterName))
-	g.Expect(mhc.Spec.MaxUnhealthy.String()).To(Equal("100%"))
 	g.Expect(mhc.Spec.NodeStartupTimeout).ToNot(BeNil())
 	g.Expect(*mhc.Spec.NodeStartupTimeout).To(BeComparableTo(metav1.Duration{Duration: 10 * time.Minute}))
 	g.Expect(mhc.Spec.RemediationTemplate.Namespace).To(Equal(mhc.Namespace))


### PR DESCRIPTION
**What this PR does / why we need it**:
MaxUnhealthy has been marked as deprecated. Update machineHealthCheck webhook to not default it to 100%.

While trying to remove the deprecated `MaxUnhealthy` I notice that this is being defaulted by capi webhooks to 100%.  This creates confusion. That being said, im not 100% sure if leaving it undefined creates issues.

Relates to:
- https://github.com/kubernetes-sigs/cluster-api/pull/10853
- https://github.com/kubernetes-sigs/cluster-api/issues/10722


/area machinehealthcheck
