### PR TITLE
🌱  Add Unit tests for reconcileDelete

### DIFF
--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -3805,7 +3805,6 @@ func TestNodeDeletionWithHooks(t *testing.T) {
 		name                 string
 		deletionTimeout      *metav1.Duration
 		resultErr            bool
-		clusterDeleted       bool
 		expectNodeDeletion   bool
 		expectDeletingReason string
 		annotations          map[string]string
@@ -3851,7 +3850,7 @@ func TestNodeDeletionWithHooks(t *testing.T) {
 			expectNodeDeletion:   false,
 			expectDeletingReason: clusterv1.MachineDeletingDrainingNodeV1Beta2Reason,
 			annotations: map[string]string{
-				"machine.cluster.x-k8s.io": "",
+				"machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach": "",
 			},
 			createFakeClient: func(initObjs ...client.Object) client.Client {
 				return fake.NewClientBuilder().
@@ -3880,13 +3879,8 @@ func TestNodeDeletionWithHooks(t *testing.T) {
 				reconcileDeleteCache:     cache.New[cache.ReconcileEntry](),
 			}
 
-			cluster := testCluster.DeepCopy()
-			if tc.clusterDeleted {
-				cluster.DeletionTimestamp = &metav1.Time{Time: deletionTime.Add(time.Hour)}
-			}
-
 			s := &scope{
-				cluster:                   cluster,
+				cluster:                   &testCluster,
 				machine:                   m,
 				infraMachineIsNotFound:    true,
 				bootstrapConfigIsNotFound: true,
@@ -3932,7 +3926,7 @@ func TestNodeDeletionWithPreDrainHook(t *testing.T) {
 				clusterv1.MachineControlPlaneLabel: "",
 			},
 			Annotations: map[string]string{
-				"machine.cluster.x-k8s.io": "",
+				"machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach": "",
 			},
 			Finalizers:        []string{clusterv1.MachineFinalizer},
 			DeletionTimestamp: &metav1.Time{Time: deletionTime},
@@ -3980,7 +3974,6 @@ func TestNodeDeletionWithPreDrainHook(t *testing.T) {
 		name                 string
 		deletionTimeout      *metav1.Duration
 		resultErr            bool
-		clusterDeleted       bool
 		expectNodeDeletion   bool
 		expectDeletingReason string
 		pods                 []*corev1.Pod
@@ -4069,13 +4062,8 @@ func TestNodeDeletionWithPreDrainHook(t *testing.T) {
 				reconcileDeleteCache:     cache.New[cache.ReconcileEntry](),
 			}
 
-			cluster := testCluster.DeepCopy()
-			if tc.clusterDeleted {
-				cluster.DeletionTimestamp = &metav1.Time{Time: deletionTime.Add(time.Hour)}
-			}
-
 			s := &scope{
-				cluster:                   cluster,
+				cluster:                   &testCluster,
 				machine:                   m,
 				infraMachineIsNotFound:    true,
 				bootstrapConfigIsNotFound: true,
@@ -4238,13 +4226,8 @@ func TestNodeDeletionWithInfraAndBootstrap(t *testing.T) {
 				reconcileDeleteCache:     cache.New[cache.ReconcileEntry](),
 			}
 
-			cluster := testCluster.DeepCopy()
-			if tc.clusterDeleted {
-				cluster.DeletionTimestamp = &metav1.Time{Time: deletionTime.Add(time.Hour)}
-			}
-
 			s := &scope{
-				cluster:                   cluster,
+				cluster:                   &testCluster,
 				machine:                   m,
 				infraMachineIsNotFound:    tc.infraMachineFound,
 				infraMachine:              tc.infraMachine,
@@ -4392,7 +4375,6 @@ func TestNodeDeletionWithVolumeDetach(t *testing.T) {
 		deletionTimeout      *metav1.Duration
 		resultErr            bool
 		remoteObjects        []client.Object
-		clusterDeleted       bool
 		expectNodeDeletion   bool
 		expectDeletingReason string
 		createFakeClient     func(...client.Object) client.Client
@@ -4483,13 +4465,8 @@ func TestNodeDeletionWithVolumeDetach(t *testing.T) {
 				reconcileDeleteCache:     cache.New[cache.ReconcileEntry](),
 			}
 
-			cluster := testCluster.DeepCopy()
-			if tc.clusterDeleted {
-				cluster.DeletionTimestamp = &metav1.Time{Time: deletionTime.Add(time.Hour)}
-			}
-
 			s := &scope{
-				cluster:                   cluster,
+				cluster:                   &testCluster,
 				machine:                   m,
 				infraMachineIsNotFound:    true,
 				bootstrapConfigIsNotFound: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
--> 🌱 

**What this PR does / why we need it**:
ThIs improves test coverage of Machine Controller reconcileDelete

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/11626

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->