### PR TITLE
🌱 Allow readiness and availability gates with negative polarity

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -514,6 +514,10 @@ type ClusterAvailabilityGate struct {
 	// +kubebuilder:validation:MaxLength=316
 	// +kubebuilder:validation:MinLength=1
 	ConditionType string `json:"conditionType"`
+
+	// negativePolarity must be set to true if False represents normal operation for the conditionType specified in this availabilityGate.
+	// +optional
+	NegativePolarity bool `json:"negativePolarity,omitempty"`
 }
 
 // Topology encapsulates the information of the managed resources.

--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -467,6 +467,10 @@ type MachineReadinessGate struct {
 	// +kubebuilder:validation:MaxLength=316
 	// +kubebuilder:validation:MinLength=1
 	ConditionType string `json:"conditionType"`
+
+	// negativePolarity must be set to true if False represents normal operation for the conditionType specified in this availabilityGate.
+	// +optional
+	NegativePolarity bool `json:"negativePolarity,omitempty"`
 }
 
 // ANCHOR_END: MachineSpec

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -244,6 +244,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterAvailabilityGate(ref common
 							Format:      "",
 						},
 					},
+					"negativePolarity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "negativePolarity must be set to true if False represents normal operation for the conditionType specified in this availabilityGate.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"conditionType"},
 			},
@@ -3676,6 +3683,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineReadinessGate(ref common.Re
 							Description: "conditionType refers to a positive polarity condition (status true means good) with matching type in the Machine's condition list. If the conditions doesn't exist, it will be treated as unknown. Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.",
 							Default:     "",
 							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"negativePolarity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "negativePolarity must be set to true if False represents normal operation for the conditionType specified in this availabilityGate.",
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -466,6 +466,10 @@ spec:
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
+                    negativePolarity:
+                      description: negativePolarity must be set to true if False represents
+                        normal operation for the conditionType specified in this availabilityGate.
+                      type: boolean
                   required:
                   - conditionType
                   type: object
@@ -747,6 +751,11 @@ spec:
                           minLength: 1
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
+                        negativePolarity:
+                          description: negativePolarity must be set to true if False
+                            represents normal operation for the conditionType specified
+                            in this availabilityGate.
+                          type: boolean
                       required:
                       - conditionType
                       type: object
@@ -1634,6 +1643,11 @@ spec:
                                 minLength: 1
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
+                              negativePolarity:
+                                description: negativePolarity must be set to true
+                                  if False represents normal operation for the conditionType
+                                  specified in this availabilityGate.
+                                type: boolean
                             required:
                             - conditionType
                             type: object

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -778,6 +778,10 @@ spec:
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
+                    negativePolarity:
+                      description: negativePolarity must be set to true if False represents
+                        normal operation for the conditionType specified in this availabilityGate.
+                      type: boolean
                   required:
                   - conditionType
                   type: object
@@ -1157,6 +1161,11 @@ spec:
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                               type: string
+                            negativePolarity:
+                              description: negativePolarity must be set to true if
+                                False represents normal operation for the conditionType
+                                specified in this availabilityGate.
+                              type: boolean
                           required:
                           - conditionType
                           type: object
@@ -1500,6 +1509,11 @@ spec:
                                     minLength: 1
                                     pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                     type: string
+                                  negativePolarity:
+                                    description: negativePolarity must be set to true
+                                      if False represents normal operation for the
+                                      conditionType specified in this availabilityGate.
+                                    type: boolean
                                 required:
                                 - conditionType
                                 type: object

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1556,6 +1556,11 @@ spec:
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                               type: string
+                            negativePolarity:
+                              description: negativePolarity must be set to true if
+                                False represents normal operation for the conditionType
+                                specified in this availabilityGate.
+                              type: boolean
                           required:
                           - conditionType
                           type: object

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1289,6 +1289,11 @@ spec:
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                               type: string
+                            negativePolarity:
+                              description: negativePolarity must be set to true if
+                                False represents normal operation for the conditionType
+                                specified in this availabilityGate.
+                              type: boolean
                           required:
                           - conditionType
                           type: object

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1055,6 +1055,10 @@ spec:
                       minLength: 1
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
+                    negativePolarity:
+                      description: negativePolarity must be set to true if False represents
+                        normal operation for the conditionType specified in this availabilityGate.
+                      type: boolean
                   required:
                   - conditionType
                   type: object

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1308,6 +1308,11 @@ spec:
                               minLength: 1
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                               type: string
+                            negativePolarity:
+                              description: negativePolarity must be set to true if
+                                False represents normal operation for the conditionType
+                                specified in this availabilityGate.
+                              type: boolean
                           required:
                           - conditionType
                           type: object

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -4324,6 +4324,11 @@ spec:
                           minLength: 1
                           pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                           type: string
+                        negativePolarity:
+                          description: negativePolarity must be set to true if False
+                            represents normal operation for the conditionType specified
+                            in this availabilityGate.
+                          type: boolean
                       required:
                       - conditionType
                       type: object

--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -1064,12 +1064,16 @@ func setAvailableCondition(ctx context.Context, cluster *clusterv1.Cluster, clus
 		clusterv1.ClusterWorkersAvailableV1Beta2Condition,
 		clusterv1.ClusterTopologyReconciledV1Beta2Condition,
 	}
+	negativePolarityConditionTypes := []string{clusterv1.ClusterDeletingV1Beta2Condition}
 	availabilityGates := cluster.Spec.AvailabilityGates
 	if availabilityGates == nil && clusterClass != nil {
 		availabilityGates = clusterClass.Spec.AvailabilityGates
 	}
 	for _, g := range availabilityGates {
 		forConditionTypes = append(forConditionTypes, g.ConditionType)
+		if g.NegativePolarity {
+			negativePolarityConditionTypes = append(negativePolarityConditionTypes, g.ConditionType)
+		}
 	}
 
 	summaryOpts := []v1beta2conditions.SummaryOption{
@@ -1082,7 +1086,7 @@ func setAvailableCondition(ctx context.Context, cluster *clusterv1.Cluster, clus
 			MergeStrategy: clusterConditionCustomMergeStrategy{
 				cluster: cluster,
 				// Instruct merge to consider Deleting condition with negative polarity,
-				negativePolarityConditionTypes: []string{clusterv1.ClusterDeletingV1Beta2Condition},
+				negativePolarityConditionTypes: negativePolarityConditionTypes,
 			},
 		},
 	}

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -2379,6 +2379,10 @@ func TestSetAvailableCondition(t *testing.T) {
 						{
 							ConditionType: "MyAvailabilityGate",
 						},
+						{
+							ConditionType:    "MyAvailabilityGateWithNegativePolarity",
+							NegativePolarity: true,
+						},
 					},
 				},
 				Status: clusterv1.ClusterStatus{
@@ -2415,6 +2419,12 @@ func TestSetAvailableCondition(t *testing.T) {
 								Reason:  "SomeReason",
 								Message: "Some message",
 							},
+							{
+								Type:    "MyAvailabilityGateWithNegativePolarity",
+								Status:  metav1.ConditionTrue,
+								Reason:  "SomeReason",
+								Message: "Some other message",
+							},
 						},
 					},
 				},
@@ -2429,10 +2439,11 @@ func TestSetAvailableCondition(t *testing.T) {
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:    clusterv1.ClusterAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  clusterv1.ClusterNotAvailableV1Beta2Reason,
-				Message: "* MyAvailabilityGate: Some message",
+				Type:   clusterv1.ClusterAvailableV1Beta2Condition,
+				Status: metav1.ConditionFalse,
+				Reason: clusterv1.ClusterNotAvailableV1Beta2Reason,
+				Message: "* MyAvailabilityGate: Some message\n" +
+					"* MyAvailabilityGateWithNegativePolarity: Some other message",
 			},
 		},
 		{
@@ -2476,6 +2487,12 @@ func TestSetAvailableCondition(t *testing.T) {
 								Reason:  "SomeReason",
 								Message: "Some message",
 							},
+							{
+								Type:    "MyClusterClassAvailabilityGateWithNegativePolarity",
+								Status:  metav1.ConditionTrue,
+								Reason:  "SomeReason",
+								Message: "Some other message",
+							},
 						},
 					},
 				},
