### PR TITLE
🌱 Call etcd member list and alarms once in KCP's updateManagedEtcdConditions

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -69,12 +69,8 @@ type ControlPlane struct {
 
 	// EtcdMembers is the list of members read while computing reconcileControlPlaneConditions; also additional info below
 	// comes from the same func.
-	// NOTE: Those info are computed based on the info KCP was able to collect during inspection (e.g. if on a 3 CP
-	// control plane one etcd member is down, those info are based on the answer collected from two members only).
 	// NOTE: Those info are specifically designed for computing KCP's Available condition.
 	EtcdMembers                       []*etcd.Member
-	EtcdMembersAgreeOnMemberList      bool
-	EtcdMembersAgreeOnClusterID       bool
 	EtcdMembersAndMachinesAreMatching bool
 
 	managementCluster ManagementCluster

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1090,11 +1090,6 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 		return nil
 	}
 
-	// No op if there are potential issues affecting the list of etcdMembers
-	if !controlPlane.EtcdMembersAgreeOnMemberList || !controlPlane.EtcdMembersAgreeOnClusterID {
-		return nil
-	}
-
 	// No op if for any reason the etcdMember list is not populated at this stage.
 	if controlPlane.EtcdMembers == nil {
 		return nil

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -168,7 +168,7 @@ func (r *KubeadmControlPlaneReconciler) updateV1Beta2Status(ctx context.Context,
 	setMachinesUpToDateCondition(ctx, controlPlane.KCP, controlPlane.Machines)
 	setRemediatingCondition(ctx, controlPlane.KCP, controlPlane.MachinesToBeRemediatedByKCP(), controlPlane.UnhealthyMachines())
 	setDeletingCondition(ctx, controlPlane.KCP, controlPlane.DeletingReason, controlPlane.DeletingMessage)
-	setAvailableCondition(ctx, controlPlane.KCP, controlPlane.IsEtcdManaged(), controlPlane.EtcdMembers, controlPlane.EtcdMembersAgreeOnMemberList, controlPlane.EtcdMembersAgreeOnClusterID, controlPlane.EtcdMembersAndMachinesAreMatching, controlPlane.Machines)
+	setAvailableCondition(ctx, controlPlane.KCP, controlPlane.IsEtcdManaged(), controlPlane.EtcdMembers, controlPlane.EtcdMembersAndMachinesAreMatching, controlPlane.Machines)
 }
 
 func setReplicas(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines) {
@@ -513,7 +513,7 @@ func setDeletingCondition(_ context.Context, kcp *controlplanev1.KubeadmControlP
 	})
 }
 
