### PR TITLE
🌱 Consider IsProvisioning to determine if ControlPlane is stable

### DIFF
--- a/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/existing-my-cluster.yaml
@@ -110,6 +110,8 @@ spec:
       maxSurge: 1
     type: RollingUpdate
   version: v1.21.2
+status:
+  version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/exp/topology/scope/upgradetracker.go
+++ b/exp/topology/scope/upgradetracker.go
@@ -154,6 +154,11 @@ func NewUpgradeTracker(opts ...UpgradeTrackerOption) *UpgradeTracker {
 
 // IsControlPlaneStable returns true is the ControlPlane is stable.
 func (t *ControlPlaneUpgradeTracker) IsControlPlaneStable() bool {
+	// If the current control plane is provisioning it is not considered stable.
+	if t.IsProvisioning {
+		return false
+	}
+
 	// If the current control plane is upgrading it is not considered stable.
 	if t.IsUpgrading {
 		return false


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Just makes sense that we should consider a control plane that is provisioning not as stable


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->