### PR TITLE
⚠️ Add MaxItems markers to API fields

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -88,6 +88,7 @@ issues:
     linters:
       - kal
   # It does not make sense to add a maxItems marker on the *List structs as they are not used to generate CRD YAMLs.
+  # This exclude will  be removed once https://github.com/JoelSpeed/kal/issues/38 is resolved.
   - path: "api/v1beta1/*"
     text: "maxlength: field Items must have a maximum items, add kubebuilder:validation:MaxItems marker"
     linters:

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -74,8 +74,22 @@ issues:
     text: "field Prefix should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
     linters:
       - kal
-  - path: "api/v1alpha1/*|api/v1alpha3/*|api/v1beta1/*"
+  - path: "api/v1alpha1/*|api/v1alpha3/*"
     text: "maxlength"
+    linters:
+      - kal
+  - path: "api/v1beta1/*"
+    text: "must have a maximum length, add (kubebuilder:validation:MaxLength|kubebuilder:validation:items:MaxLength) marker"
+    linters:
+      - kal
+  # controller-gen does not allow to add MaxItems to Schemaless fields
+  - path: "api/v1beta1/*"
+    text: "maxlength: field (AllOf|OneOf|AnyOf) must have a maximum items, add kubebuilder:validation:MaxItems marker"
+    linters:
+      - kal
+  # It does not make sense to add a maxItems marker on the *List structs as they are not used to generate CRD YAMLs.
+  - path: "api/v1beta1/*"
+    text: "maxlength: field Items must have a maximum items, add kubebuilder:validation:MaxItems marker"
     linters:
       - kal
   - path: "api/v1alpha1/*|api/v1beta1/*"

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -556,6 +556,7 @@ type Topology struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=1000
 	Variables []ClusterVariable `json:"variables,omitempty"`
 }
 
@@ -624,12 +625,14 @@ type WorkersTopology struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=10000
 	MachineDeployments []MachineDeploymentTopology `json:"machineDeployments,omitempty"`
 
 	// machinePools is a list of machine pools in the cluster.
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=10000
 	MachinePools []MachinePoolTopology `json:"machinePools,omitempty"`
 }
 
@@ -758,6 +761,7 @@ type MachinePoolTopology struct {
 	// failureDomains is the list of failure domains the machine pool will be created in.
 	// Must match a key in the FailureDomains map stored on the cluster object.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
@@ -825,6 +829,7 @@ type ControlPlaneVariables struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=1000
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 
@@ -834,6 +839,7 @@ type MachineDeploymentVariables struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=1000
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 
@@ -843,6 +849,7 @@ type MachinePoolVariables struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
+	// +kubebuilder:validation:MaxItems=1000
 	Overrides []ClusterVariable `json:"overrides,omitempty"`
 }
 
@@ -878,6 +885,7 @@ type ClusterNetwork struct {
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
 	// cidrBlocks is a list of CIDR blocks.
+	// +kubebuilder:validation:MaxItems=1000
 	CIDRBlocks []string `json:"cidrBlocks"`
 }
 

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -625,14 +625,14 @@ type WorkersTopology struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10000
+	// +kubebuilder:validation:MaxItems=2000
 	MachineDeployments []MachineDeploymentTopology `json:"machineDeployments,omitempty"`
 
 	// machinePools is a list of machine pools in the cluster.
 	// +optional
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=10000
+	// +kubebuilder:validation:MaxItems=2000
 	MachinePools []MachinePoolTopology `json:"machinePools,omitempty"`
 }
 
@@ -761,7 +761,7 @@ type MachinePoolTopology struct {
 	// failureDomains is the list of failure domains the machine pool will be created in.
 	// Must match a key in the FailureDomains map stored on the cluster object.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
@@ -885,7 +885,7 @@ type ClusterNetwork struct {
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
 	// cidrBlocks is a list of CIDR blocks.
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	CIDRBlocks []string `json:"cidrBlocks"`
 }
 

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -237,7 +237,7 @@ type WorkersClass struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=class
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	MachineDeployments []MachineDeploymentClass `json:"machineDeployments,omitempty"`
 
 	// machinePools is a list of machine pool classes that can be used to create
@@ -245,7 +245,7 @@ type WorkersClass struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=class
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	MachinePools []MachinePoolClass `json:"machinePools,omitempty"`
 }
 
