### PR TITLE
[release-1.9] 🌱  Add --additional-sync-machine-labels to allow syncing additional labels to Nodes

### DIFF
--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -72,6 +73,8 @@ type MachineReconciler struct {
 	WatchFilterValue string
 
 	RemoteConditionsGracePeriod time.Duration
+
+	AdditionalSyncMachineLabels []*regexp.Regexp
 }
 
 func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -81,6 +84,7 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		ClusterCache:                r.ClusterCache,
 		WatchFilterValue:            r.WatchFilterValue,
 		RemoteConditionsGracePeriod: r.RemoteConditionsGracePeriod,
+		AdditionalSyncMachineLabels: r.AdditionalSyncMachineLabels,
 	}).SetupWithManager(ctx, mgr, options)
 }
 

--- a/docs/book/src/reference/api/metadata-propagation.md
+++ b/docs/book/src/reference/api/metadata-propagation.md
@@ -63,7 +63,9 @@ Top-level labels that meet a specific cretria are propagated to the Node labels 
 - `.labels.[label-meets-criteria]` => `Node.labels`
 - `.annotations` => Not propagated.
 
-Label should meet one of the following criteria to propagate to Node: 
+Labels that meet at least one of the following criteria are always propagated to the Node:
 - Has `node-role.kubernetes.io` as prefix.
 - Belongs to `node-restriction.kubernetes.io` domain.
-- Belongs to `node.cluster.x-k8s.io` domain.  
+- Belongs to `node.cluster.x-k8s.io` domain.
+
+In addition, any labels that match at least one of the regexes provided by the `--additional-sync-machine-labels` flag on the manager will be synced from the Machine to the Node.

--- a/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
+++ b/docs/proposals/20220927-label-sync-between-machine-and-nodes.md
@@ -68,6 +68,7 @@ With the "divide and conquer" principle in mind this proposal aims to address th
 
 - Support label sync from Machine to the linked Kubernetes node, limited to `node-role.kubernetes.io/` prefix and the `node-restriction.kubernetes.io` domain.
 - Support syncing labels from Machine to the linked Kubernetes node for the Cluster API owned `node.cluster.x-k8s.io` domain.
+- Support a flag to sync additional user configured labels from the Machine to the Node.
 
 ### Non-Goals
 
@@ -98,7 +99,9 @@ While designing a solution for syncing labels between Machine and underlying Kub
 
 ### Label domains & prefixes
 
-The idea of scoping synchronization to a well defined set of labels is a first answer to security/concurrency concerns; labels to be managed by Cluster API have been selected based on following criteria:
+A default list of labels would always be synced from the Machines to the Nodes. An additional list of labels can be synced from the Machine to the Node by providing a list of regexes as a flag to the manager. 
+
+The following is the default list of label domains that would always be sync from Machines to Nodes:
 
 - The `node-role.kubernetes.io` label has been used widely in the past to identify the role of a Kubernetes Node (e.g. `node-role.kubernetes.io/worker=''`). For example, `kubectl get node` looks for this specific label when displaying the role to the user.
 
@@ -163,3 +166,4 @@ Users could also implement their own label synchronizer in their tooling, but th
 
 - [ ] 09/27/2022: First Draft of this document
 - [ ] 09/28/2022: First Draft of this document presented in the Cluster API office hours meeting
+- [ ] 01/09/2025: Update to support configurable label syncing Ref:[11657](https://github.com/kubernetes-sigs/cluster-api/issues/11657) 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -19,6 +19,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -99,6 +100,8 @@ type Reconciler struct {
 	WatchFilterValue string
 
 	RemoteConditionsGracePeriod time.Duration
+
+	AdditionalSyncMachineLabels []*regexp.Regexp
 
 	controller      controller.Controller
 	recorder        record.EventRecorder

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -94,6 +94,7 @@ func TestMain(m *testing.M) {
 			APIReader:                   mgr.GetAPIReader(),
 			ClusterCache:                clusterCache,
 			RemoteConditionsGracePeriod: 5 * time.Minute,
+			AdditionalSyncMachineLabels: nil,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
 		}


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/11650