-func setAvailableCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, etcdIsManaged bool, etcdMembers []*etcd.Member, etcdMembersAgreeOnMemberList, etcdMembersAgreeOnClusterID, etcdMembersAndMachinesAreMatching bool, machines collections.Machines) {
+func setAvailableCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, etcdIsManaged bool, etcdMembers []*etcd.Member, etcdMembersAndMachinesAreMatching bool, machines collections.Machines) {
 	if !kcp.Status.Initialized {
 		v1beta2conditions.Set(kcp, metav1.Condition{
 			Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
@@ -545,26 +545,6 @@ func setAvailableCondition(_ context.Context, kcp *controlplanev1.KubeadmControl
 				Status:  metav1.ConditionUnknown,
 				Reason:  controlplanev1.KubeadmControlPlaneAvailableInspectionFailedV1Beta2Reason,
 				Message: "Failed to get etcd members",
-			})
-			return
-		}
-
-		if !etcdMembersAgreeOnMemberList {
-			v1beta2conditions.Set(kcp, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneNotAvailableV1Beta2Reason,
-				Message: "At least one etcd member reports a list of etcd members different than the list reported by other members",
-			})
-			return
-		}
-
-		if !etcdMembersAgreeOnClusterID {
-			v1beta2conditions.Set(kcp, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneNotAvailableV1Beta2Reason,
-				Message: "At least one etcd member reports a cluster ID different than the cluster ID reported by other members",
 			})
 			return
 		}

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -850,8 +850,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 				},
-				EtcdMembers:                  []*etcd.Member{},
-				EtcdMembersAgreeOnMemberList: false,
+				EtcdMembers: []*etcd.Member{},
 			},
 			expectCondition: metav1.Condition{
 				Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
@@ -887,8 +886,6 @@ func Test_setAvailableCondition(t *testing.T) {
 				EtcdMembers: []*etcd.Member{
 					{Name: "m1", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -939,8 +936,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1011,53 +1006,6 @@ func Test_setAvailableCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "KCP is not available, etcd members do not agree on member list",
-			controlPlane: &internal.ControlPlane{
-				KCP: &controlplanev1.KubeadmControlPlane{
-					Spec: controlplanev1.KubeadmControlPlaneSpec{
-						KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
-							ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
-								Etcd: bootstrapv1.Etcd{Local: &bootstrapv1.LocalEtcd{}},
-							},
-						},
-					},
-					Status: controlplanev1.KubeadmControlPlaneStatus{Initialized: true},
-				},
-				EtcdMembers:                  []*etcd.Member{},
-				EtcdMembersAgreeOnMemberList: false,
-			},
-			expectCondition: metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneNotAvailableV1Beta2Reason,
-				Message: "At least one etcd member reports a list of etcd members different than the list reported by other members",
-			},
-		},
-		{
-			name: "KCP is not available, etcd members do not agree on cluster ID",
-			controlPlane: &internal.ControlPlane{
-				KCP: &controlplanev1.KubeadmControlPlane{
-					Spec: controlplanev1.KubeadmControlPlaneSpec{
-						KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
-							ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
-								Etcd: bootstrapv1.Etcd{Local: &bootstrapv1.LocalEtcd{}},
-							},
-						},
-					},
-					Status: controlplanev1.KubeadmControlPlaneStatus{Initialized: true},
-				},
-				EtcdMembers:                  []*etcd.Member{},
-				EtcdMembersAgreeOnMemberList: true,
-				EtcdMembersAgreeOnClusterID:  false,
-			},
-			expectCondition: metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneNotAvailableV1Beta2Reason,
-				Message: "At least one etcd member reports a cluster ID different than the cluster ID reported by other members",
-			},
-		},
-		{
 			name: "KCP is not available, etcd members and machines list do not match",
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
@@ -1071,8 +1019,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					Status: controlplanev1.KubeadmControlPlaneStatus{Initialized: true},
 				},
 				EtcdMembers:                       []*etcd.Member{},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: false,
 			},
 			expectCondition: metav1.Condition{
@@ -1125,8 +1071,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1177,8 +1121,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1231,8 +1173,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1273,8 +1213,6 @@ func Test_setAvailableCondition(t *testing.T) {
 				EtcdMembers: []*etcd.Member{
 					{Name: "m1", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1335,8 +1273,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m3", IsLearner: false},
 					{Name: "", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1400,8 +1336,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m3", IsLearner: false},
 					{Name: "m4", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1463,8 +1397,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m3", IsLearner: false},
 					{Name: "m4", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1517,8 +1449,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1579,8 +1509,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m3", IsLearner: false},
 					{Name: "m4", IsLearner: true},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1625,8 +1553,6 @@ func Test_setAvailableCondition(t *testing.T) {
 				EtcdMembers: []*etcd.Member{
 					{Name: "m1", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1678,8 +1604,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					{Name: "m2", IsLearner: false},
 					{Name: "m3", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1718,8 +1642,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					},
 				),
 				EtcdMembers:                       []*etcd.Member{{}, {}, {}},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1768,8 +1690,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					},
 				),
 				EtcdMembers:                       nil,
-				EtcdMembersAgreeOnMemberList:      false,
-				EtcdMembersAgreeOnClusterID:       false,
 				EtcdMembersAndMachinesAreMatching: false,
 			},
 			expectCondition: metav1.Condition{
@@ -1815,8 +1735,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					},
 				),
 				EtcdMembers:                       nil,
-				EtcdMembersAgreeOnMemberList:      false,
-				EtcdMembersAgreeOnClusterID:       false,
 				EtcdMembersAndMachinesAreMatching: false,
 			},
 			expectCondition: metav1.Condition{
@@ -1853,8 +1771,6 @@ func Test_setAvailableCondition(t *testing.T) {
 				EtcdMembers: []*etcd.Member{
 					{Name: "m1", IsLearner: false},
 				},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1892,8 +1808,6 @@ func Test_setAvailableCondition(t *testing.T) {
 					},
 				),
 				EtcdMembers:                       []*etcd.Member{{Name: "m1"}},
-				EtcdMembersAgreeOnMemberList:      true,
-				EtcdMembersAgreeOnClusterID:       true,
 				EtcdMembersAndMachinesAreMatching: true,
 			},
 			expectCondition: metav1.Condition{
@@ -1908,7 +1822,7 @@ func Test_setAvailableCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			setAvailableCondition(ctx, tt.controlPlane.KCP, tt.controlPlane.IsEtcdManaged(), tt.controlPlane.EtcdMembers, tt.controlPlane.EtcdMembersAgreeOnMemberList, tt.controlPlane.EtcdMembersAgreeOnClusterID, tt.controlPlane.EtcdMembersAndMachinesAreMatching, tt.controlPlane.Machines)
+			setAvailableCondition(ctx, tt.controlPlane.KCP, tt.controlPlane.IsEtcdManaged(), tt.controlPlane.EtcdMembers, tt.controlPlane.EtcdMembersAndMachinesAreMatching, tt.controlPlane.Machines)
 
 			availableCondition := v1beta2conditions.Get(tt.controlPlane.KCP, controlplanev1.KubeadmControlPlaneAvailableV1Beta2Condition)
 			g.Expect(availableCondition).ToNot(BeNil())

--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -145,7 +145,7 @@ var (
 func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error) {
 	dialer, err := proxy.NewDialer(config.Proxy)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to create a dialer for %s", config.Endpoint)
+		return nil, errors.Wrapf(err, "unable to create a dialer for the etcd client connecting to %s", config.Endpoint)
 	}
 
 	etcdClient, err := clientv3.New(clientv3.Config{
@@ -169,9 +169,6 @@ func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error)
 	client, err := newEtcdClient(ctx, etcdClient, callTimeout)
 	if err != nil {
 		closeErr := etcdClient.Close()
-		if closeErr != nil {
-			return nil, err
-		}
 		return nil, kerrors.NewAggregate([]error{err, closeErr})
 	}
 	return client, nil

--- a/controlplane/kubeadm/internal/etcd_client_generator.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"context"
 	"crypto/tls"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -83,7 +84,7 @@ func (c *EtcdClientGenerator) forFirstAvailableNode(ctx context.Context, nodeNam
 		}
 		return client, nil
 	}
-	return nil, errors.Wrap(kerrors.NewAggregate(errs), "could not establish a connection to any etcd node")
+	return nil, errors.Wrapf(kerrors.NewAggregate(errs), "could not establish a connection to etcd members hosted on %s", strings.Join(nodeNames, ","))
 }
 
 // forLeader takes a list of nodes and returns a client to the leader node.

--- a/controlplane/kubeadm/internal/etcd_client_generator_test.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator_test.go
@@ -71,7 +71,7 @@ func TestFirstAvailableNode(t *testing.T) {
 			cc: func(context.Context, string) (*etcd.Client, error) {
 				return nil, errors.New("something went wrong")
 			},
-			expectedErr: "could not establish a connection to any etcd node: something went wrong",
+			expectedErr: "could not establish a connection to etcd members hosted on node-1,node-2: something went wrong",
 		},
 		{
 			name:  "Returns client when some of the nodes are down but at least one node is up",
@@ -204,7 +204,7 @@ func TestForLeader(t *testing.T) {
 			cc: func(context.Context, string) (*etcd.Client, error) {
 				return nil, errors.New("node down")
 			},
-			expectedErr: "could not establish a connection to the etcd leader: [could not establish a connection to any etcd node: node down, failed to connect to etcd node]",
+			expectedErr: "could not establish a connection to the etcd leader: [could not establish a connection to etcd members hosted on node-down-1: node down, failed to connect to etcd node, could not establish a connection to etcd members hosted on node-down-2: node down, could not establish a connection to etcd members hosted on node-down-3: node down]",
 		},
 	}
 

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -65,8 +65,10 @@ func (w *Workload) updateExternalEtcdConditions(_ context.Context, controlPlane 
 }
 
 func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane *ControlPlane) {
-	// NOTE: This methods uses control plane nodes only to get in contact with etcd but then it relies on etcd
-	// as ultimate source of truth for the list of members and for their health.
+	log := ctrl.LoggerFrom(ctx)
+
+	// Read control plane nodes (instead of using node ref from the machines) so we will avoid trying to connect to nodes
+	// that have been incidentally deleted; also this allows to detect nodes without a machine.
 	controlPlaneNodes, err := w.getControlPlaneNodes(ctx)
 	if err != nil {
 		for _, m := range controlPlane.Machines {
@@ -91,14 +93,7 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 		return
 	}
 
-	// Update conditions for etcd members on the nodes.
-	var (
-		// kcpErrors is used to store errors that can't be reported on any machine.
-		kcpErrors []string
-		// clusterID is used to store and compare the etcd's cluster id.
-		clusterID *uint64
-	)
-
+	// Update etcd member healthy conditions for provisioning machines (machines without a node yet, and thus without a matching etcd member).
 	provisioningMachines := controlPlane.Machines.Filter(collections.Not(collections.HasNode()))
 	for _, machine := range provisioningMachines {
 		var msg string
@@ -118,86 +113,42 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 		})
 	}
 
-	for _, node := range controlPlaneNodes.Items {
-		// Search for the machine corresponding to the node.
-		var machine *clusterv1.Machine
-		for _, m := range controlPlane.Machines {
-			if m.Status.NodeRef != nil && m.Status.NodeRef.Name == node.Name {
-				machine = m
-			}
-		}
+	// Update etcd member healthy conditions for machines being deleted (machines where we cannot rely on the status of kubelet/etcd member).
+	for _, machine := range controlPlane.Machines.Filter(collections.HasDeletionTimestamp) {
+		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
 
-		if machine == nil {
-			// If there are machines still provisioning there is the chance that a chance that a node might be linked to a machine soon,
-			// otherwise report the error at KCP level given that there is no machine to report on.
-			if len(provisioningMachines) > 0 {
+		v1beta2conditions.Set(machine, metav1.Condition{
+			Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+			Status:  metav1.ConditionFalse,
+			Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberDeletingV1Beta2Reason,
+			Message: "Machine is deleting",
+		})
+	}
+
+	// Update etcd member healthy conditions for machines not provisioning or deleting.
+	// This is implemented by reading info about members and alarms from etcd.
+	machinesNotProvisioningOrDeleting := controlPlane.Machines.Filter(collections.And(collections.HasNode(), collections.Not(collections.HasDeletionTimestamp)))
+	currentMembers, alarms, err := w.getCurrentEtcdMembersAndAlarms(ctx, machinesNotProvisioningOrDeleting, controlPlaneNodes)
+	if err == nil {
+		controlPlane.EtcdMembers = currentMembers
+
+		for _, machine := range machinesNotProvisioningOrDeleting {
+			// Retrieve the member hosted on the machine.
+			// If not found, report the issue on the machine.
+			member := etcdutil.MemberForName(currentMembers, machine.Status.NodeRef.Name)
+			if member == nil {
+				conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member reports the cluster is composed by members %s, but the member hosted on this Machine is not included", etcdutil.MemberNames(currentMembers))
+
+				v1beta2conditions.Set(machine, metav1.Condition{
+					Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+					Status:  metav1.ConditionFalse,
+					Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
+					Message: fmt.Sprintf("Etcd reports the cluster is composed by %s, but the etcd member hosted on this Machine is not included", etcdutil.MemberNames(currentMembers)),
+				})
 				continue
 			}
-			kcpErrors = append(kcpErrors, fmt.Sprintf("Control plane Node %s does not have a corresponding Machine", node.Name))
-			continue
-		}
 
-		// If the machine is deleting, report all the conditions as deleting.
-		if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
-			conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
-
-			v1beta2conditions.Set(machine, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberDeletingV1Beta2Reason,
-				Message: "Machine is deleting",
-			})
-			continue
-		}
-
-		currentMembers, alarms, err := w.getCurrentEtcdMembers(ctx, machine, node.Name)
-		if err != nil {
-			// Note. even if we fail reading the member list from one node/etcd members we do not set EtcdMembersAgreeOnMemberList and EtcdMembersAgreeOnClusterID to false
-			// (those info are computed on what we can collect during inspection, so we can reason about availability even if there is a certain degree of problems in the cluster).
-
-			// While scaling up/down or rolling out new CP machines this error might happen.
-			continue
-		}
-
-		// Check if the list of members IDs reported is the same as all other members.
-		// NOTE: the first member reporting this information is the baseline for this information.
-		// Also, if this is the first node we are reading from let's
-		// assume all the members agree on member list and cluster id.
-		if controlPlane.EtcdMembers == nil {
-			controlPlane.EtcdMembers = currentMembers
-			controlPlane.EtcdMembersAgreeOnMemberList = true
-			controlPlane.EtcdMembersAgreeOnClusterID = true
-		}
-		if !etcdutil.MemberEqual(controlPlane.EtcdMembers, currentMembers) {
-			controlPlane.EtcdMembersAgreeOnMemberList = false
-			conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member reports the cluster is composed by members %s, but all previously seen etcd members are reporting %s", etcdutil.MemberNames(currentMembers), etcdutil.MemberNames(controlPlane.EtcdMembers))
-
-			v1beta2conditions.Set(machine, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
-				Message: fmt.Sprintf("The etcd member hosted on this Machine reports the cluster is composed by %s, but all previously seen etcd members are reporting %s", etcdutil.MemberNames(currentMembers), etcdutil.MemberNames(controlPlane.EtcdMembers)),
-			})
-
-			// While scaling up/down or rolling out new CP machines this error might happen because we are reading the list from different nodes at different time.
-			continue
-		}
-
-		// Retrieve the member and check for alarms.
-		// NB. The member for this node always exists given forFirstAvailableNode(node) used above
-		member := etcdutil.MemberForName(currentMembers, node.Name)
-		if member == nil {
-			conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member reports the cluster is composed by members %s, but the member hosted on this Machine is not included", etcdutil.MemberNames(currentMembers))
-
-			v1beta2conditions.Set(machine, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
-				Message: fmt.Sprintf("Etcd reports the cluster is composed by %s, but the etcd member hosted on this Machine is not included", etcdutil.MemberNames(currentMembers)),
-			})
-			continue
-		}
-		if len(alarms) > 0 {
+			// Check for alarms for the etcd member
 			alarmList := []string{}
 			for _, alarm := range alarms {
 				if alarm.MemberID != member.ID {
@@ -222,47 +173,44 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 				})
 				continue
 			}
-		}
 
-		// Check if the member belongs to the same cluster as all other members.
-		// NOTE: the first member reporting this information is the baseline for this information.
-		if clusterID == nil {
-			clusterID = &member.ClusterID
-		}
-		if *clusterID != member.ClusterID {
-			controlPlane.EtcdMembersAgreeOnClusterID = false
-			conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member has cluster ID %d, but all previously seen etcd members have cluster ID %d", member.ClusterID, *clusterID)
+			// Otherwise consider the member healthy
+			conditions.MarkTrue(machine, controlplanev1.MachineEtcdMemberHealthyCondition)
 
 			v1beta2conditions.Set(machine, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
-				Message: fmt.Sprintf("Etcd member has cluster ID %d, but all previously seen etcd members have cluster ID %d", member.ClusterID, *clusterID),
+				Type:   controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+				Status: metav1.ConditionTrue,
+				Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Reason,
 			})
-			continue
 		}
-
-		conditions.MarkTrue(machine, controlplanev1.MachineEtcdMemberHealthyCondition)
-
-		v1beta2conditions.Set(machine, metav1.Condition{
-			Type:   controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-			Status: metav1.ConditionTrue,
-			Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Reason,
-		})
-	}
-
-	// Make sure that the list of etcd members and machines is consistent.
-	// NOTE: Members/Machines consistency is computed based on the info KCP was able to collect during inspection (e.g. if on a 3 CP
-	// control plane one etcd member is down, the comparison is based on the answer collected from two members only).
-	// NOTE: We surface the result of compareMachinesAndMembers for the Available condition only if all the etcd members agree
-	// on member list and cluster id (if not, we consider the list of members not reliable).
-	membersAndMachinesAreMatching, membersAndMachinesCompareErrors := compareMachinesAndMembers(controlPlane, controlPlaneNodes, controlPlane.EtcdMembers)
-	if controlPlane.EtcdMembersAgreeOnMemberList && controlPlane.EtcdMembersAgreeOnClusterID {
-		controlPlane.EtcdMembersAndMachinesAreMatching = membersAndMachinesAreMatching
 	} else {
-		controlPlane.EtcdMembersAndMachinesAreMatching = false
+		// In case of errors, getCurrentEtcdMembersAndAlarms sets etcd member healthy conditions with the proper message;
+		// KCP still have to aggregate conditions set by  in case of errors + continue to reconcile at best effort, so we only log this error.
+		log.Error(err, "Failed to get current etcd members and alarms")
 	}
