### PR TITLE
:book: clarify semantic meaning of the Version fields

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -388,7 +388,7 @@ type MachineSpec struct {
 	// offered by an infrastructure provider.
 	InfrastructureRef corev1.ObjectReference `json:"infrastructureRef"`
 
-	// version defines the desired Kubernetes version.
+	// version defines the desired Kubernetes distribution version.
 	// This field is meant to be optionally used by bootstrap providers.
 	// +optional
 	Version *string `json:"version,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -3922,7 +3922,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSpec(ref common.ReferenceCa
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.",
+							Description: "version defines the desired Kubernetes distribution version. This field is meant to be optionally used by bootstrap providers.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1536,7 +1536,7 @@ spec:
                         x-kubernetes-list-type: map
                       version:
                         description: |-
-                          version defines the desired Kubernetes version.
+                          version defines the desired Kubernetes distribution version.
                           This field is meant to be optionally used by bootstrap providers.
                         type: string
                     required:

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1299,7 +1299,7 @@ spec:
                         x-kubernetes-list-type: map
                       version:
                         description: |-
-                          version defines the desired Kubernetes version.
+                          version defines the desired Kubernetes distribution version.
                           This field is meant to be optionally used by bootstrap providers.
                         type: string
                     required:

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1065,7 +1065,7 @@ spec:
                 x-kubernetes-list-type: map
               version:
                 description: |-
-                  version defines the desired Kubernetes version.
+                  version defines the desired Kubernetes distribution version.
                   This field is meant to be optionally used by bootstrap providers.
                 type: string
             required:

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1274,7 +1274,7 @@ spec:
                         x-kubernetes-list-type: map
                       version:
                         description: |-
-                          version defines the desired Kubernetes version.
+                          version defines the desired Kubernetes distribution version.
                           This field is meant to be optionally used by bootstrap providers.
                         type: string
                     required:

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -57,28 +57,28 @@ repo or add an item to the agenda in the [Cluster API community meeting](https:/
 
 ## Rules (contract version v1beta1)
 
-| Rule                                                                 | Mandatory | Note                                                                                                                       |
-|----------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------|
-| [All resources: scope]                                               | Yes       |                                                                                                                            |
-| [All resources: `TypeMeta` and `ObjectMeta`field]                    | Yes       |                                                                                                                            |
-| [All resources: `APIVersion` field value]                            | Yes       |                                                                                                                            |
-| [ControlPlane, ControlPlaneList resource definition]                 | Yes       |                                                                                                                            |
-| [ControlPlane: endpoint]                                             | No        | Mandatory if control plane endpoint is not provided by other means.                                                        |
-| [ControlPlane: replicas]                                             | No        | Mandatory if control plane has a notion of number of instances.                                                            |
-| [ControlPlane: version]                                              | No        | Mandatory if control plane allows direct management of the Kubernetes version in use; Mandatory for cluster class support. |
-| [ControlPlane: machines]                                             | No        | Mandatory if control plane instances are represented with a set of Cluster API Machines.                                   |
-| [ControlPlane: initialization completed]                             | Yes       |                                                                                                                            |
-| [ControlPlane: conditions]                                           | No        |                                                                                                                            |
-| [ControlPlane: terminal failures]                                    | No        |                                                                                                                            |
-| [ControlPlaneTemplate, ControlPlaneTemplateList resource definition] | No        | Mandatory for ClusterClasses support                                                                                       |
-| [Cluster kubeconfig management]                                      | Yes       |                                                                                                                            |
-| [Cluster certificate management]                                     | No        |                                                                                                                            |
-| [Machine placement]                                                  | No        |                                                                                                                            |
-| [Metadata propagation]                                               | No        |                                                                                                                            |
-| [MinReadySeconds and UpToDate propagation]                           | No        |                                                                                                                            |
-| [Support for running multiple instances]                             | No        | Mandatory for clusterctl CLI support                                                                                       |
-| [Clusterctl support]                                                 | No        | Mandatory for clusterctl CLI support                                                                                       |
-| [ControlPlane: pausing]                                              | No        |                                                                                                                            |
+| Rule                                                                 | Mandatory | Note                                                                                                                                    |
+|----------------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| [All resources: scope]                                               | Yes       |                                                                                                                                         |
+| [All resources: `TypeMeta` and `ObjectMeta`field]                    | Yes       |                                                                                                                                         |
+| [All resources: `APIVersion` field value]                            | Yes       |                                                                                                                                         |
+| [ControlPlane, ControlPlaneList resource definition]                 | Yes       |                                                                                                                                         |
+| [ControlPlane: endpoint]                                             | No        | Mandatory if control plane endpoint is not provided by other means.                                                                     |
+| [ControlPlane: replicas]                                             | No        | Mandatory if control plane has a notion of number of instances.                                                                         |
+| [ControlPlane: version]                                              | No        | Mandatory if control plane allows direct management of the Kubernetes distribution version in use; Mandatory for cluster class support. |
+| [ControlPlane: machines]                                             | No        | Mandatory if control plane instances are represented with a set of Cluster API Machines.                                                |
+| [ControlPlane: initialization completed]                             | Yes       |                                                                                                                                         |
+| [ControlPlane: conditions]                                           | No        |                                                                                                                                         |
+| [ControlPlane: terminal failures]                                    | No        |                                                                                                                                         |
+| [ControlPlaneTemplate, ControlPlaneTemplateList resource definition] | No        | Mandatory for ClusterClasses support                                                                                                    |
+| [Cluster kubeconfig management]                                      | Yes       |                                                                                                                                         |
+| [Cluster certificate management]                                     | No        |                                                                                                                                         |
+| [Machine placement]                                                  | No        |                                                                                                                                         |
+| [Metadata propagation]                                               | No        |                                                                                                                                         |
+| [MinReadySeconds and UpToDate propagation]                           | No        |                                                                                                                                         |
+| [Support for running multiple instances]                             | No        | Mandatory for clusterctl CLI support                                                                                                    |
+| [Clusterctl support]                                                 | No        | Mandatory for clusterctl CLI support                                                                                                    |
+| [ControlPlane: pausing]                                              | No        |                                                                                                                                         |
 
 ### All resources: scope
 
@@ -384,7 +384,7 @@ the ControlPlane `spec`.
 
 ```go
 type FooControlPlaneSpec struct {
-    // version defines the desired Kubernetes version for the control plane. 
+    // version defines the desired Kubernetes distribution version for the control plane.
     // The value must be a valid semantic version; also if the value provided by the user does not start with the v prefix, it
     // must be added.
     Version string `json:"version"`
@@ -398,7 +398,7 @@ Following fields MUST be implemented in the ControlPlane `status`.
 
 ```go
 type FooControlPlaneStatus struct {
-    // version represents the minimum Kubernetes version for the control plane machines
+    // version represents the minimum Kubernetes distribution version for the control plane machines
     // in the cluster.
     // +optional
     Version *string `json:"version,omitempty"`
@@ -408,9 +408,15 @@ type FooControlPlaneStatus struct {
 }
 ```
 
-NOTE: The minimum Kubernetes version, and more specifically the API server version, will be used to determine 
-when a control plane is fully upgraded (spec.version == status.version) and for enforcing Kubernetes version skew 
-policies when a Cluster derived from a ClusterClass is managed by the Topology controller.
+NOTE: The minimum Kubernetes distribution version, and more specifically the API server version, will be used to determine
+when a control plane is fully upgraded (spec.version == status.version) and for enforcing Kubernetes version skew
+policies[1](#kubernetes-version-in-skew-policy) when a Cluster derived from a ClusterClass is managed by the Topology controller.
+
+#### Kubernetes version in version skew policies
+
+`controlplane.spec.version` and `machineset/machinedeploment.spec.template.spec.version` represent a Kubernetes distribution version.
+However, in the case of the machine preflight for kubernetes version policies, it is coupled with an actual Kubernetes version.
+This particular check will not be reliable if Kubernetes distribution version is used.
 
 ### ControlPlane: machines
 

--- a/docs/book/src/tasks/experimental-features/machineset-preflight-checks.md
+++ b/docs/book/src/tasks/experimental-features/machineset-preflight-checks.md
@@ -30,6 +30,7 @@ Enabling `MachineSetPreflightChecks` provides safety in such circumstances by ma
     * The Cluster uses a ControlPlane provider.
     * ControlPlane version is defined (`ControlPlane.spec.version` is set).
     * MachineSet version is defined (`MachineSet.spec.template.spec.version` is set).
+* Note that in this case, an actual Kubernetes version is needed (as opposed as a Kubernetes distribution version).
 
 ### `KubeadmVersionSkew`
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The aim of this PR is to clarify the semantic meaning of the Version fields. At the moment, the documentation heavily implies that version fields should contain a Kubernetes version.
However this is problematic when working with Kubernetes distributions, especially the ones with a versioning schema totally different from Kubernetes (i.e. OpenShift).

### UX problem

At the moment, to install a k8s distribution, the user needs to work out what k8s version corresponds to the desired k8s distribution version. However, this is not even always possible: for example, in the OpenShift case, a minor release is based on a given Z patch of k8s, and other Z releases for the same Y version might be based on the same k8s Z patch. As a practical example, OpenShift 4.17.0 is based on 1.30.4 and OpenShift 4.17.1 is also based on 1.30.4, making a bidirectional conversion actually impossible.

### Kubernetes version references

Unfortunately this is not straightforward, as there are multiple references to explicit Kubernetes versions.
* [machine preflight check](https://github.com/kubernetes-sigs/cluster-api/blob/main/internal/controllers/machineset/machineset_preflight.go#L179) explicitly referencing a kubernetes version (since when the skew version policy changes). In this case the referenced version is 1.28.0, which should fall out of support in less than 12 months time
* [setting minimum version](https://github.com/kubernetes-sigs/cluster-api/blob/main/main.go#L290-L293). In this case, we might be able to drop this check as Cluster API already doesn't support versions below 1.22 (in this case we're toggling between 1.20 and 1.22)


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->