### PR TITLE
🌱 topology: fix godoc for LocalObjectTemplatesAreCompatible

### DIFF
--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -86,7 +86,7 @@ func ObjectsAreInTheSameNamespace(current, desired client.Object) field.ErrorLis
 }
 
 // LocalObjectTemplatesAreCompatible checks if two referenced objects are compatible, meaning that
-// they are of the same GroupKind and in the same namespace.
+// they are of the same GroupKind.
 func LocalObjectTemplatesAreCompatible(current, desired clusterv1.LocalObjectTemplate, pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Follow up to: https://github.com/kubernetes-sigs/cluster-api/pull/11352

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area topology