### PR TITLE
🌱 Improve Machine create and delete logs

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -390,7 +390,7 @@ func (c *ControlPlane) InjectTestManagementCluster(managementCluster ManagementC
 	c.workloadCluster = nil
 }
 
-// StatusToLogKeyAndValues returns following key/value pairs describing the overall status of the control plane:
+// StatusToLogKeyAndValues returns the following key/value pairs describing the overall status of the control plane:
 // - machines is the list of KCP machines; each machine might have additional notes surfacing
 //   - if the machine has been created in the current reconcile
 //   - if machines node ref is not yet set

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -309,7 +309,7 @@ func TestStatusToLogKeyAndValues(t *testing.T) {
 
 	got := c.StatusToLogKeyAndValues(machineJustCreated, machineJustDeleted)
 
-	g.Expect(got).To((HaveLen(4)))
+	g.Expect(got).To(HaveLen(4))
 	g.Expect(got[0]).To(Equal("machines"))
 	machines := strings.Join([]string{
 		"healthy",

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package internal
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +28,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
@@ -250,6 +253,75 @@ func TestHasHealthyMachineStillProvisioning(t *testing.T) {
 		g := NewWithT(t)
 		g.Expect(c.HasHealthyMachineStillProvisioning()).To(BeFalse())
 	})
+}
+
+func TestStatusToLogKeyAndValues(t *testing.T) {
+	healthyMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "healthy"},
+		Status: clusterv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{Name: "healthy-node"},
+			Conditions: []clusterv1.Condition{
+				{Type: controlplanev1.MachineAPIServerPodHealthyCondition, Status: corev1.ConditionTrue},
+				{Type: controlplanev1.MachineControllerManagerPodHealthyCondition, Status: corev1.ConditionTrue},
+				{Type: controlplanev1.MachineSchedulerPodHealthyCondition, Status: corev1.ConditionTrue},
+				{Type: controlplanev1.MachineEtcdPodHealthyCondition, Status: corev1.ConditionTrue},
+				{Type: controlplanev1.MachineEtcdMemberHealthyCondition, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	machineWithoutNode := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "without-node"},
+		Status: clusterv1.MachineStatus{
+			NodeRef: nil,
+			Conditions: []clusterv1.Condition{
+				{Type: controlplanev1.MachineAPIServerPodHealthyCondition, Status: corev1.ConditionUnknown},
+				{Type: controlplanev1.MachineControllerManagerPodHealthyCondition, Status: corev1.ConditionUnknown},
+				{Type: controlplanev1.MachineSchedulerPodHealthyCondition, Status: corev1.ConditionUnknown},
+				{Type: controlplanev1.MachineEtcdPodHealthyCondition, Status: corev1.ConditionUnknown},
+				{Type: controlplanev1.MachineEtcdMemberHealthyCondition, Status: corev1.ConditionFalse}, // not a real use case, but used to test a code branch.
+			},
+		},
+	}
+
+	machineJustCreated := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "just-created"}}
+
+	machineJustDeleted := healthyMachine.DeepCopy()
+	machineJustDeleted.Name = "just-deleted"
+
+	machineNotUpToDate := healthyMachine.DeepCopy()
+	machineNotUpToDate.Name = "not-up-to-date"
+
+	machineMarkedForRemediation := healthyMachine.DeepCopy()
+	machineMarkedForRemediation.Name = "marked-for-remediation"
+	machineMarkedForRemediation.Status.Conditions = append(machineMarkedForRemediation.Status.Conditions,
+		clusterv1.Condition{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: corev1.ConditionFalse},
+		clusterv1.Condition{Type: clusterv1.MachineOwnerRemediatedCondition, Status: corev1.ConditionFalse},
+	)
+
+	g := NewWithT(t)
+	c := &ControlPlane{
+		KCP:                 &controlplanev1.KubeadmControlPlane{},
+		Machines:            collections.FromMachines(healthyMachine, machineWithoutNode, machineJustDeleted, machineNotUpToDate, machineMarkedForRemediation),
+		machinesNotUptoDate: collections.FromMachines(machineNotUpToDate),
+		EtcdMembers:         []*etcd.Member{{Name: "m1"}, {Name: "m2"}, {Name: "m3"}},
+	}
+
+	got := c.StatusToLogKeyAndValues(machineJustCreated, machineJustDeleted)
+
+	g.Expect(got).To((HaveLen(4)))
+	g.Expect(got[0]).To(Equal("machines"))
+	machines := strings.Join([]string{
+		"healthy",
+		"just-created (just created)",
+		"just-deleted (just deleted)",
+		"marked-for-remediation (marked for remediation)",
+		"not-up-to-date (not up-to-date)",
+		"without-node (status.nodeRef not set, APIServerPod health unknown, ControllerManagerPod health unknown, SchedulerPod health unknown, EtcdPod health unknown, EtcdMember not healthy)",
+	}, ", ")
+	g.Expect(got[1]).To(Equal(machines), cmp.Diff(got[1], machines))
+	g.Expect(got[2]).To(Equal("etcdMembers"))
+	g.Expect(got[3]).To(Equal("m1, m2, m3"))
 }
 
 type machineOpt func(*clusterv1.Machine)

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -672,7 +672,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, con
 			continue
 		}
 
-		log.Info("Deleting control plane Machine")
+		log.Info("Deleting Machine (KCP deleted)")
 		if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrapf(err, "failed to delete control plane Machine %s", klog.KObj(machineToDelete)))
 		}

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -672,11 +672,13 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, con
 			continue
 		}
 
-		log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToDelete)...).
-			Info("Deleting Machine (KCP deleted)")
 		if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrapf(err, "failed to delete control plane Machine %s", klog.KObj(machineToDelete)))
 		}
+		// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.
+		// Also, setting DeletionTimestamp doesn't mean the Machine is actually deleted (deletion takes some time).
+		log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToDelete)...).
+			Info("Deleting Machine (KubeadmControlPlane deleted)")
 	}
 	if len(errs) > 0 {
 		err := kerrors.NewAggregate(errs)

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -672,7 +672,8 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, con
 			continue
 		}
 
-		log.Info("Deleting Machine (KCP deleted)")
+		log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToDelete)...).
+			Info("Deleting Machine (KCP deleted)")
 		if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrapf(err, "failed to delete control plane Machine %s", klog.KObj(machineToDelete)))
 		}

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -184,6 +185,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileExternalReference(ctx context.C
 
 func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, bootstrapSpec *bootstrapv1.KubeadmConfigSpec, failureDomain *string) error {
 	var errs []error
+	log := ctrl.LoggerFrom(ctx)
 
 	// Compute desired Machine
 	machine, err := r.computeDesiredMachine(kcp, cluster, failureDomain, nil)
@@ -252,6 +254,10 @@ func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx conte
 		return kerrors.NewAggregate(errs)
 	}
 
+	log.Info("Machine created (scale up)",
+		"Machine", klog.KObj(machine),
+		infraRef.Kind, klog.KRef(infraRef.Namespace, infraRef.Name),
+		bootstrapRef.Kind, klog.KRef(bootstrapRef.Namespace, bootstrapRef.Name))
 	return nil
 }
 

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -374,7 +374,8 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
 		JoinConfiguration: &bootstrapv1.JoinConfiguration{},
 	}
-	g.Expect(r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, nil)).To(Succeed())
+	_, err := r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, nil)
+	g.Expect(err).To(Succeed())
 
 	machineList := &clusterv1.MachineList{}
 	g.Expect(env.GetAPIReader().List(ctx, machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
@@ -463,7 +464,8 @@ func TestCloneConfigsAndGenerateMachineFail(t *testing.T) {
 
 	// Try to break Infra Cloning
 	kcp.Spec.MachineTemplate.InfrastructureRef.Name = "something_invalid"
-	g.Expect(r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, nil)).To(HaveOccurred())
+	_, err := r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, nil)
+	g.Expect(err).To(HaveOccurred())
 	g.Expect(&kcp.GetConditions()[0]).Should(conditions.HaveSameStateOf(&clusterv1.Condition{
 		Type:     controlplanev1.MachinesCreatedCondition,
 		Status:   corev1.ConditionFalse,

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -311,7 +311,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	}
 
 	// Surface the operation is in progress.
-	log.Info("Remediating unhealthy machine")
+	log.Info("Deleting Machine (remediating unhealthy Machine)")
 	conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationInProgressReason, clusterv1.ConditionSeverityWarning, "")
 
 	v1beta2conditions.Set(machineToBeRemediated, metav1.Condition{

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -311,6 +311,8 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	}
 
 	// Surface the operation is in progress.
+	// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.
+	// Also, setting DeletionTimestamp doesn't mean the Machine is actually deleted (deletion takes some time).
 	log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToBeRemediated)...).
 		Info("Deleting Machine (remediating unhealthy Machine)")
 	conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationInProgressReason, clusterv1.ConditionSeverityWarning, "")

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -311,7 +311,8 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	}
 
 	// Surface the operation is in progress.
-	log.Info("Deleting Machine (remediating unhealthy Machine)")
+	log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToBeRemediated)...).
+		Info("Deleting Machine (remediating unhealthy Machine)")
 	conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedCondition, clusterv1.RemediationInProgressReason, clusterv1.ConditionSeverityWarning, "")
 
 	v1beta2conditions.Set(machineToBeRemediated, metav1.Condition{

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -158,6 +158,8 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 			"Failed to delete control plane Machine %s for cluster %s control plane: %v", machineToDelete.Name, klog.KObj(controlPlane.Cluster), err)
 		return ctrl.Result{}, err
 	}
