### PR TITLE
🌱  Use labels for kustomize

### DIFF
--- a/docs/book/src/developer/providers/contracts/bootstrap-config.md
+++ b/docs/book/src/developer/providers/contracts/bootstrap-config.md
@@ -135,13 +135,14 @@ The value is an underscore-delimited (_) list of versions. Each value MUST point
 The label allows Cluster API controllers to perform automatic conversions for object references, the controllers will pick
 the last available version in the list if multiple versions are found.
 
-To apply the label to CRDs it’s possible to use commonLabels in your `kustomize.yaml` file, usually in `config/crd`:
+To apply the label to CRDs it’s possible to use labels in your `kustomization.yaml` file, usually in `config/crd`:
 
 ```yaml
-commonLabels:
-  cluster.x-k8s.io/v1alpha2: v1alpha1
-  cluster.x-k8s.io/v1alpha3: v1alpha2
-  cluster.x-k8s.io/v1beta1: v1beta1
+labels:
+- pairs:
+    cluster.x-k8s.io/v1alpha2: v1alpha1
+    cluster.x-k8s.io/v1alpha3: v1alpha2
+    cluster.x-k8s.io/v1beta1: v1beta1
 ```
 
 An example of this is in the [Kubeadm Bootstrap provider](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/controlplane/kubeadm/config/crd/kustomization.yaml).

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -160,13 +160,14 @@ The value is an underscore-delimited (_) list of versions. Each value MUST point
 The label allows Cluster API controllers to perform automatic conversions for object references, the controllers will pick
 the last available version in the list if multiple versions are found.
 
-To apply the label to CRDs it’s possible to use commonLabels in your `kustomize.yaml` file, usually in `config/crd`:
+To apply the label to CRDs it’s possible to use labels in your `kustomization.yaml` file, usually in `config/crd`:
 
 ```yaml
-commonLabels:
-  cluster.x-k8s.io/v1alpha2: v1alpha1
-  cluster.x-k8s.io/v1alpha3: v1alpha2
-  cluster.x-k8s.io/v1beta1: v1beta1
+labels:
+- pairs:
+    cluster.x-k8s.io/v1alpha2: v1alpha1
+    cluster.x-k8s.io/v1alpha3: v1alpha2
+    cluster.x-k8s.io/v1beta1: v1beta1
 ```
 
 An example of this is in the [Kubeadm Bootstrap provider](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/controlplane/kubeadm/config/crd/kustomization.yaml).

--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -144,13 +144,14 @@ The value is an underscore-delimited (_) list of versions. Each value MUST point
 The label allows Cluster API controllers to perform automatic conversions for object references, the controllers will pick
 the last available version in the list if multiple versions are found.
 
-To apply the label to CRDs it’s possible to use commonLabels in your `kustomize.yaml` file, usually in `config/crd`:
+To apply the label to CRDs it’s possible to use labels in your `kustomization.yaml` file, usually in `config/crd`:
 
 ```yaml
-commonLabels:
-  cluster.x-k8s.io/v1alpha2: v1alpha1
-  cluster.x-k8s.io/v1alpha3: v1alpha2
-  cluster.x-k8s.io/v1beta1: v1beta1
+labels:
+- pairs:
+    cluster.x-k8s.io/v1alpha2: v1alpha1
+    cluster.x-k8s.io/v1alpha3: v1alpha2
+    cluster.x-k8s.io/v1beta1: v1beta1
 ```
 
 An example of this is in the [Kubeadm Bootstrap provider](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/controlplane/kubeadm/config/crd/kustomization.yaml).

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -135,13 +135,14 @@ The value is an underscore-delimited (_) list of versions. Each value MUST point
 The label allows Cluster API controllers to perform automatic conversions for object references, the controllers will pick
 the last available version in the list if multiple versions are found.
 
-To apply the label to CRDs it’s possible to use commonLabels in your `kustomize.yaml` file, usually in `config/crd`:
+To apply the label to CRDs it’s possible to use labels in your `kustomization.yaml` file, usually in `config/crd`:
 
 ```yaml
-commonLabels:
-  cluster.x-k8s.io/v1alpha2: v1alpha1
-  cluster.x-k8s.io/v1alpha3: v1alpha2
-  cluster.x-k8s.io/v1beta1: v1beta1
+labels:
+- pairs:
+    cluster.x-k8s.io/v1alpha2: v1alpha1
+    cluster.x-k8s.io/v1alpha3: v1alpha2
+    cluster.x-k8s.io/v1beta1: v1beta1
 ```
 
 An example of this is in the [Kubeadm Bootstrap provider](https://github.com/kubernetes-sigs/cluster-api/blob/release-1.1/controlplane/kubeadm/config/crd/kustomization.yaml).

--- a/docs/book/src/developer/providers/getting-started/building-running-and-testing.md
+++ b/docs/book/src/developer/providers/getting-started/building-running-and-testing.md
@@ -59,9 +59,11 @@ Conditions:
 
 In this guide, we are building an _infrastructure provider_. We must tell cluster-api and its developer tooling which type of provider it is. Edit `config/default/kustomization.yaml` and add the following common label. The prefix `infrastructure-` [is used][label_prefix] to detect the provider type.
 
-```sh
-commonLabels:
-  cluster.x-k8s.io/provider: infrastructure-mailgun
+```yaml
+labels:
+- includeSelectors: true
+  pairs:
+    cluster.x-k8s.io/provider: infrastructure-mailgun
 ```
 
 Now you can apply your provider as well:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* Use [labels](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/) to add labels to CRDs
* Fix `kustomize.yaml` -> `kustomization.yaml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
I'm developing a CAPI infrastructure provider, and I got a warning when executing`kustomize build`.

```console
$ kustomize build > /dev/null
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```
ref: https://github.com/kubernetes-sigs/kustomize/pull/5464


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation