### PR TITLE
🚀 Release v1.8.10

### DIFF
--- a/CHANGELOG/v1.8.10.md
+++ b/CHANGELOG/v1.8.10.md
@@ -1,0 +1,34 @@
+## 👌 Kubernetes version support
+
+- Management Cluster: v1.27.x -> v1.31.x
+- Workload Cluster: v1.25.x -> v1.31.x
+
+[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+## Changes since v1.8.9
+## :chart_with_upwards_trend: Overview
+- 6 new commits merged
+- 1 bug fixed 🐛
+
+## :bug: Bug Fixes
+- CI: Should only test a max of k8s 1.31 (#11842)
+- CI: Scripts: fix checking out k/k release branch (#11839)
+
+## :seedling: Others
+- clusterctl: Bump cert-manager to v1.16.3 (#11726)
+- Dependency: Bump go to v1.22.11 (#11738)
+- Dependency: Bump go to v1.22.12 (#11805)
+- e2e: Attempt older version upgrades twice to work around flake with the docker controller (#11794)
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds release notes for Cluster API [v1.8.10](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.8.10).

**Which issue(s) this PR fixes**:

Refs #11656

/area release