### PR TITLE
🐛 Fix periodic resync in in-memory provider

### DIFF
--- a/test/infrastructure/inmemory/pkg/runtime/cache/client_test.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/client_test.go
@@ -804,5 +804,5 @@ func (h *fakeHandler) OnDelete(resourceGroup string, obj client.Object) {
 }
 
 func (h *fakeHandler) OnGeneric(resourceGroup string, obj client.Object) {
-	h.events = append(h.events, fmt.Sprintf("%s, %s=%s, Synced", resourceGroup, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()))
+	h.events = append(h.events, fmt.Sprintf("%s, %s=%s, Generic", resourceGroup, obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName()))
 }

--- a/test/infrastructure/inmemory/pkg/runtime/cache/informer.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/informer.go
@@ -122,7 +122,7 @@ func (c *cache) informSync(resourceGroup string, obj client.Object) {
 		defer i.lock.RUnlock()
 
 		for _, h := range i.handlers {
-			h.OnGeneric(resourceGroup, obj)
+			h.OnUpdate(resourceGroup, obj, obj)
 		}
 	}
 }

--- a/test/infrastructure/inmemory/pkg/runtime/cache/sync_test.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/sync_test.go
@@ -79,7 +79,7 @@ func Test_cache_sync(t *testing.T) {
 		return false
 	}, 10*time.Second, 200*time.Millisecond).Should(BeTrue(), "object should be synced")
 
-	g.Expect(h.Events()).To(ContainElement("foo, CloudMachine=baz, Synced"))
+	g.Expect(h.Events()).To(ContainElement("foo, CloudMachine=baz, Updated"))
 
 	cancel()
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
In general generic events only exist in controller-runtime.

Our in-memory kube-apiserver should return update events on resync like the regular kube-apiserver

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->