@@ -2486,14 +2503,19 @@ func TestSetAvailableCondition(t *testing.T) {
 						{
 							ConditionType: "MyClusterClassAvailabilityGate",
 						},
+						{
+							ConditionType:    "MyClusterClassAvailabilityGateWithNegativePolarity",
+							NegativePolarity: true,
+						},
 					},
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:    clusterv1.ClusterAvailableV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  clusterv1.ClusterNotAvailableV1Beta2Reason,
-				Message: "* MyClusterClassAvailabilityGate: Some message",
+				Type:   clusterv1.ClusterAvailableV1Beta2Condition,
+				Status: metav1.ConditionFalse,
+				Reason: clusterv1.ClusterNotAvailableV1Beta2Reason,
+				Message: "* MyClusterClassAvailabilityGate: Some message\n" +
+					"* MyClusterClassAvailabilityGateWithNegativePolarity: Some other message",
 			},
 		},
 		{

--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -630,8 +630,12 @@ func setReadyCondition(ctx context.Context, machine *clusterv1.Machine) {
 		clusterv1.MachineNodeHealthyV1Beta2Condition,
 		clusterv1.MachineHealthCheckSucceededV1Beta2Condition,
 	}
+	negativePolarityConditionTypes := []string{clusterv1.MachineDeletingV1Beta2Condition}
 	for _, g := range machine.Spec.ReadinessGates {
 		forConditionTypes = append(forConditionTypes, g.ConditionType)
+		if g.NegativePolarity {
+			negativePolarityConditionTypes = append(negativePolarityConditionTypes, g.ConditionType)
+		}
 	}
 
 	summaryOpts := []v1beta2conditions.SummaryOption{
@@ -646,7 +650,7 @@ func setReadyCondition(ctx context.Context, machine *clusterv1.Machine) {
 			MergeStrategy: machineConditionCustomMergeStrategy{
 				machine: machine,
 				// Instruct merge to consider Deleting condition with negative polarity,
-				negativePolarityConditionTypes: []string{clusterv1.MachineDeletingV1Beta2Condition},
+				negativePolarityConditionTypes: negativePolarityConditionTypes,
 			},
 		},
 		// Instruct summary to consider Deleting condition with negative polarity.

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -1529,7 +1529,13 @@ func TestSetReadyCondition(t *testing.T) {
 				},
 				Spec: clusterv1.MachineSpec{
 					ReadinessGates: []clusterv1.MachineReadinessGate{
-						{ConditionType: "MyReadinessGate"},
+						{
+							ConditionType: "MyReadinessGate",
+						},
+						{
+							ConditionType:    "MyReadinessGateGateWithNegativePolarity",
+							NegativePolarity: true,
+						},
 					},
 				},
 				Status: clusterv1.MachineStatus{
@@ -1562,6 +1568,12 @@ func TestSetReadyCondition(t *testing.T) {
 								Message: "Some message",
 							},
 							{
+								Type:    "MyReadinessGateGateWithNegativePolarity",
+								Status:  metav1.ConditionTrue,
+								Reason:  "SomeReason",
+								Message: "Some other message",
+							},
+							{
 								Type:   clusterv1.MachineDeletingV1Beta2Condition,
 								Status: metav1.ConditionFalse,
 								Reason: clusterv1.MachineNotDeletingV1Beta2Reason,
@@ -1571,10 +1583,11 @@ func TestSetReadyCondition(t *testing.T) {
 				},
 			},
 			expectCondition: metav1.Condition{
-				Type:    clusterv1.MachineReadyV1Beta2Condition,
-				Status:  metav1.ConditionFalse,
-				Reason:  clusterv1.MachineNotReadyV1Beta2Reason,
-				Message: "* MyReadinessGate: Some message",
+				Type:   clusterv1.MachineReadyV1Beta2Condition,
+				Status: metav1.ConditionFalse,
+				Reason: clusterv1.MachineNotReadyV1Beta2Reason,
+				Message: "* MyReadinessGate: Some message\n" +
+					"* MyReadinessGateGateWithNegativePolarity: Some other message",
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up of two feedback on the proposal for updating status in CAPI resources, and it adds support for negative polarity conditions to ReadinessGates and AvailabilityGates

rif https://github.com/kubernetes-sigs/cluster-api/issues/11474

/area conditions