-	kcpErrors = append(kcpErrors, membersAndMachinesCompareErrors...)
+
+	// Check if the list of etcd members and machines match each other.
+	// In case there are errors that we cannot link to a specific machine, consider them as kcp errors.
+	membersAndMachinesAreMatching, membersAndMachinesCompareErrors := compareMachinesAndMembers(controlPlane, controlPlaneNodes, controlPlane.EtcdMembers)
+	controlPlane.EtcdMembersAndMachinesAreMatching = membersAndMachinesAreMatching
+	kcpErrors := membersAndMachinesCompareErrors
+
+	// Report error at KCP level if there are nodes without a corresponding machine.
+	// Note: Skip this check if there are machines still provisioning because there is the chance that a node might be linked to a machine soon.
+	if len(provisioningMachines) == 0 {
+		for _, node := range controlPlaneNodes.Items {
+			isNodeRef := false
+			for _, m := range controlPlane.Machines {
+				if m.Status.NodeRef != nil && m.Status.NodeRef.Name == node.Name {
+					isNodeRef = true
+					break
+				}
+			}
+			if !isNodeRef {
+				kcpErrors = append(kcpErrors, fmt.Sprintf("Control plane Node %s does not have a corresponding Machine", node.Name))
+			}
+		}
+	}
 
 	// Aggregate components error from machines at KCP level
 	aggregateConditionsFromMachinesToKCP(aggregateConditionsFromMachinesToKCPInput{
@@ -298,66 +246,134 @@ func unwrapAll(err error) error {
 	return err
 }
 
-func (w *Workload) getCurrentEtcdMembers(ctx context.Context, machine *clusterv1.Machine, nodeName string) ([]*etcd.Member, []etcd.MemberAlarm, error) {
-	// Create the etcd Client for the etcd Pod scheduled on the Node
-	etcdClient, err := w.etcdClientGenerator.forFirstAvailableNode(ctx, []string{nodeName})
-	if err != nil {
-		conditions.MarkUnknown(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberInspectionFailedReason, "Failed to connect to the etcd Pod on the %s Node: %s", nodeName, err)
+// getCurrentEtcdMembersAndAlarms returns the current list of etcd member and alarms.
+// Considering that the underlying etcd SDK calls (MemberList and AlarmList) requires quorum across all etcd members, it is possible
+// to run those calls towards any etcd Pod hosting an etcd member.
+func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines collections.Machines, nodes *corev1.NodeList) ([]*etcd.Member, []etcd.MemberAlarm, error) {
+	// Get the list of nodes hosting an etcd member sorted by the last known etcd health,
+	// so the client generator in the following line will try to connect first to nodes with higher chance to answer.
+	nodeNames := getNodeNamesSortedByLastKnownEtcdHealth(nodes, machines)
+	if len(nodeNames) == 0 {
+		return nil, nil, nil
+	}
 
-		v1beta2conditions.Set(machine, metav1.Condition{
-			Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-			Status:  metav1.ConditionUnknown,
-			Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
-			Message: fmt.Sprintf("Failed to connect to the etcd Pod on the %s Node: %s", nodeName, unwrapAll(err)),
-		})
-		return nil, nil, errors.Wrapf(err, "failed to get current etcd members: failed to connect to the etcd Pod on the %s Node", nodeName)
+	// Create the etcd Client for one of the etcd Pods running on the given nodes.
+	etcdClient, err := w.etcdClientGenerator.forFirstAvailableNode(ctx, nodeNames)
+	if err != nil {
+		for _, m := range machines {
+			conditions.MarkUnknown(m, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberInspectionFailedReason, "Failed to connect to etcd: %s", err)
+
+			v1beta2conditions.Set(m, metav1.Condition{
+				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
+				Message: fmt.Sprintf("Failed to connect to etcd: %s", unwrapAll(err)),
+			})
+		}
+		return nil, nil, errors.Wrapf(err, "failed to get an etcd client for %s Nodes", strings.Join(nodeNames, ","))
 	}
 	defer etcdClient.Close()
 
-	// While creating a new client, forFirstAvailableNode retrieves the status for the endpoint; check if the endpoint has errors.
+	// While creating a new client, forFirstAvailableNode also reads the status for the endpoint we are connected to; check if the endpoint has errors.
 	if len(etcdClient.Errors) > 0 {
-		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member status reports errors: %s", strings.Join(etcdClient.Errors, ", "))
+		for _, m := range machines {
+			conditions.MarkFalse(m, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
 
-		v1beta2conditions.Set(machine, metav1.Condition{
-			Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-			Status:  metav1.ConditionFalse,
-			Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
-			Message: fmt.Sprintf("Etcd reports errors: %s", strings.Join(etcdClient.Errors, ", ")),
-		})
-		return nil, nil, errors.Errorf("failed to get current etcd members: etcd member status reports errors: %s", strings.Join(etcdClient.Errors, ", "))
+			v1beta2conditions.Set(m, metav1.Condition{
+				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+				Status:  metav1.ConditionFalse,
+				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason,
+				Message: fmt.Sprintf("Etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", ")),
+			})
+		}
+		return nil, nil, errors.Errorf("etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
 	}
 
-	// Gets the list etcd members known by this member.
+	// Gets the list of etcd members in the cluster.
 	currentMembers, err := etcdClient.Members(ctx)
 	if err != nil {
-		// NB. We should never be in here, given that we just received answer to the etcd calls included in forFirstAvailableNode;
-		// however, we are considering the calls to Members a signal of etcd not being stable.
-		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get answer from the etcd member on the %s Node", nodeName)
+		for _, m := range machines {
+			conditions.MarkFalse(m, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get etcd members")
 
-		v1beta2conditions.Set(machine, metav1.Condition{
-			Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-			Status:  metav1.ConditionUnknown,
-			Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
-			Message: fmt.Sprintf("Failed to get answer from the etcd member on the %s Node: %s", nodeName, err.Error()),
-		})
-		return nil, nil, errors.Wrapf(err, "failed to get answer from the etcd member on the %s Node", nodeName)
+			v1beta2conditions.Set(m, metav1.Condition{
+				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
+				Message: fmt.Sprintf("Failed to get etcd members: %s", unwrapAll(err)),
+			})
+		}
+		return nil, nil, errors.Wrapf(err, "failed to get etcd members")
 	}
 
 	// Gets the list of etcd alarms.
 	alarms, err := etcdClient.Alarms(ctx)
 	if err != nil {
-		conditions.MarkFalse(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get answer from the etcd alarms on the %s Node", nodeName)
+		for _, m := range machines {
+			conditions.MarkFalse(m, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get etcd alarms")
 
-		v1beta2conditions.Set(machine, metav1.Condition{
-			Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
-			Status:  metav1.ConditionUnknown,
-			Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
-			Message: fmt.Sprintf("Failed to get answer from the etcd alarms on the %s Node: %s", nodeName, err.Error()),
-		})
-		return nil, nil, errors.Wrapf(err, "failed to get answer from the etcd alarms on the %s Node", nodeName)
+			v1beta2conditions.Set(m, metav1.Condition{
+				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason,
+				Message: fmt.Sprintf("Failed to get etcd alarms: %s", unwrapAll(err)),
+			})
+		}
+		return nil, nil, errors.Wrapf(err, "failed to get etcd alarms")
 	}
 
 	return currentMembers, alarms, nil
+}
+
+// getNodeNamesSortedByLastKnownEtcdHealth return the list of nodes hosting an etcd member sorted by the last known etcd health.
+// Note: sorting by last known etcd health is a best effort operations; only nodes with a corresponding machine are considered.
+func getNodeNamesSortedByLastKnownEtcdHealth(nodes *corev1.NodeList, machines collections.Machines) []string {
+	// Get the list of nodes and the corresponding MachineEtcdMemberHealthyCondition
+	nodeNames := []string{}
+	nodeEtcdHealthyCondition := map[string]clusterv1.Condition{}
+
+	for _, node := range nodes.Items {
+		var machine *clusterv1.Machine
+		for _, m := range machines {
+			if m.Status.NodeRef != nil && m.Status.NodeRef.Name == node.Name {
+				machine = m
+				break
+			}
+		}
+		// Ignore nodes without a corresponding machine (this should never happen).
+		if machine == nil {
+			continue
+		}
+
+		nodeNames = append(nodeNames, node.Name)
+		if c := conditions.Get(machine, controlplanev1.MachineEtcdMemberHealthyCondition); c != nil {
+			nodeEtcdHealthyCondition[node.Name] = *c
+		}
+		nodeEtcdHealthyCondition[node.Name] = clusterv1.Condition{
+			Type:   controlplanev1.MachineEtcdMemberHealthyCondition,
+			Status: corev1.ConditionUnknown,
+		}
+	}
+
+	// Sort by nodes by last known etcd member health.
+	sort.Slice(nodeNames, func(i, j int) bool {
+		iCondition := nodeEtcdHealthyCondition[nodeNames[i]]
+		jCondition := nodeEtcdHealthyCondition[nodeNames[j]]
+
+		// Nodes with last known etcd healthy members goes first, because most likely we can connect to them again.
+		// NOTE: This isn't always true, it is a best effort assumption (e.g. kubelet might have issues preventing connection to an healthy member to be established).
+		if iCondition.Status == corev1.ConditionTrue && jCondition.Status != corev1.ConditionTrue {
+			return true
+		}
+		if iCondition.Status != corev1.ConditionTrue && jCondition.Status == corev1.ConditionTrue {
+			return false
+		}
+
+		// Note: we are not making assumption on the chances to connect when last known etcd health is FALSE and UNKNOWN.
+
+		// Otherwise pick randomly one of the nodes to avoid trying to connect always to the same nodes first.
+		return time.Now().UnixMilli()%2 == 0
+	})
+	return nodeNames
 }
 
 func compareMachinesAndMembers(controlPlane *ControlPlane, nodes *corev1.NodeList, members []*etcd.Member) (bool, []string) {
@@ -365,9 +381,9 @@ func compareMachinesAndMembers(controlPlane *ControlPlane, nodes *corev1.NodeLis
 	var kcpErrors []string
 
 	// If it failed to get members, consider the check failed in case there is at least a machine already provisioned
-	// (tolerate if we fail getting members when the cluster is provisioning the first machine).
+	// (tolerate if we fail getting members when the cluster is still creating or provisioning the first machine).
 	if members == nil {
-		if len(controlPlane.Machines.Filter(collections.HasNode())) > 0 {
+		if len(controlPlane.Machines.Filter(collections.HasNode())) > 0 || len(controlPlane.Machines) == 0 {
 			membersAndMachinesAreMatching = false
 		}
 		return membersAndMachinesAreMatching, nil

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -347,6 +347,7 @@ func getNodeNamesSortedByLastKnownEtcdHealth(nodes *corev1.NodeList, machines co
 		nodeNames = append(nodeNames, node.Name)
 		if c := conditions.Get(machine, controlplanev1.MachineEtcdMemberHealthyCondition); c != nil {
 			nodeEtcdHealthyCondition[node.Name] = *c
+			continue
 		}
 		nodeEtcdHealthyCondition[node.Name] = clusterv1.Condition{
 			Type:   controlplanev1.MachineEtcdMemberHealthyCondition,
@@ -380,10 +381,9 @@ func compareMachinesAndMembers(controlPlane *ControlPlane, nodes *corev1.NodeLis
 	membersAndMachinesAreMatching := true
 	var kcpErrors []string
 
-	// If it failed to get members, consider the check failed in case there is at least a machine already provisioned
-	// (tolerate if we fail getting members when the cluster is still creating or provisioning the first machine).
+	// If it failed to get members, consider the check failed in case there is at least a machine already provisioned.
 	if members == nil {
-		if len(controlPlane.Machines.Filter(collections.HasNode())) > 0 || len(controlPlane.Machines) == 0 {
+		if len(controlPlane.Machines.Filter(collections.HasNode())) > 0 {
 			membersAndMachinesAreMatching = false
 		}
 		return membersAndMachinesAreMatching, nil

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -249,7 +249,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				Reason:  controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyV1Beta2Reason,
 				Message: "* Control plane Node n1 does not have a corresponding Machine",
 			},
-			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
+			expectedEtcdMembersAndMachinesAreMatching: true,
 		},
 		{
 			name: "failure creating the etcd client should report unknown condition",

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -175,8 +177,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 		expectedMachineConditions                 map[string]clusterv1.Conditions
 		expectedMachineV1Beta2Conditions          map[string][]metav1.Condition
 		expectedEtcdMembers                       []string
-		expectedEtcdMembersAgreeOnMemberList      bool
-		expectedEtcdMembersAgreeOnClusterID       bool
 		expectedEtcdMembersAndMachinesAreMatching bool
 	}{
 		{
@@ -185,7 +185,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeMachine("m1"),
 			},
 			injectClient: &fakeClient{
-				listErr: errors.New("failed to list Nodes"),
+				listErr: errors.New("something went wrong"),
 			},
 			expectedKCPCondition: conditions.UnknownCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterInspectionFailedReason, "Failed to list Nodes which are hosting the etcd members"),
 			expectedMachineConditions: map[string]clusterv1.Conditions{
@@ -204,8 +204,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Failed to get the Node hosting the etcd member"},
 				},
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading nodes, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading nodes, we can not make assumptions.
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading nodes, we can not make assumptions.
 		},
 		{
@@ -234,39 +232,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Waiting for a Node with spec.providerID n1 to exist"},
 				},
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
-		},
-		{
-			name: "If there are provisioning machines, a node without machine should be ignored in v1beta1, reported in v1beta2 (with providerID)",
-			machines: []*clusterv1.Machine{
-				fakeMachine("m1", withProviderID("dummy-provider-id")), // without NodeRef (provisioning)
-			},
-			injectClient: &fakeClient{
-				list: &corev1.NodeList{
-					Items: []corev1.Node{*fakeNode("n1")},
-				},
-			},
-			expectedKCPCondition: nil,
-			expectedMachineConditions: map[string]clusterv1.Conditions{
-				"m1": {},
-			},
-			expectedKCPV1Beta2Condition: &metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition,
-				Status: metav1.ConditionUnknown,
-				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterHealthUnknownV1Beta2Reason,
-				Message: "* Machine m1:\n" +
-					"  * EtcdMemberHealthy: Waiting for a Node with spec.providerID dummy-provider-id to exist",
-			},
-			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
-				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Waiting for a Node with spec.providerID dummy-provider-id to exist"},
-				},
-			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
+			expectedEtcdMembersAndMachinesAreMatching: true, // there is a single provisioning machine, member list not yet available (too early to say members and machines do not match).
 		},
 		{
 			name:     "If there are no provisioning machines, a node without machine should be reported as False condition at KCP level",
@@ -283,8 +249,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				Reason:  controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyV1Beta2Reason,
 				Message: "* Control plane Node n1 does not have a corresponding Machine",
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading members, we can not make assumptions.
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
 		},
 		{
@@ -298,12 +262,12 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesErr: errors.New("failed to get client for node"),
+				forNodesErr: errors.New("something went wrong"),
 			},
 			expectedKCPCondition: conditions.UnknownCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnknownReason, "Following Machines are reporting unknown etcd member status: m1"),
 			expectedMachineConditions: map[string]clusterv1.Conditions{
 				"m1": {
-					*conditions.UnknownCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberInspectionFailedReason, "Failed to connect to the etcd Pod on the %s Node: failed to get client for node", "n1"),
+					*conditions.UnknownCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberInspectionFailedReason, "Failed to connect to etcd: something went wrong"),
 				},
 			},
 			expectedKCPV1Beta2Condition: &metav1.Condition{
@@ -311,15 +275,13 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * EtcdMemberHealthy: Failed to connect to the etcd Pod on the n1 Node: failed to get client for node",
+					"  * EtcdMemberHealthy: Failed to connect to etcd: something went wrong",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Failed to connect to the etcd Pod on the n1 Node: failed to get client for node"},
+					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Failed to connect to etcd: something went wrong"},
 				},
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // failure in reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // failure in reading members, we can not make assumptions.
 			expectedEtcdMembersAndMachinesAreMatching: false, // failure in reading members, we can not make assumptions.
 		},
 		{
@@ -337,13 +299,14 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints: []string{},
 					},
-					Errors: []string{"some errors"},
+					Endpoint: "n1",
+					Errors:   []string{"something went wrong"},
 				},
 			},
 			expectedKCPCondition: conditions.FalseCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnhealthyReason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m1"),
 			expectedMachineConditions: map[string]clusterv1.Conditions{
 				"m1": {
-					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member status reports errors: %s", "some errors"),
+					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd endpoint n1 reports errors: %s", "something went wrong"),
 				},
 			},
 			expectedKCPV1Beta2Condition: &metav1.Condition{
@@ -351,15 +314,13 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				Status: metav1.ConditionFalse,
 				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * EtcdMemberHealthy: Etcd reports errors: some errors",
+					"  * EtcdMemberHealthy: Etcd endpoint n1 reports errors: something went wrong",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason, Message: "Etcd reports errors: some errors"},
+					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason, Message: "Etcd endpoint n1 reports errors: something went wrong"},
 				},
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading members, we can not make assumptions.
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
 		},
 		{
@@ -376,14 +337,14 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints: []string{},
-						ErrorResponse: errors.New("failed to list members"),
+						ErrorResponse: errors.New("something went wrong"),
 					},
 				},
 			},
 			expectedKCPCondition: conditions.FalseCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnhealthyReason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m1"),
 			expectedMachineConditions: map[string]clusterv1.Conditions{
 				"m1": {
-					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get answer from the etcd member on the %s Node", "n1"),
+					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Failed to get etcd members"),
 				},
 			},
 			expectedKCPV1Beta2Condition: &metav1.Condition{
@@ -391,15 +352,13 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				Status: metav1.ConditionUnknown,
 				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterHealthUnknownV1Beta2Reason,
 				Message: "* Machine m1:\n" +
-					"  * EtcdMemberHealthy: Failed to get answer from the etcd member on the n1 Node: failed to get list of members for etcd cluster: failed to list members",
+					"  * EtcdMemberHealthy: Failed to get etcd members: something went wrong",
 			},
 			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
 				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Failed to get answer from the etcd member on the n1 Node: failed to get list of members for etcd cluster: failed to list members"},
+					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionUnknown, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedV1Beta2Reason, Message: "Failed to get etcd members: something went wrong"},
 				},
 			},
