### PR TITLE
:seedling: Attempt older version upgrades twice to work around flake with the docker controller

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -39,7 +39,7 @@ var (
 )
 
 // Note: This test should not be changed during "prepare main branch".
-var _ = Describe("When testing clusterctl upgrades (v0.3=>v1.5=>current)", func() {
+var _ = Describe("When testing clusterctl upgrades (v0.3=>v1.5=>current)", FlakeAttempts(2), func() {
 	// We are testing v0.3=>v1.5=>current to ensure that old entries with v1alpha3 in managed files do not cause issues
 	// as described in https://github.com/kubernetes-sigs/cluster-api/issues/10051.
 	// NOTE: The combination of v0.3=>v1.5=>current allows us to verify this without being forced to upgrade
@@ -116,7 +116,7 @@ var _ = Describe("When testing clusterctl upgrades (v0.3=>v1.5=>current)", func(
 })
 
 // Note: This test should not be changed during "prepare main branch".
-var _ = Describe("When testing clusterctl upgrades (v0.4=>v1.6=>current)", func() {
+var _ = Describe("When testing clusterctl upgrades (v0.4=>v1.6=>current)", FlakeAttempts(2), func() {
 	// We are testing v0.4=>v1.6=>current to ensure that old entries with v1alpha4 in managed files do not cause issues
 	// as described in https://github.com/kubernetes-sigs/cluster-api/issues/10051.
 	// NOTE: The combination of v0.4=>v1.6=>current allows us to verify this without being forced to upgrade


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: This is a recommendation from this comment https://github.com/kubernetes-sigs/cluster-api/issues/11610#issuecomment-2607792687 in #11610 to work around flaky upgrade tests and improve our CI signal. The root cause seems to be related to the docker controller but only affects older versions. So the goal is to just reduce the flakey signal by retrying the tests on those older versions (which just show up in our upgrade tests). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11209
Fixes #11610

/area e2e-testing

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->