### PR TITLE
🌱 Add --additional-sync-machine-labels to allow syncing additional labels to Nodes

### DIFF
--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,6 +73,8 @@ type MachineReconciler struct {
 	WatchFilterValue string
 
 	RemoteConditionsGracePeriod time.Duration
+
+	AdditionalSyncMachineLabels []*regexp.Regexp
 }
 
 func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -81,6 +84,7 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		ClusterCache:                r.ClusterCache,
 		WatchFilterValue:            r.WatchFilterValue,
 		RemoteConditionsGracePeriod: r.RemoteConditionsGracePeriod,
+		AdditionalSyncMachineLabels: r.AdditionalSyncMachineLabels,
 	}).SetupWithManager(ctx, mgr, options)
 }
 

--- a/docs/book/src/reference/api/metadata-propagation.md
+++ b/docs/book/src/reference/api/metadata-propagation.md
@@ -63,7 +63,9 @@ Top-level labels that meet a specific cretria are propagated to the Node labels 
 - `.labels.[label-meets-criteria]` => `Node.labels`
 - `.annotations` => Not propagated.
 
-Label should meet one of the following criteria to propagate to Node: 
+Labels that meet at least one of the following criteria are always propagated to the Node:
 - Has `node-role.kubernetes.io` as prefix.
 - Belongs to `node-restriction.kubernetes.io` domain.
-- Belongs to `node.cluster.x-k8s.io` domain.  
+- Belongs to `node.cluster.x-k8s.io` domain.
+
+In addition, any labels that match at least one of the regexes provided by the `--additional-sync-machine-labels` flag on the manager will be synced from the Machine to the Node.

--- a/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
+++ b/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
@@ -68,6 +68,7 @@ With the "divide and conquer" principle in mind this proposal aims to address th
 
 - Support label sync from Machine to the linked Kubernetes node, limited to `node-role.kubernetes.io/` prefix and the `node-restriction.kubernetes.io` domain.
 - Support syncing labels from Machine to the linked Kubernetes node for the Cluster API owned `node.cluster.x-k8s.io` domain.
+- Support a flag to sync additional user configured labels from the Machine to the Node.
 
 ### Non-Goals
 
@@ -98,7 +99,9 @@ While designing a solution for syncing labels between Machine and underlying Kub
 
 ### Label domains & prefixes
 
-The idea of scoping synchronization to a well defined set of labels is a first answer to security/concurrency concerns; labels to be managed by Cluster API have been selected based on following criteria:
+A default list of labels would always be synced from the Machines to the Nodes. An additional list of labels can be synced from the Machine to the Node by providing a list of regexes as a flag to the manager. 
+
+The following is the default list of label domains that would always be sync from Machines to Nodes:
 
 - The `node-role.kubernetes.io` label has been used widely in the past to identify the role of a Kubernetes Node (e.g. `node-role.kubernetes.io/worker=''`). For example, `kubectl get node` looks for this specific label when displaying the role to the user.
 
@@ -163,3 +166,4 @@ Users could also implement their own label synchronizer in their tooling, but th
 
 - [ ] 09/27/2022: First Draft of this document
 - [ ] 09/28/2022: First Draft of this document presented in the Cluster API office hours meeting
+- [ ] 01/09/2025: Update to support configurable label syncing Ref:[11657](https://github.com/kubernetes-sigs/cluster-api/issues/11657) 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -98,6 +99,8 @@ type Reconciler struct {
 	WatchFilterValue string
 
 	RemoteConditionsGracePeriod time.Duration
+
+	AdditionalSyncMachineLabels []*regexp.Regexp
 
 	controller      controller.Controller
 	recorder        record.EventRecorder

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -94,6 +94,7 @@ func TestMain(m *testing.M) {
 			APIReader:                   mgr.GetAPIReader(),
 			ClusterCache:                clusterCache,
 			RemoteConditionsGracePeriod: 5 * time.Minute,
+			AdditionalSyncMachineLabels: nil,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
 		}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	goruntime "runtime"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -125,6 +127,7 @@ var (
 	machinePoolConcurrency        int
 	clusterResourceSetConcurrency int
 	machineHealthCheckConcurrency int
+	additionalSyncMachineLabels   []string
 )
 
 func init() {
@@ -250,6 +253,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
+
+	fs.StringArrayVar(&additionalSyncMachineLabels, "additional-sync-machine-labels", []string{},
+		"List of regexes to select the additional set of labels to sync from the Machine to the Node. A label will be synced as long as it matches at least one of the regexes.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
 
@@ -559,12 +565,28 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 		setupLog.Error(err, "Unable to create controller", "controller", "Cluster")
 		os.Exit(1)
 	}
+
+	var errs []error
+	var additionalSyncMachineLabelRegexes []*regexp.Regexp
+	for _, re := range additionalSyncMachineLabels {
+		reg, err := regexp.Compile(re)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			additionalSyncMachineLabelRegexes = append(additionalSyncMachineLabelRegexes, reg)
+		}
+	}
+	if len(errs) > 0 {
+		setupLog.Error(fmt.Errorf("at least one of --additional-sync-machine-labels regexes is invalid: %w", kerrors.NewAggregate(errs)), "Unable to start manager")
+		os.Exit(1)
+	}
 	if err := (&controllers.MachineReconciler{
 		Client:                      mgr.GetClient(),
 		APIReader:                   mgr.GetAPIReader(),
 		ClusterCache:                clusterCache,
 		WatchFilterValue:            watchFilterValue,
 		RemoteConditionsGracePeriod: remoteConditionsGracePeriod,
+		AdditionalSyncMachineLabels: additionalSyncMachineLabelRegexes,
 	}).SetupWithManager(ctx, mgr, concurrency(machineConcurrency)); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "Machine")
 		os.Exit(1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Add an flag to the CAPI manager to dictate the labels that should be synced form the Machine to the node. If the flag is not specified it defaults to:
```
Has node-role.kubernetes.io as prefix.
Belongs to node-restriction.kubernetes.io domain.
Belongs to node.cluster.x-k8s.io domain.
```
Any value specified by the flag would be additional to the list to default values. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11657

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machine