### PR TITLE
🌱 Reconcile topology only when necessary

### DIFF
--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -185,6 +185,11 @@ func clusterChangeIsRelevant(scheme *runtime.Scheme, logger logr.Logger) predica
 				log = log.WithValues(gvk.Kind, klog.KObj(e.ObjectOld))
 			}
 
+			if e.ObjectOld.GetResourceVersion() == e.ObjectNew.GetResourceVersion() {
+				log.V(6).Info("Cluster resync event, allowing further processing")
+				return true
+			}
+
 			oldObj, ok := e.ObjectOld.(*clusterv1.Cluster)
 			if !ok {
 				log.V(4).Info("Expected Cluster", "type", fmt.Sprintf("%T", e.ObjectOld))
@@ -200,10 +205,10 @@ func clusterChangeIsRelevant(scheme *runtime.Scheme, logger logr.Logger) predica
 			newObj = dropNotRelevant(newObj)
 
 			if reflect.DeepEqual(oldObj, newObj) {
-				logger.V(6).Info("Cluster does not have relevant changes, blocking further processing")
+				log.V(6).Info("Cluster does not have relevant changes, blocking further processing")
 				return false
 			}
-			logger.V(6).Info("Cluster has relevant changes, allowing further processing")
+			log.V(6).Info("Cluster has relevant changes, allowing further processing")
 			return true
 		},
 		CreateFunc:  func(event.CreateEvent) bool { return true },
@@ -247,10 +252,10 @@ func machineDeploymentChangeIsRelevant(scheme *runtime.Scheme, logger logr.Logge
 			newObj = dropNotRelevant(newObj)
 
 			if reflect.DeepEqual(oldObj, newObj) {
-				logger.V(6).Info("MachineDeployment does not have relevant changes, blocking further processing")
+				log.V(6).Info("MachineDeployment does not have relevant changes, blocking further processing")
 				return false
 			}
-			logger.V(6).Info("MachineDeployment has relevant changes, allowing further processing")
+			log.V(6).Info("MachineDeployment has relevant changes, allowing further processing")
 			return true
 		},
 		CreateFunc:  func(event.CreateEvent) bool { return true },


### PR DESCRIPTION
**What this PR does / why we need it**:
The topology controller is responsible to enforce the desired state of the cluster, and it does this ensuring that the spec of the cluster itself and the spec of the dependant objects like e.g. Machine Deployment is consistent with what defined in the ClusterClass.

That means that this controller should not care of changes to objects status (or at least to a subset of changes in status).
This PR introduces two predicates starting to drop reconcile events when the changes are not relevant for the topology controller

/area cluster
