### PR TITLE
🐛 Fix MDR unit test

### DIFF
--- a/internal/webhooks/test/machinedrainrules_test.go
+++ b/internal/webhooks/test/machinedrainrules_test.go
@@ -152,7 +152,7 @@ func Test_validate(t *testing.T) {
 				"spec.pods[0].namespaceSelector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string(nil), MatchExpressions:[]v1.LabelSelectorRequirement{v1.LabelSelectorRequirement{Key:\"\", Operator:\"Invalid-Operator\", Values:[]string(nil)}}}: \"Invalid-Operator\" is not a valid label selector operator]",
 		},
 		{
-			name: "Return error if selectors are not unique",
+			name: "Return error if machine selectors are not unique",
 			machineDrainRule: &clusterv1.MachineDrainRule{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mdr",
@@ -188,6 +188,22 @@ func Test_validate(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			wantErr: "MachineDrainRule.cluster.x-k8s.io \"mdr\" is invalid: " +
+				"spec.machines: Invalid value: \"array\": entries in machines must be unique",
+		},
+		{
+			name: "Return error if pod selectors are not unique",
+			machineDrainRule: &clusterv1.MachineDrainRule{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mdr",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: clusterv1.MachineDrainRuleSpec{
+					Drain: clusterv1.MachineDrainRuleDrainConfig{
+						Behavior: clusterv1.MachineDrainRuleDrainBehaviorSkip,
+					},
 					Pods: []clusterv1.MachineDrainRulePodSelector{
 						{
 							Selector: &metav1.LabelSelector{
@@ -216,9 +232,8 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineDrainRule.cluster.x-k8s.io \"mdr\" is invalid: [" +
-				"spec.machines: Invalid value: \"array\": entries in machines must be unique, " +
-				"spec.pods: Invalid value: \"array\": entries in pods must be unique]",
+			wantErr: "MachineDrainRule.cluster.x-k8s.io \"mdr\" is invalid: " +
+				"spec.pods: Invalid value: \"array\": entries in pods must be unique",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
CEL validation does not produce error messages with consistent order if the validation is on different fields of an object.

See: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api/11835/pull-cluster-api-test-main/1891887690366849024

This PR changes the tests to only validate one CEL expression at a time.

The reason is probably that properties are stored in a map here and there is no sorting: https://github.com/kubernetes/kubernetes/blob/5420b2fe9a84af57cc24793c8f8ac8821b65f42f/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go#L833

Related Slack thread: https://kubernetes.slack.com/archives/C08AA0FFWG3/p1739975552359909 (in cluster-api-release channel)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->