### PR TITLE
:seedling:Use context.WithTimeoutCause and context.WithCancelCause for better readability

### DIFF
--- a/cmd/clusterctl/client/repository/repository_gitlab.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab.go
@@ -147,7 +147,7 @@ func (g *gitLabRepository) GetFile(ctx context.Context, version, path string) ([
 		return content, nil
 	}
 
-	timeoutctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	timeoutctx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, errors.New("http request timeout expired"))
 	defer cancel()
 	request, err := http.NewRequestWithContext(timeoutctx, http.MethodGet, url, http.NoBody)
 	if err != nil {

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,7 +107,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 
 			testClusterKey = util.ObjectKey(testCluster)
 
-			_, cancel := context.WithCancel(ctx)
+			_, cancel := context.WithCancelCause(ctx)
 			cc = &stoppableCache{cancelFunc: cancel}
 			cct.clusterAccessors[testClusterKey] = &clusterAccessor{cache: cc}
 
@@ -123,7 +124,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			t.Log("Deleting Namespace")
 			g.Expect(env.Delete(ctx, ns)).To(Succeed())
 			t.Log("Stopping the manager")
-			cc.cancelFunc()
+			cc.cancelFunc(errors.New("context cancelled"))
 			mgrCancel()
 		}
 

--- a/controllers/remote/stoppable_cache.go
+++ b/controllers/remote/stoppable_cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
@@ -29,7 +30,7 @@ type stoppableCache struct {
 
 	lock       sync.Mutex
 	stopped    bool
-	cancelFunc context.CancelFunc
+	cancelFunc context.CancelCauseFunc
 }
 
 // Stop cancels the cache.Cache's context, unless it has already been stopped.
@@ -42,5 +43,5 @@ func (cc *stoppableCache) Stop() {
 	}
 
 	cc.stopped = true
-	cc.cancelFunc()
+	cc.cancelFunc(errors.New("cache stopped"))
 }

--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -180,7 +180,7 @@ func newEtcdClient(ctx context.Context, etcdClient etcd, callTimeout time.Durati
 		return nil, errors.New("etcd client was not configured with any endpoints")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, callTimeout, errors.New("call timeout expired"))
 	defer cancel()
 
 	status, err := etcdClient.Status(ctx, endpoints[0])
