### PR TITLE
:seedling: Better error message when metadata.yaml might be out of date.

### DIFF
--- a/cmd/clusterctl/client/repository/repository_versions.go
+++ b/cmd/clusterctl/client/repository/repository_versions.go
@@ -110,7 +110,7 @@ func latestPatchRelease(ctx context.Context, repo Repository, major, minor *int3
 	}
 
 	if len(versionCandidates) == 0 {
-		return "", errors.New("failed to find releases tagged with a valid semantic version number")
+		return "", errors.New("failed to find releases tagged with a valid semantic version number (metadata.yaml up-to-date?)")
 	}
 
 	// Sort parsed versions by semantic version order.
@@ -149,5 +149,5 @@ func latestPatchRelease(ctx context.Context, repo Repository, major, minor *int3
 	}
 
 	// If we reached this point, it means we didn't find any release.
-	return "", errors.New("failed to find releases tagged with a valid semantic version number")
+	return "", errors.New("failed to find releases tagged with a valid semantic version number (metadata.yaml up-to-date?)")
 }

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -402,7 +402,7 @@ func resolveReleaseMarker(ctx context.Context, releaseMarker string, goproxyClie
 	}
 
 	// If we reached this point, it means we didn't find any release.
-	return "", errors.New("failed to find releases tagged with a valid semantic version number")
+	return "", errors.New("failed to find releases tagged with a valid semantic version number (metadata.yaml up-to-date?)")
 }
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

If you do not update metadata.yaml, you might get a hard-to-understand error message in e2e tests (and other places):

> failed to find releases tagged with a valid semantic version number

Related: https://github.com/kubernetes-sigs/cluster-api/issues/10332#issuecomment-2023936698

This PR adds:

> (metadata.yaml up-to-date?)

