### PR TITLE
🐛 Also patch external refs if the UID differs

### DIFF
--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -131,6 +131,7 @@ func ensureOwnerRefAndLabel(ctx context.Context, c client.Client, obj *unstructu
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Cluster",
 		Name:       cluster.Name,
+		UID:        cluster.UID,
 		Controller: ptr.To(true),
 	}
 

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -434,6 +434,7 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, clusterClass *cluste
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "ClusterClass",
 		Name:       clusterClass.Name,
+		UID:        clusterClass.UID,
 	}
 
 	if util.HasExactOwnerRef(obj.GetOwnerReferences(), desiredOwnerRef) {

--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -98,6 +98,7 @@ func (r *Reconciler) ensureExternalOwnershipAndWatch(ctx context.Context, cluste
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Machine",
 		Name:       m.Name,
+		UID:        m.UID,
 		Controller: ptr.To(true),
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -342,6 +342,7 @@ func HasExactOwnerRef(ownerReferences []metav1.OwnerReference, ref metav1.OwnerR
 		if r.APIVersion == ref.APIVersion &&
 			r.Kind == ref.Kind &&
 			r.Name == ref.Name &&
+			r.UID == ref.UID &&
 			ptr.Deref(r.Controller, false) == ptr.Deref(ref.Controller, false) {
 			return true
 		}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
follow-up to #11666

After #11666 we stopped patching external referenced objects when the UID differs. This PR fixes that case.

(Not entirely sure if this case ever happens, because I'm not sure if clusterctl move preserves the ownerRefs, but just playing it safe doesn't hurt)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->