### PR TITLE
🚀 Release v1.9.5

### DIFF
--- a/CHANGELOG/v1.9.5.md
+++ b/CHANGELOG/v1.9.5.md
@@ -1,0 +1,54 @@
+## 👌 Kubernetes version support
+
+- Management Cluster: v1.28.x -> v1.32.x
+- Workload Cluster: v1.26.x -> v1.32.x
+
+[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+## Changes since v1.9.4
+## :chart_with_upwards_trend: Overview
+- 23 new commits merged
+- 6 feature additions ✨
+- 4 bugs fixed 🐛
+
+## :sparkles: New Features
+- ClusterClass: Add classNamespace to topology (#11730)
+- ClusterClass: Add e2e tests & clusterctl changes for cross-ns CC ref (#11845)
+- ClusterClass: Clusterctl move support for a cross namespace ClusterClass reference (#11846)
+- clusterctl: Add addon provider fleet to registry (#11829)
+- e2e: Extend scale test and make ExtensionConfig name in RuntimeSDK test configurable (#11844)
+- Machine: Add MachineDrainRule "WaitCompleted" (#11758)
+
+## :bug: Bug Fixes
+- Clustercache: Increase timeout for informer List+Watch calls from 10s to 11m (#11767)
+- ClusterClass: Ensure Cluster topology controller is not stuck when MDs are stuck in deletion (#11787)
+- clusterctl: Fix: send delete request before removing finalizers (#11821)
+- MachinePool: Check machinepool feature-flag before watching in cluster controller (#11779)
+- CI: Scripts: fix checking out k/k release branch (#11841)
+
+## :seedling: Others
+- clusterctl: Bump cert-manager to v1.16.3 (#11715)
+- clusterctl: Remove OCNE providers (#11831)
+- Conditions: Handle "waiting for completion" in KCP, MD, MS and Machine conditions (#11825)
+- Controller-runtime: Bump to controller-runtime v0.19.5 (#11748)
+- Dependency: Bump go to v1.22.11 (#11739)
+- Dependency: Bump go to v1.22.12 (#11804)
+- Dependency: Bump to controller-runtime v0.19.6 (#11851)
+- e2e: Add optional ClusterctlVariables to QuickStartSpecInput (#11785)
+- e2e: Attempt older version upgrades twice to work around flake with the docker controller (#11793)
+- KCP: Improve KCP remediation of multiple failures (#11746)
+- Machine: Add --additional-sync-machine-labels to allow syncing additional labels to Nodes (#11762)
+- MachineDeployment: Improve MachineSet create and delete logs (#11765)
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- sigs.k8s.io/controller-runtime: v0.19.4 → v0.19.6
+
+### Removed
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds release notes for Cluster API [v1.9.5](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.9.5).

**Which issue(s) this PR fixes**:

Refs #11656

/area release