### PR TITLE
✨ Implement `Priority` and `Serial` settings for discovered handlers

### DIFF
--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -228,6 +228,11 @@ spec:
                     name:
                       description: name is the unique name of the ExtensionHandler.
                       type: string
+                    priority:
+                      description: Priority defines the order in which this handler
+                        will be invoked. Hooks are executed in the descending order.
+                      format: int32
+                      type: integer
                     requestHook:
                       description: requestHook defines the versioned runtime hook
                         which this ExtensionHandler serves.
@@ -243,6 +248,10 @@ spec:
                       - apiVersion
                       - hook
                       type: object
+                    serial:
+                      description: Serial defines if the blocked hook is allowed to
+                        run in parallel with others.
+                      type: boolean
                     timeoutSeconds:
                       description: |-
                         timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -131,6 +131,14 @@ type ExtensionHandler struct {
 	// Defaults to Fail if not set.
 	// +optional
 	FailurePolicy *FailurePolicy `json:"failurePolicy,omitempty"`
+
+	// Priority defines the order in which this handler will be invoked. Hooks are executed in the descending order.
+	// +optional
+	Priority int32 `json:"priority,omitempty"`
+
+	// Serial defines if the blocked hook is allowed to run in parallel with others.
+	// +optional
+	Serial bool `json:"serial,omitempty"`
 }
 
 // GroupVersionHook defines the runtime hook when the ExtensionHandler is called.

--- a/exp/runtime/hooks/api/v1alpha1/discovery_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/discovery_types.go
@@ -63,6 +63,14 @@ type ExtensionHandler struct {
 	// failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
 	// This is defaulted to FailurePolicyFail if not defined.
 	FailurePolicy *FailurePolicy `json:"failurePolicy,omitempty"`
+
+	// Priority defines the order in which this handler will be invoked. Hooks are executed in the descending order.
+	// +optional
+	Priority int32 `json:"priority,omitempty"`
+
+	// Serial defines if the blocked hook is allowed to run in parallel with others.
+	// +optional
+	Serial bool `json:"serial,omitempty"`
 }
 
 // GroupVersionHook defines the runtime hook when the ExtensionHandler is called.

--- a/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
+++ b/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
@@ -1317,6 +1317,20 @@ func schema_runtime_hooks_api_v1alpha1_ExtensionHandler(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"priority": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Priority defines the order in which this handler will be invoked. Hooks are executed in the descending order.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"serial": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Serial defines if the blocked hook is allowed to run in parallel with others.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"name", "requestHook"},
 			},

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -229,6 +229,10 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 		handlers := discoveredExtensionConfig.Status.Handlers
 		g.Expect(handlers).To(HaveLen(1))
 		g.Expect(handlers[0].Name).To(Equal("first.ext1"))
+		g.Expect(handlers[0].RequestHook.Hook).To(Equal("FakeHook"))
+		g.Expect(handlers[0].RequestHook.APIVersion).To(Equal("test.runtime.cluster.x-k8s.io/v1alpha1"))
+		g.Expect(handlers[0].Serial).To(BeTrue())
+		g.Expect(handlers[0].Priority).To(Equal(int32(100)))
 
 		// Expect exactly one condition and expect the condition to have type RuntimeExtensionDiscoveredCondition and
 		// Status true.
@@ -345,6 +349,8 @@ func discoveryHandler(handlerList ...string) func(http.ResponseWriter, *http.Req
 				Hook:       "FakeHook",
 				APIVersion: fakev1alpha1.GroupVersion.String(),
 			},
+			Serial:   true,
+			Priority: 100,
 		})
 	}
 	response := &runtimehooksv1.DiscoveryResponse{

--- a/exp/runtime/server/server.go
+++ b/exp/runtime/server/server.go
@@ -150,6 +150,12 @@ type ExtensionHandler struct {
 	// If left undefined, this will be defaulted to FailurePolicyFail when processing the answer to the discovery
 	// call for this server.
 	FailurePolicy *runtimehooksv1.FailurePolicy
+
+	// Priority defines the order in which this handler will be invoked. Hooks are executed in the descending order.
+	Priority int32
+
+	// Serial defines if the blocked hook is allowed to run in parallel with others.
+	Serial bool
 }
 
 // AddExtensionHandler adds an extension handler to the server.
@@ -268,6 +274,8 @@ func discoveryHandler(handlers map[string]ExtensionHandler) func(context.Context
 			},
 			TimeoutSeconds: handler.TimeoutSeconds,
 			FailurePolicy:  handler.FailurePolicy,
+			Priority:       handler.Priority,
+			Serial:         handler.Serial,
 		})
 	}
 

