### PR TITLE
🌱 Add ginkgo labels to e2e tests

### DIFF
--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When using the autoscaler with Cluster API using ClusterClass [ClusterClass]", func() {
+var _ = Describe("When using the autoscaler with Cluster API using ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
 	AutoscalerSpec(ctx, func() AutoscalerSpecInput {
 		return AutoscalerSpecInput{
 			E2EConfig:                             e2eConfig,

--- a/test/e2e/cluster_deletion_test.go
+++ b/test/e2e/cluster_deletion_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When performing cluster deletion with ClusterClass [ClusterClass]", func() {
+var _ = Describe("When performing cluster deletion with ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterDeletionSpec(ctx, func() ClusterDeletionSpecInput {
 		return ClusterDeletionSpecInput{
 			E2EConfig:                e2eConfig,

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with RuntimeSDK [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterUpgradeWithRuntimeSDKSpec(ctx, func() ClusterUpgradeWithRuntimeSDKSpecInput {
 		version, err := semver.ParseTolerant(e2eConfig.GetVariable(KubernetesVersionUpgradeFrom))
 		Expect(err).ToNot(HaveOccurred(), "Invalid argument, KUBERNETES_VERSION_UPGRADE_FROM is not a valid version")

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass and testing K8S conformance [Conformance] [K8s-Upgrade] [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass and testing K8S conformance [Conformance] [K8s-Upgrade] [ClusterClass]", Label("Conformance", "K8s-Upgrade", "ClusterClass"), func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:              e2eConfig,
@@ -51,7 +51,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass and testi
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:              e2eConfig,
@@ -70,7 +70,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass [ClusterC
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane [ClusterClass]", Label("ClusterClass"), func() {
 	controlPlaneMachineCount := int64(3)
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
@@ -203,7 +203,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane using scale-in rollout [ClusterClass]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane using scale-in rollout [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:              e2eConfig,

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
+var _ = Describe("When testing ClusterClass changes [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterClassChangesSpec(ctx, func() ClusterClassChangesSpecInput {
 		return ClusterClassChangesSpecInput{
 			E2EConfig:              e2eConfig,

--- a/test/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/clusterclass_rollout_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", func() {
+var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterClassRolloutSpec(ctx, func() ClusterClassRolloutSpecInput {
 		return ClusterClassRolloutSpecInput{
 			E2EConfig:              e2eConfig,

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -219,7 +219,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.0=>current)", func() {
 })
 
 // Note: This test should be changed during "prepare main branch", it should test n-2 => current.
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.8=>current) [ClusterClass]", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.8=>current) [ClusterClass]", Label("ClusterClass"), func() {
 	// Get n-2 latest stable release
 	version := "1.8"
 	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
@@ -252,7 +252,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.8=>cur
 })
 
 // Note: This test should be changed during "prepare main branch", it should test n-1 => current.
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>current) [ClusterClass]", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>current) [ClusterClass]", Label("ClusterClass"), func() {
 	// Get n-1 latest stable release
 	version := "1.9"
 	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
@@ -279,7 +279,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>cur
 })
 
 // Note: This test should be changed during "prepare main branch", it should test n-1 => current.
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>current) on K8S latest ci mgmt cluster [ClusterClass]", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>current) on K8S latest ci mgmt cluster [ClusterClass]", Label("ClusterClass"), func() {
 	// Get n-1 latest stable release
 	version := "1.9"
 	stableRelease, err := GetStableReleaseOfMinor(ctx, version)

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/kubernetesversions"
 )
 
-var _ = Describe("When testing K8S conformance [Conformance] [K8s-Install]", func() {
+var _ = Describe("When testing K8S conformance [Conformance] [K8s-Install]", Label("Conformance", "K8s-Install"), func() {
 	// Note: This installs a cluster based on KUBERNETES_VERSION and runs conformance tests.
 	K8SConformanceSpec(ctx, func() K8SConformanceSpecInput {
 		return K8SConformanceSpecInput{
@@ -42,7 +42,7 @@ var _ = Describe("When testing K8S conformance [Conformance] [K8s-Install]", fun
 	})
 })
 
-var _ = Describe("When testing K8S conformance with K8S latest ci [Conformance] [K8s-Install-ci-latest]", func() {
+var _ = Describe("When testing K8S conformance with K8S latest ci [Conformance] [K8s-Install-ci-latest]", Label("Conformance", "K8s-Install-ci-latest"), func() {
 	// Note: This installs a cluster based on KUBERNETES_VERSION_LATEST_CI and runs conformance tests.
 	// Note: We are resolving KUBERNETES_VERSION_LATEST_CI and then setting the resolved version as
 	// KUBERNETES_VERSION env var. This only works without side effects on other tests because we are

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -76,7 +76,7 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Blocking] [ClusterClass]", Label("PR-Blocking", "ClusterClass"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -125,7 +125,7 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 })
 
 // NOTE: This test requires an IPv6 management cluster (can be configured via IP_FAMILY=IPv6).
-var _ = Describe("When following the Cluster API quick-start with IPv6 [IPv6]", func() {
+var _ = Describe("When following the Cluster API quick-start with IPv6 [IPv6]", Label("IPv6"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -153,7 +153,7 @@ var _ = Describe("When following the Cluster API quick-start with Ignition", fun
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with dualstack and ipv4 primary [IPv6]", func() {
+var _ = Describe("When following the Cluster API quick-start with dualstack and ipv4 primary [IPv6]", Label("IPv6"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -180,7 +180,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with dualstack and ipv6 primary [IPv6]", func() {
+var _ = Describe("When following the Cluster API quick-start with dualstack and ipv6 primary [IPv6]", Label("IPv6"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,
@@ -207,7 +207,7 @@ var _ = Describe("When following the Cluster API quick-start with dualstack and 
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass without any worker definitions [ClusterClass]", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass without any worker definitions [ClusterClass]", Label("ClusterClass"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:              e2eConfig,

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass [ClusterClass]", func() {
+var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
 	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
 		return SelfHostedSpecInput{
 			E2EConfig:                e2eConfig,
@@ -40,7 +40,7 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters using
 	})
 })
 
-var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass with a HA control plane [ClusterClass]", func() {
+var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass with a HA control plane [ClusterClass]", Label("ClusterClass"), func() {
 	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
 		return SelfHostedSpecInput{
 			E2EConfig:                e2eConfig,
@@ -56,7 +56,7 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters using
 	})
 })
 
-var _ = Describe("When testing Cluster API working on single-node self-hosted clusters using ClusterClass [ClusterClass]", func() {
+var _ = Describe("When testing Cluster API working on single-node self-hosted clusters using ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
 	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
 		return SelfHostedSpecInput{
 			E2EConfig:                e2eConfig,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
adds ginkgo labels to e2e tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #9620

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing