### PR TITLE
🐛 Default to topology flavor in NodeDrainTimeoutSpec

### DIFF
--- a/test/e2e/node_drain.go
+++ b/test/e2e/node_drain.go
@@ -58,7 +58,7 @@ type NodeDrainTimeoutSpecInput struct {
 
 	// Flavor, if specified, must refer to a template that uses a Cluster with ClusterClass.
 	// The cluster must use a KubeadmControlPlane and a MachineDeployment.
-	// If not specified, "node-drain" is used.
+	// If not specified, "topology" is used.
 	Flavor *string
 
 	// Allows to inject a function to be run after test namespace is created.
@@ -138,7 +138,7 @@ func NodeDrainTimeoutSpec(ctx context.Context, inputGetter func() NodeDrainTimeo
 				ClusterctlConfigPath:     input.ClusterctlConfigPath,
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   infrastructureProvider,
-				Flavor:                   ptr.Deref(input.Flavor, "node-drain"),
+				Flavor:                   ptr.Deref(input.Flavor, "topology"),
 				Namespace:                namespace.Name,
 				ClusterName:              clusterName,
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),


### PR DESCRIPTION
**What this PR does / why we need it**:

The node-drain Docker test template was removed in #11127, but remained as the default flavor for `NodeDrainTimeoutSpec`. This can cause a nil pointer exception when a subsequent function expects `Spec.Toplogy` to be set.

CAPI explicitly supplies the `topology` flavor when calling the spec, so it didn't see this problem (but CAPZ did).

**Which issue(s) this PR fixes**:
Refs kubernetes-sigs/cluster-api-provider-azure#5316

/area testing