--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -184,10 +184,12 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 				WaitForKubeProxyUpgrade:        input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForDNSUpgrade:              input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForEtcdUpgrade:             input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
-				PreWaitForControlPlaneToBeUpgraded: func() {
-					if input.PreWaitForControlPlaneToBeUpgraded != nil {
-						input.PreWaitForControlPlaneToBeUpgraded(input.BootstrapClusterProxy, namespace.Name, clusterName)
-					}
+				PreWaitForControlPlaneToBeUpgraded: []func(){
+					func() {
+						if input.PreWaitForControlPlaneToBeUpgraded != nil {
+							input.PreWaitForControlPlaneToBeUpgraded(input.BootstrapClusterProxy, namespace.Name, clusterName)
+						}
+					},
 				},
 			})
 		} else {

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -342,6 +342,17 @@ func setupLifecycleHookHandlers(mgr ctrl.Manager, runtimeExtensionWebhookServer 
 	}
 
 	if err := runtimeExtensionWebhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:        lifecycle.JustBeforeClusterUpgrade,
+		Name:        "just-before-cluster-upgrade",
+		HandlerFunc: lifecycleExtensionHandlers.DoJustBeforeClusterUpgrade,
+		Priority:    10,
+		Serial:      true,
+	}); err != nil {
+		setupLog.Error(err, "Error adding handler")
+		os.Exit(1)
+	}
+
+	if err := runtimeExtensionWebhookServer.AddExtensionHandler(server.ExtensionHandler{
 		Hook:        runtimehooksv1.BeforeClusterUpgrade,
 		Name:        "before-cluster-upgrade",
 		HandlerFunc: lifecycleExtensionHandlers.DoBeforeClusterUpgrade,

--- a/test/framework/cluster_topology_helpers.go
+++ b/test/framework/cluster_topology_helpers.go
@@ -73,7 +73,7 @@ type UpgradeClusterTopologyAndWaitForUpgradeInput struct {
 	WaitForKubeProxyUpgrade            []interface{}
 	WaitForDNSUpgrade                  []interface{}
 	WaitForEtcdUpgrade                 []interface{}
-	PreWaitForControlPlaneToBeUpgraded func()
+	PreWaitForControlPlaneToBeUpgraded []func()
 	PreWaitForWorkersToBeUpgraded      func()
 	SkipKubeProxyCheck                 bool
 }
@@ -113,7 +113,9 @@ func UpgradeClusterTopologyAndWaitForUpgrade(ctx context.Context, input UpgradeC
 	// and blocking correctly.
 	if input.PreWaitForControlPlaneToBeUpgraded != nil {
 		log.Logf("Calling PreWaitForControlPlaneToBeUpgraded")
-		input.PreWaitForControlPlaneToBeUpgraded()
+		for _, f := range input.PreWaitForControlPlaneToBeUpgraded {
+			f()
+		}
 	}
 
 	log.Logf("Waiting for control-plane machines to have the upgraded Kubernetes version")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In-place upgrades defines [`machine-updates`](https://github.com/kubernetes-sigs/cluster-api/blob/70d7eca688e83155f5aa6e3925ffc558ba00b2ce/docs/proposals/20240807-in-place-updates.md#machine-updates) process as looping until completion for each registered updater.

In order to leverage runtime extensions in processing these updaters, handler execution needs to be able to block (retry until completion) on individual updater, in case it responds with pending status before requesting other unfinished hooks. This PR introduces `serial` setting for the handler discovery.

Additionally, current handlers list is not guarantied to be ordered, so it may cause a situation when:
- Updater A has finished
- Updater B is serial and is pending
- Updater C has not started (waiting on B)

On the second iteration:
- Updater A has finished
- Updater C has finished (jumped the queue and skipped waiting on B)
- Updater B is serial and is pending

To address this, a `priority` field is added, which allows updaters to declare execution order.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/rancher/highlander/issues/118

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area runtime-sdk