### PR TITLE
[release-1.7] 🌱 Bump go to v1.22.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.22.10
+GO_VERSION ?= 1.22.11
 GO_DIRECTIVE_VERSION ?= 1.21
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -184,7 +184,7 @@ def load_provider_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.22.10 as tilt-helper
+FROM golang:1.22.11 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22
 # Support live reloading with Tilt
@@ -195,7 +195,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.22.10 as tilt
+FROM golang:1.22.11 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .


### PR DESCRIPTION
/area dependency

See the [release notes](https://github.com/golang/go/issues?q=milestone%3AGo1.22.11+label%3ACherryPickApproved) for more detail. 

(CAPI's `main` branch is on go v1.23.5 now, which I assume we don't want to cherry-pick into the previous release branches. )