### PR TITLE
:sparkles: Add support to clusterctl for inserting workload kubeconfig into an existing kubeconfig file

### DIFF
--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -19,9 +19,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
@@ -32,6 +34,7 @@ type getKubeconfigOptions struct {
 	kubeconfig        string
 	kubeconfigContext string
 	namespace         string
+	intoKubeconfig    bool
 }
 
 var gk = &getKubeconfigOptions{}
@@ -67,6 +70,8 @@ func init() {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+	getKubeconfigCmd.Flags().BoolVar(&gk.intoKubeconfig, "into-kubeconfig", false,
+		"Inserts the workload cluster kubeconfig into the kubeconfig file.")
 
 	// completions
 	getKubeconfigCmd.ValidArgsFunction = resourceNameCompletionFunc(
@@ -98,6 +103,34 @@ func runGetKubeconfig(workloadClusterName string) error {
 	if err != nil {
 		return err
 	}
+	if gk.intoKubeconfig {
+		return intoKubeconfig(out)
+	}
+
 	fmt.Println(out)
 	return nil
+}
+
+func intoKubeconfig(kubeconfig string) error {
+	kubeconfigFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(kubeconfigFile.Name())
+
+	if _, err = kubeconfigFile.WriteString(kubeconfig); err != nil {
+		return err
+	}
+	if err = kubeconfigFile.Close(); err != nil {
+		return err
+	}
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.Precedence = append(rules.Precedence, kubeconfigFile.Name())
+	config, err := rules.Load()
+	if err != nil {
+		return err
+	}
+
+	return clientcmd.WriteToFile(*config, rules.Precedence[0])
 }

--- a/docs/book/src/clusterctl/commands/get-kubeconfig.md
+++ b/docs/book/src/clusterctl/commands/get-kubeconfig.md
@@ -1,6 +1,6 @@
 # clusterctl get kubeconfig
 
-This command prints the kubeconfig of an existing workload cluster into stdout.
+This command prints the kubeconfig of an existing workload cluster into stdout or inserts it into the default or defined kubeconfig file.
 This functionality is available in clusterctl v0.3.9 or newer.
 
 ## Examples
@@ -9,6 +9,12 @@ Get the kubeconfig of a workload cluster named foo.
 
 ```bash
 clusterctl get kubeconfig foo
+```
+
+Get the kubeconfig of a workload cluster named foo and insert it into the default kubeconfig file.
+
+```bash
+clusterctl get kubeconfig foo --into-kubeconfig
 ```
 
 Get the kubeconfig of a workload cluster named foo in the namespace bar


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10133 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->