+	// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.
+	// Also, setting DeletionTimestamp doesn't mean the Machine is actually deleted (deletion takes some time).
 	logger.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToDelete)...).
 		Info("Deleting Machine (scale down)", "Machine", klog.KObj(machineToDelete))
 

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -139,6 +139,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 	}
 
 	logger = logger.WithValues("Machine", klog.KObj(machineToDelete))
+	logger.Info("Deleting Machine (scale down)")
 	if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete control plane machine")
 		r.recorder.Eventf(controlPlane.KCP, corev1.EventTypeWarning, "FailedScaleDown",

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -427,7 +427,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 	// else delete owned machines.
 	for _, machine := range machineList {
 		if machine.DeletionTimestamp.IsZero() {
-			log.Info("Deleting Machine", "Machine", klog.KObj(machine))
+			log.Info("Deleting Machine (MS deleted)", "Machine", klog.KObj(machine))
 			if err := r.Client.Delete(ctx, machine); err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, errors.Wrapf(err, "failed to delete Machine %s", klog.KObj(machine))
 			}
@@ -794,7 +794,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 				continue
 			}
 
-			log.Info(fmt.Sprintf("Created machine %d of %d", i+1, diff), "Machine", klog.KObj(machine))
+			log.Info(fmt.Sprintf("Machine created (scale up, creating %d of %d)", i+1, diff), "Machine", klog.KObj(machine))
 			r.recorder.Eventf(ms, corev1.EventTypeNormal, "SuccessfulCreate", "Created machine %q", machine.Name)
 			machineList = append(machineList, machine)
 		}
@@ -816,7 +816,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 		for i, machine := range machinesToDelete {
 			log := log.WithValues("Machine", klog.KObj(machine))
 			if machine.GetDeletionTimestamp().IsZero() {
-				log.Info(fmt.Sprintf("Deleting machine %d of %d", i+1, diff))
+				log.Info(fmt.Sprintf("Deleting Machine (scale down, deleting %d of %d)", i+1, diff))
 				if err := r.Client.Delete(ctx, machine); err != nil {
 					log.Error(err, "Unable to delete Machine")
 					r.recorder.Eventf(ms, corev1.EventTypeWarning, "FailedDelete", "Failed to delete machine %q: %v", machine.Name, err)
@@ -825,7 +825,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 				}
 				r.recorder.Eventf(ms, corev1.EventTypeNormal, "SuccessfulDelete", "Deleted machine %q", machine.Name)
 			} else {
-				log.Info(fmt.Sprintf("Waiting for machine %d of %d to be deleted", i+1, diff))
+				log.Info(fmt.Sprintf("Waiting for Machine to be deleted (scale down, deleting %d of %d)", i+1, diff))
 			}
 		}
 
@@ -1492,7 +1492,7 @@ func (r *Reconciler) reconcileUnhealthyMachines(ctx context.Context, s *scope) (
 	}
 	var errs []error
 	for _, m := range machinesToRemediate {
-		log.Info("Deleting unhealthy Machine", "Machine", klog.KObj(m))
+		log.Info("Deleting Machine (remediating unhealthy Machine)", "Machine", klog.KObj(m))
 		if err := r.Client.Delete(ctx, m); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrapf(err, "failed to delete Machine %s", klog.KObj(m)))
 		}

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -427,7 +427,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 	// else delete owned machines.
 	for _, machine := range machineList {
 		if machine.DeletionTimestamp.IsZero() {
-			log.Info("Deleting Machine (MS deleted)", "Machine", klog.KObj(machine))
+			log.Info("Deleting Machine (MachineSet deleted)", "Machine", klog.KObj(machine))
 			if err := r.Client.Delete(ctx, machine); err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, errors.Wrapf(err, "failed to delete Machine %s", klog.KObj(machine))
 			}

--- a/util/collections/machine_collection.go
+++ b/util/collections/machine_collection.go
@@ -123,6 +123,16 @@ func ToMachineList(machines Machines) clusterv1.MachineList {
 	return ml
 }
 
+// Has return true when the collection has the given machine.
+func (s Machines) Has(machine *clusterv1.Machine) bool {
+	for _, m := range s {
+		if m.Name == machine.Name && m.Namespace == machine.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
 // Insert adds items to the set.
 func (s Machines) Insert(machines ...*clusterv1.Machine) {
 	for i := range machines {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improve logs whenever we create a Machine in KCP or MS, more specifically
- All the message text are consistent and include the reason why creation or deletion happened (scale up, scale down, remediation, KCP/MS deleted)
- Missing log messages on KCP machine creation has been added

/area machine