### PR TITLE
🌱 cluster: validate that infrastructureRef and controlPlaneRef cannot be unset

### DIFF
--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -209,7 +209,17 @@ func (webhook *Cluster) validate(ctx context.Context, oldCluster, newCluster *cl
 			)
 		}
 	}
+
 	specPath := field.NewPath("spec")
+	if newCluster.Spec.InfrastructureRef == nil && oldCluster != nil && oldCluster.Spec.InfrastructureRef != nil {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				specPath.Child("infrastructureRef"),
+				"cannot be removed",
+			),
+		)
+	}
 	if newCluster.Spec.InfrastructureRef != nil && newCluster.Spec.InfrastructureRef.Namespace != newCluster.Namespace {
 		allErrs = append(
 			allErrs,
@@ -221,6 +231,15 @@ func (webhook *Cluster) validate(ctx context.Context, oldCluster, newCluster *cl
 		)
 	}
 
+	if newCluster.Spec.ControlPlaneRef == nil && oldCluster != nil && oldCluster.Spec.ControlPlaneRef != nil {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				specPath.Child("controlPlaneRef"),
+				"cannot be removed",
+			),
+		)
+	}
 	if newCluster.Spec.ControlPlaneRef != nil && newCluster.Spec.ControlPlaneRef.Namespace != newCluster.Namespace {
 		allErrs = append(
 			allErrs,

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1613,6 +1613,26 @@ func TestClusterValidation(t *testing.T) {
 			in:        builder.Cluster("fooNamespace", "thisNameContainsInvalid!@NonAlphanumerics").Build(),
 			expectErr: true,
 		},
+		{
+			name: "error when controlPlaneRef gets unset",
+			in: builder.Cluster("fooNamespace", "cluster1").
+				Build(),
+			old: builder.Cluster("fooNamespace", "cluster1").
+				WithControlPlane(
+					builder.ControlPlane("fooNamespace", "cp1").Build()).
+				Build(),
+			expectErr: true,
+		},
+		{
+			name: "error when infrastructureRef gets unset",
+			in: builder.Cluster("fooNamespace", "cluster1").
+				Build(),
+			old: builder.Cluster("fooNamespace", "cluster1").
+				WithInfrastructureCluster(
+					builder.InfrastructureClusterTemplate("fooNamespace", "infra1").Build()).
+				Build(),
+			expectErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Unsetting a controlPlaneRef or infrastructureRef is unexpected (changing may be okay).

Especially in case of topology based clusters, unsetting controlPlaneRef or infrastructureRef without deleting an old one (which could happen by accident) leads to having two instances of ControlPlane and/or InfraClusters and leading to issues.

Also maybe helps to figure out: 

- #11750

/test help

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area cluster