### PR TITLE
✨ machineset: Extend ControlPlaneIsStable preflight check to check for a pending topology based ControlPlane version upgrade

### DIFF
--- a/docs/book/src/tasks/experimental-features/machineset-preflight-checks.md
+++ b/docs/book/src/tasks/experimental-features/machineset-preflight-checks.md
@@ -18,7 +18,7 @@ Enabling `MachineSetPreflightChecks` provides safety in such circumstances by ma
 
 ### `ControlPlaneIsStable`
 
-* This preflight check ensures that the ControlPlane is currently stable i.e. the ControlPlane is currently neither provisioning nor upgrading.   
+* This preflight check ensures that the ControlPlane is currently stable i.e. the ControlPlane is currently neither provisioning, upgrading nor pending an upgrade.   
 * This preflight check is only performed if:
   * The Cluster uses a ControlPlane provider.
   * ControlPlane version is defined (`ControlPlane.spec.version` is set).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Extends the `ControlPlaneIsStable` to also consider a pending Control Plane upgrade from topology as blocking.

Note: this checks that `Cluster.spec.topology.version` is equal to `ControlPlane.spec.version`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area machineset