### PR TITLE
:seedling: Add missing comments with serialized prefix

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -484,7 +484,7 @@ type ClusterSpec struct {
 	// +optional
 	InfrastructureRef *corev1.ObjectReference `json:"infrastructureRef,omitempty"`
 
-	// This encapsulates the topology for the cluster.
+	// topology encapsulates the topology for the cluster.
 	// NOTE: It is required to enable the ClusterTopology
 	// feature gate flag to activate managed topologies support;
 	// this feature is highly experimental, and parts of it might still be not implemented.
@@ -844,6 +844,7 @@ type ClusterNetwork struct {
 
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
+	// cidrBlocks is a list of CIDR blocks.
 	CIDRBlocks []string `json:"cidrBlocks"`
 }
 

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -296,13 +296,15 @@ type MachineHealthCheckClass struct {
 	// +optional
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
-	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+	// Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
 	// "selector" are not healthy.
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
+	// unhealthyRange specifies the range of unhealthy machines allowed.
 	// Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-	// is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+	// is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
 	// Eg. "[3-5]" - This means that remediation will be allowed only when:
 	// (a) there are at least 3 unhealthy machines (and)
 	// (b) there are at most 5 unhealthy machines

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -65,7 +65,8 @@ type MachineHealthCheckSpec struct {
 	// +optional
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
-	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+	// Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
 	// "selector" are not healthy.
 	//
 	// Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
@@ -73,8 +74,9 @@ type MachineHealthCheckSpec struct {
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
+	// unhealthyRange specifies the range of unhealthy machines allowed.
 	// Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-	// is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+	// is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
 	// Eg. "[3-5]" - This means that remediation will be allowed only when:
 	// (a) there are at least 3 unhealthy machines (and)
 	// (b) there are at most 5 unhealthy machines
@@ -118,14 +120,20 @@ type MachineHealthCheckSpec struct {
 // specified as a duration.  When the named condition has been in the given
 // status for at least the timeout value, a node is considered unhealthy.
 type UnhealthyCondition struct {
+	// type of Node condition
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Type corev1.NodeConditionType `json:"type"`
 
+	// status of the condition, one of True, False, Unknown.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Status corev1.ConditionStatus `json:"status"`
 
+	// timeout is the duration that a node must be in a given status for,
+	// after which the node is considered unhealthy.
+	// For example, with a value of "1h", the node must match the status
+	// for at least 1 hour before being considered unhealthy.
 	Timeout metav1.Duration `json:"timeout"`
 }
 

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -309,6 +309,10 @@ type MachineSetStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// failureReason will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a succinct value suitable
+	// for machine interpretation.
+	//
 	// In the event that there is a terminal problem reconciling the
 	// replicas, both FailureReason and FailureMessage will be set. FailureReason
 	// will be populated with a succinct value suitable for machine
@@ -332,10 +336,16 @@ type MachineSetStatus struct {
 	//
 	// +optional
 	FailureReason *capierrors.MachineSetStatusError `json:"failureReason,omitempty"`
+
+	// failureMessage will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a more verbose string suitable
+	// for logging and human consumption.
+	//
 	// Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
 	//
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
+
 	// conditions defines current service state of the MachineSet.
 	// +optional
 	Conditions Conditions `json:"conditions,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -924,7 +924,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterSpec(ref common.ReferenceCa
 					},
 					"topology": {
 						SchemaProps: spec.SchemaProps{
-							Description: "This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
+							Description: "topology encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.",
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.Topology"),
 						},
 					},
@@ -2893,13 +2893,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheckClass(ref common
 					},
 					"maxUnhealthy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+							Description: "maxUnhealthy specifies the maximum number of unhealthy machines allowed. Any further remediation is only allowed if at most \"maxUnhealthy\" machines selected by \"selector\" are not healthy.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
 					"unhealthyRange": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+							Description: "unhealthyRange specifies the range of unhealthy machines allowed. Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"unhealthyRange\". Takes precedence over maxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3011,13 +3011,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheckSpec(ref common.
 					},
 					"maxUnhealthy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.",
+							Description: "maxUnhealthy specifies the maximum number of unhealthy machines allowed. Any further remediation is only allowed if at most \"maxUnhealthy\" machines selected by \"selector\" are not healthy.\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
 					"unhealthyRange": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.",
+							Description: "unhealthyRange specifies the range of unhealthy machines allowed. Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"unhealthyRange\". Takes precedence over maxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3154,13 +3154,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheckTopology(ref com
 					},
 					"maxUnhealthy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy.",
+							Description: "maxUnhealthy specifies the maximum number of unhealthy machines allowed. Any further remediation is only allowed if at most \"maxUnhealthy\" machines selected by \"selector\" are not healthy.",
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
 					"unhealthyRange": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"UnhealthyRange\". Takes precedence over MaxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
+							Description: "unhealthyRange specifies the range of unhealthy machines allowed. Any further remediation is only allowed if the number of machines selected by \"selector\" as not healthy is within the range of \"unhealthyRange\". Takes precedence over maxUnhealthy. Eg. \"[3-5]\" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3826,14 +3826,14 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSetStatus(ref common.Refere
 					},
 					"failureReason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption.\n\nThese fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.",
+							Description: "failureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation.\n\nIn the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption.\n\nThese fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured.\n\nAny transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"failureMessage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.",
+							Description: "failureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption.\n\nDeprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4221,7 +4221,8 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_NetworkRanges(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"cidrBlocks": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "cidrBlocks is a list of CIDR blocks.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -4568,21 +4569,24 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_UnhealthyCondition(ref common.Refe
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "type of Node condition",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "status of the condition, one of True, False, Unknown.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+							Description: "timeout is the duration that a node must be in a given status for, after which the node is considered unhealthy. For example, with a value of \"1h\", the node must match the status for at least 1 hour before being considered unhealthy.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 				},

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -662,7 +662,9 @@ type KubeConfigAuthExec struct {
 // KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
 // credential plugin.
 type KubeConfigAuthExecEnv struct {
-	Name  string `json:"name"`
+	// name of the environment variable
+	Name string `json:"name"`
+	// value of the environment variable
 	Value string `json:"value"`
 }
 

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_types.go
@@ -24,6 +24,7 @@ import (
 
 // KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
 type KubeadmConfigTemplateSpec struct {
+	// template defines the desired state of KubeadmConfigTemplate.
 	Template KubeadmConfigTemplateResource `json:"template"`
 }
 

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -3408,8 +3408,12 @@ spec:
                                             credential plugin.
                                           properties:
                                             name:
+                                              description: name of the environment
+                                                variable
                                               type: string
                                             value:
+                                              description: value of the environment
+                                                variable
                                               type: string
                                           required:
                                           - name

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -46,7 +46,7 @@ spec:
             description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
             properties:
               template:
-                description: KubeadmConfigTemplateResource defines the Template structure.
+                description: template defines the desired state of KubeadmConfigTemplate.
                 properties:
                   spec:
                     description: |-
@@ -1005,7 +1005,7 @@ spec:
             description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
             properties:
               template:
-                description: KubeadmConfigTemplateResource defines the Template structure.
+                description: template defines the desired state of KubeadmConfigTemplate.
                 properties:
                   spec:
                     description: |-
@@ -1961,7 +1961,7 @@ spec:
             description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
             properties:
               template:
-                description: KubeadmConfigTemplateResource defines the Template structure.
+                description: template defines the desired state of KubeadmConfigTemplate.
                 properties:
                   metadata:
                     description: |-
@@ -3396,8 +3396,12 @@ spec:
                                                     credential plugin.
                                                   properties:
                                                     name:
+                                                      description: name of the environment
+                                                        variable
                                                       type: string
                                                     value:
+                                                      description: value of the environment
+                                                        variable
                                                       type: string
                                                   required:
                                                   - name

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -462,7 +462,8 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                          maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                          Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                           "selector" are not healthy.
                         x-kubernetes-int-or-string: true
                       nodeStartupTimeout:
@@ -541,11 +542,19 @@ spec:
                             status for at least the timeout value, a node is considered unhealthy.
                           properties:
                             status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
                               minLength: 1
                               type: string
                             timeout:
+                              description: |-
+                                timeout is the duration that a node must be in a given status for,
+                                after which the node is considered unhealthy.
+                                For example, with a value of "1h", the node must match the status
+                                for at least 1 hour before being considered unhealthy.
                               type: string
                             type:
+                              description: type of Node condition
                               minLength: 1
                               type: string
                           required:
@@ -556,8 +565,9 @@ spec:
                         type: array
                       unhealthyRange:
                         description: |-
+                          unhealthyRange specifies the range of unhealthy machines allowed.
                           Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                          is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                          is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                           Eg. "[3-5]" - This means that remediation will be allowed only when:
                           (a) there are at least 3 unhealthy machines (and)
                           (b) there are at most 5 unhealthy machines
@@ -1383,7 +1393,8 @@ spec:
                               - type: integer
                               - type: string
                               description: |-
-                                Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                                 "selector" are not healthy.
                               x-kubernetes-int-or-string: true
                             nodeStartupTimeout:
@@ -1462,11 +1473,19 @@ spec:
                                   status for at least the timeout value, a node is considered unhealthy.
                                 properties:
                                   status:
+                                    description: status of the condition, one of True,
+                                      False, Unknown.
                                     minLength: 1
                                     type: string
                                   timeout:
+                                    description: |-
+                                      timeout is the duration that a node must be in a given status for,
+                                      after which the node is considered unhealthy.
+                                      For example, with a value of "1h", the node must match the status
+                                      for at least 1 hour before being considered unhealthy.
                                     type: string
                                   type:
+                                    description: type of Node condition
                                     minLength: 1
                                     type: string
                                 required:
@@ -1477,8 +1496,9 @@ spec:
                               type: array
                             unhealthyRange:
                               description: |-
+                                unhealthyRange specifies the range of unhealthy machines allowed.
                                 Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                                is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                                 Eg. "[3-5]" - This means that remediation will be allowed only when:
                                 (a) there are at least 3 unhealthy machines (and)
                                 (b) there are at most 5 unhealthy machines

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -63,6 +63,7 @@ spec:
                       are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -77,6 +78,7 @@ spec:
                       VIPs are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -351,6 +353,7 @@ spec:
                       are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -365,6 +368,7 @@ spec:
                       VIPs are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -483,7 +487,7 @@ spec:
                 type: boolean
               topology:
                 description: |-
-                  This encapsulates the topology for the cluster.
+                  topology encapsulates the topology for the cluster.
                   NOTE: It is required to enable the ClusterTopology
                   feature gate flag to activate managed topologies support;
                   this feature is highly experimental, and parts of it might still be not implemented.
@@ -793,6 +797,7 @@ spec:
                       are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -807,6 +812,7 @@ spec:
                       VIPs are allocated.
                     properties:
                       cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
                         type: array
@@ -925,7 +931,7 @@ spec:
                 type: boolean
               topology:
                 description: |-
-                  This encapsulates the topology for the cluster.
+                  topology encapsulates the topology for the cluster.
                   NOTE: It is required to enable the ClusterTopology
                   feature gate flag to activate managed topologies support;
                   this feature is highly experimental, and parts of it might still be not implemented.
@@ -968,7 +974,8 @@ spec:
                             - type: integer
                             - type: string
                             description: |-
-                              Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                              maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                              Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                               "selector" are not healthy.
                             x-kubernetes-int-or-string: true
                           nodeStartupTimeout:
@@ -1047,11 +1054,19 @@ spec:
                                 status for at least the timeout value, a node is considered unhealthy.
                               properties:
                                 status:
+                                  description: status of the condition, one of True,
+                                    False, Unknown.
                                   minLength: 1
                                   type: string
                                 timeout:
+                                  description: |-
+                                    timeout is the duration that a node must be in a given status for,
+                                    after which the node is considered unhealthy.
+                                    For example, with a value of "1h", the node must match the status
+                                    for at least 1 hour before being considered unhealthy.
                                   type: string
                                 type:
+                                  description: type of Node condition
                                   minLength: 1
                                   type: string
                               required:
@@ -1062,8 +1077,9 @@ spec:
                             type: array
                           unhealthyRange:
                             description: |-
+                              unhealthyRange specifies the range of unhealthy machines allowed.
                               Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                              is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                              is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                               Eg. "[3-5]" - This means that remediation will be allowed only when:
                               (a) there are at least 3 unhealthy machines (and)
                               (b) there are at most 5 unhealthy machines
@@ -1256,7 +1272,8 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                                    maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                    Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                                     "selector" are not healthy.
                                   x-kubernetes-int-or-string: true
                                 nodeStartupTimeout:
@@ -1335,11 +1352,19 @@ spec:
                                       status for at least the timeout value, a node is considered unhealthy.
                                     properties:
                                       status:
+                                        description: status of the condition, one
+                                          of True, False, Unknown.
                                         minLength: 1
                                         type: string
                                       timeout:
+                                        description: |-
+                                          timeout is the duration that a node must be in a given status for,
+                                          after which the node is considered unhealthy.
+                                          For example, with a value of "1h", the node must match the status
+                                          for at least 1 hour before being considered unhealthy.
                                         type: string
                                       type:
+                                        description: type of Node condition
                                         minLength: 1
                                         type: string
                                     required:
@@ -1350,8 +1375,9 @@ spec:
                                   type: array
                                 unhealthyRange:
                                   description: |-
+                                    unhealthyRange specifies the range of unhealthy machines allowed.
                                     Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                                    is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                                    is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                                     Eg. "[3-5]" - This means that remediation will be allowed only when:
                                     (a) there are at least 3 unhealthy machines (and)
                                     (b) there are at most 5 unhealthy machines

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -71,13 +71,14 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                   "selector" are not healthy.
                 x-kubernetes-int-or-string: true
               nodeStartupTimeout:
                 description: |-
-                  Machines older than this duration without a node will be considered to have
-                  failed and will be remediated.
+                  nodeStartupTimeout is the duration after which machines without a node will be considered to
+                  have failed and will be remediated.
                 type: string
               remediationTemplate:
                 description: |-
@@ -187,11 +188,18 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
+                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -350,13 +358,14 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                   "selector" are not healthy.
                 x-kubernetes-int-or-string: true
               nodeStartupTimeout:
                 description: |-
-                  Machines older than this duration without a node will be considered to have
-                  failed and will be remediated.
+                  nodeStartupTimeout is the duration after which machines without a node will be considered to
+                  have failed and will be remediated.
                   If not set, this value is defaulted to 10 minutes.
                   If you wish to disable this feature, set the value explicitly to 0.
                 type: string
@@ -468,11 +477,18 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
+                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -484,8 +500,9 @@ spec:
                 type: array
               unhealthyRange:
                 description: |-
+                  unhealthyRange specifies the range of unhealthy machines allowed.
                   Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                   Eg. "[3-5]" - This means that remediation will be allowed only when:
                   (a) there are at least 3 unhealthy machines (and)
                   (b) there are at most 5 unhealthy machines
@@ -637,7 +654,8 @@ spec:
                 - type: integer
                 - type: string
                 description: |-
-                  Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
                   "selector" are not healthy.
 
                   Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
@@ -765,11 +783,18 @@ spec:
                     status for at least the timeout value, a node is considered unhealthy.
                   properties:
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       minLength: 1
                       type: string
                     timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
                       type: string
                     type:
+                      description: type of Node condition
                       minLength: 1
                       type: string
                   required:
@@ -780,8 +805,9 @@ spec:
                 type: array
               unhealthyRange:
                 description: |-
+                  unhealthyRange specifies the range of unhealthy machines allowed.
                   Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-                  is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
                   Eg. "[3-5]" - This means that remediation will be allowed only when:
                   (a) there are at least 3 unhealthy machines (and)
                   (b) there are at most 5 unhealthy machines

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -434,9 +434,17 @@ spec:
                 format: int32
                 type: integer
               failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
                 type: string
               failureReason:
                 description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine
@@ -855,9 +863,17 @@ spec:
                   type: object
                 type: array
               failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
                 type: string
               failureReason:
                 description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine
@@ -1369,12 +1385,19 @@ spec:
                   type: object
                 type: array
               failureMessage:
-                description: 'Deprecated: This field is deprecated and is going to
-                  be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md
-                  for more details.'
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
                 type: string
               failureReason:
                 description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
                   In the event that there is a terminal problem reconciling the
                   replicas, both FailureReason and FailureMessage will be set. FailureReason
                   will be populated with a succinct value suitable for machine

--- a/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
@@ -25,6 +25,7 @@ import (
 
 // KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.
 type KubeadmControlPlaneTemplateSpec struct {
+	// template defines the desired state of KubeadmControlPlaneTemplate.
 	Template KubeadmControlPlaneTemplateResource `json:"template"`
 }
 

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3891,8 +3891,12 @@ spec:
                                                 credential plugin.
                                               properties:
                                                 name:
+                                                  description: name of the environment
+                                                    variable
                                                   type: string
                                                 value:
+                                                  description: value of the environment
+                                                    variable
                                                   type: string
                                               required:
                                               - name

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -52,8 +52,7 @@ spec:
               of KubeadmControlPlaneTemplate.
             properties:
               template:
-                description: KubeadmControlPlaneTemplateResource describes the data
-                  needed to create a KubeadmControlPlane from a template.
+                description: template defines the desired state of KubeadmControlPlaneTemplate.
                 properties:
                   spec:
                     description: KubeadmControlPlaneSpec defines the desired state
@@ -1165,8 +1164,7 @@ spec:
               of KubeadmControlPlaneTemplate.
             properties:
               template:
-                description: KubeadmControlPlaneTemplateResource describes the data
-                  needed to create a KubeadmControlPlane from a template.
+                description: template defines the desired state of KubeadmControlPlaneTemplate.
                 properties:
                   metadata:
                     description: |-
@@ -2627,8 +2625,12 @@ spec:
                                                         credential plugin.
                                                       properties:
                                                         name:
+                                                          description: name of the
+                                                            environment variable
                                                           type: string
                                                         value:
+                                                          description: value of the
+                                                            environment variable
                                                           type: string
                                                       required:
                                                       - name

--- a/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfigtemplate_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfigtemplate_types.go
@@ -22,6 +22,7 @@ import (
 
 // KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
 type KubeadmConfigTemplateSpec struct {
+	// template defines the desired state of KubeadmConfigTemplate.
 	Template KubeadmConfigTemplateResource `json:"template"`
 }
 

--- a/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfigtemplate_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfigtemplate_types.go
@@ -22,6 +22,7 @@ import (
 
 // KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
 type KubeadmConfigTemplateSpec struct {
+	// template defines the desired state of KubeadmConfigTemplate.
 	Template KubeadmConfigTemplateResource `json:"template"`
 }
 

--- a/internal/apis/controlplane/kubeadm/v1alpha4/kubeadmcontrolplanetemplate_types.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha4/kubeadmcontrolplanetemplate_types.go
@@ -22,6 +22,7 @@ import (
 
 // KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.
 type KubeadmControlPlaneTemplateSpec struct {
+	// template defines the desired state of KubeadmControlPlaneTemplate.
 	Template KubeadmControlPlaneTemplateResource `json:"template"`
 }
 

--- a/internal/apis/core/v1alpha3/cluster_types.go
+++ b/internal/apis/core/v1alpha3/cluster_types.go
@@ -92,6 +92,7 @@ type ClusterNetwork struct {
 
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
+	// cidrBlocks is a list of CIDR blocks.
 	CIDRBlocks []string `json:"cidrBlocks"`
 }
 

--- a/internal/apis/core/v1alpha3/machinehealthcheck_types.go
+++ b/internal/apis/core/v1alpha3/machinehealthcheck_types.go
@@ -40,13 +40,14 @@ type MachineHealthCheckSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions"`
 
-	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+	// Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
 	// "selector" are not healthy.
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
-	// Machines older than this duration without a node will be considered to have
-	// failed and will be remediated.
+	// nodeStartupTimeout is the duration after which machines without a node will be considered to
+	// have failed and will be remediated.
 	// +optional
 	NodeStartupTimeout *metav1.Duration `json:"nodeStartupTimeout,omitempty"`
 
@@ -68,14 +69,20 @@ type MachineHealthCheckSpec struct {
 // specified as a duration.  When the named condition has been in the given
 // status for at least the timeout value, a node is considered unhealthy.
 type UnhealthyCondition struct {
+	// type of Node condition
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Type corev1.NodeConditionType `json:"type"`
 
+	// status of the condition, one of True, False, Unknown.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Status corev1.ConditionStatus `json:"status"`
 
+	// timeout is the duration that a node must be in a given status for,
+	// after which the node is considered unhealthy.
+	// For example, with a value of "1h", the node must match the status
+	// for at least 1 hour before being considered unhealthy.
 	Timeout metav1.Duration `json:"timeout"`
 }
 

--- a/internal/apis/core/v1alpha3/machineset_types.go
+++ b/internal/apis/core/v1alpha3/machineset_types.go
@@ -135,6 +135,10 @@ type MachineSetStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// failureReason will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a succinct value suitable
+	// for machine interpretation.
+	//
 	// In the event that there is a terminal problem reconciling the
 	// replicas, both FailureReason and FailureMessage will be set. FailureReason
 	// will be populated with a succinct value suitable for machine
@@ -155,6 +159,10 @@ type MachineSetStatus struct {
 	// controller's output.
 	// +optional
 	FailureReason *capierrors.MachineSetStatusError `json:"failureReason,omitempty"`
+
+	// failureMessage will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a more verbose string suitable
+	// for logging and human consumption.
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
 }

--- a/internal/apis/core/v1alpha4/cluster_types.go
+++ b/internal/apis/core/v1alpha4/cluster_types.go
@@ -61,7 +61,7 @@ type ClusterSpec struct {
 	// +optional
 	InfrastructureRef *corev1.ObjectReference `json:"infrastructureRef,omitempty"`
 
-	// This encapsulates the topology for the cluster.
+	// topology encapsulates the topology for the cluster.
 	// NOTE: It is required to enable the ClusterTopology
 	// feature gate flag to activate managed topologies support;
 	// this feature is highly experimental, and parts of it might still be not implemented.
@@ -172,6 +172,7 @@ type ClusterNetwork struct {
 
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
+	// cidrBlocks is a list of CIDR blocks.
 	CIDRBlocks []string `json:"cidrBlocks"`
 }
 

--- a/internal/apis/core/v1alpha4/machinehealthcheck_types.go
+++ b/internal/apis/core/v1alpha4/machinehealthcheck_types.go
@@ -40,13 +40,15 @@ type MachineHealthCheckSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions"`
 
-	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by
+	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+	// Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
 	// "selector" are not healthy.
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
+	// unhealthyRange specifies the range of unhealthy machines allowed.
 	// Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
-	// is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy.
+	// is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
 	// Eg. "[3-5]" - This means that remediation will be allowed only when:
 	// (a) there are at least 3 unhealthy machines (and)
 	// (b) there are at most 5 unhealthy machines
@@ -54,8 +56,8 @@ type MachineHealthCheckSpec struct {
 	// +kubebuilder:validation:Pattern=^\[[0-9]+-[0-9]+\]$
 	UnhealthyRange *string `json:"unhealthyRange,omitempty"`
 
-	// Machines older than this duration without a node will be considered to have
-	// failed and will be remediated.
+	// nodeStartupTimeout is the duration after which machines without a node will be considered to
+	// have failed and will be remediated.
 	// If not set, this value is defaulted to 10 minutes.
 	// If you wish to disable this feature, set the value explicitly to 0.
 	// +optional
@@ -79,14 +81,20 @@ type MachineHealthCheckSpec struct {
 // specified as a duration.  When the named condition has been in the given
 // status for at least the timeout value, a node is considered unhealthy.
 type UnhealthyCondition struct {
+	// type of Node condition
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Type corev1.NodeConditionType `json:"type"`
 
+	// status of the condition, one of True, False, Unknown.
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:MinLength=1
 	Status corev1.ConditionStatus `json:"status"`
 
+	// timeout is the duration that a node must be in a given status for,
+	// after which the node is considered unhealthy.
+	// For example, with a value of "1h", the node must match the status
+	// for at least 1 hour before being considered unhealthy.
 	Timeout metav1.Duration `json:"timeout"`
 }
 

--- a/internal/apis/core/v1alpha4/machineset_types.go
+++ b/internal/apis/core/v1alpha4/machineset_types.go
@@ -142,6 +142,10 @@ type MachineSetStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// failureReason will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a succinct value suitable
+	// for machine interpretation.
+	//
 	// In the event that there is a terminal problem reconciling the
 	// replicas, both FailureReason and FailureMessage will be set. FailureReason
 	// will be populated with a succinct value suitable for machine
@@ -162,8 +166,13 @@ type MachineSetStatus struct {
 	// controller's output.
 	// +optional
 	FailureReason *capierrors.MachineSetStatusError `json:"failureReason,omitempty"`
+
+	// failureMessage will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a more verbose string suitable
+	// for logging and human consumption.
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
+
 	// conditions defines current service state of the MachineSet.
 	// +optional
 	Conditions Conditions `json:"conditions,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* Add missing comments
* Rewrite comments to start with serialized names
    * of all Kubernetes API resource

but non-API resources are ignored. This is the list of ignored fields.
* RuntimeHooks
* version package
* clusterctl package
```
❯ ./hack/tools/staticchecker/staticchecker ./... 2>&1 | grep -v " Items " | grep -v " Spec " | grep -v " Status " | grep -v test | grep -v upstreamv1beta
/cluster-api/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go:30:2: Cluster should have a comment starting with 'cluster ' (missing)
/cluster-api/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go:31:2: ControlPlane should have a comment starting with 'controlPlane ' (missing)
/cluster-api/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go:32:2: MachineDeployment should have a comment starting with 'machineDeployment ' (missing)
/cluster-api/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go:33:2: MachinePool should have a comment starting with 'machinePool ' (missing)
/cluster-api/version/version.go:69:2: Major should have a comment starting with 'major ' (missing)
/cluster-api/version/version.go:70:2: Minor should have a comment starting with 'minor ' (missing)
/cluster-api/version/version.go:71:2: GitVersion should have a comment starting with 'gitVersion ' (missing)
/cluster-api/version/version.go:72:2: GitCommit should have a comment starting with 'gitCommit ' (missing)
/cluster-api/version/version.go:73:2: GitTreeState should have a comment starting with 'gitTreeState ' (missing)
/cluster-api/version/version.go:74:2: BuildDate should have a comment starting with 'buildDate ' (missing)
/cluster-api/version/version.go:75:2: GoVersion should have a comment starting with 'goVersion ' (missing)
/cluster-api/version/version.go:76:2: Compiler should have a comment starting with 'compiler ' (missing)
/cluster-api/version/version.go:77:2: Platform should have a comment starting with 'platform ' (missing)
/cluster-api/cmd/clusterctl/api/v1alpha3/metadata_type.go:32:2: ReleaseSeries should have a comment starting with 'releaseSeries '
/cluster-api/cmd/clusterctl/cmd/version.go:32:2: ClientVersion should have a comment starting with 'clusterctl ' (missing)
```

I'm not a native English speaker, so I appreciate it if you tell me know gramatical mistakes or awkwardness !

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
A part of #11238

The left task is only adding missing `spec` `status` `items`. updated task list https://github.com/kubernetes-sigs/cluster-api/issues/11238#issuecomment-2546398743

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
