### PR TITLE
✨ clusterctl move support for a cross namespace ClusterClass reference

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -1190,7 +1190,7 @@ var (
 // the objects gets immediately deleted (force delete).
 func (o *objectMover) deleteSourceObject(ctx context.Context, nodeToDelete *node) error {
 	// Don't delete cluster-wide nodes or nodes that are below a hierarchy that starts with a global object (e.g. a secrets owned by a global identity object).
-	if nodeToDelete.isGlobal || nodeToDelete.isGlobalHierarchy {
+	if nodeToDelete.isGlobal || nodeToDelete.isGlobalHierarchy || nodeToDelete.shouldNotDelete {
 		return nil
 	}
 

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -1305,7 +1305,7 @@ func Test_objectMover_move(t *testing.T) {
 
 				err := csFrom.Get(ctx, key, oFrom)
 				if err == nil {
-					if !node.isGlobal && !node.isGlobalHierarchy {
+					if !node.isGlobal && !node.isGlobalHierarchy && !node.shouldNotDelete {
 						t.Errorf("%s %v not deleted in source cluster", oFrom.GetKind(), key)
 						continue
 					}
@@ -1417,7 +1417,7 @@ func Test_objectMover_move_with_Mutator(t *testing.T) {
 
 				err := csFrom.Get(ctx, key, oFrom)
 				if err == nil {
-					if !node.isGlobal && !node.isGlobalHierarchy {
+					if !node.isGlobal && !node.isGlobalHierarchy && !node.shouldNotDelete {
 						t.Errorf("%s %v not deleted in source cluster", oFrom.GetKind(), key)
 						continue
 					}
@@ -1846,6 +1846,8 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 
 	cluster1 := test.NewFakeCluster("namespace-1", "cluster-1")
 	cluster2 := test.NewFakeCluster("namespace-2", "cluster-2")
+	cluster3 := test.NewFakeCluster("namespace-1", "cluster-3").WithTopologyClass("cluster-class-1").WithTopologyClassNamespace("namespace-2")
+	clusterClass1 := test.NewFakeClusterClass("namespace-2", "cluster-class-1")
 	globalObj := test.NewFakeClusterExternalObject("eo-1")
 
 	clustersObjs := append(cluster1.Objs(), cluster2.Objs()...)
@@ -1870,6 +1872,16 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			name: "ensureNamespaces moves namespace-1 and namespace-2 to target",
 			fields: fields{
 				objs: clustersObjs,
+			},
+			args: args{
+				toProxy: test.NewFakeProxy(),
+			},
+			expectedNamespaces: []string{"namespace-1", "namespace-2"},
+		},
+		{
+			name: "ensureNamespaces moves namespace-1 and namespace-2 from cross-namespace CC reference",
+			fields: fields{
+				objs: append(cluster3.Objs(), clusterClass1.Objs()...),
 			},
 			args: args{
 				toProxy: test.NewFakeProxy(),

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -240,6 +240,7 @@ func TestObjectGraph_getDiscoveryTypeMetaList(t *testing.T) {
 type wantGraphItem struct {
 	virtual            bool
 	isGlobal           bool
+	shouldNotDelete    bool
 	forceMove          bool
 	forceMoveHierarchy bool
 	owners             []string
@@ -255,16 +256,22 @@ func assertGraph(t *testing.T, got *objectGraph, want wantGraph) {
 
 	g := NewWithT(t)
 
+	for uid := range got.uidToNode {
+		_, ok := want.nodes[string(uid)]
+		g.Expect(ok).To(BeTrue(), "node %q is unexpected", uid)
+	}
+
 	g.Expect(got.uidToNode).To(HaveLen(len(want.nodes)), "the number of nodes in the objectGraph doesn't match the number of expected nodes - got: %d expected: %d", len(got.uidToNode), len(want.nodes))
 
 	for uid, wantNode := range want.nodes {
 		gotNode, ok := got.uidToNode[types.UID(uid)]
 		g.Expect(ok).To(BeTrue(), "node %q not found", uid)
+
 		g.Expect(gotNode.virtual).To(Equal(wantNode.virtual), "node %q.virtual does not have the expected value", uid)
 		g.Expect(gotNode.isGlobal).To(Equal(wantNode.isGlobal), "node %q.isGlobal does not have the expected value", uid)
 		g.Expect(gotNode.forceMove).To(Equal(wantNode.forceMove), "node %q.forceMove does not have the expected value", uid)
 		g.Expect(gotNode.forceMoveHierarchy).To(Equal(wantNode.forceMoveHierarchy), "node %q.forceMoveHierarchy does not have the expected value", uid)
-		g.Expect(gotNode.owners).To(HaveLen(len(wantNode.owners)), "node %q.owner does not have the expected length", uid)
+		g.Expect(gotNode.shouldNotDelete).To(Equal(wantNode.shouldNotDelete), "node %q.shouldNotDelete does not have the expected value", uid)
 
 		for _, wantOwner := range wantNode.owners {
 			found := false
@@ -289,6 +296,8 @@ func assertGraph(t *testing.T, got *objectGraph, want wantGraph) {
 			}
 			g.Expect(found).To(BeTrue(), "node %q.softOwners does not contain %q", uid, wantOwner)
 		}
+
+		g.Expect(gotNode.owners).To(HaveLen(len(wantNode.owners)), "node %q.owner does not have the expected length", uid)
 	}
 }
 
@@ -1396,9 +1405,9 @@ var objectGraphsTests = []struct {
 		want: wantGraph{
 			nodes: map[string]wantGraphItem{
 				"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericClusterInfrastructureIdentity, infra1-identity": {
-					isGlobal:           true,
 					forceMove:          true,
 					forceMoveHierarchy: true,
+					isGlobal:           true,
 				},
 				"/v1, Kind=Secret, infra1-system/infra1-identity-credentials": {
 					owners: []string{
@@ -1896,6 +1905,244 @@ func TestObjectGraph_DiscoveryByNamespace(t *testing.T) {
 						owners: []string{
 							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "two independent clusters, in different namespaces referencing the same clusterclass in moved namespace",
+			args: args{
+				namespace: "ns1", // read only from ns1
+				objs: func() []client.Object {
+					objs := []client.Object{}
+					objs = append(objs, test.NewFakeClusterClass("ns1", "class1").Objs()...)
+					objs = append(objs, test.NewFakeClusterClass("ns1", "class2").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns2", "cluster1").WithTopologyClass("class2").WithTopologyClassNamespace("ns1").Objs()...)
+					return objs
+				}(),
+			},
+			want: wantGraph{
+				nodes: map[string]wantGraphItem{
+					"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns1/cluster1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-ca": {
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1", // NB. this secret is not linked to the cluster through owner ref
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-kubeconfig": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+					},
+					"controlplane.cluster.x-k8s.io/v1beta1, Kind=GenericControlPlaneTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class2": {
+						// Expected to be moved but not deleted after
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						shouldNotDelete:    true,
+					},
+					"controlplane.cluster.x-k8s.io/v1beta1, Kind=GenericControlPlaneTemplate, ns1/class2": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class2",
+						},
+						shouldNotDelete: true,
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureClusterTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureClusterTemplate, ns1/class2": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class2",
+						},
+						shouldNotDelete: true,
+					},
+				},
+			},
+		},
+		{
+			name: "two independent clusters, in different namespaces referencing own classes in separate namespaces should not overlap",
+			args: args{
+				namespace: "ns1", // read only from ns1
+				objs: func() []client.Object {
+					objs := []client.Object{}
+					objs = append(objs, test.NewFakeClusterClass("ns1", "class1").Objs()...)
+					objs = append(objs, test.NewFakeClusterClass("ns2", "class2").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns2", "cluster1").WithTopologyClass("class2").WithTopologyClassNamespace("ns2").Objs()...)
+					return objs
+				}(),
+			},
+			want: wantGraph{
+				nodes: map[string]wantGraphItem{
+					"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns1/cluster1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-ca": {
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1", // NB. this secret is not linked to the cluster through owner ref
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-kubeconfig": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+					},
+					"controlplane.cluster.x-k8s.io/v1beta1, Kind=GenericControlPlaneTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureClusterTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two clusters, in different namespaces referencing same class, read only 1",
+			args: args{
+				namespace: "ns1", // read only from ns1
+				objs: func() []client.Object {
+					objs := []client.Object{}
+					objs = append(objs, test.NewFakeClusterClass("ns1", "class1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns2", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					return objs
+				}(),
+			},
+			want: wantGraph{
+				nodes: map[string]wantGraphItem{
+					"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns1/cluster1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-ca": {
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1", // NB. this secret is not linked to the cluster through owner ref
+						},
+					},
+					"/v1, Kind=Secret, ns1/cluster1-kubeconfig": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns1/cluster1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureClusterTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+						shouldNotDelete: true,
+					},
+					"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						shouldNotDelete:    true,
+					},
+					"controlplane.cluster.x-k8s.io/v1beta1, Kind=GenericControlPlaneTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+						shouldNotDelete: true,
+					},
+				},
+			},
+		},
+		{
+			name: "two clusters, in different namespaces referencing class from other namespace, read only 1",
+			args: args{
+				namespace: "ns2", // read only from ns2
+				objs: func() []client.Object {
+					objs := []client.Object{}
+					objs = append(objs, test.NewFakeClusterClass("ns1", "class1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns2", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					objs = append(objs, test.NewFakeCluster("ns1", "cluster1").WithTopologyClass("class1").WithTopologyClassNamespace("ns1").Objs()...)
+					return deduplicateObjects(objs)
+				}(),
+			},
+			want: wantGraph{
+				nodes: map[string]wantGraphItem{
+					"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns2/cluster1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureCluster, ns2/cluster1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns2/cluster1",
+						},
+					},
+					"/v1, Kind=Secret, ns2/cluster1-ca": {
+						softOwners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns2/cluster1", // NB. this secret is not linked to the cluster through owner ref
+						},
+					},
+					"/v1, Kind=Secret, ns2/cluster1-kubeconfig": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=Cluster, ns2/cluster1",
+						},
+					},
+					"infrastructure.cluster.x-k8s.io/v1beta1, Kind=GenericInfrastructureClusterTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+						shouldNotDelete: true,
+					},
+					"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1": {
+						forceMove:          true,
+						forceMoveHierarchy: true,
+						shouldNotDelete:    true,
+					},
+					"controlplane.cluster.x-k8s.io/v1beta1, Kind=GenericControlPlaneTemplate, ns1/class1": {
+						owners: []string{
+							"cluster.x-k8s.io/v1beta1, Kind=ClusterClass, ns1/class1",
+						},
+						shouldNotDelete: true,
 					},
 				},
 			},

--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -101,7 +101,7 @@ func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph, f
 		objList := new(unstructured.UnstructuredList)
 
 		if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
-			return getObjList(ctx, o.proxy, typeMeta, selectors, objList)
+			return getObjList(ctx, o.proxy, &typeMeta, selectors, objList)
 		}); err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func discoverOwnerGraph(ctx context.Context, namespace string, o *objectGraph, f
 					providerNamespaceSelector := []client.ListOption{client.InNamespace(p.Namespace)}
 					providerNamespaceSecretList := new(unstructured.UnstructuredList)
 					if err := retryWithExponentialBackoff(ctx, discoveryBackoff, func(ctx context.Context) error {
-						return getObjList(ctx, o.proxy, typeMeta, providerNamespaceSelector, providerNamespaceSecretList)
+						return getObjList(ctx, o.proxy, &typeMeta, providerNamespaceSelector, providerNamespaceSecretList)
 					}); err != nil {
 						return nil, err
 					}

--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -44,16 +44,17 @@ import (
 )
 
 type FakeCluster struct {
-	namespace             string
-	name                  string
-	controlPlane          *FakeControlPlane
-	machinePools          []*FakeMachinePool
-	machineDeployments    []*FakeMachineDeployment
-	machineSets           []*FakeMachineSet
-	machines              []*FakeMachine
-	withCloudConfigSecret bool
-	withCredentialSecret  bool
-	topologyClass         *string
+	namespace              string
+	name                   string
+	controlPlane           *FakeControlPlane
+	machinePools           []*FakeMachinePool
+	machineDeployments     []*FakeMachineDeployment
+	machineSets            []*FakeMachineSet
+	machines               []*FakeMachine
+	withCloudConfigSecret  bool
+	withCredentialSecret   bool
+	topologyClass          *string
+	topologyClassNamespace *string
 }
 
 // NewFakeCluster return a FakeCluster that can generate a cluster object, all its own ancillary objects:
@@ -109,6 +110,11 @@ func (f *FakeCluster) WithTopologyClass(class string) *FakeCluster {
 	return f
 }
 
+func (f *FakeCluster) WithTopologyClassNamespace(namespace string) *FakeCluster {
+	f.topologyClassNamespace = &namespace
+	return f
+}
+
 func (f *FakeCluster) Objs() []client.Object {
 	clusterInfrastructure := &fakeinfrastructure.GenericInfrastructureCluster{
 		TypeMeta: metav1.TypeMeta{
@@ -145,6 +151,9 @@ func (f *FakeCluster) Objs() []client.Object {
 
 	if f.topologyClass != nil {
 		cluster.Spec.Topology = &clusterv1.Topology{Class: *f.topologyClass}
+		if f.topologyClassNamespace != nil {
+			cluster.Spec.Topology.ClassNamespace = *f.topologyClassNamespace
+		}
 	}
 
 	// Ensure the cluster gets a UID to be used by dependant objects for creating OwnerReferences.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

A follow-up on #11395 functionality, which integrates `classNamespace` field with `clusterctl move`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #5673

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
