### PR TITLE
🌱 tilt: use unique names for local_resources and buttons

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -541,7 +541,7 @@ def deploy_clusterclass(clusterclass_name, label, filename, substitutions):
     delete_clusterclass_cmd = kubectl_cmd + " --namespace=$NAMESPACE delete clusterclass " + clusterclass_name + ' --ignore-not-found=true; echo "\n"'
 
     local_resource(
-        name = clusterclass_name,
+        name = clusterclass_name + ".clusterclass",
         cmd = ["bash", "-c", apply_clusterclass_cmd],
         env = substitutions,
         auto_init = False,
@@ -550,7 +550,7 @@ def deploy_clusterclass(clusterclass_name, label, filename, substitutions):
     )
 
     cmd_button(
-        clusterclass_name + ":apply",
+        clusterclass_name + ".clusterclass:apply",
         argv = ["bash", "-c", apply_clusterclass_cmd],
         env = dictonary_to_list_of_string(substitutions),
         resource = clusterclass_name,
@@ -562,7 +562,7 @@ def deploy_clusterclass(clusterclass_name, label, filename, substitutions):
     )
 
     cmd_button(
-        clusterclass_name + ":delete",
+        clusterclass_name + ".clusterclass:delete",
         argv = ["bash", "-c", delete_clusterclass_cmd],
         env = dictonary_to_list_of_string(substitutions),
         resource = clusterclass_name,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Follow-up fix for:

- #11819

We have the following files and the tilt names then clash:
- test/infrastructure/docker/templates/clusterclass-in-memory.yaml
- test/infrastructure/docker/templates/cluster-template-in-memory.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area devtools