### PR TITLE
✨ clusterctl: Add support for valid GitHub URLs

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -212,7 +212,7 @@ func isURLSplitValid(s []string) bool {
 //  2. https://github.com/{owner}/{Repository}/releases/download/{versionTag}/{[path/to/]componentsClient.yaml}
 //
 // The only difference being the order of "releases", "download" and "tag|latest".
-// It's worth noting that the first one will get redirected to the second one with an HTTP 302
+// It's worth noting that the first one will get redirected to the second one with an HTTP 302.
 func isURLSplitValidWithDownload(s []string) bool {
 	return len(s) >= 6 &&
 		((s[2] == githubReleaseRepository && s[3] == githubLatestReleaseLabel && s[4] == githubReleaseDownload) ||


### PR DESCRIPTION
**What this PR does / why we need it**:
Following [this already closed issue](https://github.com/kubernetes-sigs/cluster-api/issues/2830), URLs in the `clusterctl` config are invalid and do not point to any resource. This PR adds the support for having valid URLs while also keeping backwards compatibility by supporting the old (invalid) format. 

**Which issue(s) this PR fixes**:
In #2830, the invalid URL part was seemingly ignored in the mentioned issue. 

/area clusterctl