### PR TITLE
✨ Extend scale test and make ExtensionConfig name in RuntimeSDK test configurable

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -90,9 +91,15 @@ type ClusterUpgradeWithRuntimeSDKSpecInput struct {
 	// If not specified, this is a no-op.
 	PostUpgrade func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
 
+	// ExtensionConfigName is the name of the ExtensionConfig. Defaults to "k8s-upgrade-with-runtimesdk".
+	// This value is provided to clusterctl as "EXTENSION_CONFIG_NAME" variable and can be used to template the
+	// name of the ExtensionConfig into the ClusterClass.
+	ExtensionConfigName string
+
 	// ExtensionServiceNamespace is the namespace where the service for the Runtime SDK is located
 	// and is used to configure in the test-namespace scoped ExtensionConfig.
 	ExtensionServiceNamespace string
+
 	// ExtensionServiceName is the name of the service to configure in the test-namespace scoped ExtensionConfig.
 	ExtensionServiceName string
 }
@@ -133,6 +140,9 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 
 		Expect(input.ExtensionServiceNamespace).ToNot(BeEmpty())
 		Expect(input.ExtensionServiceName).ToNot(BeEmpty())
+		if input.ExtensionConfigName == "" {
+			input.ExtensionConfigName = specName
+		}
 
 		if input.ControlPlaneMachineCount == nil {
 			controlPlaneMachineCount = 1
@@ -161,8 +171,11 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 
 		By("Deploy Test Extension ExtensionConfig")
 
+		// In this test we are defaulting all handlers to blocking because we expect the handlers to block the
+		// cluster lifecycle by default. Setting defaultAllHandlersToBlocking to true enforces that the test-extension
+		// automatically creates the ConfigMap with blocking preloaded responses.
 		Expect(input.BootstrapClusterProxy.GetClient().Create(ctx,
-			extensionConfig(specName, namespace.Name, input.ExtensionServiceNamespace, input.ExtensionServiceName))).
+			extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, true, namespace.Name))).
 			To(Succeed(), "Failed to create the extension config")
 
 		By("Creating a workload cluster; creation waits for BeforeClusterCreateHook to gate the operation")
@@ -175,6 +188,11 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
 		if input.InfrastructureProvider != nil {
 			infrastructureProvider = *input.InfrastructureProvider
+		}
+
+		variables := map[string]string{
+			// This is used to template the name of the ExtensionConfig into the ClusterClass.
+			"EXTENSION_CONFIG_NAME": input.ExtensionConfigName,
 		}
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -190,6 +208,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersionUpgradeFrom),
 				ControlPlaneMachineCount: ptr.To[int64](controlPlaneMachineCount),
 				WorkerMachineCount:       ptr.To[int64](workerMachineCount),
+				ClusterctlVariables:      variables,
 			},
 			PreWaitForCluster: func() {
 				beforeClusterCreateTestHandler(ctx,
@@ -304,8 +323,8 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 		if !input.SkipCleanup {
 			// Delete the extensionConfig first to ensure the BeforeDeleteCluster hook doesn't block deletion.
 			Eventually(func() error {
-				return input.BootstrapClusterProxy.GetClient().Delete(ctx, extensionConfig(specName, namespace.Name, input.ExtensionServiceNamespace, input.ExtensionServiceName))
-			}, 10*time.Second, 1*time.Second).Should(Succeed(), "delete extensionConfig failed")
+				return input.BootstrapClusterProxy.GetClient().Delete(ctx, extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, true, namespace.Name))
+			}, 10*time.Second, 1*time.Second).Should(Succeed(), "Deleting ExtensionConfig failed")
 
 			Byf("Deleting cluster %s", klog.KObj(clusterResources.Cluster))
 			// While https://github.com/kubernetes-sigs/cluster-api/issues/2955 is addressed in future iterations, there is a chance
@@ -429,8 +448,8 @@ func machineSetPreflightChecksTestHandler(ctx context.Context, c client.Client, 
 // We make sure this cluster-wide object does not conflict with others by using a random generated
 // name and a NamespaceSelector selecting on the namespace of the current test.
 // Thus, this object is "namespaced" to the current test even though it's a cluster-wide object.
-func extensionConfig(name, namespace, extensionServiceNamespace, extensionServiceName string) *runtimev1.ExtensionConfig {
-	return &runtimev1.ExtensionConfig{
+func extensionConfig(name, extensionServiceNamespace, extensionServiceName string, defaultAllHandlersToBlocking bool, namespaces ...string) *runtimev1.ExtensionConfig {
+	cfg := &runtimev1.ExtensionConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			// Note: We have to use a constant name here as we have to be able to reference it in the ClusterClass
 			// when configuring external patches.
@@ -448,25 +467,24 @@ func extensionConfig(name, namespace, extensionServiceNamespace, extensionServic
 					Namespace: extensionServiceNamespace,
 				},
 			},
-			NamespaceSelector: &metav1.LabelSelector{
-				// Note: we are limiting the test extension to be used by the namespace where the test is run.
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "kubernetes.io/metadata.name",
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{namespace},
-					},
-				},
-			},
 			Settings: map[string]string{
-				// In the E2E test we are defaulting all handlers to blocking because cluster_upgrade_runtimesdk_test
-				// expects the handlers to block the cluster lifecycle by default.
-				// Setting this value to true enforces that the test-extension automatically creates the ConfigMap with
-				// blocking preloaded responses.
-				"defaultAllHandlersToBlocking": "true",
+				"defaultAllHandlersToBlocking": strconv.FormatBool(defaultAllHandlersToBlocking),
 			},
 		},
 	}
