### PR TITLE
✨Add support for clusterctl gitlab auth

### DIFF
--- a/cmd/clusterctl/client/config/variables_client.go
+++ b/cmd/clusterctl/client/config/variables_client.go
@@ -19,6 +19,8 @@ package config
 const (
 	// GitHubTokenVariable defines a variable hosting the GitHub access token.
 	GitHubTokenVariable = "github-token"
+	// GitLabAccessTokenVariable defines a variable hosting the GitLab access token. This can be used with Personal and Project access tokens.
+	GitLabAccessTokenVariable = "gitlab-access-token"
 )
 
 // VariablesClient has methods to work with environment variables and with variables defined in the clusterctl configuration file.

--- a/cmd/clusterctl/client/repository/client.go
+++ b/cmd/clusterctl/client/repository/client.go
@@ -187,7 +187,7 @@ func repositoryFactory(ctx context.Context, providerConfig config.Provider, conf
 
 		// if the url is a GitLab repository
 		if strings.HasPrefix(rURL.Host, gitlabHostPrefix) && strings.HasPrefix(rURL.EscapedPath(), gitlabPackagesAPIPrefix) {
-			repo, err := NewGitLabRepository(providerConfig, configVariablesClient)
+			repo, err := NewGitLabRepository(ctx, providerConfig, configVariablesClient)
 			if err != nil {
 				return nil, errors.Wrap(err, "error creating the GitLab repository client")
 			}

--- a/cmd/clusterctl/client/repository/repository_gitlab_test.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab_test.go
@@ -49,15 +49,15 @@ func Test_gitLabRepository_newGitLabRepository(t *testing.T) {
 				variableClient: test.NewFakeVariableClient(),
 			},
 			want: &gitLabRepository{
-				providerConfig:        config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
-				configVariablesClient: test.NewFakeVariableClient(),
-				httpClient:            http.DefaultClient,
-				host:                  "gitlab.example.org",
-				projectSlug:           "group%2Fproject",
-				packageName:           "my-package",
-				defaultVersion:        "v1.0",
-				rootPath:              ".",
-				componentsPath:        "path",
+				providerConfig:           config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				configVariablesClient:    test.NewFakeVariableClient(),
+				authenticatingHTTPClient: http.DefaultClient,
+				host:                     "gitlab.example.org",
+				projectSlug:              "group%2Fproject",
+				packageName:              "my-package",
+				defaultVersion:           "v1.0",
+				rootPath:                 ".",
+				componentsPath:           "path",
 			},
 			wantedErr: "",
 		},
@@ -131,7 +131,7 @@ func Test_gitLabRepository_newGitLabRepository(t *testing.T) {
 			g := NewWithT(t)
 			resetCaches()
 
-			gitLab, err := NewGitLabRepository(tt.field.providerConfig, tt.field.variableClient)
+			gitLab, err := NewGitLabRepository(context.Background(), tt.field.providerConfig, tt.field.variableClient)
 			if tt.wantedErr != "" {
 				g.Expect(err).To(MatchError(tt.wantedErr))
 				return
@@ -193,8 +193,8 @@ func Test_gitLabRepository_getFile(t *testing.T) {
 			g := NewWithT(t)
 			resetCaches()
 
-			gitLab, err := NewGitLabRepository(providerConfig, configVariablesClient)
-			gitLab.(*gitLabRepository).httpClient = client
+			gitLab, err := NewGitLabRepository(context.Background(), providerConfig, configVariablesClient)
+			gitLab.(*gitLabRepository).authenticatingHTTPClient = client
 			g.Expect(err).ToNot(HaveOccurred())
 
 			got, err := gitLab.GetFile(context.Background(), tt.version, tt.fileName)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support in clusterctl for gitlab instances that require auth.
**Which issue(s) this PR fixes**
Fixes # n/a

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area clusterctl
-->
/area clusterctl
