### PR TITLE
✨ kcp: add preflight check for pending version upgrade from topology

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -91,6 +91,8 @@ type PreflightCheckResults struct {
 	ControlPlaneComponentsNotHealthy bool
 	// EtcdClusterNotHealthy reports true if preflight check detected that the etcd cluster is not fully healthy.
 	EtcdClusterNotHealthy bool
+	// TopologyVersionMismatch reports true if preflight check detected that the Cluster's topology version does not match the control plane's version
+	TopologyVersionMismatch bool
 }
 
 // NewControlPlane returns an instantiated ControlPlane.

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -122,7 +122,10 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 				predicates.All(mgr.GetScheme(), predicateLog,
 					predicates.ResourceIsChanged(mgr.GetScheme(), predicateLog),
 					predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
-					predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), predicateLog),
+					predicates.Any(mgr.GetScheme(), predicateLog,
+						predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), predicateLog),
+						predicates.ClusterTopologyVersionChanged(mgr.GetScheme(), predicateLog),
+					),
 				),
 			),
 		).

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -320,8 +320,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
 
-		assertMachineCondition(ctx, g, m1, clusterv1.MachineOwnerRemediatedCondition, corev1.ConditionFalse, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate if a version upgrade is pending")
-		assertMachineV1beta2Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta2Condition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachineCannotBeRemediatedV1Beta2Reason, "KubeadmControlPlane can't remediate if a version upgrade is pending")
+		assertMachineCondition(ctx, g, m1, clusterv1.MachineOwnerRemediatedCondition, corev1.ConditionFalse, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate while waiting for a version upgrade to v1.20.1 to be propagated from Cluster.spec.topology")
+		assertMachineV1beta2Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta2Condition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachineRemediationDeferredV1Beta2Reason, "KubeadmControlPlane can't remediate while waiting for a version upgrade to v1.20.1 to be propagated from Cluster.spec.topology")
 
 		err = env.Get(ctx, client.ObjectKey{Namespace: m1.Namespace, Name: m1.Name}, m1)
 		g.Expect(err).ToNot(HaveOccurred())

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -29,12 +29,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
+	utilfeature "k8s.io/component-base/featuregate/testing"
 	utilptr "k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta2conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
