### PR TITLE
:book: Use long name version for Canonical Kubernetes

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -7,7 +7,7 @@ updated info about which API version they are supporting.
 
 ## Bootstrap
 - [Amazon Elastic Kubernetes Service (EKS)](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/main/bootstrap/eks)
-- [Canonical Kubernetes](https://github.com/canonical/cluster-api-k8s)
+- [Canonical Kubernetes Platform](https://github.com/canonical/cluster-api-k8s)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/bootstrap/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-bootstrap-provider-microk8s)
 - [Oracle Cloud Native Environment (OCNE)](https://github.com/verrazzano/cluster-api-provider-ocne)
@@ -16,7 +16,7 @@ updated info about which API version they are supporting.
 - [k0smotron/k0s](https://github.com/k0sproject/k0smotron)
 
 ## Control Plane
-- [Canonical Kubernetes](https://github.com/canonical/cluster-api-k8s)
+- [Canonical Kubernetes Platform](https://github.com/canonical/cluster-api-k8s)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-control-plane-provider-microk8s)
 - [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a minor update on the name of the Canonical Kubernetes. We would rather use the long version of it in the docs.

**Which issue(s) this PR fixes**: None

/area documentation 
