### PR TITLE
⚠️ Deprecate the ClusterResourceSet feature flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -271,6 +271,10 @@ issues:
   - linters:
     - staticcheck
     text: "SA1019: (clusterv1alpha3.*|clusterv1alpha4.*) is deprecated: This type will be removed in one of the next releases."
+  # Specific exclude rules for deprecated feature flags
+  - linters:
+      - staticcheck
+    text: "SA1019: feature.ClusterResourceSet is deprecated: ClusterResourceSet feature is now GA and the corresponding feature flag will be removed in 1.12 release."
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -40,6 +40,8 @@ const (
 	// alpha: v0.3
 	// beta: v0.4
 	// GA: v1.10
+	//
+	// Deprecated: ClusterResourceSet feature is now GA and the corresponding feature flag will be removed in 1.12 release.
 	ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
 
 	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.


### PR DESCRIPTION
**What this PR does / why we need it**:
Given that the ClusterResourceSet is now GA, the corresponding feature flag shold be deprecated, and it will be removed in 1.12.

Please note that, based on the behaviour implemented by http://k8s.io/component-base for GA flags:
- the ClusterResourceSet flag disappears from the CLI help
- the ClusterResourceSet flag can still be used and it is operational (it can be set to false)
- when you use the ClusterResourceSet flag, you get a warning

Ref https://github.com/kubernetes-sigs/cluster-api/issues/11114

/area clusterresourceset