### PR TITLE
🌱 reduce size of ipv6 service cidr to /112 because the old ip allocator is limited to that size

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -387,7 +387,7 @@ variables:
   IP_FAMILY: "dual"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   DOCKER_POD_CIDRS: "192.168.0.0/16"
-  DOCKER_SERVICE_IPV6_CIDRS: "fd00:100:64::/108"
+  DOCKER_SERVICE_IPV6_CIDRS: "fd00:100:64::/112"
   DOCKER_POD_IPV6_CIDRS: "fd00:100:96::/48"
   CNI: "./data/cni/kindnet/kindnet.yaml"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   clusterNetwork:
     services:
-      cidrBlocks: ["fd00:100:64::/108"]
+      cidrBlocks: ["fd00:100:64::/112"]
     pods:
       cidrBlocks: ["fd00:100:96::/48"]
     serviceDomain: cluster.local


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This should fix https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-latestk8s-main

Example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-latestk8s-main/1882645681580019712

```
I0124 04:47:10.578889 14 utils.go:776] Unexpected error: Failed to create node-port-service service: Internal error occurred: failed to allocate a serviceIP: range is full: 
    <*errors.StatusError | 0xc0038a1d60>: 
    Internal error occurred: failed to allocate a serviceIP: range is full
    {
        ErrStatus: 
            code: 500
            details:
              causes:
              - message: 'failed to allocate a serviceIP: range is full'
            message: 'Internal error occurred: failed to allocate a serviceIP: range is full'
            metadata: {}
            reason: InternalError
            status: Failure,
    }
```

This is propably fixed in k8s via this KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1880-multiple-service-cidrs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->