### PR TITLE
🌱 scripts: fix checking out k/k release branch

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -153,7 +153,7 @@ kind::prepareKindestImage() {
 
   # if pre-pull failed, or ALWAYS_BUILD_KIND_IMAGES is true build the images locally.
  if [[ "$retVal" != 0 ]] || [[ "$ALWAYS_BUILD_KIND_IMAGES" = "true" ]]; then
-    echo "+ building image for Kuberentes $version locally. This is either because the image wasn't available in docker hub or ALWAYS_BUILD_KIND_IMAGES is set to true"
+    echo "+ building image for Kubernetes $version locally. This is either because the image wasn't available in docker hub or ALWAYS_BUILD_KIND_IMAGES is set to true"
     kind::buildNodeImage "$version"
   fi
 }
@@ -204,16 +204,19 @@ k8s::checkoutBranch() {
   else
     # otherwise we are requiring a Kubernetes version that should be built from HEAD
     # of one of the existing branches
-    echo "+ checking for existing branches"
-    git fetch --all
-
     local major
     local minor
     major=$(echo "${version#v}" | awk '{split($0,a,"."); print a[1]}')
     minor=$(echo "${version#v}" | awk '{split($0,a,"."); print a[2]}')
 
+    echo "+ Trying to fetch branch release-$major.$minor"
+    # shellcheck disable=SC2015
+    git fetch --filter=blob:none https://github.com/kubernetes/kubernetes.git "release-$major.$minor" \
+      && git checkout FETCH_HEAD \
+      && git branch --force "release-$major.$minor" || true
+
     local releaseBranch
-    releaseBranch="$(git branch -r | grep "release-$major.$minor$" || true)"
+    releaseBranch="$(git branch | grep "release-$major.$minor$" | awk '{print $NF}' || true)"
     if [[ "$releaseBranch" != "" ]]; then
       # if there is already a release branch for the required Kubernetes branch, use it
       echo "+ checkout $releaseBranch branch"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

CI currently builds kubernetes from master branch instead of release branches. This fixes the git checkout part.

The checkout done in clonerefs does only checkout tags and a `git fetch --all` does not bring in branches.

This adapts the way of fetching branches to how its done by clonerefs.

xref: https://kubernetes.slack.com/archives/C08AA0FFWG3/p1739449748554519?thread_ts=1738954219.172549&cid=C08AA0FFWG3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci