### PR TITLE
🌱 Bump conversion-gen to v0.32.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ GOTESTSUM_BIN := gotestsum
 GOTESTSUM := $(abspath $(TOOLS_BIN_DIR)/$(GOTESTSUM_BIN)-$(GOTESTSUM_VER))
 GOTESTSUM_PKG := gotest.tools/gotestsum
 
-CONVERSION_GEN_VER := v0.32.0
+CONVERSION_GEN_VER := v0.32.2
 CONVERSION_GEN_BIN := conversion-gen
 # We are intentionally using the binary without version suffix, to avoid the version
 # in generated files.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `conversion-gen` tool to [v0.32.2](https://github.com/kubernetes/code-generator/releases/tag/v0.32.2).

**Which issue(s) this PR fixes**:

Refs #11656: "Bump dependencies"

/area dependency