### PR TITLE
🌱 CI: default building kind node-images depending on KIND_BUILD_IMAGES env variable instead of ginkgo magic regexes

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -40,51 +40,34 @@ capi:buildDockerImages () {
 # Note: We do this to ensure that the kindest/node image gets built if it does
 # not already exist, e.g. for pre-releases, but only if necessary.
 k8s::prepareKindestImagesVariables() {
+  KIND_BUILD_IMAGES="${KIND_BUILD_IMAGES:-}"
+
   # Always default KUBERNETES_VERSION_MANAGEMENT because we always create a management cluster out of it.
   if [[ -z "${KUBERNETES_VERSION_MANAGEMENT:-}" ]]; then
     KUBERNETES_VERSION_MANAGEMENT=$(grep KUBERNETES_VERSION_MANAGEMENT: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
     echo "Defaulting KUBERNETES_VERSION_MANAGEMENT to ${KUBERNETES_VERSION_MANAGEMENT} to trigger image build (because env var is not set)"
   fi
 
-  if [[ ${GINKGO_FOCUS:-} == *"K8s-Install-ci-latest"* ]]; then
-    # If the test focuses on [K8s-Install-ci-latest], only default KUBERNETES_VERSION_LATEST_CI
-    # to the value in the e2e config and only if it is not set.
-    # Note: We do this because we want to specify KUBERNETES_VERSION_LATEST_CI *only* in the e2e config.
-    if [[ -z "${KUBERNETES_VERSION_LATEST_CI:-}" ]]; then
-      KUBERNETES_VERSION_LATEST_CI=$(grep KUBERNETES_VERSION_LATEST_CI: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
-      echo "Defaulting KUBERNETES_VERSION_LATEST_CI to ${KUBERNETES_VERSION_LATEST_CI} to trigger image build (because env var is not set)"
-    fi
-  elif [[ ${GINKGO_FOCUS:-} != *"K8s-Upgrade"* ]]; then
-    # In any other case which is not [K8s-Upgrade], default KUBERNETES_VERSION if it is not set to make sure
-    # the corresponding kindest/node image exists.
-    if [[ -z "${KUBERNETES_VERSION:-}" ]]; then
-      KUBERNETES_VERSION=$(grep KUBERNETES_VERSION: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
-      echo "Defaulting KUBERNETES_VERSION to ${KUBERNETES_VERSION} to trigger image build (because env var is not set)"
-    fi
+  # Default KUBERNETES_VERSION, KUBERNETES_VERSION_LATEST_CI, KUBERNETES_VERSION_UPGRADE_TO or KUBERNETES_VERSION_UPGRADE_FROM if set in KIND_BUILD_IMAGES var.
+
+  if [[ ",${KIND_BUILD_IMAGES}," == *",KUBERNETES_VERSION,"* ]] && [[ -z "${KUBERNETES_VERSION:-}" ]]; then
+    KUBERNETES_VERSION=$(grep KUBERNETES_VERSION: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+    echo "Defaulting KUBERNETES_VERSION to ${KUBERNETES_VERSION} to trigger image build (because env var is not set)"
   fi
 
-  # Tests not focusing on anything and skipping [Conformance] run a clusterctl upgrade test
-  # on the latest kubernetes version as management cluster.
-  if  [[ ${GINKGO_FOCUS:-} == "" ]] && [[ ${GINKGO_SKIP} == *"Conformance"* ]]; then
-    # Note: We do this because we want to specify KUBERNETES_VERSION_LATEST_CI *only* in the e2e config.
-    if [[ -z "${KUBERNETES_VERSION_LATEST_CI:-}" ]]; then
-      KUBERNETES_VERSION_LATEST_CI=$(grep KUBERNETES_VERSION_LATEST_CI: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
-      echo "Defaulting KUBERNETES_VERSION_LATEST_CI to ${KUBERNETES_VERSION_LATEST_CI} to trigger image build (because env var is not set)"
-    fi
+  if [[ ",${KIND_BUILD_IMAGES}," == *",KUBERNETES_VERSION_LATEST_CI,"* ]] && [[ -z "${KUBERNETES_VERSION_LATEST_CI:-}" ]]; then
+    KUBERNETES_VERSION_LATEST_CI=$(grep KUBERNETES_VERSION_LATEST_CI: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+    echo "Defaulting KUBERNETES_VERSION_LATEST_CI to ${KUBERNETES_VERSION_LATEST_CI} to trigger image build (because env var is not set)"
   fi
 
-  # Tests not focusing on [PR-Blocking], [K8s-Install] or [K8s-Install-ci-latest],
-  # also run upgrade tests so default KUBERNETES_VERSION_UPGRADE_TO and KUBERNETES_VERSION_UPGRADE_FROM
-  # to the value in the e2e config if they are not set.
-  if [[ ${GINKGO_FOCUS:-} != *"PR-Blocking"* ]] && [[ ${GINKGO_FOCUS:-} != *"K8s-Install"* ]]; then
-    if [[ -z "${KUBERNETES_VERSION_UPGRADE_TO:-}" ]]; then
-      KUBERNETES_VERSION_UPGRADE_TO=$(grep KUBERNETES_VERSION_UPGRADE_TO: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
-      echo "Defaulting KUBERNETES_VERSION_UPGRADE_TO to ${KUBERNETES_VERSION_UPGRADE_TO} to trigger image build (because env var is not set)"
-    fi
-    if [[ -z "${KUBERNETES_VERSION_UPGRADE_FROM:-}" ]]; then
-      KUBERNETES_VERSION_UPGRADE_FROM=$(grep KUBERNETES_VERSION_UPGRADE_FROM: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
-      echo "Defaulting KUBERNETES_VERSION_UPGRADE_FROM to ${KUBERNETES_VERSION_UPGRADE_FROM} to trigger image build (because env var is not set)"
-    fi
+  if [[ ",${KIND_BUILD_IMAGES}," == *",KUBERNETES_VERSION_UPGRADE_TO,"* ]] && [[ -z "${KUBERNETES_VERSION_UPGRADE_TO:-}" ]]; then
+    KUBERNETES_VERSION_UPGRADE_TO=$(grep KUBERNETES_VERSION_UPGRADE_TO: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+    echo "Defaulting KUBERNETES_VERSION_UPGRADE_TO to ${KUBERNETES_VERSION_UPGRADE_TO} to trigger image build (because env var is not set)"
+  fi
+
+  if [[ ",${KIND_BUILD_IMAGES}," == *",KUBERNETES_VERSION_UPGRADE_FROM,"* ]] && [[ -z "${KUBERNETES_VERSION_UPGRADE_FROM:-}" ]]; then
+    KUBERNETES_VERSION_UPGRADE_FROM=$(grep KUBERNETES_VERSION_UPGRADE_FROM: < "$E2E_CONF_FILE" | awk -F'"' '{ print $2}')
+    echo "Defaulting KUBERNETES_VERSION_UPGRADE_FROM to ${KUBERNETES_VERSION_UPGRADE_FROM} to trigger image build (because env var is not set)"
   fi
 }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Removes the magic matching on GINKGO_FOCUS and GINKGO_SKIP for defaulting vars for building kind node images.

Instead we now explicitly mention which variables to default on a per-job base in test-infra and pass it as envvar. 

Needs the following PR to merge first:
- https://github.com/kubernetes/test-infra/pull/34252

/hold

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci