### PR TITLE
🌱 observability: bump helm charts to newer versions

### DIFF
--- a/hack/observability/grafana/chart/kustomization.yaml
+++ b/hack/observability/grafana/chart/kustomization.yaml
@@ -4,7 +4,7 @@ helmCharts:
     releaseName: grafana
     namespace: observability
     valuesFile: values.yaml
-    version: 6.56.5
+    version: 8.8.2
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/kube-state-metrics/kustomization.yaml
+++ b/hack/observability/kube-state-metrics/kustomization.yaml
@@ -15,7 +15,7 @@ helmCharts:
     namespace: observability
     releaseName: kube-state-metrics
     valuesFile: values.yaml
-    version: 5.12.1
+    version: 5.27.0
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/loki/kustomization.yaml
+++ b/hack/observability/loki/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     releaseName: loki
     namespace: observability
     valuesFile: values.yaml
-    version: 5.5.4
+    version: 6.24.0
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/loki/values.yaml
+++ b/hack/observability/loki/values.yaml
@@ -16,12 +16,54 @@ loki:
   limits_config:
     ingestion_rate_mb: 1024
     ingestion_burst_size_mb: 1024
+  useTestSchema: true
+
+deploymentMode: SingleBinary
 
 singleBinary:
   replicas: 1
 
 gateway:
   enabled: false
+
+lokiCanary:
+  enabled: false
+
+chunksCache:
+  enabled: false
+
+resultsCache:
+  enabled: false
+
+minio:
+  enabled: false
+
+# Zero out replica counts of other deployment modes
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+queryScheduler:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0
+indexGateway:
+  replicas: 0
+bloomCompactor:
+  replicas: 0
+bloomGateway:
+  replicas: 0
 
 # We are disabling basically everything because we just want
 # Loki and no additional monitoring.

--- a/hack/observability/metrics-server/kustomization.yaml
+++ b/hack/observability/metrics-server/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   releaseName: metrics-server
   namespace: observability
   valuesFile: values.yaml
-  version: 3.10.0
+  version: 3.12.2
 
 helmGlobals:
   # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/parca/kustomization.yaml
+++ b/hack/observability/parca/kustomization.yaml
@@ -9,7 +9,7 @@ helmCharts:
     # Setting namespace via this field currently does not work with this Helm chart.
     namespace: default
     valuesFile: values.yaml
-    version: 4.10.0
+    version: 4.19.0
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/prometheus/kustomization.yaml
+++ b/hack/observability/prometheus/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     releaseName: prometheus
     namespace: observability
     valuesFile: values.yaml
-    version: 24.1.0
+    version: 26.0.1
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/promtail/kustomization.yaml
+++ b/hack/observability/promtail/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
     releaseName: promtail
     namespace: observability
     valuesFile: values.yaml
-    version: 6.11.2
+    version: 6.16.6
 
 helmGlobals:
     # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/tempo/kustomization.yaml
+++ b/hack/observability/tempo/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
   releaseName: tempo
   namespace: observability
   valuesFile: values.yaml
-  version: 1.3.1
+  version: 1.16.0
 
 helmGlobals:
   # Store chart in ".charts" folder instead of "charts".


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:


Updates all helm charts of the observability stack to the latest versions including checks:

* grafana
  * checked all dashboards
* kube-state-metrics
 * confirmed via dashboards are working
* loki
  * queried logs successfully via grafana
* metrics-server
  * `kubectl top node` and `kubectl top pod -A`
* parca
  * 25 Good endpoints before
  * 25 Good endpoints after
  * Note: test-extension was broken before and after
* prometheus:
  * all scrape targets are green
  * same targets exist
* promtail
  * queried logs successfully via grafana
* tempo
  * was queryable, but did not have any traces (because we don't have traces)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area devtooling