### PR TITLE
🌱 Drop MemberUpdate from etcd client in KCP

### DIFF
--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -44,7 +44,6 @@ type etcd interface {
 	Endpoints() []string
 	MemberList(ctx context.Context) (*clientv3.MemberListResponse, error)
 	MemberRemove(ctx context.Context, id uint64) (*clientv3.MemberRemoveResponse, error)
-	MemberUpdate(ctx context.Context, id uint64, peerURLs []string) (*clientv3.MemberUpdateResponse, error)
 	MoveLeader(ctx context.Context, id uint64) (*clientv3.MoveLeaderResponse, error)
 	Status(ctx context.Context, endpoint string) (*clientv3.StatusResponse, error)
 }
@@ -254,24 +253,6 @@ func (c *Client) RemoveMember(ctx context.Context, id uint64) error {
 
 	_, err := c.EtcdClient.MemberRemove(ctx, id)
 	return errors.Wrapf(err, "failed to remove member: %v", id)
-}
-
-// UpdateMemberPeerURLs updates the list of peer URLs.
-func (c *Client) UpdateMemberPeerURLs(ctx context.Context, id uint64, peerURLs []string) ([]*Member, error) {
-	ctx, cancel := context.WithTimeout(ctx, c.CallTimeout)
-	defer cancel()
-
-	response, err := c.EtcdClient.MemberUpdate(ctx, id, peerURLs)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to update etcd member %v's peer list to %+v", id, peerURLs)
-	}
-
-	members := make([]*Member, 0, len(response.Members))
-	for _, m := range response.Members {
-		members = append(members, pbMemberToMember(m))
-	}
-
-	return members, nil
 }
 
 // Alarms retrieves all alarms on a cluster.

--- a/controlplane/kubeadm/internal/etcd/etcd_test.go
+++ b/controlplane/kubeadm/internal/etcd/etcd_test.go
@@ -74,13 +74,7 @@ func TestEtcdMembers_WithSuccess(t *testing.T) {
 				{ID: 1234, Name: "foo", PeerURLs: []string{"https://1.2.3.4:2000"}},
 			},
 		},
-		MoveLeaderResponse: &clientv3.MoveLeaderResponse{},
-		MemberUpdateResponse: &clientv3.MemberUpdateResponse{
-			Header: &etcdserverpb.ResponseHeader{},
-			Members: []*etcdserverpb.Member{
-				{ID: 1234, Name: "foo", PeerURLs: []string{"https://1.2.3.4:2000", "https://4.5.6.7:2000"}},
-			},
-		},
+		MoveLeaderResponse:   &clientv3.MoveLeaderResponse{},
 		MemberRemoveResponse: &clientv3.MemberRemoveResponse{},
 		AlarmResponse:        &clientv3.AlarmResponse{},
 		StatusResponse:       &clientv3.StatusResponse{},
@@ -98,9 +92,4 @@ func TestEtcdMembers_WithSuccess(t *testing.T) {
 
 	err = client.RemoveMember(ctx, 1234)
 	g.Expect(err).ToNot(HaveOccurred())
-
-	updatedMembers, err := client.UpdateMemberPeerURLs(ctx, 1234, []string{"https://4.5.6.7:2000"})
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(updatedMembers[0].PeerURLs).To(HaveLen(2))
-	g.Expect(updatedMembers[0].PeerURLs).To(Equal([]string{"https://1.2.3.4:2000", "https://4.5.6.7:2000"}))
 }

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -28,7 +28,6 @@ type FakeEtcdClient struct { //nolint:revive
 	EtcdEndpoints        []string
 	MemberListResponse   *clientv3.MemberListResponse
 	MemberRemoveResponse *clientv3.MemberRemoveResponse
-	MemberUpdateResponse *clientv3.MemberUpdateResponse
 	MoveLeaderResponse   *clientv3.MoveLeaderResponse
 	StatusResponse       *clientv3.StatusResponse
 	ErrorResponse        error
@@ -59,9 +58,6 @@ func (c *FakeEtcdClient) MemberList(_ context.Context) (*clientv3.MemberListResp
 func (c *FakeEtcdClient) MemberRemove(_ context.Context, i uint64) (*clientv3.MemberRemoveResponse, error) {
 	c.RemovedMember = i
 	return c.MemberRemoveResponse, c.ErrorResponse
-}
-func (c *FakeEtcdClient) MemberUpdate(_ context.Context, _ uint64, _ []string) (*clientv3.MemberUpdateResponse, error) {
-	return c.MemberUpdateResponse, c.ErrorResponse
 }
 func (c *FakeEtcdClient) Status(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
 	return c.StatusResponse, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop MemberUpdate from etcd client in KCP (unused)