-			expectedEtcdMembersAgreeOnMemberList:      false, // without reading members, we can not make assumptions.
-			expectedEtcdMembersAgreeOnClusterID:       false, // without reading members, we can not make assumptions.
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
 		},
 		{
@@ -448,183 +407,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembers:                       []string{"n1"},
-			expectedEtcdMembersAgreeOnMemberList:      true,
-			expectedEtcdMembersAgreeOnClusterID:       true,
 			expectedEtcdMembersAndMachinesAreMatching: true,
-		},
-		{
-			name: "etcd members with different Cluster ID should report false condition",
-			machines: []*clusterv1.Machine{
-				fakeMachine("m1", withNodeRef("n1")),
-				fakeMachine("m2", withNodeRef("n2")),
-			},
-			injectClient: &fakeClient{
-				list: &corev1.NodeList{
-					Items: []corev1.Node{
-						*fakeNode("n1"),
-						*fakeNode("n2"),
-					},
-				},
-			},
-			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
-					switch n[0] {
-					case "n1":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
-									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										{Name: "n2", ID: uint64(2)},
-									},
-								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					case "n2":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(2), // different Cluster ID
-									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										{Name: "n2", ID: uint64(2)},
-									},
-								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					default:
-						return nil, errors.New("no client for this node")
-					}
-				},
-			},
-			expectedKCPCondition: conditions.FalseCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnhealthyReason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m2"),
-			expectedMachineConditions: map[string]clusterv1.Conditions{
-				"m1": {
-					*conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyCondition),
-				},
-				"m2": {
-					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member has cluster ID %d, but all previously seen etcd members have cluster ID %d", uint64(2), uint64(1)),
-				},
-			},
-			expectedKCPV1Beta2Condition: &metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition,
-				Status: metav1.ConditionFalse,
-				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyV1Beta2Reason,
-				Message: "* Machine m2:\n" +
-					"  * EtcdMemberHealthy: Etcd member has cluster ID 2, but all previously seen etcd members have cluster ID 1",
-			},
-			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
-				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Reason, Message: ""},
-				},
-				"m2": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason, Message: "Etcd member has cluster ID 2, but all previously seen etcd members have cluster ID 1"},
-				},
-			},
-			expectedEtcdMembers:                       []string{"n1", "n2"},
-			expectedEtcdMembersAgreeOnMemberList:      true,
-			expectedEtcdMembersAgreeOnClusterID:       false,
-			expectedEtcdMembersAndMachinesAreMatching: false,
-		},
-		{
-			name: "etcd members with different member list should report false condition",
-			machines: []*clusterv1.Machine{
-				fakeMachine("m1", withNodeRef("n1")),
-				fakeMachine("m2", withNodeRef("n2")),
-			},
-			injectClient: &fakeClient{
-				list: &corev1.NodeList{
-					Items: []corev1.Node{
-						*fakeNode("n1"),
-						*fakeNode("n2"),
-					},
-				},
-			},
-			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
-					switch n[0] {
-					case "n1":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
-									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										{Name: "n2", ID: uint64(2)},
-									},
-								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					case "n2":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
-									},
-									Members: []*pb.Member{ // different member list
-										{Name: "n2", ID: uint64(2)},
-										{Name: "n3", ID: uint64(3)},
-									},
-								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					default:
-						return nil, errors.New("no client for this node")
-					}
-				},
-			},
-			expectedKCPCondition: conditions.FalseCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnhealthyReason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m2"),
-			expectedMachineConditions: map[string]clusterv1.Conditions{
-				"m1": {
-					*conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyCondition),
-				},
-				"m2": {
-					*conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberUnhealthyReason, clusterv1.ConditionSeverityError, "Etcd member reports the cluster is composed by members [n2 n3], but all previously seen etcd members are reporting [n1 n2]"),
-				},
-			},
-			expectedKCPV1Beta2Condition: &metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneEtcdClusterHealthyV1Beta2Condition,
-				Status: metav1.ConditionFalse,
-				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyV1Beta2Reason,
-				Message: "* Machine m2:\n" +
-					"  * EtcdMemberHealthy: The etcd member hosted on this Machine reports the cluster is composed by [n2 n3], but all previously seen etcd members are reporting [n1 n2]",
-			},
-			expectedMachineV1Beta2Conditions: map[string][]metav1.Condition{
-				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Reason, Message: ""},
-				},
-				"m2": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyV1Beta2Condition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyV1Beta2Reason, Message: "The etcd member hosted on this Machine reports the cluster is composed by [n2 n3], but all previously seen etcd members are reporting [n1 n2]"},
-				},
-			},
-			expectedEtcdMembers:                       []string{"n1", "n2"},
-			expectedEtcdMembersAgreeOnMemberList:      false,
-			expectedEtcdMembersAgreeOnClusterID:       true,
-			expectedEtcdMembersAndMachinesAreMatching: false,
 		},
 		{
 			name: "a machine without a member should report false condition",
@@ -641,29 +424,33 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
-					switch n[0] {
-					case "n1":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
+				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+					var errs []error
+					for _, n := range nodeNames {
+						switch n {
+						case "n1":
+							return &etcd.Client{
+								EtcdClient: &fake2.FakeEtcdClient{
+									EtcdEndpoints: []string{},
+									MemberListResponse: &clientv3.MemberListResponse{
+										Header: &pb.ResponseHeader{
+											ClusterId: uint64(1),
+										},
+										Members: []*pb.Member{
+											{Name: "n1", ID: uint64(1)},
+											// member n2 is missing
+										},
 									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										// member n2 is missing
+									AlarmResponse: &clientv3.AlarmResponse{
+										Alarms: []*pb.AlarmMember{},
 									},
 								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					default:
-						return nil, errors.New("no client for this node")
+							}, nil
+						default:
+							errs = append(errs, errors.New("no client for this node"))
+						}
 					}
+					return nil, errors.Wrapf(kerrors.NewAggregate(errs), "could not establish a connection to etcd members hosted on %s", strings.Join(nodeNames, ","))
 				},
 			},
 			expectedKCPCondition: conditions.FalseCondition(controlplanev1.EtcdClusterHealthyCondition, controlplanev1.EtcdClusterUnhealthyReason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m2"),
@@ -691,8 +478,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembers:                       []string{"n1"},
-			expectedEtcdMembersAgreeOnMemberList:      true,
-			expectedEtcdMembersAgreeOnClusterID:       true,
 			expectedEtcdMembersAndMachinesAreMatching: false,
 		},
 		{
@@ -710,47 +495,51 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
-					switch n[0] {
-					case "n1":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
+				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+					var errs []error
+					for _, n := range nodeNames {
+						switch n {
+						case "n1":
+							return &etcd.Client{
+								EtcdClient: &fake2.FakeEtcdClient{
+									EtcdEndpoints: []string{},
+									MemberListResponse: &clientv3.MemberListResponse{
+										Header: &pb.ResponseHeader{
+											ClusterId: uint64(1),
+										},
+										Members: []*pb.Member{
+											{Name: "n1", ID: uint64(1)},
+											{Name: "n2", ID: uint64(2)},
+										},
 									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										{Name: "n2", ID: uint64(2)},
-									},
-								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
-								},
-							},
-						}, nil
-					case "n2":
-						return &etcd.Client{
-							EtcdClient: &fake2.FakeEtcdClient{
-								EtcdEndpoints: []string{},
-								MemberListResponse: &clientv3.MemberListResponse{
-									Header: &pb.ResponseHeader{
-										ClusterId: uint64(1),
-									},
-									Members: []*pb.Member{
-										{Name: "n1", ID: uint64(1)},
-										{Name: "n2", ID: uint64(2)},
+									AlarmResponse: &clientv3.AlarmResponse{
+										Alarms: []*pb.AlarmMember{},
 									},
 								},
-								AlarmResponse: &clientv3.AlarmResponse{
-									Alarms: []*pb.AlarmMember{},
+							}, nil
+						case "n2":
+							return &etcd.Client{
+								EtcdClient: &fake2.FakeEtcdClient{
+									EtcdEndpoints: []string{},
+									MemberListResponse: &clientv3.MemberListResponse{
+										Header: &pb.ResponseHeader{
+											ClusterId: uint64(1),
+										},
+										Members: []*pb.Member{
+											{Name: "n1", ID: uint64(1)},
+											{Name: "n2", ID: uint64(2)},
+										},
+									},
+									AlarmResponse: &clientv3.AlarmResponse{
+										Alarms: []*pb.AlarmMember{},
+									},
 								},
-							},
-						}, nil
-					default:
-						return nil, errors.New("no client for this node")
+							}, nil
+						default:
+							errs = append(errs, errors.New("no client for this node"))
+						}
 					}
+					return nil, errors.Wrapf(kerrors.NewAggregate(errs), "could not establish a connection to etcd members hosted on %s", strings.Join(nodeNames, ","))
 				},
 			},
 			expectedKCPCondition: conditions.TrueCondition(controlplanev1.EtcdClusterHealthyCondition),
@@ -776,8 +565,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembers:                       []string{"n1", "n2"},
-			expectedEtcdMembersAgreeOnMemberList:      true,
-			expectedEtcdMembersAgreeOnClusterID:       true,
 			expectedEtcdMembersAndMachinesAreMatching: true,
 		},
 	}
