### PR TITLE
⚠️ Remove deprecated flag for old infra machine naming

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,6 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=false}"
           image: controller:latest
           name: manager

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -92,18 +92,14 @@ type MachineSetReconciler struct {
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
-
-	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
-	DeprecatedInfraMachineNaming bool
 }
 
 func (r *MachineSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinesetcontroller.Reconciler{
-		Client:                       r.Client,
-		APIReader:                    r.APIReader,
-		ClusterCache:                 r.ClusterCache,
-		WatchFilterValue:             r.WatchFilterValue,
-		DeprecatedInfraMachineNaming: r.DeprecatedInfraMachineNaming,
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		ClusterCache:     r.ClusterCache,
+		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }
 

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -22,7 +22,6 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=false}"
           image: controller:latest
           name: manager

--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -41,21 +41,17 @@ type KubeadmControlPlaneReconciler struct {
 	WatchFilterValue string
 
 	RemoteConditionsGracePeriod time.Duration
-
-	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
-	DeprecatedInfraMachineNaming bool
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:                       r.Client,
-		SecretCachingClient:          r.SecretCachingClient,
-		ClusterCache:                 r.ClusterCache,
-		EtcdDialTimeout:              r.EtcdDialTimeout,
-		EtcdCallTimeout:              r.EtcdCallTimeout,
-		WatchFilterValue:             r.WatchFilterValue,
-		RemoteConditionsGracePeriod:  r.RemoteConditionsGracePeriod,
-		DeprecatedInfraMachineNaming: r.DeprecatedInfraMachineNaming,
+		Client:                      r.Client,
+		SecretCachingClient:         r.SecretCachingClient,
+		ClusterCache:                r.ClusterCache,
+		EtcdDialTimeout:             r.EtcdDialTimeout,
+		EtcdCallTimeout:             r.EtcdCallTimeout,
+		WatchFilterValue:            r.WatchFilterValue,
+		RemoteConditionsGracePeriod: r.RemoteConditionsGracePeriod,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -91,9 +91,6 @@ type KubeadmControlPlaneReconciler struct {
 
 	RemoteConditionsGracePeriod time.Duration
 
-	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
-	DeprecatedInfraMachineNaming bool
-
 	managementCluster         internal.ManagementCluster
 	managementClusterUncached internal.ManagementCluster
 	ssaCache                  ssa.Cache

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apiserver/pkg/storage/names"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -200,17 +199,12 @@ func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx conte
 		UID:        kcp.UID,
 	}
 
-	infraMachineName := machine.Name
-	if r.DeprecatedInfraMachineNaming {
-		infraMachineName = names.SimpleNameGenerator.GenerateName(kcp.Spec.MachineTemplate.InfrastructureRef.Name + "-")
-	}
-
 	// Clone the infrastructure template
 	infraRef, err := external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 		Client:      r.Client,
 		TemplateRef: &kcp.Spec.MachineTemplate.InfrastructureRef,
 		Namespace:   kcp.Namespace,
-		Name:        infraMachineName,
+		Name:        machine.Name,
 		OwnerRef:    infraCloneOwner,
 		ClusterName: cluster.Name,
 		Labels:      internal.ControlPlaneMachineLabelsForCluster(kcp, cluster.Name),

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -93,12 +93,11 @@ var (
 	managerOptions              = flags.ManagerOptions{}
 	logOptions                  = logs.NewOptions()
 	// KCP specific flags.
-	remoteConditionsGracePeriod     time.Duration
-	kubeadmControlPlaneConcurrency  int
-	clusterCacheConcurrency         int
-	etcdDialTimeout                 time.Duration
-	etcdCallTimeout                 time.Duration
-	useDeprecatedInfraMachineNaming bool
+	remoteConditionsGracePeriod    time.Duration
+	kubeadmControlPlaneConcurrency int
+	clusterCacheConcurrency        int
+	etcdDialTimeout                time.Duration
+	etcdCallTimeout                time.Duration
 )
 
 func init() {
@@ -185,10 +184,6 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.DurationVar(&etcdCallTimeout, "etcd-call-timeout-duration", etcd.DefaultCallTimeout,
 		"Duration that the etcd client waits at most for read and write operations to etcd.")
-
-	fs.BoolVar(&useDeprecatedInfraMachineNaming, "use-deprecated-infra-machine-naming", false,
-		"Use the deprecated naming convention for infra machines where they are named after the InfraMachineTemplate.")
-	_ = fs.MarkDeprecated("use-deprecated-infra-machine-naming", "This flag will be removed in v1.10.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
 
@@ -393,14 +388,13 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:                       mgr.GetClient(),
-		SecretCachingClient:          secretCachingClient,
-		ClusterCache:                 clusterCache,
-		WatchFilterValue:             watchFilterValue,
-		EtcdDialTimeout:              etcdDialTimeout,
-		EtcdCallTimeout:              etcdCallTimeout,
-		RemoteConditionsGracePeriod:  remoteConditionsGracePeriod,
-		DeprecatedInfraMachineNaming: useDeprecatedInfraMachineNaming,
+		Client:                      mgr.GetClient(),
+		SecretCachingClient:         secretCachingClient,
+		ClusterCache:                clusterCache,
+		WatchFilterValue:            watchFilterValue,
+		EtcdDialTimeout:             etcdDialTimeout,
+		EtcdCallTimeout:             etcdCallTimeout,
+		RemoteConditionsGracePeriod: remoteConditionsGracePeriod,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")
 		os.Exit(1)

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -97,9 +96,6 @@ type Reconciler struct {
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
-
-	// Deprecated: DeprecatedInfraMachineNaming. Name the InfraStructureMachines after the InfraMachineTemplate.
-	DeprecatedInfraMachineNaming bool
 
 	ssaCache ssa.Cache
 	recorder record.EventRecorder
@@ -754,16 +750,12 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 				log = log.WithValues(bootstrapRef.Kind, klog.KRef(bootstrapRef.Namespace, bootstrapRef.Name))
 			}
 
-			infraMachineName := machine.Name
-			if r.DeprecatedInfraMachineNaming {
-				infraMachineName = names.SimpleNameGenerator.GenerateName(ms.Spec.Template.Spec.InfrastructureRef.Name + "-")
-			}
 			// Create the InfraMachine.
 			infraRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 				Client:      r.Client,
 				TemplateRef: &ms.Spec.Template.Spec.InfrastructureRef,
 				Namespace:   machine.Namespace,
-				Name:        infraMachineName,
+				Name:        machine.Name,
 				ClusterName: machine.Spec.ClusterName,
 				Labels:      machine.Labels,
 				Annotations: machine.Annotations,

--- a/main.go
+++ b/main.go
@@ -112,20 +112,19 @@ var (
 	managerOptions              = flags.ManagerOptions{}
 	logOptions                  = logs.NewOptions()
 	// core Cluster API specific flags.
-	remoteConnectionGracePeriod     time.Duration
-	remoteConditionsGracePeriod     time.Duration
-	clusterTopologyConcurrency      int
-	clusterCacheConcurrency         int
-	clusterClassConcurrency         int
-	clusterConcurrency              int
-	extensionConfigConcurrency      int
-	machineConcurrency              int
-	machineSetConcurrency           int
-	machineDeploymentConcurrency    int
-	machinePoolConcurrency          int
-	clusterResourceSetConcurrency   int
-	machineHealthCheckConcurrency   int
-	useDeprecatedInfraMachineNaming bool
+	remoteConnectionGracePeriod   time.Duration
+	remoteConditionsGracePeriod   time.Duration
+	clusterTopologyConcurrency    int
+	clusterCacheConcurrency       int
+	clusterClassConcurrency       int
+	clusterConcurrency            int
+	extensionConfigConcurrency    int
+	machineConcurrency            int
+	machineSetConcurrency         int
+	machineDeploymentConcurrency  int
+	machinePoolConcurrency        int
+	clusterResourceSetConcurrency int
+	machineHealthCheckConcurrency int
 )
 
 func init() {
@@ -251,10 +250,6 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
-
-	fs.BoolVar(&useDeprecatedInfraMachineNaming, "use-deprecated-infra-machine-naming", false,
-		"Use deprecated infrastructure machine naming")
-	_ = fs.MarkDeprecated("use-deprecated-infra-machine-naming", "This flag will be removed in v1.10.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
 
@@ -575,11 +570,10 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineSetReconciler{
-		Client:                       mgr.GetClient(),
-		APIReader:                    mgr.GetAPIReader(),
-		ClusterCache:                 clusterCache,
-		WatchFilterValue:             watchFilterValue,
-		DeprecatedInfraMachineNaming: useDeprecatedInfraMachineNaming,
+		Client:           mgr.GetClient(),
+		APIReader:        mgr.GetAPIReader(),
+		ClusterCache:     clusterCache,
+		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(machineSetConcurrency)); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "MachineSet")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the flag `--use-deprecated-infra-machine-naming`, which was planned to disappear in CAPI v1.9.

**Which issue(s) this PR fixes**:
Refs #10576
Refs #11172

/area provider/control-plane-kubeadm
/area machineset