### PR TITLE
🌱 Deprecate old ClusterClass index

### DIFF
--- a/api/v1beta1/index/cluster.go
+++ b/api/v1beta1/index/cluster.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	// ClusterClassNameField is used by the Cluster controller to index Clusters by ClusterClass name.
+	//
+	// Deprecated: This constant will be removed in an upcoming release, please use ClusterClassRefPath instead.
 	ClusterClassNameField = "spec.topology.class"
 
 	// ClusterClassRefPath is used by the Cluster controller to index Clusters by ClusterClass name and namespace.
@@ -70,6 +72,8 @@ func ClusterClassRef(cc *clusterv1.ClusterClass) string {
 
 // ByClusterClassName adds the cluster class name  index to the
 // managers cache.
+//
+// Deprecated: This func will be removed in an upcoming release, please use ByClusterClassRef instead.
 func ByClusterClassName(ctx context.Context, mgr ctrl.Manager) error {
 	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Cluster{},
 		ClusterClassNameField,
@@ -81,6 +85,8 @@ func ByClusterClassName(ctx context.Context, mgr ctrl.Manager) error {
 }
 
 // ClusterByClusterClassClassName contains the logic to index Clusters by ClusterClass name.
+//
+// Deprecated: This func will be removed in an upcoming release, please use ClusterByClusterClassRef instead.
 func ClusterByClusterClassClassName(o client.Object) []string {
 	cluster, ok := o.(*clusterv1.Cluster)
 	if !ok {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/11352#pullrequestreview-2564853352

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->