### PR TITLE
🌱 Enable the conditions rule from KAL

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -16,13 +16,14 @@ linters-settings:
       settings:
         linters:
           enable:
+          - "conditions" # Ensure conditions have the correct json tags and markers.
+
           # Per discussion in July 2024, we are keeping phase fields for now.
           # See https://github.com/kubernetes-sigs/cluster-api/pull/10897#discussion_r1685929508
           # and https://github.com/kubernetes-sigs/cluster-api/pull/10897#discussion_r1685919394.
           # - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
           
           # Linters below this line are disabled, pending conversation on how and when to enable them.
-          # - "conditions" # Ensure conditions have the correct json tags and markers.
           # - "commentstart" # Ensure comments start with the serialized version of the field name.
           # - "integers" # Ensure only int32 and int64 are used for integers.
           # - "jsontags" # Ensure every field has a json tag.
@@ -58,5 +59,9 @@ issues:
   exclude-rules:
   # KAL should only run on API folders.
   - path-except: "api/*"
+    linters:
+      - kal
+  - path: "api/v1beta1/*|api/v1alpha1/*"
+    text: "Conditions field must be a slice of metav1.Condition"
     linters:
       - kal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR enables checks for Conditions fields in KAL.

It will enforce:
* `Conditions` is the first item in the status object (this could be disabled if we want)
* The appropriate `+listType=map` and `+listMapKey=type` markers are added
* The conditions are optional
* The conditions are `[]metav1.Condition`

Our existing conditions types fail because they are not `[]metav1.Condition`, but are otherwise compliant. An exception has been added for v1beta1 and v1alpha1 APIs to allow the custom CAPI condition type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11834

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->