### PR TITLE
:seedling: Add comments for metadata

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -1077,7 +1077,9 @@ func (v APIEndpoint) String() string {
 
 // Cluster is the Schema for the clusters API.
 type Cluster struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Cluster.
@@ -1214,6 +1216,8 @@ func (f ClusterIPFamily) String() string {
 // ClusterList contains a list of Cluster.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Clusters.
 	Items []Cluster `json:"items"`

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -72,7 +72,9 @@ const (
 
 // ClusterClass is a template which can be used to create managed topologies.
 type ClusterClass struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of ClusterClass.
@@ -1115,6 +1117,8 @@ func (c *ClusterClass) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // ClusterClassList contains a list of Cluster.
 type ClusterClassList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterClasses.
 	Items []ClusterClass `json:"items"`

--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -663,7 +663,9 @@ type Bootstrap struct {
 
 // Machine is the Schema for the machines API.
 type Machine struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Machine.
@@ -703,6 +705,8 @@ func (m *Machine) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // MachineList contains a list of Machine.
 type MachineList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Machines.
 	Items []Machine `json:"items"`

--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -582,7 +582,9 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 
 // MachineDeployment is the Schema for the machinedeployments API.
 type MachineDeployment struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineDeployment.
@@ -596,6 +598,8 @@ type MachineDeployment struct {
 // MachineDeploymentList contains a list of MachineDeployment.
 type MachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineDeployments.
 	Items []MachineDeployment `json:"items"`

--- a/api/v1beta1/machinedrainrules_types.go
+++ b/api/v1beta1/machinedrainrules_types.go
@@ -205,6 +205,8 @@ type MachineDrainRulePodSelector struct {
 type MachineDrainRule struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +required
 	metav1.ObjectMeta `json:"metadata"`
 
@@ -219,6 +221,8 @@ type MachineDrainRule struct {
 type MachineDrainRuleList struct {
 	metav1.TypeMeta `json:",inline"`
 
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	// +required
 	metav1.ListMeta `json:"metadata"`
 

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -202,7 +202,9 @@ type MachineHealthCheckV1Beta2Status struct {
 
 // MachineHealthCheck is the Schema for the machinehealthchecks API.
 type MachineHealthCheck struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of machine health check policy
@@ -243,6 +245,8 @@ func (m *MachineHealthCheck) SetV1Beta2Conditions(conditions []metav1.Condition)
 // MachineHealthCheckList contains a list of MachineHealthCheck.
 type MachineHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineHealthChecks.
 	Items []MachineHealthCheck `json:"items"`

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -236,7 +236,7 @@ const (
 
 // MachineTemplateSpec describes the data needed to create a Machine from a template.
 type MachineTemplateSpec struct {
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
@@ -419,7 +419,9 @@ func (m *MachineSet) Validate() field.ErrorList {
 
 // MachineSet is the Schema for the machinesets API.
 type MachineSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineSet.
@@ -459,6 +461,8 @@ func (m *MachineSet) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // MachineSetList contains a list of MachineSet.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineSets.
 	Items []MachineSet `json:"items"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -205,8 +205,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_Cluster(ref common.ReferenceCallba
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -276,8 +277,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterClass(ref common.ReferenceC
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -325,8 +327,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterClassList(ref common.Refere
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -843,8 +846,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterList(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1929,8 +1933,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_Machine(ref common.ReferenceCallba
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -2035,8 +2040,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeployment(ref common.Refer
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -2244,8 +2250,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentList(ref common.R
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2728,8 +2735,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDrainRule(ref common.Refere
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -2800,8 +2808,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDrainRuleList(ref common.Re
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2965,8 +2974,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheck(ref common.Refe
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -3068,8 +3078,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineHealthCheckList(ref common.
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3367,8 +3378,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineList(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3756,8 +3768,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSet(ref common.ReferenceCal
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -3805,8 +3818,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSetList(ref common.Referenc
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -4281,7 +4295,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineTemplateSpec(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -474,7 +474,9 @@ type KubeadmConfigV1Beta2Status struct {
 
 // KubeadmConfig is the Schema for the kubeadmconfigs API.
 type KubeadmConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfig.
@@ -514,6 +516,8 @@ func (c *KubeadmConfig) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // KubeadmConfigList contains a list of KubeadmConfig.
 type KubeadmConfigList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigs.
 	Items []KubeadmConfig `json:"items"`

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_types.go
@@ -46,7 +46,9 @@ type KubeadmConfigTemplateResource struct {
 
 // KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
 type KubeadmConfigTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfigTemplate.
@@ -58,6 +60,8 @@ type KubeadmConfigTemplate struct {
 // KubeadmConfigTemplateList contains a list of KubeadmConfigTemplate.
 type KubeadmConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigTemplates.
 	Items []KubeadmConfigTemplate `json:"items"`

--- a/cmd/clusterctl/api/v1alpha3/metadata_type.go
+++ b/cmd/clusterctl/api/v1alpha3/metadata_type.go
@@ -26,7 +26,9 @@ import (
 
 // Metadata for a provider repository.
 type Metadata struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// releaseSeries maps a provider release series (major/minor) with an API Version of Cluster API (contract).

--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -31,7 +31,9 @@ import (
 
 // Provider defines an entry in the provider inventory.
 type Provider struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// providerName indicates the name of the provider.
@@ -165,6 +167,8 @@ func (p ProviderType) Order() int {
 // ProviderList contains a list of Provider.
 type ProviderList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Providers.
 	Items []Provider `json:"items"`

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -216,7 +216,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -776,7 +776,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1357,7 +1357,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -153,7 +153,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -672,7 +672,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1090,7 +1090,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -145,7 +145,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -636,7 +636,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -1109,7 +1109,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      metadata is the standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
@@ -420,7 +420,9 @@ type LastRemediationStatus struct {
 
 // KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
 type KubeadmControlPlane struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmControlPlane.
@@ -460,6 +462,8 @@ func (in *KubeadmControlPlane) SetV1Beta2Conditions(conditions []metav1.Conditio
 // KubeadmControlPlaneList contains a list of KubeadmControlPlane.
 type KubeadmControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmControlPlanes.
 	Items []KubeadmControlPlane `json:"items"`

--- a/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
@@ -36,7 +36,9 @@ type KubeadmControlPlaneTemplateSpec struct {
 
 // KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
 type KubeadmControlPlaneTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmControlPlaneTemplate.
@@ -48,6 +50,8 @@ type KubeadmControlPlaneTemplate struct {
 // KubeadmControlPlaneTemplateList contains a list of KubeadmControlPlaneTemplate.
 type KubeadmControlPlaneTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmControlPlaneTemplates.
 	Items []KubeadmControlPlaneTemplate `json:"items"`

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -176,7 +176,9 @@ func (m *ClusterResourceSet) SetV1Beta2Conditions(conditions []metav1.Condition)
 // ClusterResourceSet is the Schema for the clusterresourcesets API.
 // For advanced use cases an add-on provider should be used instead.
 type ClusterResourceSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of ClusterResourceSet.
@@ -190,6 +192,8 @@ type ClusterResourceSet struct {
 // ClusterResourceSetList contains a list of ClusterResourceSet.
 type ClusterResourceSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSets.
 	Items []ClusterResourceSet `json:"items"`

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -173,7 +173,9 @@ func referSameObject(a, b metav1.OwnerReference) bool {
 
 // ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
 type ClusterResourceSetBinding struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// spec is the desired state of ClusterResourceSetBinding.
 	Spec ClusterResourceSetBindingSpec `json:"spec,omitempty"`
@@ -200,6 +202,8 @@ type ClusterResourceSetBindingSpec struct {
 // ClusterResourceSetBindingList contains a list of ClusterResourceSetBinding.
 type ClusterResourceSetBindingList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSetBindings.
 	Items []ClusterResourceSetBinding `json:"items"`

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -259,7 +259,9 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 
 // MachinePool is the Schema for the machinepools API.
 type MachinePool struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachinePool.
@@ -299,6 +301,8 @@ func (m *MachinePool) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // MachinePoolList contains a list of MachinePool.
 type MachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachinePools.
 	Items []MachinePool `json:"items"`

--- a/exp/ipam/api/v1alpha1/ipaddress_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddress_types.go
@@ -49,7 +49,9 @@ type IPAddressSpec struct {
 
 // IPAddress is the Schema for the ipaddress API.
 type IPAddress struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of IPAddress.
@@ -61,6 +63,8 @@ type IPAddress struct {
 // IPAddressList is a list of IPAddress.
 type IPAddressList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of IPAddresses.
 	Items []IPAddress `json:"items"`

--- a/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1alpha1/ipaddressclaim_types.go
@@ -49,7 +49,9 @@ type IPAddressClaimStatus struct {
 
 // IPAddressClaim is the Schema for the ipaddressclaim API.
 type IPAddressClaim struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of IPAddressClaim.
@@ -73,6 +75,8 @@ func (m *IPAddressClaim) SetConditions(conditions clusterv1.Conditions) {
 // IPAddressClaimList is a list of IPAddressClaims.
 type IPAddressClaimList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of IPAddressClaims.
 	Items []IPAddressClaim `json:"items"`

--- a/exp/ipam/api/v1beta1/ipaddress_types.go
+++ b/exp/ipam/api/v1beta1/ipaddress_types.go
@@ -50,7 +50,9 @@ type IPAddressSpec struct {
 
 // IPAddress is the Schema for the ipaddress API.
 type IPAddress struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of IPAddress.
@@ -62,6 +64,8 @@ type IPAddress struct {
 // IPAddressList is a list of IPAddress.
 type IPAddressList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of IPAddresses.
 	Items []IPAddress `json:"items"`

--- a/exp/ipam/api/v1beta1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1beta1/ipaddressclaim_types.go
@@ -54,7 +54,9 @@ type IPAddressClaimStatus struct {
 
 // IPAddressClaim is the Schema for the ipaddressclaim API.
 type IPAddressClaim struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of IPAddressClaim.
@@ -78,6 +80,8 @@ func (m *IPAddressClaim) SetConditions(conditions clusterv1.Conditions) {
 // IPAddressClaimList is a list of IPAddressClaims.
 type IPAddressClaimList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of IPAddressClaims.
 	Items []IPAddressClaim `json:"items"`

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -183,7 +183,9 @@ const (
 
 // ExtensionConfig is the Schema for the ExtensionConfig API.
 type ExtensionConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of the ExtensionConfig.
@@ -224,6 +226,8 @@ func (e *ExtensionConfig) SetV1Beta2Conditions(conditions []metav1.Condition) {
 // ExtensionConfigList contains a list of ExtensionConfig.
 type ExtensionConfigList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ExtensionConfigs.
 	Items []ExtensionConfig `json:"items"`

--- a/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfig_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfig_types.go
@@ -141,7 +141,9 @@ type KubeadmConfigStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfig.
@@ -167,6 +169,8 @@ func (c *KubeadmConfig) SetConditions(conditions clusterv1alpha3.Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigs.
 	Items []KubeadmConfig `json:"items"`

--- a/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfigtemplate_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha3/kubeadmconfigtemplate_types.go
@@ -41,7 +41,9 @@ type KubeadmConfigTemplateResource struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfigTemplate.
@@ -55,6 +57,8 @@ type KubeadmConfigTemplate struct {
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigTemplates.
 	Items []KubeadmConfigTemplate `json:"items"`

--- a/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfig_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfig_types.go
@@ -134,7 +134,9 @@ type KubeadmConfigStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfig struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfig.
@@ -160,6 +162,8 @@ func (c *KubeadmConfig) SetConditions(conditions clusterv1alpha4.Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigs.
 	Items []KubeadmConfig `json:"items"`

--- a/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfigtemplate_types.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha4/kubeadmconfigtemplate_types.go
@@ -42,7 +42,9 @@ type KubeadmConfigTemplateResource struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmConfigTemplate.
@@ -56,6 +58,8 @@ type KubeadmConfigTemplate struct {
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmConfigTemplates.
 	Items []KubeadmConfigTemplate `json:"items"`

--- a/internal/apis/controlplane/kubeadm/v1alpha3/kubeadm_control_plane_types.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha3/kubeadm_control_plane_types.go
@@ -201,7 +201,9 @@ type KubeadmControlPlaneStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlane struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmControlPlane.
@@ -227,6 +229,8 @@ func (in *KubeadmControlPlane) SetConditions(conditions clusterv1alpha3.Conditio
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmControlPlanes.
 	Items []KubeadmControlPlane `json:"items"`

--- a/internal/apis/controlplane/kubeadm/v1alpha4/kubeadm_control_plane_types.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha4/kubeadm_control_plane_types.go
@@ -216,7 +216,9 @@ type KubeadmControlPlaneStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlane struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmControlPlane.
@@ -242,6 +244,8 @@ func (in *KubeadmControlPlane) SetConditions(conditions clusterv1alpha4.Conditio
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmControlPlanes.
 	Items []KubeadmControlPlane `json:"items"`

--- a/internal/apis/controlplane/kubeadm/v1alpha4/kubeadmcontrolplanetemplate_types.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha4/kubeadmcontrolplanetemplate_types.go
@@ -36,7 +36,9 @@ type KubeadmControlPlaneTemplateSpec struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of KubeadmControlPlaneTemplate.
@@ -50,6 +52,8 @@ type KubeadmControlPlaneTemplate struct {
 // Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of KubeadmControlPlaneTemplates.
 	Items []KubeadmControlPlaneTemplate `json:"items"`

--- a/internal/apis/core/exp/addons/v1alpha3/clusterresourceset_types.go
+++ b/internal/apis/core/exp/addons/v1alpha3/clusterresourceset_types.go
@@ -120,7 +120,9 @@ func (m *ClusterResourceSet) SetConditions(conditions clusterv1alpha3.Conditions
 //
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of ClusterResourceSet.
@@ -136,6 +138,8 @@ type ClusterResourceSet struct {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSets.
 	Items []ClusterResourceSet `json:"items"`

--- a/internal/apis/core/exp/addons/v1alpha3/clusterresourcesetbinding_types.go
+++ b/internal/apis/core/exp/addons/v1alpha3/clusterresourcesetbinding_types.go
@@ -110,7 +110,9 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 //
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBinding struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// spec is the desired state of ClusterResourceSetBinding.
 	Spec ClusterResourceSetBindingSpec `json:"spec,omitempty"`
@@ -133,6 +135,8 @@ type ClusterResourceSetBindingSpec struct {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBindingList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSetBindings.
 	Items []ClusterResourceSetBinding `json:"items"`

--- a/internal/apis/core/exp/addons/v1alpha4/clusterresourceset_types.go
+++ b/internal/apis/core/exp/addons/v1alpha4/clusterresourceset_types.go
@@ -122,7 +122,9 @@ func (m *ClusterResourceSet) SetConditions(conditions clusterv1alpha4.Conditions
 //
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of ClusterResourceSet.
@@ -138,6 +140,8 @@ type ClusterResourceSet struct {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSets.
 	Items []ClusterResourceSet `json:"items"`

--- a/internal/apis/core/exp/addons/v1alpha4/clusterresourcesetbinding_types.go
+++ b/internal/apis/core/exp/addons/v1alpha4/clusterresourcesetbinding_types.go
@@ -111,7 +111,9 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 //
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBinding struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// spec is the desired state of ClusterResourceSetBinding.
 	Spec ClusterResourceSetBindingSpec `json:"spec,omitempty"`
@@ -134,6 +136,8 @@ type ClusterResourceSetBindingSpec struct {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBindingList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterResourceSetBindings.
 	Items []ClusterResourceSetBinding `json:"items"`

--- a/internal/apis/core/exp/v1alpha3/machinepool_types.go
+++ b/internal/apis/core/exp/v1alpha3/machinepool_types.go
@@ -218,7 +218,9 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachinePool struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachinePool.
@@ -244,6 +246,8 @@ func (m *MachinePool) SetConditions(conditions clusterv1alpha3.Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachinePools.
 	Items []MachinePool `json:"items"`

--- a/internal/apis/core/exp/v1alpha4/machinepool_types.go
+++ b/internal/apis/core/exp/v1alpha4/machinepool_types.go
@@ -214,7 +214,9 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachinePool struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachinePool.
@@ -240,6 +242,8 @@ func (m *MachinePool) SetConditions(conditions clusterv1alpha4.Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachinePools.
 	Items []MachinePool `json:"items"`

--- a/internal/apis/core/v1alpha3/cluster_types.go
+++ b/internal/apis/core/v1alpha3/cluster_types.go
@@ -209,7 +209,9 @@ func (v APIEndpoint) String() string {
 
 // Cluster is the Schema for the clusters API.
 type Cluster struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Cluster.
@@ -233,6 +235,8 @@ func (c *Cluster) SetConditions(conditions Conditions) {
 // ClusterList contains a list of Cluster.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Clusters.
 	Items []Cluster `json:"items"`

--- a/internal/apis/core/v1alpha3/machine_types.go
+++ b/internal/apis/core/v1alpha3/machine_types.go
@@ -250,7 +250,9 @@ type Bootstrap struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type Machine struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Machine.
@@ -276,6 +278,8 @@ func (m *Machine) SetConditions(conditions Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Machines.
 	Items []Machine `json:"items"`

--- a/internal/apis/core/v1alpha3/machinedeployment_types.go
+++ b/internal/apis/core/v1alpha3/machinedeployment_types.go
@@ -256,7 +256,9 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineDeployment struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineDeployment.
@@ -272,6 +274,8 @@ type MachineDeployment struct {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineDeployments.
 	Items []MachineDeployment `json:"items"`

--- a/internal/apis/core/v1alpha3/machinehealthcheck_types.go
+++ b/internal/apis/core/v1alpha3/machinehealthcheck_types.go
@@ -133,7 +133,9 @@ type MachineHealthCheckStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheck struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of machine health check policy
@@ -160,6 +162,8 @@ func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineHealthChecks.
 	Items []MachineHealthCheck `json:"items"`

--- a/internal/apis/core/v1alpha3/machineset_types.go
+++ b/internal/apis/core/v1alpha3/machineset_types.go
@@ -68,7 +68,7 @@ type MachineSetSpec struct {
 
 // MachineTemplateSpec describes the data needed to create a Machine from a template.
 type MachineTemplateSpec struct {
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
@@ -206,7 +206,9 @@ func (m *MachineSet) Validate() field.ErrorList {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineSet.
@@ -222,6 +224,8 @@ type MachineSet struct {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineSets.
 	Items []MachineSet `json:"items"`

--- a/internal/apis/core/v1alpha4/cluster_types.go
+++ b/internal/apis/core/v1alpha4/cluster_types.go
@@ -288,7 +288,9 @@ func (v APIEndpoint) String() string {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type Cluster struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Cluster.
@@ -398,6 +400,8 @@ func (f ClusterIPFamily) String() string {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Clusters.
 	Items []Cluster `json:"items"`

--- a/internal/apis/core/v1alpha4/clusterclass_types.go
+++ b/internal/apis/core/v1alpha4/clusterclass_types.go
@@ -31,7 +31,9 @@ import (
 //
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterClass struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of ClusterClass.
@@ -130,6 +132,8 @@ type LocalObjectTemplate struct {
 // Deprecated: This type will be removed in one of the next releases.
 type ClusterClassList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of ClusterClasses.
 	Items []ClusterClass `json:"items"`

--- a/internal/apis/core/v1alpha4/machine_types.go
+++ b/internal/apis/core/v1alpha4/machine_types.go
@@ -249,7 +249,9 @@ type Bootstrap struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type Machine struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of Machine.
@@ -275,6 +277,8 @@ func (m *Machine) SetConditions(conditions Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of Machines.
 	Items []Machine `json:"items"`

--- a/internal/apis/core/v1alpha4/machinedeployment_types.go
+++ b/internal/apis/core/v1alpha4/machinedeployment_types.go
@@ -287,7 +287,9 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineDeployment struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineDeployment.
@@ -303,6 +305,8 @@ type MachineDeployment struct {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineDeployments.
 	Items []MachineDeployment `json:"items"`

--- a/internal/apis/core/v1alpha4/machinehealthcheck_types.go
+++ b/internal/apis/core/v1alpha4/machinehealthcheck_types.go
@@ -147,7 +147,9 @@ type MachineHealthCheckStatus struct {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheck struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the specification of machine health check policy
@@ -174,6 +176,8 @@ func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineHealthChecks.
 	Items []MachineHealthCheck `json:"items"`

--- a/internal/apis/core/v1alpha4/machineset_types.go
+++ b/internal/apis/core/v1alpha4/machineset_types.go
@@ -75,7 +75,7 @@ type MachineSetSpec struct {
 
 // MachineTemplateSpec describes the data needed to create a Machine from a template.
 type MachineTemplateSpec struct {
-	// Standard object's metadata.
+	// metadata is the standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
@@ -219,7 +219,9 @@ func (m *MachineSet) Validate() field.ErrorList {
 //
 // Deprecated: This type will be removed in one of the next releases.
 type MachineSet struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec is the desired state of MachineSet.
@@ -235,6 +237,8 @@ type MachineSet struct {
 // Deprecated: This type will be removed in one of the next releases.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
 	metav1.ListMeta `json:"metadata,omitempty"`
 	// items is the list of MachineSets.
 	Items []MachineSet `json:"items"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* Add comments for metav1.ObjectMeta
```
	// metadata is the standard object's metadata.
	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
```

* Add comments for metav1.ListMeta
```
	// metadata is the standard list's metadata.
	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#lists-and-simple-kinds
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
As a part of #11238

We got errors when `commentstart` is enabled:

```
exp/api/v1beta1/machinepool_types.go:263:2: commentstart: field  is missing godoc comment (kal)
        metav1.ObjectMeta `json:"metadata,omitempty"`
        ^
exp/api/v1beta1/machinepool_types.go:302:2: commentstart: field  is missing godoc comment (kal)
        metav1.ListMeta `json:"metadata,omitempty"`
        ^
exp/runtime/api/v1alpha1/extensionconfig_types.go:187:2: commentstart: field  is missing godoc comment (kal)
        metav1.ObjectMeta `json:"metadata,omitempty"`
        ^
exp/runtime/api/v1alpha1/extensionconfig_types.go:227:2: commentstart: field  is missing godoc comment (kal)
        metav1.ListMeta `json:"metadata,omitempty"`
        ^
controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go:424:2: commentstart: field  is missing godoc comment (kal)
        metav1.ObjectMeta `json:"metadata,omitempty"`
        ^
controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go:463:2: commentstart: field  is missing godoc comment (kal)
        metav1.ListMeta `json:"metadata,omitempty"`
```

and I'll send a PR to enable `commentstart` linter as soon as https://github.com/JoelSpeed/kal/pull/50 is fixed.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation