### PR TITLE
🌱  Use std API instead of exp API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.18
 	go.etcd.io/etcd/client/v3 v3.5.18
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/text v0.21.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0

--- a/internal/controllers/machine/drain/drain.go
+++ b/internal/controllers/machine/drain/drain.go
@@ -20,13 +20,14 @@ package drain
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -484,8 +485,7 @@ func (r EvictionResult) ConditionMessage(nodeDrainStartTime *metav1.Time) string
 			conditionMessage, kind, PodListToString(r.PodsDeletionTimestampSet, 3))
 	}
 	if len(r.PodsFailedEviction) > 0 {
-		sortedFailureMessages := maps.Keys(r.PodsFailedEviction)
-		sort.Strings(sortedFailureMessages)
+		sortedFailureMessages := slices.Sorted(maps.Keys(r.PodsFailedEviction))
 
 		skippedFailureMessages := []string{}
 		if len(sortedFailureMessages) > 5 {

--- a/internal/controllers/topology/cluster/current_state_test.go
+++ b/internal/controllers/topology/cluster/current_state_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package cluster
 
 import (
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1166,7 +1167,7 @@ func TestGetCurrentState(t *testing.T) {
 			}
 
 			// Don't compare the deletionTimestamps as there are some minor differences in how they are stored pre/post fake client.
-			for _, md := range append(maps.Values(got.MachineDeployments), maps.Values(tt.want.MachineDeployments)...) {
+			for _, md := range append(slices.Collect(maps.Values(got.MachineDeployments)), slices.Collect(maps.Values(tt.want.MachineDeployments))...) {
 				md.Object.DeletionTimestamp = nil
 			}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

golang.org/x/exp is experimental library, so it's good to use standard lib's API if the API is provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
