### PR TITLE
🌱 Improve Machine remediation logs

### DIFF
--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -541,8 +541,9 @@ func (r *Reconciler) patchUnhealthyTargets(ctx context.Context, logger logr.Logg
 			t.Machine,
 			corev1.EventTypeNormal,
 			EventMachineMarkedUnhealthy,
-			"Machine %v has been marked as unhealthy",
-			t.string(),
+			"Machine %s has been marked as unhealthy by %s",
+			klog.KObj(t.Machine),
+			klog.KObj(t.MHC),
 		)
 	}
 	return errList

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
@@ -64,15 +64,6 @@ type healthCheckTarget struct {
 	nodeMissing bool
 }
 
-func (t *healthCheckTarget) string() string {
-	return fmt.Sprintf("%s/%s/%s/%s",
-		t.MHC.GetNamespace(),
-		t.MHC.GetName(),
-		t.Machine.GetName(),
-		t.nodeName(),
-	)
-}
-
 // Get the node name if the target has a node.
 func (t *healthCheckTarget) nodeName() string {
 	if t.Node != nil {
@@ -331,7 +322,7 @@ func (r *Reconciler) healthCheckTargets(targets []healthCheckTarget, logger logr
 	var healthy []healthCheckTarget
 
 	for _, t := range targets {
-		logger := logger.WithValues("target", t.string())
+		logger := logger.WithValues("Machine", klog.KObj(t.Machine), "Node", klog.KObj(t.Node))
 		logger.V(3).Info("Health checking target")
 		needsRemediation, nextCheck := t.needsRemediation(logger, timeoutForMachineToHaveNode)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improve logs added when a machine is remediated by adding key value pair for Machine ns/name and another for the node name, while dropping the key "target" which contained a confusing "MHC.Namespace/MHC.Name/Machine.Name/Node.Name".

Also, message now uses a more intuitive "Machine has failed health check..." instead of "Target has failed health check"

/area machinehalthcheck