### PR TITLE
[release-1.9] 🐛 ensure kubeadm controller always sets all v1beta2 conditions

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -317,9 +317,30 @@ func (r *KubeadmConfigReconciler) reconcile(ctx context.Context, scope *Scope, c
 			Status: metav1.ConditionTrue,
 			Reason: bootstrapv1.KubeadmConfigDataSecretAvailableV1Beta2Reason,
 		})
+		v1beta2conditions.Set(scope.Config, metav1.Condition{
+			Type:   bootstrapv1.KubeadmConfigCertificatesAvailableV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: bootstrapv1.KubeadmConfigCertificatesAvailableV1Beta2Reason,
+		})
 		return ctrl.Result{}, nil
 	// Status is ready means a config has been generated.
+	// This also solves the upgrade scenario to a version which includes v1beta2 to ensure v1beta2 conditions are properly set.
 	case config.Status.Ready:
+		// Based on existing code paths status.Ready is only true if status.dataSecretName is set
+		// So we can assume that the DataSecret is available.
+		conditions.MarkTrue(config, bootstrapv1.DataSecretAvailableCondition)
+		v1beta2conditions.Set(scope.Config, metav1.Condition{
+			Type:   bootstrapv1.KubeadmConfigDataSecretAvailableV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: bootstrapv1.KubeadmConfigDataSecretAvailableV1Beta2Reason,
+		})
+		// Same applies for the CertificatesAvailable, which must have been the case to generate
+		// the DataSecret.
+		v1beta2conditions.Set(scope.Config, metav1.Condition{
+			Type:   bootstrapv1.KubeadmConfigCertificatesAvailableV1Beta2Condition,
+			Status: metav1.ConditionTrue,
+			Reason: bootstrapv1.KubeadmConfigCertificatesAvailableV1Beta2Reason,
+		})
 		if config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil {
 			if !configOwner.HasNodeRefs() {
 				// If the BootstrapToken has been generated for a join but the config owner has no nodeRefs,

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	v1beta2conditions "sigs.k8s.io/cluster-api/util/conditions/v1beta2"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/cluster-api/util/test/builder"
@@ -2593,4 +2594,97 @@ func assertHasTrueCondition(g *WithT, myclient client.Client, req ctrl.Request, 
 	c := conditions.Get(config, t)
 	g.Expect(c).ToNot(BeNil())
 	g.Expect(c.Status).To(Equal(corev1.ConditionTrue))
+}
+
+func TestKubeadmConfigReconciler_Reconcile_v1beta2_conditions(t *testing.T) {
+	// Setup work for an initialized cluster
+	clusterName := "my-cluster"
+	cluster := builder.Cluster(metav1.NamespaceDefault, clusterName).Build()
+	conditions.MarkTrue(cluster, clusterv1.ControlPlaneInitializedCondition)
+	cluster.Status.InfrastructureReady = true
+	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+		Host: "example.com",
+		Port: 6443,
+	}
+
+	machine := builder.Machine(metav1.NamespaceDefault, "my-machine").
+		WithVersion("v1.19.1").
+		WithClusterName(cluster.Name).
+		WithBootstrapTemplate(bootstrapbuilder.KubeadmConfig(metav1.NamespaceDefault, "").Unstructured()).
+		Build()
+
+	kubeadmConfig := newKubeadmConfig(metav1.NamespaceDefault, "kubeadmconfig")
+
+	tests := []struct {
+		name    string
+		config  *bootstrapv1.KubeadmConfig
+		machine *clusterv1.Machine
+	}{
+		{
+			name:    "conditions should be true again after reconciling",
+			config:  kubeadmConfig.DeepCopy(),
+			machine: machine.DeepCopy(),
+		},
+		{
+			name:   "conditions should be true again after status got emptied out",
+			config: kubeadmConfig.DeepCopy(),
+			machine: func() *clusterv1.Machine {
+				m := machine.DeepCopy()
+				m.Spec.Bootstrap.DataSecretName = ptr.To("foo")
+				return m
+			}(),
+		},
+		{
+			name: "conditions should be true after upgrading to v1beta2",
+			config: func() *bootstrapv1.KubeadmConfig {
+				c := kubeadmConfig.DeepCopy()
+				c.Status.Ready = true
+				return c
+			}(),
+			machine: machine.DeepCopy(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cluster := cluster.DeepCopy()
+			tt.config.SetOwnerReferences([]metav1.OwnerReference{{
+				APIVersion: clusterv1.GroupVersion.String(),
+				Kind:       "Machine",
+				Name:       tt.machine.Name,
+			}})
+
+			objects := []client.Object{cluster, tt.machine, tt.config}
+			objects = append(objects, createSecrets(t, cluster, tt.config)...)
+
+			myclient := fake.NewClientBuilder().WithObjects(objects...).WithStatusSubresource(&bootstrapv1.KubeadmConfig{}).Build()
+
+			r := &KubeadmConfigReconciler{
+				Client:              myclient,
+				SecretCachingClient: myclient,
+				ClusterCache:        clustercache.NewFakeClusterCache(myclient, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}),
+				KubeadmInitLock:     &myInitLocker{},
+			}
+
+			key := client.ObjectKey{Namespace: tt.config.Namespace, Name: tt.config.Name}
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			newConfig := &bootstrapv1.KubeadmConfig{}
+			g.Expect(myclient.Get(ctx, key, newConfig)).To(Succeed())
+
+			for _, conditionType := range []string{bootstrapv1.KubeadmConfigReadyV1Beta2Condition, bootstrapv1.KubeadmConfigCertificatesAvailableV1Beta2Condition, bootstrapv1.KubeadmConfigDataSecretAvailableV1Beta2Condition} {
+				condition := v1beta2conditions.Get(newConfig, conditionType)
+				g.Expect(condition).ToNot(BeNil(), "condition %s is missing", conditionType)
+				g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(condition.Message).To(BeEmpty())
+			}
+			for _, conditionType := range []string{clusterv1.PausedV1Beta2Condition} {
+				condition := v1beta2conditions.Get(newConfig, conditionType)
+				g.Expect(condition).ToNot(BeNil(), "condition %s is missing", conditionType)
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Message).To(BeEmpty())
+			}
+		})
+	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of 
- #11948

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


/area provider/bootstrap-kubeadm