### PR TITLE
🌱 Add KAL linter for linting API conventions

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -33,3 +33,5 @@ jobs:
           version: v1.63.4
           args: --out-format=colored-line-number
           working-directory: ${{matrix.working-directory}}
+      - name: Lint API
+        run: GOLANGCI_LINT_EXTRA_ARGS=--out-format=colored-line-number make lint-api

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,62 @@
+run:
+  timeout: 10m
+  go: "1.23"
+  allow-parallel-runners: true
+
+linters:
+  disable-all: true
+  enable:
+    - kal # linter for Kube API conventions
+   
+linters-settings:
+  custom:
+    kal:
+      type: "module"
+      description: KAL is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+      settings:
+        linters:
+          enable:
+          # Per discussion in July 2024, we are keeping phase fields for now.
+          # See https://github.com/kubernetes-sigs/cluster-api/pull/10897#discussion_r1685929508
+          # and https://github.com/kubernetes-sigs/cluster-api/pull/10897#discussion_r1685919394.
+          # - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
+          
+          # Linters below this line are disabled, pending conversation on how and when to enable them.
+          # - "conditions" # Ensure conditions have the correct json tags and markers.
+          # - "commentstart" # Ensure comments start with the serialized version of the field name.
+          # - "integers" # Ensure only int32 and int64 are used for integers.
+          # - "jsontags" # Ensure every field has a json tag.
+          # - "maxlength" # Ensure all strings and arrays have maximum lengths/maximum items.
+          # - "nobools" # Bools do not evolve over time, should use enums instead.
+          # - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
+          # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+          # - "statussubresource" # All root objects that have a `status` field should have a status subresource.
+          disable:
+          - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
+        lintersConfig:
+          conditions:
+            isFirstField: Warn # Require conditions to be the first field in the status struct.
+            usePatchStrategy: Forbid # Conditions should not use the patch strategy on CRDs.
+            useProtobuf: Forbid # We don't use protobuf, so protobuf tags are not required.
+        # jsonTags:
+        #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
+        # optionalOrRequired:
+        #   preferredOptionalMarker: optional | kubebuilder:validation:Optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
+        #   preferredRequiredMarker: required | kubebuilder:validation:Required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`.
+        # requiredFields:
+        #   pointerPolicy: Warn | SuggestFix # Defaults to `SuggestFix`. We want our required fields to not be pointers.
+
+issues:
+  exclude-files:
+    - "zz_generated.*\\.go$"
+    - "vendored_openapi\\.go$"
+    # We don't want to invest time to fix new linter findings in old API types.
+    - "internal/apis/.*"
+    - ".*_test.go"  # Exclude test files.
+  max-same-issues: 0
+  max-issues-per-linter: 0
+  exclude-rules:
+  # KAL should only run on API folders.
+  - path-except: "api/*"
+    linters:
+      - kal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -226,6 +226,7 @@ linters-settings:
       - name: constant-logical-expr
   goconst:
     ignore-tests: true
+
 issues:
   exclude-files:
     - "zz_generated.*\\.go$"

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,0 +1,6 @@
+version:  v1.63.4
+name: golangci-lint-kal-v1.63.4
+destination: ./bin
+plugins:
+- module: 'github.com/JoelSpeed/kal'
+  version: v0.0.0-20250208110507-b94e5ede1177


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds [KAL](https://github.com/JoelSpeed/kal) to the linter workflows to lint API conventions.

The linter is a WIP project that I have been working on and the focus of the project is to try and enforce API conventions via a linter, to take off some of the cognitive load of API review.

At the moment, there are 10 sub-linters implemented, each of which I've listed out within the configuration with a description of what they mean.

We should discuss each one and agree upon them, and then, the intention is that we can use this linter for the new v1beta2 types.

The set up here runs KAL separately from the main golangci-lint run, so that the GitHub workflow for linting can continue to use the official GH action, which has some caching and speed improvements over running the binary manually.

The config for KAL is set to run only on files containing `api/v1beta2` in the name. Since we don't have any of those yet, I've temporarily added `api/v1beta1` so that we can see what the output might look like. We will want to remove that before merging.

I've also updated GolangCI-Lint to v1.63.4. v1.63 introduced the ability for custom linters to apply fixes to the code, so `lint-fix` will work with KAL as well provided we use a v1.63 or later version. I figured it best to update the main version of the linter at the same time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->