### PR TITLE
🌱  Use HasOwnerReference in controller-runtime

### DIFF
--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -169,7 +170,10 @@ func TestComputeInfrastructureCluster(t *testing.T) {
 		obj, err := computeInfrastructureCluster(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
-		g.Expect(ownerrefs.HasOwnerReferenceFrom(obj, shim)).To(BeTrue())
+
+		b, err := ctrlutil.HasOwnerReference(obj.GetOwnerReferences(), shim, fakeScheme)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(b).To(BeTrue())
 	})
 }
 
@@ -663,7 +667,9 @@ func TestComputeControlPlane(t *testing.T) {
 		obj, err := (&generator{}).computeControlPlane(ctx, s, nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
-		g.Expect(ownerrefs.HasOwnerReferenceFrom(obj, shim)).To(BeTrue())
+		b, err := ctrlutil.HasOwnerReference(obj.GetOwnerReferences(), shim, fakeScheme)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(b).To(BeTrue())
 	})
 }
 

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -383,22 +383,6 @@ func assertHasOwnerReference(obj, obj2 client.Object) error {
 	return err
 }
 
-func isOwnerReferenceEqual(a, b metav1.OwnerReference) bool {
-	if a.APIVersion != b.APIVersion {
-		return false
-	}
-	if a.Kind != b.Kind {
-		return false
-	}
-	if a.Name != b.Name {
-		return false
-	}
-	if a.UID != b.UID {
-		return false
-	}
-	return true
-}
-
 func TestReconciler_reconcileVariables(t *testing.T) {
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)
 

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -378,8 +378,8 @@ func assertMachinePoolClass(ctx context.Context, actualClusterClass *clusterv1.C
 		builder.BootstrapGroupVersion)
 }
 
-func assertHasOwnerReference(obj, obj2 client.Object) error {
-	_, err := ctrlutil.HasOwnerReference(obj.GetOwnerReferences(), obj2, fakeScheme)
+func assertHasOwnerReference(owner, obj client.Object) error {
+	_, err := ctrlutil.HasOwnerReference(owner.GetOwnerReferences(), obj, fakeScheme)
 	return err
 }
 

--- a/internal/controllers/clusterclass/suite_test.go
+++ b/internal/controllers/clusterclass/suite_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -79,18 +78,6 @@ func TestMain(m *testing.M) {
 		SetupIndexes:        setupIndexes,
 		SetupReconcilers:    setupReconcilers,
 	}))
-}
-
-// ownerReferenceTo converts an object to an OwnerReference.
-// Note: We pass in gvk explicitly as we can't rely on GVK being set on all objects
-// (only on Unstructured).
-func ownerReferenceTo(obj client.Object, gvk schema.GroupVersionKind) *metav1.OwnerReference {
-	return &metav1.OwnerReference{
-		APIVersion: gvk.GroupVersion().String(),
-		Kind:       gvk.Kind,
-		Name:       obj.GetName(),
-		UID:        obj.GetUID(),
-	}
 }
 
 // referenceExistsWithCorrectKindAndAPIVersion asserts that the passed ObjectReference is not nil and that it has the correct kind and apiVersion.

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -278,7 +278,7 @@ func TestReconcileShim(t *testing.T) {
 
 		// Run reconcileClusterShim using a nil client, so an error will be triggered if any operation is attempted
 		r := Reconciler{
-			Client:             nil,
+			Client:             env,
 			APIReader:          env.GetAPIReader(),
 			patchHelperFactory: serverSideApplyPatchHelperFactory(nil, ssa.NewCache()),
 		}

--- a/internal/topology/ownerrefs/ownerref.go
+++ b/internal/topology/ownerrefs/ownerref.go
@@ -35,7 +35,7 @@ func OwnerReferenceTo(obj client.Object, gvk schema.GroupVersionKind) *metav1.Ow
 	}
 }
 
-// // HasOwnerReferenceFrom checks if obj has an ownerRef pointing to owner.
+// HasOwnerReferenceFrom checks if obj has an ownerRef pointing to owner.
 //
 // Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
 func HasOwnerReferenceFrom(obj, owner client.Object) bool {

--- a/internal/topology/ownerrefs/ownerref.go
+++ b/internal/topology/ownerrefs/ownerref.go
@@ -35,7 +35,9 @@ func OwnerReferenceTo(obj client.Object, gvk schema.GroupVersionKind) *metav1.Ow
 	}
 }
 
-// HasOwnerReferenceFrom checks if obj has an ownerRef pointing to owner.
+// // HasOwnerReferenceFrom checks if obj has an ownerRef pointing to owner.
+//
+// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
 func HasOwnerReferenceFrom(obj, owner client.Object) bool {
 	for _, o := range obj.GetOwnerReferences() {
 		if o.Kind == owner.GetObjectKind().GroupVersionKind().Kind && o.Name == owner.GetName() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I replaces HasOwnerReferenceFrom with HasOwnerReference of controller-runtime, then I deprecated it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->