### PR TITLE
:seedling: Change k0smotron repo location

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -314,7 +314,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         K0smotronProviderName,
-			url:          "https://github.com/k0sproject/k0smotron/releases/latest/infrastructure-components.yaml",
+			url:          "https://github.com/k0smotron/k0smotron/releases/latest/infrastructure-components.yaml",
 			providerType: clusterctlv1.InfrastructureProviderType,
 		},
 		&provider{
@@ -356,7 +356,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         K0smotronBootstrapProviderName,
-			url:          "https://github.com/k0sproject/k0smotron/releases/latest/bootstrap-components.yaml",
+			url:          "https://github.com/k0smotron/k0smotron/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
 		&provider{
@@ -403,7 +403,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         K0smotronControlPlaneProviderName,
-			url:          "https://github.com/k0sproject/k0smotron/releases/latest/control-plane-components.yaml",
+			url:          "https://github.com/k0smotron/k0smotron/releases/latest/control-plane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -105,14 +105,14 @@ var expectedOutputText = `NAME                    TYPE                       URL
 cluster-api             CoreProvider               https://github.com/myorg/myforkofclusterapi/releases/latest/                                      core_components.yaml
 another-provider        BootstrapProvider          ./                                                                                                bootstrap-components.yaml
 canonical-kubernetes    BootstrapProvider          https://github.com/canonical/cluster-api-k8s/releases/latest/                                     bootstrap-components.yaml
-k0sproject-k0smotron    BootstrapProvider          https://github.com/k0sproject/k0smotron/releases/latest/                                          bootstrap-components.yaml
+k0sproject-k0smotron    BootstrapProvider          https://github.com/k0smotron/k0smotron/releases/latest/                                           bootstrap-components.yaml
 kubeadm                 BootstrapProvider          https://github.com/kubernetes-sigs/cluster-api/releases/latest/                                   bootstrap-components.yaml
 kubekey-k3s             BootstrapProvider          https://github.com/kubesphere/kubekey/releases/latest/                                            bootstrap-components.yaml
 microk8s                BootstrapProvider          https://github.com/canonical/cluster-api-bootstrap-provider-microk8s/releases/latest/             bootstrap-components.yaml
 rke2                    BootstrapProvider          https://github.com/rancher/cluster-api-provider-rke2/releases/latest/                             bootstrap-components.yaml
 talos                   BootstrapProvider          https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/               bootstrap-components.yaml
 canonical-kubernetes    ControlPlaneProvider       https://github.com/canonical/cluster-api-k8s/releases/latest/                                     control-plane-components.yaml
-k0sproject-k0smotron    ControlPlaneProvider       https://github.com/k0sproject/k0smotron/releases/latest/                                          control-plane-components.yaml
+k0sproject-k0smotron    ControlPlaneProvider       https://github.com/k0smotron/k0smotron/releases/latest/                                           control-plane-components.yaml
 kamaji                  ControlPlaneProvider       https://github.com/clastix/cluster-api-control-plane-provider-kamaji/releases/latest/             control-plane-components.yaml
 kubeadm                 ControlPlaneProvider       https://github.com/kubernetes-sigs/cluster-api/releases/latest/                                   control-plane-components.yaml
 kubekey-k3s             ControlPlaneProvider       https://github.com/kubesphere/kubekey/releases/latest/                                            control-plane-components.yaml
@@ -133,7 +133,7 @@ hetzner                 InfrastructureProvider     https://github.com/syself/clu
 hivelocity-hivelocity   InfrastructureProvider     https://github.com/hivelocity/cluster-api-provider-hivelocity/releases/latest/                    infrastructure-components.yaml
 ibmcloud                InfrastructureProvider     https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/latest/                 infrastructure-components.yaml
 ionoscloud-ionoscloud   InfrastructureProvider     https://github.com/ionos-cloud/cluster-api-provider-ionoscloud/releases/latest/                   infrastructure-components.yaml
-k0sproject-k0smotron    InfrastructureProvider     https://github.com/k0sproject/k0smotron/releases/latest/                                          infrastructure-components.yaml
+k0sproject-k0smotron    InfrastructureProvider     https://github.com/k0smotron/k0smotron/releases/latest/                                           infrastructure-components.yaml
 kubekey                 InfrastructureProvider     https://github.com/kubesphere/kubekey/releases/latest/                                            infrastructure-components.yaml
 kubevirt                InfrastructureProvider     https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/releases/latest/                 infrastructure-components.yaml
 linode-linode           InfrastructureProvider     https://github.com/linode/cluster-api-provider-linode/releases/latest/                            infrastructure-components.yaml
@@ -176,7 +176,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: bootstrap-components.yaml
   Name: k0sproject-k0smotron
   ProviderType: BootstrapProvider
-  URL: https://github.com/k0sproject/k0smotron/releases/latest/
+  URL: https://github.com/k0smotron/k0smotron/releases/latest/
 - File: bootstrap-components.yaml
   Name: kubeadm
   ProviderType: BootstrapProvider
@@ -204,7 +204,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: control-plane-components.yaml
   Name: k0sproject-k0smotron
   ProviderType: ControlPlaneProvider
-  URL: https://github.com/k0sproject/k0smotron/releases/latest/
+  URL: https://github.com/k0smotron/k0smotron/releases/latest/
 - File: control-plane-components.yaml
   Name: kamaji
   ProviderType: ControlPlaneProvider
@@ -288,7 +288,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: infrastructure-components.yaml
   Name: k0sproject-k0smotron
   ProviderType: InfrastructureProvider
-  URL: https://github.com/k0sproject/k0smotron/releases/latest/
+  URL: https://github.com/k0smotron/k0smotron/releases/latest/
 - File: infrastructure-components.yaml
   Name: kubekey
   ProviderType: InfrastructureProvider

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -8,7 +8,7 @@ updated info about which API version they are supporting.
 ## Bootstrap
 - [Amazon Elastic Kubernetes Service (EKS)](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/main/bootstrap/eks)
 - [Canonical Kubernetes Platform](https://github.com/canonical/cluster-api-k8s)
-- [k0smotron/k0s](https://github.com/k0sproject/k0smotron)
+- [k0smotron/k0s](https://github.com/k0smotron/k0smotron)
 - [K3s](https://github.com/cluster-api-provider-k3s/cluster-api-k3s)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/bootstrap/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-bootstrap-provider-microk8s)
@@ -17,7 +17,7 @@ updated info about which API version they are supporting.
 
 ## Control Plane
 - [Canonical Kubernetes Platform](https://github.com/canonical/cluster-api-k8s)
-- [k0smotron/k0s](https://github.com/k0sproject/k0smotron)
+- [k0smotron/k0s](https://github.com/k0smotron/k0smotron)
 - [K3s](https://github.com/cluster-api-provider-k3s/cluster-api-k3s)
 - [Kamaji](https://github.com/clastix/cluster-api-control-plane-provider-kamaji)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm)
@@ -42,7 +42,7 @@ updated info about which API version they are supporting.
 - [IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud)
 - [IONOS Cloud](https://github.com/ionos-cloud/cluster-api-provider-ionoscloud)
 - [KubeKey](https://github.com/kubesphere/kubekey)
-- [k0smotron RemoteMachine (SSH)](https://github.com/k0sproject/k0smotron)
+- [k0smotron RemoteMachine (SSH)](https://github.com/k0smotron/k0smotron)
 - [KubeVirt](https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt)
 - [MAAS](https://github.com/spectrocloud/cluster-api-provider-maas)
 - [Metal3](https://github.com/metal3-io/cluster-api-provider-metal3)

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1917,7 +1917,7 @@ kind delete cluster
 [management cluster]: ../reference/glossary.md#management-cluster
 [Metal3 getting started guide]: https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/getting-started.md
 [Metal3 provider]: https://github.com/metal3-io/cluster-api-provider-metal3/
-[K0smotron provider]: https://github.com/k0sproject/k0smotron
+[K0smotron provider]: https://github.com/k0smotron/k0smotron
 [KubeKey provider]: https://github.com/kubesphere/kubekey
 [KubeVirt provider]: https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/
 [KubeVirt]: https://kubevirt.io/


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

As k0s is moving to CNCF Sandbox we needed to move k0smotron to a new org in GitHub. Hence this PR to change the location. Luckily GH handles redirects so there should be nothing currently broken. :smile:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area clusterctl