### PR TITLE
🌱 clusterctl: fix fallback to overrides directory in home when there is no overrides directory in XDG directory

### DIFF
--- a/cmd/clusterctl/client/repository/overrides.go
+++ b/cmd/clusterctl/client/repository/overrides.go
@@ -74,6 +74,13 @@ func (o *overrides) Path() (string, error) {
 		return "", err
 	}
 	basepath := filepath.Join(configDirectory, overrideFolder)
+	// Fallback to the .cluster-api directory in home if the above does not exist.
+	if _, err := os.Stat(basepath); os.IsNotExist(err) {
+		fallbackBasepath := filepath.Join(xdg.Home, config.ConfigFolder, overrideFolder)
+		if _, err := os.Stat(fallbackBasepath); err == nil {
+			basepath = fallbackBasepath
+		}
+	}
 	f, err := o.configVariablesClient.Get(overrideFolderKey)
 	if err == nil && strings.TrimSpace(f) != "" {
 		basepath = f


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #10179

/area clusterctl