+	if len(namespaces) > 0 {
+		cfg.Spec.NamespaceSelector = &metav1.LabelSelector{
+			// Note: we are limiting the test extension to be used by the namespace where the test is run.
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "kubernetes.io/metadata.name",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   namespaces,
+				},
+			},
+		}
+	}
+	return cfg
 }
 
 // Check that each hook in hooks has been called at least once by checking if its actualResponseStatus is in the hook response configmap.

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -54,9 +54,9 @@ spec:
   patches:
   - name: test-patch
     external:
-      generateExtension: generate-patches.k8s-upgrade-with-runtimesdk
-      validateExtension: validate-topology.k8s-upgrade-with-runtimesdk
-      discoverVariablesExtension: discover-variables.k8s-upgrade-with-runtimesdk
+      generateExtension: generate-patches.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
+      validateExtension: validate-topology.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
+      discoverVariablesExtension: discover-variables.${EXTENSION_CONFIG_NAME:-"k8s-upgrade-with-runtimesdk"}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate

--- a/test/e2e/data/infrastructure-inmemory/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-inmemory/main/bases/cluster-with-topology.yaml
@@ -12,6 +12,7 @@ spec:
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   topology:
     class: in-memory
+    classNamespace: ${NAMESPACE}
     version: ${KUBERNETES_VERSION}
     controlPlane:
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -20,3 +21,8 @@ spec:
         - class: default-worker
           name: md-0
           replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+      - name: kubeadmControlPlaneMaxSurge
+        value: "1"
+      - name: imageRepository
+        value: "kindest"

--- a/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
+++ b/test/e2e/data/infrastructure-inmemory/main/clusterclass-in-memory.yaml
@@ -1,56 +1,3 @@
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: ClusterClass
-metadata:
-  name: in-memory
-spec:
-  controlPlane:
-    metadata:
-      annotations:
-    machineInfrastructure:
-      ref:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-        kind: InMemoryMachineTemplate
-        name: in-memory-control-plane
-    ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-      kind: KubeadmControlPlaneTemplate
-      name: in-memory-control-plane
-    machineHealthCheck:
-      unhealthyConditions:
-        - type: Ready
-          status: Unknown
-          timeout: 300s
-        - type: Ready
-          status: "False"
-          timeout: 300s
-  infrastructure:
-    ref:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-      kind: InMemoryClusterTemplate
-      name: in-memory-cluster
-  workers:
-    machineDeployments:
-      - class: default-worker
-        template:
-          bootstrap:
-            ref:
-              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-              kind: KubeadmConfigTemplate
-              name: in-memory-default-worker-bootstraptemplate
-          infrastructure:
-            ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-              kind: InMemoryMachineTemplate
-              name: in-memory-default-worker-machinetemplate
-        machineHealthCheck:
-          unhealthyConditions:
-            - type: Ready
-              status: Unknown
-              timeout: 300s
-            - type: Ready
-              status: "False"
-              timeout: 300s
----
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: InMemoryClusterTemplate
 metadata:
@@ -95,19 +42,19 @@ spec:
       behaviour:
         vm:
           provisioning:
-            startupDuration: "30s"
+            startupDuration: "10s"
             startupJitter: "0.2"
         node:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
         apiServer:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
         etcd:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -120,19 +67,19 @@ spec:
       behaviour:
         vm:
           provisioning:
-            startupDuration: "30s"
+            startupDuration: "10s"
             startupJitter: "0.2"
         node:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
         apiServer:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
         etcd:
           provisioning:
-            startupDuration: "10s"
+            startupDuration: "2s"
             startupJitter: "0.2"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -147,3 +94,61 @@ spec:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: in-memory
+spec:
+  controlPlane:
+    metadata:
+      annotations:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: InMemoryMachineTemplate
+        name: in-memory-control-plane
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: in-memory-control-plane
+    machineHealthCheck:
+      unhealthyConditions:
+      - type: Ready
+        status: Unknown
+        timeout: 300s
+      - type: Ready
+        status: "False"
+        timeout: 300s
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      kind: InMemoryClusterTemplate
+      name: in-memory-cluster
+  workers:
+    machineDeployments:
+    - class: default-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: in-memory-default-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+            kind: InMemoryMachineTemplate
+            name: in-memory-default-worker-machinetemplate
+      machineHealthCheck:
+        unhealthyConditions:
+        - type: Ready
+          status: Unknown
+          timeout: 300s
+        - type: Ready
+          status: "False"
+          timeout: 300s
+  patches:
+  - name: test-patch
+    external:
+      generateExtension: generate-patches.${EXTENSION_CONFIG_NAME:-"scale"}
+      discoverVariablesExtension: discover-variables.${EXTENSION_CONFIG_NAME:-"scale"}

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -28,18 +28,28 @@ var _ = Describe("When testing the machinery for scale testing using in-memory p
 	// Note: This test does not support MachinePools.
 	ScaleSpec(ctx, func() ScaleSpecInput {
 		return ScaleSpecInput{
-			E2EConfig:                e2eConfig,
-			ClusterctlConfigPath:     clusterctlConfigPath,
-			InfrastructureProvider:   ptr.To("in-memory"),
-			BootstrapClusterProxy:    bootstrapClusterProxy,
-			ArtifactFolder:           artifactFolder,
-			ClusterCount:             ptr.To[int64](10),
-			Concurrency:              ptr.To[int64](5),
-			Flavor:                   ptr.To(""),
-			ControlPlaneMachineCount: ptr.To[int64](1),
-			MachineDeploymentCount:   ptr.To[int64](1),
-			WorkerMachineCount:       ptr.To[int64](3),
-			SkipCleanup:              skipCleanup,
+			E2EConfig:                         e2eConfig,
+			ClusterctlConfigPath:              clusterctlConfigPath,
+			InfrastructureProvider:            ptr.To("in-memory"),
+			BootstrapClusterProxy:             bootstrapClusterProxy,
+			ArtifactFolder:                    artifactFolder,
+			Flavor:                            ptr.To(""),
+			SkipCleanup:                       skipCleanup,
+			ClusterCount:                      ptr.To[int64](10),
+			Concurrency:                       ptr.To[int64](5),
+			ControlPlaneMachineCount:          ptr.To[int64](1),
+			MachineDeploymentCount:            ptr.To[int64](1),
+			WorkerPerMachineDeploymentCount:   ptr.To[int64](3),
+			AdditionalClusterClassCount:       ptr.To[int64](4),
+			ClusterClassName:                  "in-memory",
+			DeployClusterInSeparateNamespaces: ptr.To[bool](false),
+			UseCrossNamespaceClusterClass:     ptr.To[bool](false),
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
 		}
 	})
 })

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -448,7 +448,7 @@ func ApplyCustomClusterTemplateAndWait(ctx context.Context, input ApplyCustomClu
 	if result.Cluster.Spec.Topology != nil {
 		result.ClusterClass = framework.GetClusterClassByName(ctx, framework.GetClusterClassByNameInput{
 			Getter:    input.ClusterProxy.GetClient(),
-			Namespace: input.Namespace,
+			Namespace: result.Cluster.GetClassKey().Namespace,
 			Name:      result.Cluster.Spec.Topology.Class,
 		})
 	}

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -800,6 +800,21 @@ func (c *E2EConfig) GetVariable(varName string) string {
 	return value
 }
 
+// GetVariableBestEffort returns a variable from environment variables or from the e2e config file.
+// If the variable cannot be found it returns an empty string and does not fail.
+func (c *E2EConfig) GetVariableBestEffort(varName string) string {
+	if value, ok := os.LookupEnv(varName); ok {
+		return value
+	}
+
+	value, ok := c.Variables[varName]
+	if ok {
+		return value
+	}
+
+	return ""
+}
+
 // GetInt64PtrVariable returns an Int64Ptr variable from the e2e config file.
 func (c *E2EConfig) GetInt64PtrVariable(varName string) *int64 {
 	wCountStr := c.GetVariable(varName)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Improvements to the scale test:
* Deploy additional ClusterClasses
* Consistent overwrites for input fields via variables
* Supports testing the cross-ns ClusterClass feature
* Supports testing Runtime Extensions

Kudos to @fabriziopandini & @chrischdi for prototyping most of these changes and the collaboration on scale testing

Additionally makes the ExtensionConfig name in scale & RuntimeSDK test configurable. 

This allows to run e.g. the Runtime SDK test with different ExtensionConfig names in parallel. This can also be useful when these tests are executed by an infra provider that is using a different ExtensionConfig name in their ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->