@@ -420,7 +420,7 @@ type MachinePoolClass struct {
 	// Must match a key in the FailureDomains map stored on the cluster object.
 	// NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// namingStrategy allows changing the naming pattern used when creating the MachinePool.
@@ -888,7 +888,7 @@ type ClusterClassPatch struct {
 	// Note: Patches will be applied in the order of the array.
 	// Note: Exactly one of Definitions or External must be set.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Definitions []PatchDefinition `json:"definitions,omitempty"`
 
 	// external defines an external patch.
@@ -905,7 +905,7 @@ type PatchDefinition struct {
 	// jsonPatches defines the patches which should be applied on the templates
 	// matching the selector.
 	// Note: Patches will be applied in the order of the array.
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	JSONPatches []JSONPatch `json:"jsonPatches"`
 }
 
@@ -955,7 +955,7 @@ type PatchSelectorMatch struct {
 type PatchSelectorMatchMachineDeploymentClass struct {
 	// names selects templates by class names.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Names []string `json:"names,omitempty"`
 }
 
@@ -964,7 +964,7 @@ type PatchSelectorMatchMachineDeploymentClass struct {
 type PatchSelectorMatchMachinePoolClass struct {
 	// names selects templates by class names.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Names []string `json:"names,omitempty"`
 }
 

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -122,12 +122,14 @@ type ClusterClassSpec struct {
 	// variables defines the variables which can be configured
 	// in the Cluster topology and are then used in patches.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Variables []ClusterClassVariable `json:"variables,omitempty"`
 
 	// patches defines the patches which are applied to customize
 	// referenced templates of a ClusterClass.
 	// Note: Patches will be applied in the order of the array.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Patches []ClusterClassPatch `json:"patches,omitempty"`
 }
 
@@ -235,6 +237,7 @@ type WorkersClass struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=class
+	// +kubebuilder:validation:MaxItems=1000
 	MachineDeployments []MachineDeploymentClass `json:"machineDeployments,omitempty"`
 
 	// machinePools is a list of machine pool classes that can be used to create
@@ -242,6 +245,7 @@ type WorkersClass struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=class
+	// +kubebuilder:validation:MaxItems=1000
 	MachinePools []MachinePoolClass `json:"machinePools,omitempty"`
 }
 
@@ -356,6 +360,7 @@ type MachineHealthCheckClass struct {
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
 	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
@@ -415,6 +420,7 @@ type MachinePoolClass struct {
 	// Must match a key in the FailureDomains map stored on the cluster object.
 	// NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	FailureDomains []string `json:"failureDomains,omitempty"`
 
 	// namingStrategy allows changing the naming pattern used when creating the MachinePool.
@@ -586,6 +592,7 @@ type JSONSchemaProps struct {
 	// required specifies which fields of an object are required.
 	// NOTE: Can only be set if type is object.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Required []string `json:"required,omitempty"`
 
 	// items specifies fields of an array.
@@ -667,6 +674,7 @@ type JSONSchemaProps struct {
 	// enum is the list of valid values of the variable.
 	// NOTE: Can be set for all types.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Enum []apiextensionsv1.JSON `json:"enum,omitempty"`
 
 	// default is the default value of the variable.
@@ -678,6 +686,7 @@ type JSONSchemaProps struct {
 	// +optional
 	// +listType=map
 	// +listMapKey=rule
+	// +kubebuilder:validation:MaxItems=100
 	XValidations []ValidationRule `json:"x-kubernetes-validations,omitempty"`
 
 	// x-metadata is the metadata of a variable or a nested field within a variable.
@@ -879,6 +888,7 @@ type ClusterClassPatch struct {
 	// Note: Patches will be applied in the order of the array.
 	// Note: Exactly one of Definitions or External must be set.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Definitions []PatchDefinition `json:"definitions,omitempty"`
 
 	// external defines an external patch.
@@ -895,6 +905,7 @@ type PatchDefinition struct {
 	// jsonPatches defines the patches which should be applied on the templates
 	// matching the selector.
 	// Note: Patches will be applied in the order of the array.
+	// +kubebuilder:validation:MaxItems=1000
 	JSONPatches []JSONPatch `json:"jsonPatches"`
 }
 
@@ -944,6 +955,7 @@ type PatchSelectorMatch struct {
 type PatchSelectorMatchMachineDeploymentClass struct {
 	// names selects templates by class names.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Names []string `json:"names,omitempty"`
 }
 
@@ -952,6 +964,7 @@ type PatchSelectorMatchMachineDeploymentClass struct {
 type PatchSelectorMatchMachinePoolClass struct {
 	// names selects templates by class names.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Names []string `json:"names,omitempty"`
 }
 
@@ -1035,6 +1048,7 @@ type LocalObjectTemplate struct {
 type ClusterClassStatus struct {
 	// variables is a list of ClusterClassStatusVariable that are defined for the ClusterClass.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Variables []ClusterClassStatusVariable `json:"variables,omitempty"`
 
 	// conditions defines current observed state of the ClusterClass.
@@ -1072,6 +1086,7 @@ type ClusterClassStatusVariable struct {
 	DefinitionsConflict bool `json:"definitionsConflict"`
 
 	// definitions is a list of definitions for a variable.
+	// +kubebuilder:validation:MaxItems=100
 	Definitions []ClusterClassStatusVariableDefinition `json:"definitions"`
 }
 

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -166,7 +166,7 @@ type MachineHealthCheckStatus struct {
 
 	// targets shows the current list of machines the machine health check is watching
 	// +optional
-	// +kubebuilder:validation:MaxItems=100000
+	// +kubebuilder:validation:MaxItems=10000
 	Targets []string `json:"targets,omitempty"`
 
 	// conditions defines current service state of the MachineHealthCheck.

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -63,6 +63,7 @@ type MachineHealthCheckSpec struct {
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions,omitempty"`
 
 	// maxUnhealthy specifies the maximum number of unhealthy machines allowed.
@@ -165,6 +166,7 @@ type MachineHealthCheckStatus struct {
 
 	// targets shows the current list of machines the machine health check is watching
 	// +optional
+	// +kubebuilder:validation:MaxItems=100000
 	Targets []string `json:"targets,omitempty"`
 
 	// conditions defines current service state of the MachineHealthCheck.

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -60,7 +60,7 @@ type InitConfiguration struct {
 	// The list of phases can be obtained with the "kubeadm init --help" command.
 	// This option takes effect only on Kubernetes >=1.22.0.
 	// +optional
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=50
 	SkipPhases []string `json:"skipPhases,omitempty"`
 
 	// patches contains options related to applying patches to components deployed by kubeadm during
@@ -261,7 +261,7 @@ type NodeRegistrationOptions struct {
 
 	// ignorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
 	// +optional
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=50
 	IgnorePreflightErrors []string `json:"ignorePreflightErrors,omitempty"`
 
 	// imagePullPolicy specifies the policy for image pulling
@@ -428,7 +428,7 @@ type LocalEtcd struct {
 // Kubeadm has no knowledge of where certificate files live and they must be supplied.
 type ExternalEtcd struct {
 	// endpoints of etcd members. Required for ExternalEtcd.
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=50
 	Endpoints []string `json:"endpoints"`
 
 	// caFile is an SSL Certificate Authority file used to secure etcd communication.
@@ -477,7 +477,7 @@ type JoinConfiguration struct {
 	// The list of phases can be obtained with the "kubeadm init --help" command.
 	// This option takes effect only on Kubernetes >=1.22.0.
 	// +optional
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=50
 	SkipPhases []string `json:"skipPhases,omitempty"`
 
 	// patches contains options related to applying patches to components deployed by kubeadm during

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -38,6 +38,7 @@ type InitConfiguration struct {
 	// bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
 	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
 
 	// nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
@@ -59,6 +60,7 @@ type InitConfiguration struct {
 	// The list of phases can be obtained with the "kubeadm init --help" command.
 	// This option takes effect only on Kubernetes >=1.22.0.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	SkipPhases []string `json:"skipPhases,omitempty"`
 
 	// patches contains options related to applying patches to components deployed by kubeadm during
@@ -156,12 +158,14 @@ type ControlPlaneComponent struct {
 
 	// extraVolumes is an extra set of host volumes, mounted to the control plane component.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	ExtraVolumes []HostPathMount `json:"extraVolumes,omitempty"`
 
 	// extraEnvs is an extra set of environment variables to pass to the control plane component.
 	// Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
 	// This option takes effect only on Kubernetes >=1.31.0.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	ExtraEnvs []EnvVar `json:"extraEnvs,omitempty"`
 }
 
@@ -171,6 +175,7 @@ type APIServer struct {
 
 	// certSANs sets extra Subject Alternative Names for the API Server signing cert.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	CertSANs []string `json:"certSANs,omitempty"`
 
 	// timeoutForControlPlane controls the timeout that we use for API server to appear
@@ -245,6 +250,7 @@ type NodeRegistrationOptions struct {
 	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
 	// empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
 	// kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
@@ -255,6 +261,7 @@ type NodeRegistrationOptions struct {
 
 	// ignorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	IgnorePreflightErrors []string `json:"ignorePreflightErrors,omitempty"`
 
 	// imagePullPolicy specifies the policy for image pulling
@@ -361,10 +368,12 @@ type BootstrapToken struct {
 	// usages describes the ways in which this token can be used. Can by default be used
 	// for establishing bidirectional trust, but that can be changed here.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Usages []string `json:"usages,omitempty"`
 	// groups specifies the extra groups that this token will authenticate as when/if
 	// used for authentication
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Groups []string `json:"groups,omitempty"`
 }
 
@@ -401,13 +410,17 @@ type LocalEtcd struct {
 	// Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
 	// This option takes effect only on Kubernetes >=1.31.0.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	ExtraEnvs []EnvVar `json:"extraEnvs,omitempty"`
 
 	// serverCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	ServerCertSANs []string `json:"serverCertSANs,omitempty"`
+
 	// peerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	PeerCertSANs []string `json:"peerCertSANs,omitempty"`
 }
 
@@ -415,6 +428,7 @@ type LocalEtcd struct {
 // Kubeadm has no knowledge of where certificate files live and they must be supplied.
 type ExternalEtcd struct {
 	// endpoints of etcd members. Required for ExternalEtcd.
+	// +kubebuilder:validation:MaxItems=100
 	Endpoints []string `json:"endpoints"`
 
 	// caFile is an SSL Certificate Authority file used to secure etcd communication.
@@ -463,6 +477,7 @@ type JoinConfiguration struct {
 	// The list of phases can be obtained with the "kubeadm init --help" command.
 	// This option takes effect only on Kubernetes >=1.22.0.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	SkipPhases []string `json:"skipPhases,omitempty"`
 
 	// patches contains options related to applying patches to components deployed by kubeadm during
@@ -520,6 +535,7 @@ type BootstrapTokenDiscovery struct {
 	// ASN.1. These hashes can be calculated using, for example, OpenSSL:
 	// openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	CACertHashes []string `json:"caCertHashes,omitempty"`
 
 	// unsafeSkipCAVerification allows token-based discovery
@@ -636,12 +652,14 @@ type KubeConfigAuthExec struct {
 
 	// args is the arguments to pass to the command when executing it.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Args []string `json:"args,omitempty"`
 
 	// env defines additional environment variables to expose to the process. These
 	// are unioned with the host's environment, as well as variables client-go uses
 	// to pass argument to the plugin.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Env []KubeConfigAuthExecEnv `json:"env,omitempty"`
 
 	// apiVersion is preferred input version of the ExecInfo. The returned ExecCredentials MUST use

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -65,6 +65,7 @@ type KubeadmConfigSpec struct {
 
 	// files specifies extra files to be passed to user_data upon creation.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Files []File `json:"files,omitempty"`
 
 	// diskSetup specifies options for the creation of partition tables and file systems on devices.
@@ -73,18 +74,22 @@ type KubeadmConfigSpec struct {
 
 	// mounts specifies a list of mount points to be setup.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Mounts []MountPoints `json:"mounts,omitempty"`
 
 	// preKubeadmCommands specifies extra commands to run before kubeadm runs
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	PreKubeadmCommands []string `json:"preKubeadmCommands,omitempty"`
 
 	// postKubeadmCommands specifies extra commands to run after kubeadm runs
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	PostKubeadmCommands []string `json:"postKubeadmCommands,omitempty"`
 
 	// users specifies extra users to add
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Users []User `json:"users,omitempty"`
 
 	// ntp specifies NTP configuration
@@ -657,6 +662,7 @@ type User struct {
 
 	// sshAuthorizedKeys specifies a list of ssh authorized keys for the user
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	SSHAuthorizedKeys []string `json:"sshAuthorizedKeys,omitempty"`
 }
 
@@ -664,6 +670,7 @@ type User struct {
 type NTP struct {
 	// servers specifies which NTP servers to use
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Servers []string `json:"servers,omitempty"`
 
 	// enabled specifies whether NTP should be enabled
@@ -675,10 +682,12 @@ type NTP struct {
 type DiskSetup struct {
 	// partitions specifies the list of the partitions to setup.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Partitions []Partition `json:"partitions,omitempty"`
 
 	// filesystems specifies the list of file systems to setup.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	Filesystems []Filesystem `json:"filesystems,omitempty"`
 }
 
@@ -722,6 +731,7 @@ type Filesystem struct {
 	ReplaceFS *string `json:"replaceFS,omitempty"`
 	// extraOpts defined extra options to add to the command for creating the file system.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100
 	ExtraOpts []string `json:"extraOpts,omitempty"`
 }
 

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -65,7 +65,7 @@ type KubeadmConfigSpec struct {
 
 	// files specifies extra files to be passed to user_data upon creation.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=200
 	Files []File `json:"files,omitempty"`
 
 	// diskSetup specifies options for the creation of partition tables and file systems on devices.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2052,6 +2052,7 @@ spec:
                           for the API Server signing cert.
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       extraArgs:
                         additionalProperties:
@@ -2181,6 +2182,7 @@ spec:
                           required:
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                       extraVolumes:
                         description: extraVolumes is an extra set of host volumes,
@@ -2213,6 +2215,7 @@ spec:
                           - mountPath
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                       timeoutForControlPlane:
                         description: timeoutForControlPlane controls the timeout that
@@ -2381,6 +2384,7 @@ spec:
                           required:
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                       extraVolumes:
                         description: extraVolumes is an extra set of host volumes,
@@ -2413,6 +2417,7 @@ spec:
                           - mountPath
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                     type: object
                   dns:
@@ -2454,6 +2459,7 @@ spec:
                             description: endpoints of etcd members. Required for ExternalEtcd.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           keyFile:
                             description: |-
@@ -2606,6 +2612,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           imageRepository:
                             description: |-
@@ -2622,12 +2629,14 @@ spec:
                               Names for the etcd peer signing cert.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           serverCertSANs:
                             description: serverCertSANs sets extra Subject Alternative
                               Names for the etcd server signing cert.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                         type: object
                     type: object
@@ -2817,6 +2826,7 @@ spec:
                           required:
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                       extraVolumes:
                         description: extraVolumes is an extra set of host volumes,
@@ -2849,6 +2859,7 @@ spec:
                           - mountPath
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                     type: object
                 type: object
@@ -2870,6 +2881,7 @@ spec:
                             command for creating the file system.
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         filesystem:
                           description: filesystem specifies the file system type.
@@ -2898,6 +2910,7 @@ spec:
                       - filesystem
                       - label
                       type: object
+                    maxItems: 100
                     type: array
                   partitions:
                     description: partitions specifies the list of the partitions to
@@ -2929,6 +2942,7 @@ spec:
                       - device
                       - layout
                       type: object
+                    maxItems: 100
                     type: array
                 type: object
               files:
@@ -2990,6 +3004,7 @@ spec:
                   required:
                   - path
                   type: object
+                maxItems: 1000
                 type: array
               format:
                 description: format specifies the output format of the bootstrap data
@@ -3052,6 +3067,7 @@ spec:
                             used for authentication
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         token:
                           description: |-
@@ -3069,10 +3085,12 @@ spec:
                             for establishing bidirectional trust, but that can be changed here.
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                       required:
                       - token
                       type: object
+                    maxItems: 100
                     type: array
                   kind:
                     description: |-
@@ -3118,6 +3136,7 @@ spec:
                           errors to be ignored when the current node is registered.
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       imagePullPolicy:
                         description: |-
@@ -3185,6 +3204,7 @@ spec:
                           - effect
                           - key
                           type: object
+                        maxItems: 100
                         type: array
                     type: object
                   patches:
@@ -3213,6 +3233,7 @@ spec:
                       This option takes effect only on Kubernetes >=1.22.0.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               joinConfiguration:
@@ -3278,6 +3299,7 @@ spec:
                               openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           token:
                             description: |-
@@ -3387,6 +3409,7 @@ spec:
                                           to the command when executing it.
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       command:
                                         description: command to execute.
@@ -3413,6 +3436,7 @@ spec:
                                           - name
                                           - value
                                           type: object
+                                        maxItems: 100
                                         type: array
                                       provideClusterInfo:
                                         description: |-
@@ -3471,6 +3495,7 @@ spec:
                           errors to be ignored when the current node is registered.
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                       imagePullPolicy:
                         description: |-
@@ -3538,6 +3563,7 @@ spec:
                           - effect
                           - key
                           type: object
+                        maxItems: 100
                         type: array
                     type: object
                   patches:
@@ -3566,6 +3592,7 @@ spec:
                       This option takes effect only on Kubernetes >=1.22.0.
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               mounts:
@@ -3575,6 +3602,7 @@ spec:
                   items:
                     type: string
                   type: array
+                maxItems: 100
                 type: array
               ntp:
                 description: ntp specifies NTP configuration
@@ -3586,6 +3614,7 @@ spec:
                     description: servers specifies which NTP servers to use
                     items:
                       type: string
+                    maxItems: 100
                     type: array
                 type: object
               postKubeadmCommands:
@@ -3593,12 +3622,14 @@ spec:
                   kubeadm runs
                 items:
                   type: string
+                maxItems: 1000
                 type: array
               preKubeadmCommands:
                 description: preKubeadmCommands specifies extra commands to run before
                   kubeadm runs
                 items:
                   type: string
+                maxItems: 1000
                 type: array
               useExperimentalRetryJoin:
                 description: |-
@@ -3681,6 +3712,7 @@ spec:
                         keys for the user
                       items:
                         type: string
+                      maxItems: 100
                       type: array
                     sudo:
                       description: sudo specifies a sudo role for the user
@@ -3688,6 +3720,7 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 100
                 type: array
               verbosity:
                 description: |-

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2459,7 +2459,7 @@ spec:
                             description: endpoints of etcd members. Required for ExternalEtcd.
                             items:
                               type: string
-                            maxItems: 100
+                            maxItems: 50
                             type: array
                           keyFile:
                             description: |-
@@ -3004,7 +3004,7 @@ spec:
                   required:
                   - path
                   type: object
-                maxItems: 1000
+                maxItems: 200
                 type: array
               format:
                 description: format specifies the output format of the bootstrap data
@@ -3136,7 +3136,7 @@ spec:
                           errors to be ignored when the current node is registered.
                         items:
                           type: string
-                        maxItems: 100
+                        maxItems: 50
                         type: array
                       imagePullPolicy:
                         description: |-
@@ -3233,7 +3233,7 @@ spec:
                       This option takes effect only on Kubernetes >=1.22.0.
                     items:
                       type: string
-                    maxItems: 100
+                    maxItems: 50
                     type: array
                 type: object
               joinConfiguration:
@@ -3495,7 +3495,7 @@ spec:
                           errors to be ignored when the current node is registered.
                         items:
                           type: string
-                        maxItems: 100
+                        maxItems: 50
                         type: array
                       imagePullPolicy:
                         description: |-
@@ -3592,7 +3592,7 @@ spec:
                       This option takes effect only on Kubernetes >=1.22.0.
                     items:
                       type: string
-                    maxItems: 100
+                    maxItems: 50
                     type: array
                 type: object
               mounts:

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -1999,6 +1999,7 @@ spec:
                                   Names for the API Server signing cert.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               extraArgs:
                                 additionalProperties:
@@ -2132,6 +2133,7 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                               extraVolumes:
                                 description: extraVolumes is an extra set of host
@@ -2166,6 +2168,7 @@ spec:
                                   - mountPath
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                               timeoutForControlPlane:
                                 description: timeoutForControlPlane controls the timeout
@@ -2338,6 +2341,7 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                               extraVolumes:
                                 description: extraVolumes is an extra set of host
@@ -2372,6 +2376,7 @@ spec:
                                   - mountPath
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                             type: object
                           dns:
@@ -2414,6 +2419,7 @@ spec:
                                       for ExternalEtcd.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   keyFile:
                                     description: |-
@@ -2571,6 +2577,7 @@ spec:
                                       required:
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                   imageRepository:
                                     description: |-
@@ -2587,6 +2594,7 @@ spec:
                                       Names for the etcd peer signing cert.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   serverCertSANs:
                                     description: serverCertSANs sets extra Subject
@@ -2594,6 +2602,7 @@ spec:
                                       cert.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                 type: object
                             type: object
@@ -2787,6 +2796,7 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                               extraVolumes:
                                 description: extraVolumes is an extra set of host
@@ -2821,6 +2831,7 @@ spec:
                                   - mountPath
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                             type: object
                         type: object
@@ -2843,6 +2854,7 @@ spec:
                                     add to the command for creating the file system.
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 filesystem:
                                   description: filesystem specifies the file system
@@ -2873,6 +2885,7 @@ spec:
                               - filesystem
                               - label
                               type: object
+                            maxItems: 100
                             type: array
                           partitions:
                             description: partitions specifies the list of the partitions
@@ -2905,6 +2918,7 @@ spec:
                               - device
                               - layout
                               type: object
+                            maxItems: 100
                             type: array
                         type: object
                       files:
@@ -2967,6 +2981,7 @@ spec:
                           required:
                           - path
                           type: object
+                        maxItems: 1000
                         type: array
                       format:
                         description: format specifies the output format of the bootstrap
@@ -3032,6 +3047,7 @@ spec:
                                     used for authentication
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 token:
                                   description: |-
@@ -3049,10 +3065,12 @@ spec:
                                     for establishing bidirectional trust, but that can be changed here.
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                               required:
                               - token
                               type: object
+                            maxItems: 100
                             type: array
                           kind:
                             description: |-
@@ -3099,6 +3117,7 @@ spec:
                                   node is registered.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               imagePullPolicy:
                                 description: |-
@@ -3166,6 +3185,7 @@ spec:
                                   - effect
                                   - key
                                   type: object
+                                maxItems: 100
                                 type: array
                             type: object
                           patches:
@@ -3194,6 +3214,7 @@ spec:
                               This option takes effect only on Kubernetes >=1.22.0.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                         type: object
                       joinConfiguration:
@@ -3261,6 +3282,7 @@ spec:
                                       openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   token:
                                     description: |-
@@ -3375,6 +3397,7 @@ spec:
                                                   it.
                                                 items:
                                                   type: string
+                                                maxItems: 100
                                                 type: array
                                               command:
                                                 description: command to execute.
@@ -3401,6 +3424,7 @@ spec:
                                                   - name
                                                   - value
                                                   type: object
+                                                maxItems: 100
                                                 type: array
                                               provideClusterInfo:
                                                 description: |-
@@ -3460,6 +3484,7 @@ spec:
                                   node is registered.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               imagePullPolicy:
                                 description: |-
@@ -3527,6 +3552,7 @@ spec:
                                   - effect
                                   - key
                                   type: object
+                                maxItems: 100
                                 type: array
                             type: object
                           patches:
@@ -3555,6 +3581,7 @@ spec:
                               This option takes effect only on Kubernetes >=1.22.0.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                         type: object
                       mounts:
@@ -3566,6 +3593,7 @@ spec:
                           items:
                             type: string
                           type: array
+                        maxItems: 100
                         type: array
                       ntp:
                         description: ntp specifies NTP configuration
@@ -3577,6 +3605,7 @@ spec:
                             description: servers specifies which NTP servers to use
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                         type: object
                       postKubeadmCommands:
@@ -3584,12 +3613,14 @@ spec:
                           to run after kubeadm runs
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                       preKubeadmCommands:
                         description: preKubeadmCommands specifies extra commands to
                           run before kubeadm runs
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                       useExperimentalRetryJoin:
                         description: |-
@@ -3675,6 +3706,7 @@ spec:
                                 authorized keys for the user
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             sudo:
                               description: sudo specifies a sudo role for the user
@@ -3682,6 +3714,7 @@ spec:
                           required:
                           - name
                           type: object
+                        maxItems: 100
                         type: array
                       verbosity:
                         description: |-

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2419,7 +2419,7 @@ spec:
                                       for ExternalEtcd.
                                     items:
                                       type: string
-                                    maxItems: 100
+                                    maxItems: 50
                                     type: array
                                   keyFile:
                                     description: |-
@@ -2981,7 +2981,7 @@ spec:
                           required:
                           - path
                           type: object
-                        maxItems: 1000
+                        maxItems: 200
                         type: array
                       format:
                         description: format specifies the output format of the bootstrap
@@ -3117,7 +3117,7 @@ spec:
                                   node is registered.
                                 items:
                                   type: string
-                                maxItems: 100
+                                maxItems: 50
                                 type: array
                               imagePullPolicy:
                                 description: |-
@@ -3214,7 +3214,7 @@ spec:
                               This option takes effect only on Kubernetes >=1.22.0.
                             items:
                               type: string
-                            maxItems: 100
+                            maxItems: 50
                             type: array
                         type: object
                       joinConfiguration:
@@ -3484,7 +3484,7 @@ spec:
                                   node is registered.
                                 items:
                                   type: string
-                                maxItems: 100
+                                maxItems: 50
                                 type: array
                               imagePullPolicy:
                                 description: |-
@@ -3581,7 +3581,7 @@ spec:
                               This option takes effect only on Kubernetes >=1.22.0.
                             items:
                               type: string
-                            maxItems: 100
+                            maxItems: 50
                             type: array
                         type: object
                       mounts:

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -279,10 +279,12 @@ spec:
                         - kind
                         - name
                         type: object
+                      maxItems: 1000
                       type: array
                   required:
                   - clusterResourceSetName
                   type: object
+                maxItems: 1000
                 type: array
               clusterName:
                 description: |-

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -279,12 +279,12 @@ spec:
                         - kind
                         - name
                         type: object
-                      maxItems: 1000
+                      maxItems: 100
                       type: array
                   required:
                   - clusterResourceSetName
                   type: object
-                maxItems: 1000
+                maxItems: 100
                 type: array
               clusterName:
                 description: |-

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -462,6 +462,7 @@ spec:
                   - kind
                   - name
                   type: object
+                maxItems: 1000
                 type: array
               strategy:
                 description: strategy is the strategy to be used during applying resources.

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -462,7 +462,7 @@ spec:
                   - kind
                   - name
                   type: object
-                maxItems: 1000
+                maxItems: 100
                 type: array
               strategy:
                 description: strategy is the strategy to be used during applying resources.

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -590,6 +590,7 @@ spec:
                           - timeout
                           - type
                           type: object
+                        maxItems: 100
                         type: array
                       unhealthyRange:
                         description: |-
@@ -945,6 +946,7 @@ spec:
                               - op
                               - path
                               type: object
+                            maxItems: 1000
                             type: array
                           selector:
                             description: selector defines on which templates the patch
@@ -980,6 +982,7 @@ spec:
                                           names.
                                         items:
                                           type: string
+                                        maxItems: 1000
                                         type: array
                                     type: object
                                   machinePoolClass:
@@ -992,6 +995,7 @@ spec:
                                           names.
                                         items:
                                           type: string
+                                        maxItems: 1000
                                         type: array
                                     type: object
                                 type: object
@@ -1004,6 +1008,7 @@ spec:
                         - jsonPatches
                         - selector
                         type: object
+                      maxItems: 1000
                       type: array
                     description:
                       description: description is a human-readable description of
@@ -1049,6 +1054,7 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 1000
                 type: array
               variables:
                 description: |-
@@ -1137,6 +1143,7 @@ spec:
                                 NOTE: Can be set for all types.
                               items:
                                 x-kubernetes-preserve-unknown-fields: true
+                              maxItems: 100
                               type: array
                             example:
                               description: example is an example for this variable.
@@ -1248,6 +1255,7 @@ spec:
                                 NOTE: Can only be set if type is object.
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             type:
                               description: |-
@@ -1398,6 +1406,7 @@ spec:
                                 required:
                                 - rule
                                 type: object
+                              maxItems: 100
                               type: array
                               x-kubernetes-list-map-keys:
                               - rule
@@ -1432,6 +1441,7 @@ spec:
                   - required
                   - schema
                   type: object
+                maxItems: 1000
                 type: array
               workers:
                 description: |-
@@ -1569,6 +1579,7 @@ spec:
                                 - timeout
                                 - type
                                 type: object
+                              maxItems: 100
                               type: array
                             unhealthyRange:
                               description: |-
@@ -1894,6 +1905,7 @@ spec:
                       - class
                       - template
                       type: object
+                    maxItems: 1000
                     type: array
                     x-kubernetes-list-map-keys:
                     - class
@@ -1920,6 +1932,7 @@ spec:
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
                           items:
                             type: string
+                          maxItems: 1000
                           type: array
                         minReadySeconds:
                           description: |-
@@ -2109,6 +2122,7 @@ spec:
                       - class
                       - template
                       type: object
+                    maxItems: 1000
                     type: array
                     x-kubernetes-list-map-keys:
                     - class
@@ -2331,6 +2345,7 @@ spec:
                                       NOTE: Can be set for all types.
                                     items:
                                       x-kubernetes-preserve-unknown-fields: true
+                                    maxItems: 100
                                     type: array
                                   example:
                                     description: example is an example for this variable.
@@ -2442,6 +2457,7 @@ spec:
                                       NOTE: Can only be set if type is object.
                                     items:
                                       type: string
+                                    maxItems: 1000
                                     type: array
                                   type:
                                     description: |-
@@ -2601,6 +2617,7 @@ spec:
                                       required:
                                       - rule
                                       type: object
+                                    maxItems: 100
                                     type: array
                                     x-kubernetes-list-map-keys:
                                     - rule
@@ -2635,6 +2652,7 @@ spec:
                         - required
                         - schema
                         type: object
+                      maxItems: 100
                       type: array
                     definitionsConflict:
                       description: definitionsConflict specifies whether or not there
@@ -2647,6 +2665,7 @@ spec:
                   - definitions
                   - name
                   type: object
+                maxItems: 1000
                 type: array
             type: object
         type: object

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -946,7 +946,7 @@ spec:
                               - op
                               - path
                               type: object
-                            maxItems: 1000
+                            maxItems: 100
                             type: array
                           selector:
                             description: selector defines on which templates the patch
@@ -982,7 +982,7 @@ spec:
                                           names.
                                         items:
                                           type: string
-                                        maxItems: 1000
+                                        maxItems: 100
                                         type: array
                                     type: object
                                   machinePoolClass:
@@ -995,7 +995,7 @@ spec:
                                           names.
                                         items:
                                           type: string
-                                        maxItems: 1000
+                                        maxItems: 100
                                         type: array
                                     type: object
                                 type: object
@@ -1008,7 +1008,7 @@ spec:
                         - jsonPatches
                         - selector
                         type: object
-                      maxItems: 1000
+                      maxItems: 100
                       type: array
                     description:
                       description: description is a human-readable description of
@@ -1905,7 +1905,7 @@ spec:
                       - class
                       - template
                       type: object
-                    maxItems: 1000
+                    maxItems: 100
                     type: array
                     x-kubernetes-list-map-keys:
                     - class
@@ -1932,7 +1932,7 @@ spec:
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
                           items:
                             type: string
-                          maxItems: 1000
+                          maxItems: 100
                           type: array
                         minReadySeconds:
                           description: |-
@@ -2122,7 +2122,7 @@ spec:
                       - class
                       - template
                       type: object
-                    maxItems: 1000
+                    maxItems: 100
                     type: array
                     x-kubernetes-list-map-keys:
                     - class

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -803,7 +803,7 @@ spec:
                         description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 100
                         type: array
                     required:
                     - cidrBlocks
@@ -819,7 +819,7 @@ spec:
                         description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
-                        maxItems: 1000
+                        maxItems: 100
                         type: array
                     required:
                     - cidrBlocks
@@ -1660,7 +1660,7 @@ spec:
                           - class
                           - name
                           type: object
-                        maxItems: 10000
+                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1685,7 +1685,7 @@ spec:
                                 Must match a key in the FailureDomains map stored on the cluster object.
                               items:
                                 type: string
-                              maxItems: 1000
+                              maxItems: 100
                               type: array
                             metadata:
                               description: |-
@@ -1796,7 +1796,7 @@ spec:
                           - class
                           - name
                           type: object
-                        maxItems: 10000
+                        maxItems: 2000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -803,6 +803,7 @@ spec:
                         description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                     required:
                     - cidrBlocks
@@ -818,6 +819,7 @@ spec:
                         description: cidrBlocks is a list of CIDR blocks.
                         items:
                           type: string
+                        maxItems: 1000
                         type: array
                     required:
                     - cidrBlocks
@@ -1077,6 +1079,7 @@ spec:
                               - timeout
                               - type
                               type: object
+                            maxItems: 100
                             type: array
                           unhealthyRange:
                             description: |-
@@ -1208,6 +1211,7 @@ spec:
                               - name
                               - value
                               type: object
+                            maxItems: 1000
                             type: array
                             x-kubernetes-list-map-keys:
                             - name
@@ -1255,6 +1259,7 @@ spec:
                       - name
                       - value
                       type: object
+                    maxItems: 1000
                     type: array
                     x-kubernetes-list-map-keys:
                     - name
@@ -1408,6 +1413,7 @@ spec:
                                     - timeout
                                     - type
                                     type: object
+                                  maxItems: 100
                                   type: array
                                 unhealthyRange:
                                   description: |-
@@ -1644,6 +1650,7 @@ spec:
                                     - name
                                     - value
                                     type: object
+                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - name
@@ -1653,6 +1660,7 @@ spec:
                           - class
                           - name
                           type: object
+                        maxItems: 10000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name
@@ -1677,6 +1685,7 @@ spec:
                                 Must match a key in the FailureDomains map stored on the cluster object.
                               items:
                                 type: string
+                              maxItems: 1000
                               type: array
                             metadata:
                               description: |-
@@ -1777,6 +1786,7 @@ spec:
                                     - name
                                     - value
                                     type: object
+                                  maxItems: 1000
                                   type: array
                                   x-kubernetes-list-map-keys:
                                   - name
@@ -1786,6 +1796,7 @@ spec:
                           - class
                           - name
                           type: object
+                        maxItems: 10000
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -898,7 +898,7 @@ spec:
                   health check is watching
                 items:
                   type: string
-                maxItems: 100000
+                maxItems: 10000
                 type: array
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -802,6 +802,7 @@ spec:
                   - timeout
                   - type
                   type: object
+                maxItems: 100
                 type: array
               unhealthyRange:
                 description: |-
@@ -897,6 +898,7 @@ spec:
                   health check is watching
                 items:
                   type: string
+                maxItems: 100000
                 type: array
               v1beta2:
                 description: v1beta2 groups all the fields that will be added or modified

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1063,7 +1063,7 @@ spec:
                   should be attached to.
                 items:
                   type: string
-                maxItems: 1000
+                maxItems: 100
                 type: array
               minReadySeconds:
                 description: |-
@@ -1079,7 +1079,7 @@ spec:
                   This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
-                maxItems: 100000
+                maxItems: 10000
                 type: array
               replicas:
                 description: |-
@@ -1435,7 +1435,7 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
-                maxItems: 100000
+                maxItems: 10000
                 type: array
               observedGeneration:
                 description: observedGeneration is the latest generation observed

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1063,6 +1063,7 @@ spec:
                   should be attached to.
                 items:
                   type: string
+                maxItems: 1000
                 type: array
               minReadySeconds:
                 description: |-
@@ -1078,6 +1079,7 @@ spec:
                   This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
                 items:
                   type: string
+                maxItems: 100000
                 type: array
               replicas:
                 description: |-
@@ -1433,6 +1435,7 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                maxItems: 100000
                 type: array
               observedGeneration:
                 description: observedGeneration is the latest generation observed

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2523,6 +2523,7 @@ spec:
                               for the API Server signing cert.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           extraArgs:
                             additionalProperties:
@@ -2653,6 +2654,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           extraVolumes:
                             description: extraVolumes is an extra set of host volumes,
@@ -2686,6 +2688,7 @@ spec:
                               - mountPath
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           timeoutForControlPlane:
                             description: timeoutForControlPlane controls the timeout
@@ -2855,6 +2858,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           extraVolumes:
                             description: extraVolumes is an extra set of host volumes,
@@ -2888,6 +2892,7 @@ spec:
                               - mountPath
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                         type: object
                       dns:
@@ -2930,6 +2935,7 @@ spec:
                                   ExternalEtcd.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               keyFile:
                                 description: |-
@@ -3085,6 +3091,7 @@ spec:
                                   required:
                                   - name
                                   type: object
+                                maxItems: 100
                                 type: array
                               imageRepository:
                                 description: |-
@@ -3101,12 +3108,14 @@ spec:
                                   Names for the etcd peer signing cert.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               serverCertSANs:
                                 description: serverCertSANs sets extra Subject Alternative
                                   Names for the etcd server signing cert.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                             type: object
                         type: object
@@ -3297,6 +3306,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           extraVolumes:
                             description: extraVolumes is an extra set of host volumes,
@@ -3330,6 +3340,7 @@ spec:
                               - mountPath
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                         type: object
                     type: object
@@ -3351,6 +3362,7 @@ spec:
                                 to the command for creating the file system.
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             filesystem:
                               description: filesystem specifies the file system type.
@@ -3380,6 +3392,7 @@ spec:
                           - filesystem
                           - label
                           type: object
+                        maxItems: 100
                         type: array
                       partitions:
                         description: partitions specifies the list of the partitions
@@ -3412,6 +3425,7 @@ spec:
                           - device
                           - layout
                           type: object
+                        maxItems: 100
                         type: array
                     type: object
                   files:
@@ -3474,6 +3488,7 @@ spec:
                       required:
                       - path
                       type: object
+                    maxItems: 1000
                     type: array
                   format:
                     description: format specifies the output format of the bootstrap
@@ -3537,6 +3552,7 @@ spec:
                                 used for authentication
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                             token:
                               description: |-
@@ -3554,10 +3570,12 @@ spec:
                                 for establishing bidirectional trust, but that can be changed here.
                               items:
                                 type: string
+                              maxItems: 100
                               type: array
                           required:
                           - token
                           type: object
+                        maxItems: 100
                         type: array
                       kind:
                         description: |-
@@ -3604,6 +3622,7 @@ spec:
                               is registered.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           imagePullPolicy:
                             description: |-
@@ -3671,6 +3690,7 @@ spec:
                               - effect
                               - key
                               type: object
+                            maxItems: 100
                             type: array
                         type: object
                       patches:
@@ -3699,6 +3719,7 @@ spec:
                           This option takes effect only on Kubernetes >=1.22.0.
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   joinConfiguration:
@@ -3764,6 +3785,7 @@ spec:
                                   openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                               token:
                                 description: |-
@@ -3876,6 +3898,7 @@ spec:
                                               pass to the command when executing it.
                                             items:
                                               type: string
+                                            maxItems: 100
                                             type: array
                                           command:
                                             description: command to execute.
@@ -3902,6 +3925,7 @@ spec:
                                               - name
                                               - value
                                               type: object
+                                            maxItems: 100
                                             type: array
                                           provideClusterInfo:
                                             description: |-
@@ -3961,6 +3985,7 @@ spec:
                               is registered.
                             items:
                               type: string
+                            maxItems: 100
                             type: array
                           imagePullPolicy:
                             description: |-
@@ -4028,6 +4053,7 @@ spec:
                               - effect
                               - key
                               type: object
+                            maxItems: 100
                             type: array
                         type: object
                       patches:
@@ -4056,6 +4082,7 @@ spec:
                           This option takes effect only on Kubernetes >=1.22.0.
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   mounts:
@@ -4066,6 +4093,7 @@ spec:
                       items:
                         type: string
                       type: array
+                    maxItems: 100
                     type: array
                   ntp:
                     description: ntp specifies NTP configuration
@@ -4077,6 +4105,7 @@ spec:
                         description: servers specifies which NTP servers to use
                         items:
                           type: string
+                        maxItems: 100
                         type: array
                     type: object
                   postKubeadmCommands:
@@ -4084,12 +4113,14 @@ spec:
                       after kubeadm runs
                     items:
                       type: string
+                    maxItems: 1000
                     type: array
                   preKubeadmCommands:
                     description: preKubeadmCommands specifies extra commands to run
                       before kubeadm runs
                     items:
                       type: string
+                    maxItems: 1000
                     type: array
                   useExperimentalRetryJoin:
                     description: |-
@@ -4174,6 +4205,7 @@ spec:
                             keys for the user
                           items:
                             type: string
+                          maxItems: 100
                           type: array
                         sudo:
                           description: sudo specifies a sudo role for the user
@@ -4181,6 +4213,7 @@ spec:
                       required:
                       - name
                       type: object
+                    maxItems: 100
                     type: array
                   verbosity:
                     description: |-

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2935,7 +2935,7 @@ spec:
                                   ExternalEtcd.
                                 items:
                                   type: string
-                                maxItems: 100
+                                maxItems: 50
                                 type: array
                               keyFile:
                                 description: |-
@@ -3488,7 +3488,7 @@ spec:
                       required:
                       - path
                       type: object
-                    maxItems: 1000
+                    maxItems: 200
                     type: array
                   format:
                     description: format specifies the output format of the bootstrap
@@ -3622,7 +3622,7 @@ spec:
                               is registered.
                             items:
                               type: string
-                            maxItems: 100
+                            maxItems: 50
                             type: array
                           imagePullPolicy:
                             description: |-
@@ -3719,7 +3719,7 @@ spec:
                           This option takes effect only on Kubernetes >=1.22.0.
                         items:
                           type: string
-                        maxItems: 100
+                        maxItems: 50
                         type: array
                     type: object
                   joinConfiguration:
@@ -3985,7 +3985,7 @@ spec:
                               is registered.
                             items:
                               type: string
-                            maxItems: 100
+                            maxItems: 50
                             type: array
                           imagePullPolicy:
                             description: |-
@@ -4082,7 +4082,7 @@ spec:
                           This option takes effect only on Kubernetes >=1.22.0.
                         items:
                           type: string
-                        maxItems: 100
+                        maxItems: 50
                         type: array
                     type: object
                   mounts:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1208,6 +1208,7 @@ spec:
                                       Names for the API Server signing cert.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   extraArgs:
                                     additionalProperties:
@@ -1343,6 +1344,7 @@ spec:
                                       required:
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                   extraVolumes:
                                     description: extraVolumes is an extra set of host
@@ -1378,6 +1380,7 @@ spec:
                                       - mountPath
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                   timeoutForControlPlane:
                                     description: timeoutForControlPlane controls the
@@ -1552,6 +1555,7 @@ spec:
                                       required:
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                   extraVolumes:
                                     description: extraVolumes is an extra set of host
@@ -1587,6 +1591,7 @@ spec:
                                       - mountPath
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                 type: object
                               dns:
@@ -1629,6 +1634,7 @@ spec:
                                           for ExternalEtcd.
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       keyFile:
                                         description: |-
@@ -1790,6 +1796,7 @@ spec:
                                           required:
                                           - name
                                           type: object
+                                        maxItems: 100
                                         type: array
                                       imageRepository:
                                         description: |-
@@ -1807,6 +1814,7 @@ spec:
                                           cert.
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       serverCertSANs:
                                         description: serverCertSANs sets extra Subject
@@ -1814,6 +1822,7 @@ spec:
                                           cert.
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                     type: object
                                 type: object
@@ -2009,6 +2018,7 @@ spec:
                                       required:
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                   extraVolumes:
                                     description: extraVolumes is an extra set of host
@@ -2044,6 +2054,7 @@ spec:
                                       - mountPath
                                       - name
                                       type: object
+                                    maxItems: 100
                                     type: array
                                 type: object
                             type: object
@@ -2067,6 +2078,7 @@ spec:
                                         system.
                                       items:
                                         type: string
+                                      maxItems: 100
                                       type: array
                                     filesystem:
                                       description: filesystem specifies the file system
@@ -2098,6 +2110,7 @@ spec:
                                   - filesystem
                                   - label
                                   type: object
+                                maxItems: 100
                                 type: array
                               partitions:
                                 description: partitions specifies the list of the
@@ -2130,6 +2143,7 @@ spec:
                                   - device
                                   - layout
                                   type: object
+                                maxItems: 100
                                 type: array
                             type: object
                           files:
@@ -2193,6 +2207,7 @@ spec:
                               required:
                               - path
                               type: object
+                            maxItems: 1000
                             type: array
                           format:
                             description: format specifies the output format of the
@@ -2258,6 +2273,7 @@ spec:
                                         used for authentication
                                       items:
                                         type: string
+                                      maxItems: 100
                                       type: array
                                     token:
                                       description: |-
@@ -2275,10 +2291,12 @@ spec:
                                         for establishing bidirectional trust, but that can be changed here.
                                       items:
                                         type: string
+                                      maxItems: 100
                                       type: array
                                   required:
                                   - token
                                   type: object
+                                maxItems: 100
                                 type: array
                               kind:
                                 description: |-
@@ -2325,6 +2343,7 @@ spec:
                                       the current node is registered.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   imagePullPolicy:
                                     description: |-
@@ -2392,6 +2411,7 @@ spec:
                                       - effect
                                       - key
                                       type: object
+                                    maxItems: 100
                                     type: array
                                 type: object
                               patches:
@@ -2420,6 +2440,7 @@ spec:
                                   This option takes effect only on Kubernetes >=1.22.0.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                             type: object
                           joinConfiguration:
@@ -2487,6 +2508,7 @@ spec:
                                           openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
                                         items:
                                           type: string
+                                        maxItems: 100
                                         type: array
                                       token:
                                         description: |-
@@ -2602,6 +2624,7 @@ spec:
                                                       executing it.
                                                     items:
                                                       type: string
+                                                    maxItems: 100
                                                     type: array
                                                   command:
                                                     description: command to execute.
@@ -2628,6 +2651,7 @@ spec:
                                                       - name
                                                       - value
                                                       type: object
+                                                    maxItems: 100
                                                     type: array
                                                   provideClusterInfo:
                                                     description: |-
@@ -2687,6 +2711,7 @@ spec:
                                       the current node is registered.
                                     items:
                                       type: string
+                                    maxItems: 100
                                     type: array
                                   imagePullPolicy:
                                     description: |-
@@ -2754,6 +2779,7 @@ spec:
                                       - effect
                                       - key
                                       type: object
+                                    maxItems: 100
                                     type: array
                                 type: object
                               patches:
@@ -2782,6 +2808,7 @@ spec:
                                   This option takes effect only on Kubernetes >=1.22.0.
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                             type: object
                           mounts:
@@ -2793,6 +2820,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                            maxItems: 100
                             type: array
                           ntp:
                             description: ntp specifies NTP configuration
@@ -2806,6 +2834,7 @@ spec:
                                   use
                                 items:
                                   type: string
+                                maxItems: 100
                                 type: array
                             type: object
                           postKubeadmCommands:
@@ -2813,12 +2842,14 @@ spec:
                               to run after kubeadm runs
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           preKubeadmCommands:
                             description: preKubeadmCommands specifies extra commands
                               to run before kubeadm runs
                             items:
                               type: string
+                            maxItems: 1000
                             type: array
                           useExperimentalRetryJoin:
                             description: |-
@@ -2904,6 +2935,7 @@ spec:
                                     of ssh authorized keys for the user
                                   items:
                                     type: string
+                                  maxItems: 100
                                   type: array
                                 sudo:
                                   description: sudo specifies a sudo role for the
@@ -2912,6 +2944,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 100
                             type: array
                           verbosity:
                             description: |-

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1634,7 +1634,7 @@ spec:
                                           for ExternalEtcd.
                                         items:
                                           type: string
-                                        maxItems: 100
+                                        maxItems: 50
                                         type: array
                                       keyFile:
                                         description: |-
@@ -2207,7 +2207,7 @@ spec:
                               required:
                               - path
                               type: object
-                            maxItems: 1000
+                            maxItems: 200
                             type: array
                           format:
                             description: format specifies the output format of the
@@ -2343,7 +2343,7 @@ spec:
                                       the current node is registered.
                                     items:
                                       type: string
-                                    maxItems: 100
+                                    maxItems: 50
                                     type: array
                                   imagePullPolicy:
                                     description: |-
@@ -2440,7 +2440,7 @@ spec:
                                   This option takes effect only on Kubernetes >=1.22.0.
                                 items:
                                   type: string
-                                maxItems: 100
+                                maxItems: 50
                                 type: array
                             type: object
                           joinConfiguration:
@@ -2711,7 +2711,7 @@ spec:
                                       the current node is registered.
                                     items:
                                       type: string
-                                    maxItems: 100
+                                    maxItems: 50
                                     type: array
                                   imagePullPolicy:
                                     description: |-
@@ -2808,7 +2808,7 @@ spec:
                                   This option takes effect only on Kubernetes >=1.22.0.
                                 items:
                                   type: string
-                                maxItems: 100
+                                maxItems: 50
                                 type: array
                             type: object
                           mounts:

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -63,7 +63,7 @@ type ClusterResourceSetSpec struct {
 
 	// resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -63,6 +63,7 @@ type ClusterResourceSetSpec struct {
 
 	// resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -52,7 +52,7 @@ type ResourceSetBinding struct {
 
 	// resources is a list of resources that the ClusterResourceSet has.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Resources []ResourceBinding `json:"resources,omitempty"`
 }
 
@@ -188,7 +188,7 @@ type ClusterResourceSetBinding struct {
 type ClusterResourceSetBindingSpec struct {
 	// bindings is a list of ClusterResourceSets and their resources.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	Bindings []*ResourceSetBinding `json:"bindings,omitempty"`
 
 	// clusterName is the name of the Cluster this binding applies to.

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -52,6 +52,7 @@ type ResourceSetBinding struct {
 
 	// resources is a list of resources that the ClusterResourceSet has.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Resources []ResourceBinding `json:"resources,omitempty"`
 }
 
@@ -187,6 +188,7 @@ type ClusterResourceSetBinding struct {
 type ClusterResourceSetBindingSpec struct {
 	// bindings is a list of ClusterResourceSets and their resources.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	Bindings []*ResourceSetBinding `json:"bindings,omitempty"`
 
 	// clusterName is the name of the Cluster this binding applies to.

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -55,10 +55,12 @@ type MachinePoolSpec struct {
 	// providerIDList are the identification IDs of machine instances provided by the provider.
 	// This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100000
 	ProviderIDList []string `json:"providerIDList,omitempty"`
 
 	// failureDomains is the list of failure domains this MachinePool should be attached to.
 	// +optional
+	// +kubebuilder:validation:MaxItems=1000
 	FailureDomains []string `json:"failureDomains,omitempty"`
 }
 
@@ -70,6 +72,7 @@ type MachinePoolSpec struct {
 type MachinePoolStatus struct {
 	// nodeRefs will point to the corresponding Nodes if it they exist.
 	// +optional
+	// +kubebuilder:validation:MaxItems=100000
 	NodeRefs []corev1.ObjectReference `json:"nodeRefs,omitempty"`
 
 	// replicas is the most recently observed number of replicas.

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -55,12 +55,12 @@ type MachinePoolSpec struct {
 	// providerIDList are the identification IDs of machine instances provided by the provider.
 	// This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
 	// +optional
-	// +kubebuilder:validation:MaxItems=100000
+	// +kubebuilder:validation:MaxItems=10000
 	ProviderIDList []string `json:"providerIDList,omitempty"`
 
 	// failureDomains is the list of failure domains this MachinePool should be attached to.
 	// +optional
-	// +kubebuilder:validation:MaxItems=1000
+	// +kubebuilder:validation:MaxItems=100
 	FailureDomains []string `json:"failureDomains,omitempty"`
 }
 
@@ -72,7 +72,7 @@ type MachinePoolSpec struct {
 type MachinePoolStatus struct {
 	// nodeRefs will point to the corresponding Nodes if it they exist.
 	// +optional
-	// +kubebuilder:validation:MaxItems=100000
+	// +kubebuilder:validation:MaxItems=10000
 	NodeRefs []corev1.ObjectReference `json:"nodeRefs,omitempty"`
 
 	// replicas is the most recently observed number of replicas.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR only enables the KAL linter for `kubebuilder:validation:MaxItems`. There will be other PRs for similar markers soon.

I tried to find a good trade-off between setting some reasonable upper bounds and restricting us too much, e.g. the API fields should not limit the number of MDs or Machines we can support per Cluster.

I also tried to pick similar values for similar fields and also to use only a small set of different values to make this all a bit easier.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11834

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->