### PR TITLE
:seedling: Enable commentstart lint of KAL

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -16,6 +16,7 @@ linters-settings:
       settings:
         linters:
           enable:
+          - "commentstart" # Ensure comments start with the serialized version of the field name.
           - "conditions" # Ensure conditions have the correct json tags and markers.
           - "integers" # Ensure only int32 and int64 are used for integers.
           - "jsontags" # Ensure every field has a json tag.
@@ -31,7 +32,6 @@ linters-settings:
           # - "nophase" # Phase fields are discouraged by the Kube API conventions, use conditions instead.
           
           # Linters below this line are disabled, pending conversation on how and when to enable them.
-          # - "commentstart" # Ensure comments start with the serialized version of the field name.
           # - "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
           disable:
           - "*" # We will manually enable new linters after understanding the impact. Disable all by default.

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -3,4 +3,4 @@ name: golangci-lint-kal-v1.63.4
 destination: ./bin
 plugins:
 - module: 'github.com/JoelSpeed/kal'
-  version: v0.0.0-20250304142607-36e90ff72198
+  version: v0.0.0-20250305092907-abd233a9fed8


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
* Enable commentstart lint of KAL
* Update KAL to the latest version, which https://github.com/JoelSpeed/kal/pull/50 is introduced in

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #11238
As a part of #11834 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area misc