### PR TITLE
🌱 e2e: create ExtensionConfig including name in settings and create one…

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -505,6 +505,7 @@ func extensionConfig(name, extensionServiceNamespace, extensionServiceName strin
 				},
 			},
 			Settings: map[string]string{
+				"extensionConfigName":          name,
 				"defaultAllHandlersToBlocking": strconv.FormatBool(defaultAllHandlersToBlocking),
 			},
 		},

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -51,8 +51,8 @@ import (
 
 var hookResponsesConfigMapNameSuffix = "test-extension-hookresponses"
 
-func hookResponsesConfigMapName(clusterName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, hookResponsesConfigMapNameSuffix)
+func hookResponsesConfigMapName(clusterName, extensionConfigName string) string {
+	return fmt.Sprintf("%s-%s-%s", clusterName, extensionConfigName, hookResponsesConfigMapNameSuffix)
 }
 
 // ClusterUpgradeWithRuntimeSDKSpecInput is the input for clusterUpgradeWithRuntimeSDKSpec.
@@ -229,6 +229,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 				beforeClusterCreateTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
 					clusterRef,
+					input.ExtensionConfigName,
 					input.E2EConfig.GetIntervals(specName, "wait-cluster"))
 			},
 			PostMachinesProvisioned: func() {
@@ -295,17 +296,20 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 				beforeClusterUpgradeTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
 					clusterRef,
+					input.ExtensionConfigName,
 					input.E2EConfig.MustGetVariable(KubernetesVersionUpgradeTo),
 					input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"))
 			},
 			PreWaitForWorkersToBeUpgraded: func() {
 				machineSetPreflightChecksTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
-					clusterRef)
+					clusterRef,
+					input.ExtensionConfigName)
 
 				afterControlPlaneUpgradeTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
 					clusterRef,
+					input.ExtensionConfigName,
 					input.E2EConfig.MustGetVariable(KubernetesVersionUpgradeTo),
 					input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"))
 			},
@@ -329,11 +333,11 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 		By("Dumping resources and deleting the workload cluster; deletion waits for BeforeClusterDeleteHook to gate the operation")
 		dumpAndDeleteCluster(ctx, input.BootstrapClusterProxy, namespace.Name, clusterName, input.ArtifactFolder)
 
