### PR TITLE
🌱 observability: split up grafana configmap to not exceed the size limits on reoccuring apply

### DIFF
--- a/hack/observability/grafana/chart/values.yaml
+++ b/hack/observability/grafana/chart/values.yaml
@@ -88,8 +88,37 @@ dashboardProviders:
       options:
         path: /var/lib/grafana/dashboards/default
 
-dashboardsConfigMaps:
-  default: grafana-dashboards
+extraConfigmapMounts:
+- name: grafana-dashboard-cluster-api-mgmt-apiserver-requests
+  configMap: grafana-dashboard-cluster-api-mgmt-apiserver-requests
+  mountPath: /var/lib/grafana/dashboards/default/cluster-api-mgmt-apiserver-requests.json
+  subPath: cluster-api-mgmt-apiserver-requests.json
+  optional: false
+- name: grafana-dashboard-cluster-api-performance
+  configMap: grafana-dashboard-cluster-api-performance
+  mountPath: /var/lib/grafana/dashboards/default/cluster-api-performance.json
+  subPath: cluster-api-performance.json
+  optional: false
+- name: grafana-dashboard-cluster-api-state
+  configMap: grafana-dashboard-cluster-api-state
+  mountPath: /var/lib/grafana/dashboards/default/cluster-api-state.json
+  subPath: cluster-api-state.json
+  optional: false
+- name: grafana-dashboard-cluster-api-wl-apiserver-requests
+  configMap: grafana-dashboard-cluster-api-wl-apiserver-requests
+  mountPath: /var/lib/grafana/dashboards/default/cluster-api-wl-apiserver-requests.json
+  subPath: cluster-api-wl-apiserver-requests.json
+  optional: false
+- name: grafana-dashboard-controller-runtime
+  configMap: grafana-dashboard-controller-runtime
+  mountPath: /var/lib/grafana/dashboards/default/controller-runtime.json
+  subPath: controller-runtime.json
+  optional: false
+- name: grafana-dashboard-runtime-extensions
+  configMap: grafana-dashboard-runtime-extensions
+  mountPath: /var/lib/grafana/dashboards/default/runtime-extensions.json
+  subPath: runtime-extensions.json
+  optional: false
 
 # Disable grafana test framework
 testFramework:

--- a/hack/observability/grafana/kustomization.yaml
+++ b/hack/observability/grafana/kustomization.yaml
@@ -10,11 +10,21 @@ resources:
 namespace: observability
 
 configMapGenerator:
-- name: grafana-dashboards
+- name: grafana-dashboard-cluster-api-mgmt-apiserver-requests
   files:
   - dashboards/cluster-api-mgmt-apiserver-requests.json
+- name: grafana-dashboard-cluster-api-performance
+  files:
   - dashboards/cluster-api-performance.json
+- name: grafana-dashboard-cluster-api-state
+  files:
   - dashboards/cluster-api-state.json
+- name: grafana-dashboard-cluster-api-wl-apiserver-requests
+  files:
   - dashboards/cluster-api-wl-apiserver-requests.json
+- name: grafana-dashboard-controller-runtime
+  files:
   - dashboards/controller-runtime.json
+- name: grafana-dashboard-runtime-extensions
+  files:
   - dashboards/runtime-extensions.json


### PR DESCRIPTION
…
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Often getting the following when using tilt and having grafana enabled:

```
Build Failed: ConfigMap "grafana-dashboards-fb825bbkm2" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

This resolves that by splitting up the dashboards configmap and instead have a single configmap per dashboard.
This way, when re-applying, the `last-applied-configuration' annotations` fits in again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area devtools