@@ -204,7 +204,7 @@ func (c *Client) Close() error {
 
 // Members retrieves a list of etcd members.
 func (c *Client) Members(ctx context.Context) ([]*Member, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.CallTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.CallTimeout, errors.New("call timeout expired"))
 	defer cancel()
 
 	response, err := c.EtcdClient.MemberList(ctx)
@@ -225,7 +225,7 @@ func (c *Client) Members(ctx context.Context) ([]*Member, error) {
 
 // MoveLeader moves the leader to the provided member ID.
 func (c *Client) MoveLeader(ctx context.Context, newLeaderID uint64) error {
-	ctx, cancel := context.WithTimeout(ctx, c.CallTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.CallTimeout, errors.New("call timeout expired"))
 	defer cancel()
 
 	_, err := c.EtcdClient.MoveLeader(ctx, newLeaderID)
@@ -234,7 +234,7 @@ func (c *Client) MoveLeader(ctx context.Context, newLeaderID uint64) error {
 
 // RemoveMember removes a given member.
 func (c *Client) RemoveMember(ctx context.Context, id uint64) error {
-	ctx, cancel := context.WithTimeout(ctx, c.CallTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.CallTimeout, errors.New("call timeout expired"))
 	defer cancel()
 
 	_, err := c.EtcdClient.MemberRemove(ctx, id)
@@ -243,7 +243,7 @@ func (c *Client) RemoveMember(ctx context.Context, id uint64) error {
 
 // Alarms retrieves all alarms on a cluster.
 func (c *Client) Alarms(ctx context.Context) ([]MemberAlarm, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.CallTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.CallTimeout, errors.New("call timeout expired"))
 	defer cancel()
 
 	alarmResponse, err := c.EtcdClient.AlarmList(ctx)

--- a/exp/runtime/internal/controllers/warmup.go
+++ b/exp/runtime/internal/controllers/warmup.go
@@ -69,7 +69,7 @@ func (r *warmupRunnable) Start(ctx context.Context) error {
 	if r.warmupTimeout == 0 {
 		r.warmupTimeout = defaultWarmupTimeout
 	}
-	ctx, cancel := context.WithTimeout(ctx, r.warmupTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, r.warmupTimeout, errors.New("warmup timeout expired"))
 	defer cancel()
 
 	err := wait.PollUntilContextTimeout(ctx, r.warmupInterval, r.warmupTimeout, true, func(ctx context.Context) (done bool, err error) {

--- a/hack/tools/internal/log-push/main.go
+++ b/hack/tools/internal/log-push/main.go
@@ -170,7 +170,7 @@ func getLogsFromGCS(ctx context.Context, logPath string, logFileRegex *regexp.Re
 	klog.Infof("Getting logs from gs://%s/%s", bucket, folder)
 
 	// Set timeout.
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	ctx, cancel := context.WithTimeoutCause(ctx, 2*time.Minute, errors.New("client timeout expired"))
 	defer cancel()
 
 	// Create GCS client.

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -458,8 +458,8 @@ func runTaskGroup(ctx context.Context, name string, tasks map[string]taskFunctio
 	}(time.Now())
 
 	// Create a context to be used for canceling all the tasks when another fails.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("run task group context cancelled"))
 
 	// Make channels to pass fatal errors in WaitGroup
 	errors := make(chan error)
@@ -483,7 +483,7 @@ func runTaskGroup(ctx context.Context, name string, tasks map[string]taskFunctio
 		break
 	case err := <-errors:
 		// cancel all the running tasks
-		cancel()
+		cancel(err)
 		// consumes all the errors from the channel
 		errList := []error{err}
 	Loop:

--- a/internal/controllers/machine/drain/drain.go
+++ b/internal/controllers/machine/drain/drain.go
@@ -316,7 +316,7 @@ func (d *Helper) EvictPods(ctx context.Context, podDeleteList *PodDeleteList) Ev
 
 	// Trigger evictions for at most 10s. We'll continue on the next reconcile if we hit the timeout.
 	evictionTimeout := 10 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, evictionTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, evictionTimeout, errors.New("eviction timeout expired"))
 	defer cancel()
 
 	res := EvictionResult{

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -471,7 +471,7 @@ func httpCall(ctx context.Context, request, response runtime.Object, opts *httpC
 		extensionURL.RawQuery = values.Encode()
 
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, opts.timeout)
+		ctx, cancel = context.WithTimeoutCause(ctx, opts.timeout, errors.New("http request timeout expired"))
 		defer cancel()
 	}
 

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -151,7 +151,7 @@ func Run(ctx context.Context, input RunInput) int {
 	// Bootstrapping test environment
 	env := newEnvironment(input.ManagerCacheOptions, input.ManagerUncachedObjs...)
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
 	env.cancelManager = cancel
 
 	if input.SetupIndexes != nil {
@@ -227,7 +227,7 @@ type Environment struct {
 	Config *rest.Config
 
 	env           *envtest.Environment
-	cancelManager context.CancelFunc
+	cancelManager context.CancelCauseFunc
 }
 
 // newEnvironment creates a new environment spinning up a local api-server.
@@ -401,7 +401,7 @@ func (e *Environment) start(ctx context.Context) {
 // stop stops the test environment.
 func (e *Environment) stop() error {
 	fmt.Println("Stopping the test environment")
-	e.cancelManager()
+	e.cancelManager(errors.New("test environment stopped"))
 	return e.env.Stop()
 }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR replaces `context.WithTimeoutCause` and `context.WithCancelCause` instead of `context.Timeout`  and `context.WithCancel` for better readability of issues when the standard `context deadline exceeded` error is emitted.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11280 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->