@@ -812,8 +599,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				g.Expect(m.GetV1Beta2Conditions()).To(v1beta2conditions.MatchConditions(tt.expectedMachineV1Beta2Conditions[m.Name], v1beta2conditions.IgnoreLastTransitionTime(true)), "unexpected conditions for Machine %s", m.Name)
 			}
 
-			g.Expect(controlPane.EtcdMembersAgreeOnMemberList).To(Equal(tt.expectedEtcdMembersAgreeOnMemberList), "EtcdMembersAgreeOnMemberList does not match")
-			g.Expect(controlPane.EtcdMembersAgreeOnClusterID).To(Equal(tt.expectedEtcdMembersAgreeOnClusterID), "EtcdMembersAgreeOnClusterID does not match")
 			g.Expect(controlPane.EtcdMembersAndMachinesAreMatching).To(Equal(tt.expectedEtcdMembersAndMachinesAreMatching), "EtcdMembersAndMachinesAreMatching does not match")
 
 			var membersNames []string

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -18,12 +18,12 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/blang/semver/v4"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	pb "go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
KCP has been designed to prefer stability over speed.

This lead e.g. to ask for the same info (member list and alarms) to all the etcd members as an additional safety.

However, over time we discovered that being too much chatty with etcd has some downsides:
- it introduces race conditions, because we are asking the same info to different members at different time and things can change in between two calls
- it amplifies problems when there are connection issues (each call has its own timeout, so a reconcile is stuck for 3 times timeout)
- it adds to the reconciliation time, thus impacting performance at scale

This PR address some of those issues by reading etcd member list and alarms once (instead of reading the same info from each node) in KCP's updateManagedEtcdConditions.