-		beforeClusterDeleteHandler(ctx, input.BootstrapClusterProxy.GetClient(), clusterRef, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster"))
+		beforeClusterDeleteHandler(ctx, input.BootstrapClusterProxy.GetClient(), clusterRef, input.ExtensionConfigName, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster"))
 
 		By("Checking all lifecycle hooks have been called")
 		// Assert that each hook has been called and returned "Success" during the test.
-		Expect(checkLifecycleHookResponses(ctx, input.BootstrapClusterProxy.GetClient(), clusterRef, map[string]string{
+		Expect(checkLifecycleHookResponses(ctx, input.BootstrapClusterProxy.GetClient(), clusterRef, input.ExtensionConfigName, map[string]string{
 			"BeforeClusterCreate":          "Status: Success, RetryAfterSeconds: 0",
 			"BeforeClusterUpgrade":         "Status: Success, RetryAfterSeconds: 0",
 			"BeforeClusterDelete":          "Status: Success, RetryAfterSeconds: 0",
@@ -388,11 +392,11 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 // should be blocked by the AfterControlPlaneUpgrade hook.
 // Test the MachineSet preflight checks by scaling up the MachineDeployment. The creation on the new Machine
 // should be blocked because the preflight checks should not pass (kubeadm version skew preflight check should fail).
-func machineSetPreflightChecksTestHandler(ctx context.Context, c client.Client, clusterRef types.NamespacedName) {
+func machineSetPreflightChecksTestHandler(ctx context.Context, c client.Client, clusterRef types.NamespacedName, extensionConfigName string) {
 	// Verify that the hook is called and the topology reconciliation is blocked.
 	hookName := "AfterControlPlaneUpgrade"
 	Eventually(func() error {
-		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, clusterRef, []string{hookName}); err != nil {
+		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, clusterRef, extensionConfigName, []string{hookName}); err != nil {
 			return err
 		}
 
@@ -527,12 +531,12 @@ func extensionConfig(name, extensionServiceNamespace, extensionServiceName strin
 
 // Check that each hook in hooks has been called at least once by checking if its actualResponseStatus is in the hook response configmap.
 // If the provided hooks have both keys and values check that the values match those in the hook response configmap.
-func checkLifecycleHookResponses(ctx context.Context, c client.Client, cluster types.NamespacedName, expectedHookResponses map[string]string) error {
-	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, cluster)
+func checkLifecycleHookResponses(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, expectedHookResponses map[string]string) error {
+	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, cluster, extensionConfigName)
 	for hookName, expectedResponse := range expectedHookResponses {
 		actualResponse, ok := responseData[hookName+"-actualResponseStatus"]
 		if !ok {
-			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(cluster.Namespace, hookResponsesConfigMapName(cluster.Name)))
+			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(cluster.Namespace, hookResponsesConfigMapName(cluster.Name, extensionConfigName)))
 		}
 		if expectedResponse != "" && expectedResponse != actualResponse {
 			return errors.Errorf("hook %s was expected to be %s in configMap got %s", hookName, expectedResponse, actualResponse)
@@ -542,29 +546,29 @@ func checkLifecycleHookResponses(ctx context.Context, c client.Client, cluster t
 }
 
 // Check that each hook in expectedHooks has been called at least once by checking if its actualResponseStatus is in the hook response configmap.
-func checkLifecycleHooksCalledAtLeastOnce(ctx context.Context, c client.Client, cluster types.NamespacedName, expectedHooks []string) error {
-	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, cluster)
+func checkLifecycleHooksCalledAtLeastOnce(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, expectedHooks []string) error {
+	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, cluster, extensionConfigName)
 	for _, hookName := range expectedHooks {
 		if _, ok := responseData[hookName+"-actualResponseStatus"]; !ok {
-			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(cluster.Namespace, hookResponsesConfigMapName(cluster.Name)))
+			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(cluster.Namespace, hookResponsesConfigMapName(cluster.Name, extensionConfigName)))
 		}
 	}
 	return nil
 }
 
-func getLifecycleHookResponsesFromConfigMap(ctx context.Context, c client.Client, cluster types.NamespacedName) map[string]string {
+func getLifecycleHookResponsesFromConfigMap(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string) map[string]string {
 	configMap := &corev1.ConfigMap{}
 	Eventually(func() error {
-		return c.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: hookResponsesConfigMapName(cluster.Name)}, configMap)
+		return c.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: hookResponsesConfigMapName(cluster.Name, extensionConfigName)}, configMap)
 	}).Should(Succeed(), "Failed to get the hook response configmap")
 	return configMap.Data
 }
 
 // beforeClusterCreateTestHandler calls runtimeHookTestHandler with a blockedCondition function which returns false if
 // the Cluster has entered ClusterPhaseProvisioned.
-func beforeClusterCreateTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, intervals []interface{}) {
+func beforeClusterCreateTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, intervals []interface{}) {
 	hookName := "BeforeClusterCreate"
-	runtimeHookTestHandler(ctx, c, cluster, hookName, true, func() bool {
+	runtimeHookTestHandler(ctx, c, cluster, hookName, extensionConfigName, true, func() bool {
 		blocked := true
 		// This hook should block the Cluster from entering the "Provisioned" state.
 		cluster := framework.GetClusterByName(ctx,
@@ -639,9 +643,9 @@ func beforeClusterUpgradeAnnotationIsBlocking(ctx context.Context, c client.Clie
 
 // beforeClusterUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if
 // any of the machines in the control plane has been updated to the target Kubernetes version.
-func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, toVersion string, intervals []interface{}) {
+func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, toVersion string, intervals []interface{}) {
 	hookName := "BeforeClusterUpgrade"
-	runtimeHookTestHandler(ctx, c, cluster, hookName, true, func() bool {
+	runtimeHookTestHandler(ctx, c, cluster, hookName, extensionConfigName, true, func() bool {
 		var blocked = true
 
 		controlPlaneMachines := framework.GetControlPlaneMachinesByCluster(ctx,
@@ -657,9 +661,9 @@ func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, clust
 
 // afterControlPlaneUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if any
 // MachineDeployment in the Cluster has upgraded to the target Kubernetes version.
-func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, version string, intervals []interface{}) {
+func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, version string, intervals []interface{}) {
 	hookName := "AfterControlPlaneUpgrade"
-	runtimeHookTestHandler(ctx, c, cluster, hookName, true, func() bool {
+	runtimeHookTestHandler(ctx, c, cluster, hookName, extensionConfigName, true, func() bool {
 		var blocked = true
 
 		mds := framework.GetMachineDeploymentsByCluster(ctx,
@@ -676,9 +680,9 @@ func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, c
 
 // beforeClusterDeleteHandler calls runtimeHookTestHandler with a blocking function which returns false if the Cluster
 // can not be found in the API server.
-func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, intervals []interface{}) {
+func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, extensionConfigName string, intervals []interface{}) {
 	hookName := "BeforeClusterDelete"
-	runtimeHookTestHandler(ctx, c, cluster, hookName, false, func() bool {
+	runtimeHookTestHandler(ctx, c, cluster, hookName, extensionConfigName, false, func() bool {
 		var blocked = true
 
 		// If the Cluster is not found it has been deleted and the hook is unblocked.
@@ -697,12 +701,12 @@ func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster ty
 //
 // Note: runtimeHookTestHandler assumes that the hook passed to it is currently returning a blocking response.
 // Updating the response to be non-blocking happens inline in the function.
-func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, hookName string, withTopologyReconciledCondition bool, blockingCondition func() bool, intervals []interface{}) {
+func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster types.NamespacedName, hookName, extensionConfigName string, withTopologyReconciledCondition bool, blockingCondition func() bool, intervals []interface{}) {
 	log.Logf("Blocking with %s hook for 60 seconds after the hook has been called for the first time", hookName)
 
 	// Check that the LifecycleHook has been called at least once and - when required - that the TopologyReconciled condition is a Failure.
 	Eventually(func() error {
-		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, cluster, []string{hookName}); err != nil {
+		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, cluster, extensionConfigName, []string{hookName}); err != nil {
 			return err
 		}
 
@@ -727,7 +731,7 @@ func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster types.
 	// Patch the ConfigMap to set the hook response to "Success".
 	Byf("Setting %s response to Status:Success to unblock the reconciliation", hookName)
 
-	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: hookResponsesConfigMapName(cluster.Name), Namespace: cluster.Namespace}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: hookResponsesConfigMapName(cluster.Name, extensionConfigName), Namespace: cluster.Namespace}}
 	Eventually(func() error {
 		return c.Get(ctx, util.ObjectKey(configMap), configMap)
 	}).Should(Succeed(), "Failed to get ConfigMap %s", klog.KObj(configMap))

--- a/test/extension/config/tilt/extensionconfig.yaml
+++ b/test/extension/config/tilt/extensionconfig.yaml
@@ -5,6 +5,8 @@ metadata:
     runtime.cluster.x-k8s.io/inject-ca-from-secret: test-extension-system/test-extension-webhook-service-cert
   name: test-extension
 spec:
+  settings:
+    extensionConfigName: test-extension
   clientConfig:
     service:
       name: test-extension-webhook-service

--- a/test/extension/handlers/lifecycle/handlers.go
+++ b/test/extension/handlers/lifecycle/handlers.go
@@ -179,7 +179,7 @@ func (m *ExtensionHandlers) DoBeforeClusterDelete(ctx context.Context, request *
 func (m *ExtensionHandlers) readResponseFromConfigMap(ctx context.Context, cluster *clusterv1.Cluster, hook runtimecatalog.Hook, settings map[string]string, response runtimehooksv1.ResponseObject) error {
 	hookName := runtimecatalog.HookName(hook)
 	configMap := &corev1.ConfigMap{}
-	configMapName := fmt.Sprintf("%s-test-extension-hookresponses", cluster.Name)
+	configMapName := fmt.Sprintf("%s-%s-test-extension-hookresponses", cluster.Name, settings["extensionConfigName"])
 	if err := m.client.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: configMapName}, configMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			// A ConfigMap of responses does not exist. Create one now.

--- a/test/extension/handlers/lifecycle/handlers.go
+++ b/test/extension/handlers/lifecycle/handlers.go
@@ -66,7 +66,7 @@ func NewExtensionHandlers(client client.Client) *ExtensionHandlers {
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterCreate(ctx context.Context, request *runtimehooksv1.BeforeClusterCreateRequest, response *runtimehooksv1.BeforeClusterCreateResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterCreate is called")
 
 	settings := request.GetSettings()
@@ -88,7 +88,7 @@ func (m *ExtensionHandlers) DoBeforeClusterCreate(ctx context.Context, request *
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterUpgrade(ctx context.Context, request *runtimehooksv1.BeforeClusterUpgradeRequest, response *runtimehooksv1.BeforeClusterUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterUpgrade is called")
 
 	settings := request.GetSettings()
@@ -111,7 +111,7 @@ func (m *ExtensionHandlers) DoBeforeClusterUpgrade(ctx context.Context, request 
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterControlPlaneInitialized(ctx context.Context, request *runtimehooksv1.AfterControlPlaneInitializedRequest, response *runtimehooksv1.AfterControlPlaneInitializedResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("AfterControlPlaneInitialized is called")
 
 	settings := request.GetSettings()
@@ -134,7 +134,7 @@ func (m *ExtensionHandlers) DoAfterControlPlaneInitialized(ctx context.Context, 
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterControlPlaneUpgrade(ctx context.Context, request *runtimehooksv1.AfterControlPlaneUpgradeRequest, response *runtimehooksv1.AfterControlPlaneUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("AfterControlPlaneUpgrade is called")
 
 	settings := request.GetSettings()
@@ -157,7 +157,7 @@ func (m *ExtensionHandlers) DoAfterControlPlaneUpgrade(ctx context.Context, requ
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterClusterUpgrade(ctx context.Context, request *runtimehooksv1.AfterClusterUpgradeRequest, response *runtimehooksv1.AfterClusterUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("AfterClusterUpgrade is called")
 
 	settings := request.GetSettings()
@@ -180,7 +180,7 @@ func (m *ExtensionHandlers) DoAfterClusterUpgrade(ctx context.Context, request *
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterDelete(ctx context.Context, request *runtimehooksv1.BeforeClusterDeleteRequest, response *runtimehooksv1.BeforeClusterDeleteResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterDelete is called")
 
 	settings := request.GetSettings()

--- a/test/extension/handlers/lifecycle/handlers.go
+++ b/test/extension/handlers/lifecycle/handlers.go
@@ -40,6 +40,10 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 )
 
+const (
+	extensionConfigNameKey = "extensionConfigName"
+)
+
 // ExtensionHandlers provides a common struct shared across the lifecycle hook handlers; this is convenient
 // because in Cluster API's E2E tests all of them are using a controller runtime client and the same set of func
 // to work with the config map where preloaded answers for lifecycle hooks are stored.
@@ -62,14 +66,17 @@ func NewExtensionHandlers(client client.Client) *ExtensionHandlers {
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterCreate(ctx context.Context, request *runtimehooksv1.BeforeClusterCreateRequest, response *runtimehooksv1.BeforeClusterCreateResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterCreate is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterCreate, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterCreate, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterCreate, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterCreate, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -81,15 +88,18 @@ func (m *ExtensionHandlers) DoBeforeClusterCreate(ctx context.Context, request *
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterUpgrade(ctx context.Context, request *runtimehooksv1.BeforeClusterUpgradeRequest, response *runtimehooksv1.BeforeClusterUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterUpgrade is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterUpgrade, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterUpgrade, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterUpgrade, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterUpgrade, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -101,15 +111,18 @@ func (m *ExtensionHandlers) DoBeforeClusterUpgrade(ctx context.Context, request 
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterControlPlaneInitialized(ctx context.Context, request *runtimehooksv1.AfterControlPlaneInitializedRequest, response *runtimehooksv1.AfterControlPlaneInitializedResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("AfterControlPlaneInitialized is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneInitialized, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneInitialized, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneInitialized, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneInitialized, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -121,15 +134,18 @@ func (m *ExtensionHandlers) DoAfterControlPlaneInitialized(ctx context.Context, 
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterControlPlaneUpgrade(ctx context.Context, request *runtimehooksv1.AfterControlPlaneUpgradeRequest, response *runtimehooksv1.AfterControlPlaneUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("AfterControlPlaneUpgrade is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneUpgrade, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneUpgrade, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneUpgrade, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterControlPlaneUpgrade, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -141,15 +157,18 @@ func (m *ExtensionHandlers) DoAfterControlPlaneUpgrade(ctx context.Context, requ
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoAfterClusterUpgrade(ctx context.Context, request *runtimehooksv1.AfterClusterUpgradeRequest, response *runtimehooksv1.AfterClusterUpgradeResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("AfterClusterUpgrade is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterClusterUpgrade, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterClusterUpgrade, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterClusterUpgrade, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.AfterClusterUpgrade, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -161,14 +180,17 @@ func (m *ExtensionHandlers) DoAfterClusterUpgrade(ctx context.Context, request *
 // NOTE: custom RuntimeExtension, must implement the body of this func according to the specific use case.
 func (m *ExtensionHandlers) DoBeforeClusterDelete(ctx context.Context, request *runtimehooksv1.BeforeClusterDeleteRequest, response *runtimehooksv1.BeforeClusterDeleteResponse) {
 	log := ctrl.LoggerFrom(ctx).WithValues("Cluster", klog.KObj(&request.Cluster))
+	ctrl.LoggerInto(ctx, log)
 	log.Info("BeforeClusterDelete is called")
 
-	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterDelete, request.GetSettings(), response); err != nil {
+	settings := request.GetSettings()
+
+	if err := m.readResponseFromConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterDelete, settings, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
-	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterDelete, response); err != nil {
+	if err := m.recordCallInConfigMap(ctx, &request.Cluster, runtimehooksv1.BeforeClusterDelete, settings[extensionConfigNameKey], response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -179,7 +201,7 @@ func (m *ExtensionHandlers) DoBeforeClusterDelete(ctx context.Context, request *
 func (m *ExtensionHandlers) readResponseFromConfigMap(ctx context.Context, cluster *clusterv1.Cluster, hook runtimecatalog.Hook, settings map[string]string, response runtimehooksv1.ResponseObject) error {
 	hookName := runtimecatalog.HookName(hook)
 	configMap := &corev1.ConfigMap{}
-	configMapName := fmt.Sprintf("%s-%s-test-extension-hookresponses", cluster.Name, settings["extensionConfigName"])
+	configMapName := fmt.Sprintf("%s-%s-test-extension-hookresponses", cluster.Name, settings[extensionConfigNameKey])
 	if err := m.client.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: configMapName}, configMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			// A ConfigMap of responses does not exist. Create one now.
@@ -188,7 +210,7 @@ func (m *ExtensionHandlers) readResponseFromConfigMap(ctx context.Context, clust
 			// This allows the test-extension to have non-blocking behavior by default but can be switched to blocking
 			// as needed, example: during E2E testing.
 			defaultAllHandlersToBlocking := settings["defaultAllHandlersToBlocking"] == "true"
-			configMap = responsesConfigMap(cluster, defaultAllHandlersToBlocking)
+			configMap = responsesConfigMap(cluster, settings[extensionConfigNameKey], defaultAllHandlersToBlocking)
 			if err := m.client.Create(ctx, configMap); err != nil {
 				return errors.Wrapf(err, "failed to create the ConfigMap %s", klog.KRef(cluster.Namespace, configMapName))
 			}
@@ -208,7 +230,7 @@ func (m *ExtensionHandlers) readResponseFromConfigMap(ctx context.Context, clust
 
 // responsesConfigMap generates a ConfigMap with preloaded responses for the test extension.
 // If defaultAllHandlersToBlocking is set to true, all the preloaded responses are set to blocking.
-func responsesConfigMap(cluster *clusterv1.Cluster, defaultAllHandlersToBlocking bool) *corev1.ConfigMap {
+func responsesConfigMap(cluster *clusterv1.Cluster, extensionConfigName string, defaultAllHandlersToBlocking bool) *corev1.ConfigMap {
 	retryAfterSeconds := 0
 	if defaultAllHandlersToBlocking {
 		retryAfterSeconds = 5
@@ -216,7 +238,7 @@ func responsesConfigMap(cluster *clusterv1.Cluster, defaultAllHandlersToBlocking
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-test-extension-hookresponses", cluster.Name),
+			Name:      configMapName(cluster.Name, extensionConfigName),
 			Namespace: cluster.Namespace,
 		},
 		// Set the initial preloadedResponses for each of the tested hooks.
@@ -234,10 +256,10 @@ func responsesConfigMap(cluster *clusterv1.Cluster, defaultAllHandlersToBlocking
 	}
 }
 
-func (m *ExtensionHandlers) recordCallInConfigMap(ctx context.Context, cluster *clusterv1.Cluster, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
+func (m *ExtensionHandlers) recordCallInConfigMap(ctx context.Context, cluster *clusterv1.Cluster, hook runtimecatalog.Hook, extensionConfigName string, response runtimehooksv1.ResponseObject) error {
 	hookName := runtimecatalog.HookName(hook)
 	configMap := &corev1.ConfigMap{}
-	configMapName := fmt.Sprintf("%s-test-extension-hookresponses", cluster.Name)
+	configMapName := configMapName(cluster.Name, extensionConfigName)
 	if err := m.client.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: configMapName}, configMap); err != nil {
 		return errors.Wrapf(err, "failed to read the ConfigMap %s", klog.KRef(cluster.Namespace, configMapName))
 	}
@@ -254,4 +276,8 @@ func (m *ExtensionHandlers) recordCallInConfigMap(ctx context.Context, cluster *
 		return errors.Wrapf(err, "failed to update the ConfigMap %s", klog.KRef(cluster.Namespace, configMapName))
 	}
 	return nil
+}
+
+func configMapName(clusterName, extensionConfigName string) string {
+	return fmt.Sprintf("%s-%s-test-extension-hookresponses", clusterName, extensionConfigName)
 }

--- a/test/framework/namespace_helpers.go
+++ b/test/framework/namespace_helpers.go
@@ -61,11 +61,9 @@ func CreateNamespace(ctx context.Context, input CreateNamespaceInput, intervals 
 	}
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: input.Name,
+			Name:   input.Name,
+			Labels: input.Labels,
 		},
-	}
-	if input.Labels != nil {
-		ns.Labels = input.Labels
 	}
 	log.Logf("Creating namespace %s", input.Name)
 	Eventually(func() error {

--- a/test/framework/namespace_helpers.go
+++ b/test/framework/namespace_helpers.go
@@ -43,6 +43,7 @@ import (
 type CreateNamespaceInput struct {
 	Creator Creator
 	Name    string
+	Labels  map[string]string
 
 	// IgnoreAlreadyExists if set to true will ignore the "AlreadyExists" error if the function
 	// is trying to create a namespace that already exists.
@@ -58,11 +59,13 @@ func CreateNamespace(ctx context.Context, input CreateNamespaceInput, intervals 
 	if input.Name == "" {
 		input.Name = fmt.Sprintf("test-%s", util.RandomString(6))
 	}
-
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: input.Name,
 		},
+	}
+	if input.Labels != nil {
+		ns.Labels = input.Labels
 	}
 	log.Logf("Creating namespace %s", input.Name)
 	Eventually(func() error {
@@ -183,6 +186,7 @@ type CreateNamespaceAndWatchEventsInput struct {
 	ClientSet *kubernetes.Clientset
 	Name      string
 	LogFolder string
+	Labels    map[string]string
 
 	// IgnoreAlreadyExists if set to true will ignore the "AlreadyExists" error if the function
 	// is trying to create a namespace that already exists.
@@ -198,7 +202,7 @@ func CreateNamespaceAndWatchEvents(ctx context.Context, input CreateNamespaceAnd
 	Expect(input.Name).ToNot(BeEmpty(), "Invalid argument. input.Name can't be empty when calling ClientSet")
 	Expect(os.MkdirAll(input.LogFolder, 0750)).To(Succeed(), "Invalid argument. input.LogFolder can't be created in CreateNamespaceAndWatchEvents")
 
-	namespace := CreateNamespace(ctx, CreateNamespaceInput{Creator: input.Creator, Name: input.Name, IgnoreAlreadyExists: input.IgnoreAlreadyExists}, "40s", "10s")
+	namespace := CreateNamespace(ctx, CreateNamespaceInput{Creator: input.Creator, Name: input.Name, IgnoreAlreadyExists: input.IgnoreAlreadyExists, Labels: input.Labels}, "40s", "10s")
 	Expect(namespace).ToNot(BeNil(), "Failed to create namespace %q", input.Name)
 
 	log.Logf("Creating event watcher for namespace %q", input.Name)


### PR DESCRIPTION
… cm per ExtensionConfig<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixes issues in the runtime sdk and scale e2e tests.

Runtime SDK test-extension:
* The test-extension did re-use the same configmap also when different ExtensionConfigs lead to the request.
* This could have caused race conditions especially when the first called extension did lead initializing the configmap as not blocking

Scale tests:
* Limits the scale-test's ExtensionConfig to scale-test related namespaces only

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing