### PR TITLE
:bug: fix: send delete request before removing finalizers

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -1230,18 +1230,17 @@ func (o *objectMover) deleteSourceObject(ctx context.Context, nodeToDelete *node
 			sourceObj.GroupVersionKind(), sourceObj.GetNamespace(), sourceObj.GetName())
 	}
 
+	if err := cFrom.Delete(ctx, sourceObj); err != nil {
+		return errors.Wrapf(err, "error deleting %q %s/%s",
+			sourceObj.GroupVersionKind(), sourceObj.GetNamespace(), sourceObj.GetName())
+	}
+
 	if len(sourceObj.GetFinalizers()) > 0 {
 		if err := cFrom.Patch(ctx, sourceObj, removeFinalizersPatch); err != nil {
 			return errors.Wrapf(err, "error removing finalizers from %q %s/%s",
 				sourceObj.GroupVersionKind(), sourceObj.GetNamespace(), sourceObj.GetName())
 		}
 	}
-
-	if err := cFrom.Delete(ctx, sourceObj); err != nil {
-		return errors.Wrapf(err, "error deleting %q %s/%s",
-			sourceObj.GroupVersionKind(), sourceObj.GetNamespace(), sourceObj.GetName())
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

this PR reorders the removing finalizers and sending the delete request. i believe that this also solves https://github.com/kubernetes-sigs/cluster-api/issues/11812 because `DeletionTimestamp` will be non-zero when the cluster controller looks at the object and will ignore re-applying the finalizer. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->