### PR TITLE
🌱 Bump Kubernetes version used for testing to v1.33.0-beta.0

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -367,13 +367,13 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.32.0"
-  KUBERNETES_VERSION: "v1.32.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.31.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.32.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0-beta.0"
+  KUBERNETES_VERSION: "v1.33.0-beta.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.2"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0-beta.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.33"
-  ETCD_VERSION_UPGRADE_TO: "3.5.16-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.11.3"
+  ETCD_VERSION_UPGRADE_TO: "3.5.17-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.12.0"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "dual"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.32.0
+  version: v1.33.0-beta.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -77,7 +77,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.32.0
+      version: v1.33.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.32.0
+  version: v1.33.0-beta.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -87,7 +87,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.32.0
+      version: v1.33.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.32.0
+  version: v1.33.0-beta.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -76,7 +76,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.32.0
+      version: v1.33.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.32.0
+  version: v1.33.0-beta.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.32.0
+      version: v1.33.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/11642

/area e2e-testing