### PR TITLE
🌱 e2e/scale: make coredns and etcd upgrade variables optional

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -128,12 +128,8 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 			workerMachineCount = *input.WorkerMachineCount
 		}
 
-		if input.E2EConfig.HasVariable(EtcdVersionUpgradeTo) {
-			etcdVersionUpgradeTo = input.E2EConfig.MustGetVariable(EtcdVersionUpgradeTo)
-		}
-		if input.E2EConfig.HasVariable(CoreDNSVersionUpgradeTo) {
-			coreDNSVersionUpgradeTo = input.E2EConfig.MustGetVariable(CoreDNSVersionUpgradeTo)
-		}
+		etcdVersionUpgradeTo = input.E2EConfig.GetVariableOrEmpty(EtcdVersionUpgradeTo)
+		coreDNSVersionUpgradeTo = input.E2EConfig.GetVariableOrEmpty(CoreDNSVersionUpgradeTo)
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the Namespace events.
 		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -411,8 +411,8 @@ func ScaleSpec(ctx context.Context, inputGetter func() ScaleSpecInput) {
 			upgrader := getClusterUpgradeAndWaitFn(framework.UpgradeClusterTopologyAndWaitForUpgradeInput{
 				ClusterProxy:                input.BootstrapClusterProxy,
 				KubernetesUpgradeVersion:    input.E2EConfig.MustGetVariable(KubernetesVersionUpgradeTo),
-				EtcdImageTag:                input.E2EConfig.MustGetVariable(EtcdVersionUpgradeTo),
-				DNSImageTag:                 input.E2EConfig.MustGetVariable(CoreDNSVersionUpgradeTo),
+				EtcdImageTag:                input.E2EConfig.GetVariableOrEmpty(EtcdVersionUpgradeTo),
+				DNSImageTag:                 input.E2EConfig.GetVariableOrEmpty(CoreDNSVersionUpgradeTo),
 				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForDNSUpgrade:           input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -124,12 +124,8 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 
 			kubernetesVersion = input.E2EConfig.MustGetVariable(KubernetesVersionUpgradeFrom)
 
-			if input.E2EConfig.HasVariable(EtcdVersionUpgradeTo) {
-				etcdVersionUpgradeTo = input.E2EConfig.MustGetVariable(EtcdVersionUpgradeTo)
-			}
-			if input.E2EConfig.HasVariable(CoreDNSVersionUpgradeTo) {
-				coreDNSVersionUpgradeTo = input.E2EConfig.MustGetVariable(CoreDNSVersionUpgradeTo)
-			}
+			etcdVersionUpgradeTo = input.E2EConfig.GetVariableOrEmpty(EtcdVersionUpgradeTo)
+			coreDNSVersionUpgradeTo = input.E2EConfig.GetVariableOrEmpty(CoreDNSVersionUpgradeTo)
 		}
 
 		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Makes these variables optional in the scale test just as they are in the others. This makes it easier for providers who do not care about these versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->