@@ -273,6 +275,59 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+	})
+	t.Run("reconcileUnhealthyMachines return early if there is a pending topology upgrade", func(t *testing.T) {
+		utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
+
+		g := NewWithT(t)
+
+		m1 := createMachine(ctx, g, ns.Name, "m1-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer())
+		m2 := createMachine(ctx, g, ns.Name, "m2-healthy-", withHealthyEtcdMember())
+		m3 := createMachine(ctx, g, ns.Name, "m3-healthy-", withHealthyEtcdMember())
+
+		controlPlane := &internal.ControlPlane{
+			KCP: &controlplanev1.KubeadmControlPlane{
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: utilptr.To[int32](3),
+					Version:  "v1.19.1",
+				},
+				Status: controlplanev1.KubeadmControlPlaneStatus{
+					Initialized: true,
+				},
+			},
+			Cluster: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Version: "v1.20.1",
+					},
+				},
+			},
+			Machines: collections.FromMachines(m1, m2, m3),
+		}
+
+		r := &KubeadmControlPlaneReconciler{
+			Client:   env.GetClient(),
+			recorder: record.NewFakeRecorder(32),
+			managementCluster: &fakeManagementCluster{
+				Workload: &fakeWorkloadCluster{
+					EtcdMembersResult: nodes(controlPlane.Machines),
+				},
+			},
+		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
+		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
+
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
+		g.Expect(err).ToNot(HaveOccurred())
+
+		assertMachineCondition(ctx, g, m1, clusterv1.MachineOwnerRemediatedCondition, corev1.ConditionFalse, clusterv1.WaitingForRemediationReason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate if a version upgrade is pending")
+		assertMachineV1beta2Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta2Condition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachineCannotBeRemediatedV1Beta2Reason, "KubeadmControlPlane can't remediate if a version upgrade is pending")
+
+		err = env.Get(ctx, client.ObjectKey{Namespace: m1.Namespace, Name: m1.Name}, m1)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(m1.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		g.Expect(env.Cleanup(ctx, m1, m2, m3)).To(Succeed())
 	})
 	t.Run("Remediation does not happen if MaxRetry is reached", func(t *testing.T) {
 		g := NewWithT(t)

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -188,7 +189,7 @@ func (r *KubeadmControlPlaneReconciler) preflightChecks(ctx context.Context, con
 	if feature.Gates.Enabled(feature.ClusterTopology) {
 		// Block when we expect an upgrade to be propagated for topology clusters.
 		if controlPlane.Cluster.Spec.Topology != nil && controlPlane.Cluster.Spec.Topology.Version != controlPlane.KCP.Spec.Version {
-			logger.Info("Waiting for a pending version upgrade", "version", controlPlane.Cluster.Spec.Topology.Version)
+			logger.Info(fmt.Sprintf("Waiting for a version upgrade to %s to be propagated from Cluster.spec.topology", controlPlane.Cluster.Spec.Topology.Version))
 			controlPlane.PreflightCheckResults.TopologyVersionMismatch = true
 			return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, nil
 		}

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -806,6 +806,10 @@ func minTime(t1, t2 time.Time) time.Time {
 
 func getPreflightMessages(preflightChecks internal.PreflightCheckResults) []string {
 	additionalMessages := []string{}
+	if preflightChecks.TopologyVersionMismatch {
+		additionalMessages = append(additionalMessages, "* waiting for a pending control plane version upgrade")
+	}
+
 	if preflightChecks.HasDeletingMachine {
 		additionalMessages = append(additionalMessages, "* waiting for a control plane Machine to complete deletion")
 	}

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -162,8 +162,8 @@ func (r *KubeadmControlPlaneReconciler) updateV1Beta2Status(ctx context.Context,
 	setReplicas(ctx, controlPlane.KCP, controlPlane.Machines)
 	setInitializedCondition(ctx, controlPlane.KCP)
 	setRollingOutCondition(ctx, controlPlane.KCP, controlPlane.Machines)
-	setScalingUpCondition(ctx, controlPlane.KCP, controlPlane.Machines, controlPlane.InfraMachineTemplateIsNotFound, controlPlane.PreflightCheckResults)
-	setScalingDownCondition(ctx, controlPlane.KCP, controlPlane.Machines, controlPlane.PreflightCheckResults)
+	setScalingUpCondition(ctx, controlPlane.Cluster, controlPlane.KCP, controlPlane.Machines, controlPlane.InfraMachineTemplateIsNotFound, controlPlane.PreflightCheckResults)
+	setScalingDownCondition(ctx, controlPlane.Cluster, controlPlane.KCP, controlPlane.Machines, controlPlane.PreflightCheckResults)
 	setMachinesReadyCondition(ctx, controlPlane.KCP, controlPlane.Machines)
 	setMachinesUpToDateCondition(ctx, controlPlane.KCP, controlPlane.Machines)
 	setRemediatingCondition(ctx, controlPlane.KCP, controlPlane.MachinesToBeRemediatedByKCP(), controlPlane.UnhealthyMachines())
@@ -265,7 +265,7 @@ func setRollingOutCondition(_ context.Context, kcp *controlplanev1.KubeadmContro
 	})
 }
 
-func setScalingUpCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, infrastructureObjectNotFound bool, preflightChecks internal.PreflightCheckResults) {
+func setScalingUpCondition(_ context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, infrastructureObjectNotFound bool, preflightChecks internal.PreflightCheckResults) {
 	if kcp.Spec.Replicas == nil {
 		v1beta2conditions.Set(kcp, metav1.Condition{
 			Type:    controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition,
@@ -300,7 +300,7 @@ func setScalingUpCondition(_ context.Context, kcp *controlplanev1.KubeadmControl
 
 	message := fmt.Sprintf("Scaling up from %d to %d replicas", currentReplicas, desiredReplicas)
 
-	additionalMessages := getPreflightMessages(preflightChecks)
+	additionalMessages := getPreflightMessages(cluster, preflightChecks)
 	if missingReferencesMessage != "" {
 		additionalMessages = append(additionalMessages, fmt.Sprintf("* %s", missingReferencesMessage))
 	}
@@ -317,7 +317,7 @@ func setScalingUpCondition(_ context.Context, kcp *controlplanev1.KubeadmControl
 	})
 }
 
-func setScalingDownCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, preflightChecks internal.PreflightCheckResults) {
+func setScalingDownCondition(_ context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, machines collections.Machines, preflightChecks internal.PreflightCheckResults) {
 	if kcp.Spec.Replicas == nil {
 		v1beta2conditions.Set(kcp, metav1.Condition{
 			Type:    controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition,
@@ -345,7 +345,7 @@ func setScalingDownCondition(_ context.Context, kcp *controlplanev1.KubeadmContr
 
 	message := fmt.Sprintf("Scaling down from %d to %d replicas", currentReplicas, desiredReplicas)
 
-	additionalMessages := getPreflightMessages(preflightChecks)
+	additionalMessages := getPreflightMessages(cluster, preflightChecks)
 	if staleMessage := aggregateStaleMachines(machines); staleMessage != "" {
 		additionalMessages = append(additionalMessages, fmt.Sprintf("* %s", staleMessage))
 	}
@@ -804,10 +804,10 @@ func minTime(t1, t2 time.Time) time.Time {
 	return t1
 }
 
-func getPreflightMessages(preflightChecks internal.PreflightCheckResults) []string {
+func getPreflightMessages(cluster *clusterv1.Cluster, preflightChecks internal.PreflightCheckResults) []string {
 	additionalMessages := []string{}
 	if preflightChecks.TopologyVersionMismatch {
-		additionalMessages = append(additionalMessages, "* waiting for a pending control plane version upgrade")
+		additionalMessages = append(additionalMessages, fmt.Sprintf("* waiting for a version upgrade to %s to be propagated from Cluster.spec.topology", cluster.Spec.Topology.Version))
 	}
 
 	if preflightChecks.HasDeletingMachine {

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -351,6 +351,7 @@ func Test_setScalingUpCondition(t *testing.T) {
 					HasDeletingMachine:               true,
 					ControlPlaneComponentsNotHealthy: true,
 					EtcdClusterNotHealthy:            true,
+					TopologyVersionMismatch:          true,
 				},
 			},
 			expectCondition: metav1.Condition{
@@ -358,6 +359,7 @@ func Test_setScalingUpCondition(t *testing.T) {
 				Status: metav1.ConditionTrue,
 				Reason: controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Reason,
 				Message: "Scaling up from 3 to 5 replicas is blocked because:\n" +
+					"* waiting for a pending control plane version upgrade\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
 					"* waiting for control plane components to become healthy\n" +
 					"* waiting for etcd cluster to become healthy",
@@ -538,6 +540,7 @@ After above Pods have been removed from the Node, the following Pods will be evi
 					HasDeletingMachine:               true,
 					ControlPlaneComponentsNotHealthy: true,
 					EtcdClusterNotHealthy:            true,
+					TopologyVersionMismatch:          true,
 				},
 			},
 			expectCondition: metav1.Condition{
@@ -545,6 +548,7 @@ After above Pods have been removed from the Node, the following Pods will be evi
 				Status: metav1.ConditionTrue,
 				Reason: controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Reason,
 				Message: "Scaling down from 3 to 1 replicas is blocked because:\n" +
+					"* waiting for a pending control plane version upgrade\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
 					"* waiting for control plane components to become healthy\n" +
 					"* waiting for etcd cluster to become healthy",

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -338,6 +338,13 @@ func Test_setScalingUpCondition(t *testing.T) {
 		{
 			name: "Scaling up, preflight checks blocking",
 			controlPlane: &internal.ControlPlane{
+				Cluster: &clusterv1.Cluster{
+					Spec: clusterv1.ClusterSpec{
+						Topology: &clusterv1.Topology{
+							Version: "v1.32.0",
+						},
+					},
+				},
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Spec:   controlplanev1.KubeadmControlPlaneSpec{Replicas: ptr.To(int32(5))},
 					Status: controlplanev1.KubeadmControlPlaneStatus{Replicas: 3},
@@ -359,7 +366,7 @@ func Test_setScalingUpCondition(t *testing.T) {
 				Status: metav1.ConditionTrue,
 				Reason: controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Reason,
 				Message: "Scaling up from 3 to 5 replicas is blocked because:\n" +
-					"* waiting for a pending control plane version upgrade\n" +
+					"* waiting for a version upgrade to v1.32.0 to be propagated from Cluster.spec.topology\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
 					"* waiting for control plane components to become healthy\n" +
 					"* waiting for etcd cluster to become healthy",
@@ -370,7 +377,7 @@ func Test_setScalingUpCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			setScalingUpCondition(ctx, tt.controlPlane.KCP, tt.controlPlane.Machines, tt.controlPlane.InfraMachineTemplateIsNotFound, tt.controlPlane.PreflightCheckResults)
+			setScalingUpCondition(ctx, tt.controlPlane.Cluster, tt.controlPlane.KCP, tt.controlPlane.Machines, tt.controlPlane.InfraMachineTemplateIsNotFound, tt.controlPlane.PreflightCheckResults)
 
 			condition := v1beta2conditions.Get(tt.controlPlane.KCP, controlplanev1.KubeadmControlPlaneScalingUpV1Beta2Condition)
 			g.Expect(condition).ToNot(BeNil())
@@ -527,6 +534,13 @@ After above Pods have been removed from the Node, the following Pods will be evi
 		{
 			name: "Scaling down, preflight checks blocking",
 			controlPlane: &internal.ControlPlane{
+				Cluster: &clusterv1.Cluster{
+					Spec: clusterv1.ClusterSpec{
+						Topology: &clusterv1.Topology{
+							Version: "v1.32.0",
+						},
+					},
+				},
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Spec:   controlplanev1.KubeadmControlPlaneSpec{Replicas: ptr.To(int32(1))},
 					Status: controlplanev1.KubeadmControlPlaneStatus{Replicas: 3},
@@ -548,7 +562,7 @@ After above Pods have been removed from the Node, the following Pods will be evi
 				Status: metav1.ConditionTrue,
 				Reason: controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Reason,
 				Message: "Scaling down from 3 to 1 replicas is blocked because:\n" +
-					"* waiting for a pending control plane version upgrade\n" +
+					"* waiting for a version upgrade to v1.32.0 to be propagated from Cluster.spec.topology\n" +
 					"* waiting for a control plane Machine to complete deletion\n" +
 					"* waiting for control plane components to become healthy\n" +
 					"* waiting for etcd cluster to become healthy",
@@ -559,7 +573,7 @@ After above Pods have been removed from the Node, the following Pods will be evi
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			setScalingDownCondition(ctx, tt.controlPlane.KCP, tt.controlPlane.Machines, tt.controlPlane.PreflightCheckResults)
+			setScalingDownCondition(ctx, tt.controlPlane.Cluster, tt.controlPlane.KCP, tt.controlPlane.Machines, tt.controlPlane.PreflightCheckResults)
 
 			condition := v1beta2conditions.Get(tt.controlPlane.KCP, controlplanev1.KubeadmControlPlaneScalingDownV1Beta2Condition)
 			g.Expect(condition).ToNot(BeNil())

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -503,19 +503,6 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 		return *currentVersion, nil
 	}
 
-	// If the control plane supports replicas, check if the control plane is in the middle of a scale operation.
-	// If yes, then do not pick up the desiredVersion yet. We will pick up the new version after the control plane is stable.
-	if s.Blueprint.Topology.ControlPlane.Replicas != nil {
-		cpScaling, err := contract.ControlPlane().IsScaling(s.Current.ControlPlane.Object)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to check if the control plane is scaling")
-		}
-		if cpScaling {
-			s.UpgradeTracker.ControlPlane.IsScaling = true
-			return *currentVersion, nil
-		}
-	}
-
 	// If the control plane is not upgrading or scaling, we can assume the control plane is stable.
 	// However, we should also check for the MachineDeployments/MachinePools upgrading.
 	// If the MachineDeployments/MachinePools are upgrading, then do not pick up the desiredVersion yet.

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -808,6 +808,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 			},
 			{
 				name:            "should return cluster.spec.topology.version if the control plane is scaling",
+				hookResponse:    nonBlockingBeforeClusterUpgradeResponse,
 				topologyVersion: "v1.2.3",
 				controlPlaneObj: builder.ControlPlane("test1", "cp1").
 					WithSpecFields(map[string]interface{}{

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -807,6 +807,24 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 				expectedVersion: "v1.2.2",
 			},
 			{
+				name:            "should return cluster.spec.topology.version if the control plane is scaling",
+				topologyVersion: "v1.2.3",
+				controlPlaneObj: builder.ControlPlane("test1", "cp1").
+					WithSpecFields(map[string]interface{}{
+						"spec.version":  "v1.2.2",
+						"spec.replicas": int64(2),
+					}).
+					WithStatusFields(map[string]interface{}{
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(1),
+						"status.updatedReplicas":     int64(1),
+						"status.readyReplicas":       int64(1),
+						"status.unavailableReplicas": int64(0),
+					}).
+					Build(),
+				expectedVersion: "v1.2.3",
+			},
+			{
 				name:            "should return controlplane.spec.version if control plane is not upgrading and not scaling and one of the MachineDeployments and one of the MachinePools is upgrading",
 				topologyVersion: "v1.2.3",
 				controlPlaneObj: builder.ControlPlane("test1", "cp1").

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -2275,7 +2275,6 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 		upgradeConcurrency                   int
 		controlPlaneStartingUpgrade          bool
 		controlPlaneUpgrading                bool
-		controlPlaneScaling                  bool
 		controlPlaneProvisioning             bool
 		afterControlPlaneUpgradeHookBlocking bool
 		topologyVersion                      string
@@ -2294,8 +2293,8 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			expectPendingCreate: false,
 		},
 		{
-			name:                "should return cluster.spec.topology.version if creating a new machine deployment and if control plane is not stable - marked as pending create",
-			controlPlaneScaling: true,
+			name:                  "should return cluster.spec.topology.version if creating a new machine deployment and if control plane is not stable - marked as pending create",
+			controlPlaneUpgrading: true,
 			machineDeploymentTopology: clusterv1.MachineDeploymentTopology{
 				Name: "md-topology-1",
 			},
@@ -2334,16 +2333,6 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			currentMachineDeploymentState: currentMachineDeploymentState,
 			upgradingMachineDeployments:   []string{},
 			controlPlaneStartingUpgrade:   true,
-			topologyVersion:               "v1.2.3",
-			expectedVersion:               "v1.2.2",
-			expectPendingUpgrade:          true,
-		},
-		{
-			// Control plane is considered scaling if its spec.replicas is not equal to any of status.replicas, status.readyReplicas or status.updatedReplicas.
-			name:                          "should return machine deployment's spec.template.spec.version if control plane is scaling",
-			currentMachineDeploymentState: currentMachineDeploymentState,
-			upgradingMachineDeployments:   []string{},
-			controlPlaneScaling:           true,
 			topologyVersion:               "v1.2.3",
 			expectedVersion:               "v1.2.2",
 			expectPendingUpgrade:          true,
@@ -2413,7 +2402,6 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			}
 			s.UpgradeTracker.ControlPlane.IsStartingUpgrade = tt.controlPlaneStartingUpgrade
 			s.UpgradeTracker.ControlPlane.IsUpgrading = tt.controlPlaneUpgrading
-			s.UpgradeTracker.ControlPlane.IsScaling = tt.controlPlaneScaling
 			s.UpgradeTracker.ControlPlane.IsProvisioning = tt.controlPlaneProvisioning
 			s.UpgradeTracker.MachineDeployments.MarkUpgrading(tt.upgradingMachineDeployments...)
 
@@ -2456,7 +2444,6 @@ func TestComputeMachinePoolVersion(t *testing.T) {
 		upgradeConcurrency                   int
 		controlPlaneStartingUpgrade          bool
 		controlPlaneUpgrading                bool
-		controlPlaneScaling                  bool
 		controlPlaneProvisioning             bool
 		afterControlPlaneUpgradeHookBlocking bool
 		topologyVersion                      string
@@ -2475,8 +2462,8 @@ func TestComputeMachinePoolVersion(t *testing.T) {
 			expectPendingCreate: false,
 		},
 		{
-			name:                "should return cluster.spec.topology.version if creating a new MachinePool and if control plane is not stable - marked as pending create",
-			controlPlaneScaling: true,
+			name:                  "should return cluster.spec.topology.version if creating a new MachinePool and if control plane is not stable - marked as pending create",
+			controlPlaneUpgrading: true,
 			machinePoolTopology: clusterv1.MachinePoolTopology{
 				Name: "mp-topology-1",
 			},
@@ -2518,16 +2505,6 @@ func TestComputeMachinePoolVersion(t *testing.T) {
 			topologyVersion:             "v1.2.3",
 			expectedVersion:             "v1.2.2",
 			expectPendingUpgrade:        true,
-		},
-		{
-			// Control plane is considered scaling if its spec.replicas is not equal to any of status.replicas, status.readyReplicas or status.updatedReplicas.
-			name:                    "should return MachinePool's spec.template.spec.version if control plane is scaling",
-			currentMachinePoolState: currentMachinePoolState,
-			upgradingMachinePools:   []string{},
-			controlPlaneScaling:     true,
-			topologyVersion:         "v1.2.3",
-			expectedVersion:         "v1.2.2",
-			expectPendingUpgrade:    true,
 		},
 		{
 			name:                    "should return cluster.spec.topology.version if the control plane is not upgrading, not scaling, not ready to upgrade and none of the MachinePools are upgrading",
@@ -2594,7 +2571,6 @@ func TestComputeMachinePoolVersion(t *testing.T) {
 			}
 			s.UpgradeTracker.ControlPlane.IsStartingUpgrade = tt.controlPlaneStartingUpgrade
 			s.UpgradeTracker.ControlPlane.IsUpgrading = tt.controlPlaneUpgrading
-			s.UpgradeTracker.ControlPlane.IsScaling = tt.controlPlaneScaling
 			s.UpgradeTracker.ControlPlane.IsProvisioning = tt.controlPlaneProvisioning
 			s.UpgradeTracker.MachinePools.MarkUpgrading(tt.upgradingMachinePools...)
 

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -807,26 +807,6 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 				expectedVersion: "v1.2.2",
 			},
 			{
-				// Control plane is considered scaling if controlplane.spec.replicas is not equal to any of
-				// controlplane.status.replicas, controlplane.status.readyReplicas, controlplane.status.updatedReplicas.
-				name:            "should return controlplane.spec.version if the control plane is scaling",
-				topologyVersion: "v1.2.3",
-				controlPlaneObj: builder.ControlPlane("test1", "cp1").
-					WithSpecFields(map[string]interface{}{
-						"spec.version":  "v1.2.2",
-						"spec.replicas": int64(2),
-					}).
-					WithStatusFields(map[string]interface{}{
-						"status.version":             "v1.2.2",
-						"status.replicas":            int64(1),
-						"status.updatedReplicas":     int64(1),
-						"status.readyReplicas":       int64(1),
-						"status.unavailableReplicas": int64(0),
-					}).
-					Build(),
-				expectedVersion: "v1.2.2",
-			},
-			{
 				name:            "should return controlplane.spec.version if control plane is not upgrading and not scaling and one of the MachineDeployments and one of the MachinePools is upgrading",
 				topologyVersion: "v1.2.3",
 				controlPlaneObj: builder.ControlPlane("test1", "cp1").

--- a/exp/topology/scope/upgradetracker.go
+++ b/exp/topology/scope/upgradetracker.go
@@ -53,16 +53,6 @@ type ControlPlaneUpgradeTracker struct {
 	// If IsStartingUpgrade is true it implies that the desired Control Plane version and the current Control Plane
 	// versions are different.
 	IsStartingUpgrade bool
-
-	// IsScaling is true if the current Control Plane is scaling. False otherwise.
-	// IsScaling only represents the state of the current Control Plane. IsScaling does not represent the state
-	// of the desired Control Plane.
-	// Example:
-	// - IsScaling will be true if the current ControlPlane is scaling.
-	// - IsScaling will not be true if the current Control Plane is stable and the reconcile loop is going to scale the Control Plane.
-	// Note: Refer to control plane contract for definition of scaling.
-	// Note: IsScaling will be false if the Control Plane does not support replicas.
-	IsScaling bool
 }
 
 // WorkerUpgradeTracker holds the current upgrade status of MachineDeployments or MachinePools.
@@ -166,12 +156,6 @@ func NewUpgradeTracker(opts ...UpgradeTrackerOption) *UpgradeTracker {
 func (t *ControlPlaneUpgradeTracker) IsControlPlaneStable() bool {
 	// If the current control plane is upgrading it is not considered stable.
 	if t.IsUpgrading {
-		return false
-	}
-
-	// If control plane supports replicas, check if the control plane is in the middle of a scale operation.
-	// If the current control plane is scaling then it is not considered stable.
-	if t.IsScaling {
 		return false
 	}
 

--- a/internal/controllers/topology/cluster/conditions.go
+++ b/internal/controllers/topology/cluster/conditions.go
@@ -238,9 +238,6 @@ func (r *Reconciler) reconcileTopologyReconciledCondition(s *scope.Scope, cluste
 			}
 			fmt.Fprintf(msgBuilder, " Control plane is upgrading to version %s", *cpVersion)
 
-		case s.UpgradeTracker.ControlPlane.IsScaling:
-			msgBuilder.WriteString(" Control plane is reconciling desired replicas")
-
 		case len(s.UpgradeTracker.MachineDeployments.UpgradingNames()) > 0:
 			fmt.Fprintf(msgBuilder, " MachineDeployment(s) %s are upgrading",
 				computeNameList(s.UpgradeTracker.MachineDeployments.UpgradingNames()),

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -188,40 +188,6 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			wantV1Beta2ConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is upgrading to version v1.21.2",
 		},
 		{
-			name:         "should set the condition to false if new version is not picked up because control plane is scaling",
-			reconcileErr: nil,
-			cluster:      &clusterv1.Cluster{},
-			s: &scope.Scope{
-				Blueprint: &scope.ClusterBlueprint{
-					Topology: &clusterv1.Topology{
-						Version: "v1.22.0",
-					},
-				},
-				Current: &scope.ClusterState{
-					Cluster: &clusterv1.Cluster{},
-					ControlPlane: &scope.ControlPlaneState{
-						Object: builder.ControlPlane("ns1", "controlplane1").
-							WithVersion("v1.21.2").
-							WithReplicas(3).
-							Build(),
-					},
-				},
-				UpgradeTracker: func() *scope.UpgradeTracker {
-					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsPendingUpgrade = true
-					ut.ControlPlane.IsScaling = true
-					return ut
-				}(),
-				HookResponseTracker: scope.NewHookResponseTracker(),
-			},
-			wantConditionStatus:         corev1.ConditionFalse,
-			wantConditionReason:         clusterv1.TopologyReconciledControlPlaneUpgradePendingReason,
-			wantConditionMessage:        "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
-			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledControlPlaneUpgradePendingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "Control plane rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-		},
-		{
 			name:         "should set the condition to false if new version is not picked up because at least one of the machine deployment is upgrading",
 			reconcileErr: nil,
 			cluster:      &clusterv1.Cluster{},
@@ -414,173 +380,6 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 			wantV1Beta2ConditionMessage: "MachinePool(s) mp0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is upgrading to version v1.22.0",
 		},
 		{
-			name:         "should set the condition to false if control plane picked the new version but machine deployments did not because control plane is scaling",
-			reconcileErr: nil,
-			cluster:      &clusterv1.Cluster{},
-			s: &scope.Scope{
-				Blueprint: &scope.ClusterBlueprint{
-					Topology: &clusterv1.Topology{
-						Version: "v1.22.0",
-					},
-				},
-				Current: &scope.ClusterState{
-					Cluster: &clusterv1.Cluster{},
-					ControlPlane: &scope.ControlPlaneState{
-						Object: builder.ControlPlane("ns1", "controlplane1").
-							WithVersion("v1.22.0").
-							WithReplicas(3).
-							Build(),
-					},
-					MachineDeployments: scope.MachineDeploymentsStateMap{
-						"md0": &scope.MachineDeploymentState{
-							Object: builder.MachineDeployment("ns1", "md0-abc123").
-								WithReplicas(2).
-								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas:            int32(2),
-									UpdatedReplicas:     int32(2),
-									ReadyReplicas:       int32(2),
-									AvailableReplicas:   int32(2),
-									UnavailableReplicas: int32(0),
-								}).
-								Build(),
-						},
-					},
-				},
-				UpgradeTracker: func() *scope.UpgradeTracker {
-					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsPendingUpgrade = false
-					ut.ControlPlane.IsScaling = true
-					ut.MachineDeployments.MarkPendingUpgrade("md0-abc123")
-					return ut
-				}(),
-				HookResponseTracker: scope.NewHookResponseTracker(),
-			},
-			wantConditionStatus:         corev1.ConditionFalse,
-			wantConditionReason:         clusterv1.TopologyReconciledMachineDeploymentsUpgradePendingReason,
-			wantConditionMessage:        "MachineDeployment(s) md0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
-			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledMachineDeploymentsUpgradePendingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "MachineDeployment(s) md0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-		},
-		{
-			name:         "should set the condition to false if control plane picked the new version but machine pools did not because control plane is scaling",
-			reconcileErr: nil,
-			cluster:      &clusterv1.Cluster{},
-			s: &scope.Scope{
-				Blueprint: &scope.ClusterBlueprint{
-					Topology: &clusterv1.Topology{
-						Version: "v1.22.0",
-					},
-				},
-				Current: &scope.ClusterState{
-					Cluster: &clusterv1.Cluster{},
-					ControlPlane: &scope.ControlPlaneState{
-						Object: builder.ControlPlane("ns1", "controlplane1").
-							WithVersion("v1.22.0").
-							WithReplicas(3).
-							Build(),
-					},
-					MachinePools: scope.MachinePoolsStateMap{
-						"mp0": &scope.MachinePoolState{
-							Object: builder.MachinePool("ns1", "mp0-abc123").
-								WithReplicas(2).
-								WithStatus(expv1.MachinePoolStatus{
-									Replicas:            int32(2),
-									ReadyReplicas:       int32(2),
-									AvailableReplicas:   int32(2),
-									UnavailableReplicas: int32(0),
-								}).
-								Build(),
-						},
-					},
-				},
-				UpgradeTracker: func() *scope.UpgradeTracker {
-					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsPendingUpgrade = false
-					ut.ControlPlane.IsScaling = true
-					ut.MachinePools.MarkPendingUpgrade("mp0-abc123")
-					return ut
-				}(),
-				HookResponseTracker: scope.NewHookResponseTracker(),
-			},
-			wantConditionStatus:         corev1.ConditionFalse,
-			wantConditionReason:         clusterv1.TopologyReconciledMachinePoolsUpgradePendingReason,
-			wantConditionMessage:        "MachinePool(s) mp0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
-			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledMachinePoolsUpgradePendingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "MachinePool(s) mp0-abc123 rollout and upgrade to version v1.22.0 on hold. Control plane is reconciling desired replicas",
-		},
-		{
-			name:         "should set the condition to false if control plane picked the new version but there are machine deployments pending create because control plane is scaling",
-			reconcileErr: nil,
-			cluster:      &clusterv1.Cluster{},
-			s: &scope.Scope{
-				Blueprint: &scope.ClusterBlueprint{
-					Topology: &clusterv1.Topology{
-						Version: "v1.22.0",
-					},
-				},
-				Current: &scope.ClusterState{
-					Cluster: &clusterv1.Cluster{},
-					ControlPlane: &scope.ControlPlaneState{
-						Object: builder.ControlPlane("ns1", "controlplane1").
-							WithVersion("v1.22.0").
-							WithReplicas(3).
-							Build(),
-					},
-				},
-				UpgradeTracker: func() *scope.UpgradeTracker {
-					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsPendingUpgrade = false
-					ut.ControlPlane.IsScaling = true
-					ut.MachineDeployments.MarkPendingCreate("md0")
-					return ut
-				}(),
-				HookResponseTracker: scope.NewHookResponseTracker(),
-			},
-			wantConditionStatus:         corev1.ConditionFalse,
-			wantConditionReason:         clusterv1.TopologyReconciledMachineDeploymentsCreatePendingReason,
-			wantConditionMessage:        "MachineDeployment(s) for Topologies md0 creation on hold. Control plane is reconciling desired replicas",
-			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
-			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledMachineDeploymentsCreatePendingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "MachineDeployment(s) for Topologies md0 creation on hold. Control plane is reconciling desired replicas",
-		},
-		{
-			name:         "should set the condition to false if control plane picked the new version but there are machine pools pending create because control plane is scaling",
-			reconcileErr: nil,
-			cluster:      &clusterv1.Cluster{},
-			s: &scope.Scope{
-				Blueprint: &scope.ClusterBlueprint{
-					Topology: &clusterv1.Topology{
-						Version: "v1.22.0",
-					},
-				},
-				Current: &scope.ClusterState{
-					Cluster: &clusterv1.Cluster{},
-					ControlPlane: &scope.ControlPlaneState{
-						Object: builder.ControlPlane("ns1", "controlplane1").
-							WithVersion("v1.22.0").
-							WithReplicas(3).
-							Build(),
-					},
-				},
-				UpgradeTracker: func() *scope.UpgradeTracker {
-					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsPendingUpgrade = false
-					ut.ControlPlane.IsScaling = true
-					ut.MachinePools.MarkPendingCreate("mp0")
-					return ut
-				}(),
-				HookResponseTracker: scope.NewHookResponseTracker(),
-			},
-			wantConditionStatus:         corev1.ConditionFalse,
-			wantConditionReason:         clusterv1.TopologyReconciledMachinePoolsCreatePendingReason,
-			wantConditionMessage:        "MachinePool(s) for Topologies mp0 creation on hold. Control plane is reconciling desired replicas",
-			wantV1Beta2ConditionStatus:  metav1.ConditionFalse,
-			wantV1Beta2ConditionReason:  clusterv1.ClusterTopologyReconciledMachinePoolsCreatePendingV1Beta2Reason,
-			wantV1Beta2ConditionMessage: "MachinePool(s) for Topologies mp0 creation on hold. Control plane is reconciling desired replicas",
-		},
-		{
 			name:         "should set the condition to true if control plane picked the new version and is upgrading but there are no machine deployments or machine pools",
 			reconcileErr: nil,
 			cluster:      &clusterv1.Cluster{},
@@ -634,7 +433,6 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
 					ut.ControlPlane.IsPendingUpgrade = false
-					ut.ControlPlane.IsScaling = true
 					return ut
 				}(),
 				HookResponseTracker: scope.NewHookResponseTracker(),
@@ -1050,15 +848,15 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 
 				actualCondition := conditions.Get(tt.cluster, clusterv1.TopologyReconciledCondition)
 				g.Expect(actualCondition).ToNot(BeNil())
-				g.Expect(actualCondition.Status).To(Equal(tt.wantConditionStatus))
-				g.Expect(actualCondition.Reason).To(Equal(tt.wantConditionReason))
-				g.Expect(actualCondition.Message).To(Equal(tt.wantConditionMessage))
+				g.Expect(actualCondition.Status).To(BeEquivalentTo(tt.wantConditionStatus))
+				g.Expect(actualCondition.Reason).To(BeEquivalentTo(tt.wantConditionReason))
+				g.Expect(actualCondition.Message).To(BeEquivalentTo(tt.wantConditionMessage))
 
 				actualV1Beta2Condition := v1beta2conditions.Get(tt.cluster, clusterv1.ClusterTopologyReconciledV1Beta2Condition)
 				g.Expect(actualV1Beta2Condition).ToNot(BeNil())
-				g.Expect(actualV1Beta2Condition.Status).To(Equal(tt.wantV1Beta2ConditionStatus))
-				g.Expect(actualV1Beta2Condition.Reason).To(Equal(tt.wantV1Beta2ConditionReason))
-				g.Expect(actualV1Beta2Condition.Message).To(Equal(tt.wantV1Beta2ConditionMessage))
+				g.Expect(actualV1Beta2Condition.Status).To(BeEquivalentTo(tt.wantV1Beta2ConditionStatus))
+				g.Expect(actualV1Beta2Condition.Reason).To(BeEquivalentTo(tt.wantV1Beta2ConditionReason))
+				g.Expect(actualV1Beta2Condition.Message).To(BeEquivalentTo(tt.wantV1Beta2ConditionMessage))
 			}
 		})
 	}

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -621,7 +621,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 			wantError:          false,
 		},
 		{
-			name: "hook should not be called if the control plane is scaling - hook is marked",
+			name: "hook should be called if the control plane is scaling - hook is not marked",
 			s: &scope.Scope{
 				Blueprint: &scope.ClusterBlueprint{
 					Topology: &clusterv1.Topology{
@@ -639,7 +639,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
-						Spec: clusterv1.ClusterSpec{},
+						Spec: clusterv1.ClusterSpec{Topology: &clusterv1.Topology{}},
 					},
 					ControlPlane: &scope.ControlPlaneState{
 						Object: controlPlaneObj,
@@ -648,13 +648,12 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 				HookResponseTracker: scope.NewHookResponseTracker(),
 				UpgradeTracker: func() *scope.UpgradeTracker {
 					ut := scope.NewUpgradeTracker()
-					ut.ControlPlane.IsScaling = true
 					return ut
 				}(),
 			},
-			wantMarked:         true,
+			wantMarked:         false,
 			hookResponse:       successResponse,
-			wantHookToBeCalled: false,
+			wantHookToBeCalled: true,
 			wantError:          false,
 		},
 		{

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -347,6 +347,7 @@ func processIfTopologyManaged(scheme *runtime.Scheme, logger logr.Logger, object
 func ClusterTopologyVersionChanged(scheme *runtime.Scheme, logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			logger := logger.WithValues("predicate", "ClusterTopologyVersionChanged", "eventType", "update")
 			if gvk, err := apiutil.GVKForObject(e.ObjectOld, scheme); err == nil {
 				logger = logger.WithValues(gvk.Kind, klog.KObj(e.ObjectOld))
 			}

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -341,3 +341,45 @@ func processIfTopologyManaged(scheme *runtime.Scheme, logger logr.Logger, object
 	logger.V(6).Info("Cluster does not have topology, blocking further processing")
 	return false
 }
+
+// ClusterTopologyVersionChanged returns a Predicate that returns true when cluster.Spec.Topology.Version
+// was changed.
+func ClusterTopologyVersionChanged(scheme *runtime.Scheme, logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if gvk, err := apiutil.GVKForObject(e.ObjectOld, scheme); err == nil {
+				logger = logger.WithValues(gvk.Kind, klog.KObj(e.ObjectOld))
+			}
+
+			oldCluster, ok := e.ObjectOld.(*clusterv1.Cluster)
+			if !ok {
+				logger.V(4).Info("Expected Cluster", "type", fmt.Sprintf("%T", e.ObjectOld))
+				return false
+			}
+
+			newCluster := e.ObjectNew.(*clusterv1.Cluster)
+
+			if oldCluster.Spec.Topology == nil || newCluster.Spec.Topology == nil {
+				logger.V(6).Info("Cluster does not have topology, blocking further processing")
+				return false
+			}
+
+			if oldCluster.Spec.Topology.Version != newCluster.Spec.Topology.Version {
+				logger.V(6).Info("Cluster topology version has changed, allowing further processing")
+				return true
+			}
+
+			logger.V(6).Info("Cluster topology version has not changed, blocking further processing")
+			return false
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(_ event.GenericEvent) bool {
+			return false
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

*High-level description:*

* KCP: block scale-up/scale-down/rollout/remediation if we know there is an upcoming version upgrade pending from the topology
* Topology: Do not block propagating changes anymore when the ControlPlane is in scaling state

Note: This change only affects topology based Clusters.

*More detailed description:*

Changes to KCP:

* Adds a preflight check for KCP for topology based clusters to check if there is an upgrade pending to get propagated down (`Cluster.spec.topology.version != KCP.spec.version`)
* From the perspective of KCP it should be better to roll-forward with the new desired spec instead of first continuing with the old (propably broken) spec of KCP

Changes to the topology controller:

* Relax `computeControlPlaneVersion` to allow to propagate down changes when a Control Plane is in scaling.
	* Note: this was only used for ControlPlane providers which implement replicas.
	* The ControlPlane provider itself should know better if it should first finish scaling or rollout the new desired state instead.
	* If this check would have been kept, the above preflight check could have lead to deadlocks when e.g.:
	  * a CP machine was marked for remediation while the Cluster's `.spec.topology.version` was set to a newer one
	  * triggering a scale-up or scale-down and immediately after update the Cluster's `.spec.topology.version`
	  * pretty sure others too

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area provider/control-plane-kubeadm