### PR TITLE
🐛 Avoid redundant reconciles if only generation of Paused condition changed

### DIFF
--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -180,19 +180,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			return nil
 		}, 30*time.Second, 100*time.Millisecond).Should(Succeed())
 
-		// Reconcile the extension and assert discovery has succeeded  (the first reconcile updates observedGeneration in the Paused condition).
-		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
-		g.Expect(err).ToNot(HaveOccurred())
-
-		// Wait until the ExtensionConfig in the cache has the up-to-date Paused condition so the next Reconcile can do discovery.
-		g.Eventually(func(g Gomega) {
-			conf := &runtimev1.ExtensionConfig{}
-			g.Expect(env.Get(ctx, util.ObjectKey(extensionConfig), conf)).To(Succeed())
-			pausedCondition := v1beta2conditions.Get(conf, clusterv1.PausedV1Beta2Condition)
-			g.Expect(pausedCondition).ToNot(BeNil())
-			g.Expect(pausedCondition.ObservedGeneration).To(Equal(conf.Generation))
-		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
-
+		// Reconcile the extension and assert discovery has succeeded.
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -146,13 +146,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (retres ct
 		return ctrl.Result{}, err
 	}
 
-	if isPaused, conditionChanged, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, deployment); err != nil || isPaused || conditionChanged {
-		return ctrl.Result{}, err
-	}
-
 	// Initialize the patch helper
 	patchHelper, err := patch.NewHelper(deployment, r.Client)
 	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if isPaused, requeue, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, deployment); err != nil || isPaused || requeue {
 		return ctrl.Result{}, err
 	}
 
@@ -215,6 +215,7 @@ func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, md *
 			clusterv1.MachineDeploymentAvailableCondition,
 		}},
 		patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+			clusterv1.PausedV1Beta2Condition,
 			clusterv1.MachineDeploymentAvailableV1Beta2Condition,
 			clusterv1.MachineDeploymentMachinesReadyV1Beta2Condition,
 			clusterv1.MachineDeploymentMachinesUpToDateV1Beta2Condition,

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
@@ -202,6 +202,7 @@ func (r *ClusterBackEndReconciler) PatchDevCluster(ctx context.Context, patchHel
 			infrav1.LoadBalancerAvailableCondition,
 		}},
 		patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+			clusterv1.PausedV1Beta2Condition,
 			infrav1.DevClusterReadyV1Beta2Condition,
 			infrav1.DevClusterDockerLoadBalancerAvailableV1Beta2Condition,
 		}},

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -490,6 +490,7 @@ func (r *MachineBackendReconciler) PatchDevMachine(ctx context.Context, patchHel
 			infrav1.BootstrapExecSucceededCondition,
 		}},
 		patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+			clusterv1.PausedV1Beta2Condition,
 			infrav1.DevMachineReadyV1Beta2Condition,
 			infrav1.DevMachineDockerContainerProvisionedV1Beta2Condition,
 			infrav1.DevMachineDockerContainerBootstrapExecSucceededV1Beta2Condition,

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
@@ -160,5 +160,11 @@ func (r *ClusterBackendReconciler) PatchDevCluster(ctx context.Context, patchHel
 		return errors.New("InMemoryBackendReconciler can't be called for DevClusters without an InMemory backend")
 	}
 
-	return patchHelper.Patch(ctx, inMemoryCluster)
+	return patchHelper.Patch(
+		ctx,
+		inMemoryCluster,
+		patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+			clusterv1.PausedV1Beta2Condition,
+		}},
+	)
 }

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -1267,6 +1267,7 @@ func (r *MachineBackendReconciler) PatchDevMachine(ctx context.Context, patchHel
 			infrav1.APIServerProvisionedCondition,
 		}},
 		patch.WithOwnedV1Beta2Conditions{Conditions: []string{
+			clusterv1.PausedV1Beta2Condition,
 			infrav1.DevMachineReadyV1Beta2Condition,
 			infrav1.DevMachineInMemoryVMProvisionedV1Beta2Condition,
 			infrav1.DevMachineInMemoryNodeProvisionedV1Beta2Condition,

--- a/util/conditions/v1beta2/patch.go
+++ b/util/conditions/v1beta2/patch.go
@@ -243,3 +243,12 @@ func HasSameState(i, j *metav1.Condition) bool {
 		i.Reason == j.Reason &&
 		i.Message == j.Message
 }
+
+// HasSameStateExceptObservedGeneration returns true if a condition has the same state of another; state is defined
+// by the union of following fields: Type, Status, Reason and Message (it excludes ObservedGeneration and LastTransitionTime).
+func HasSameStateExceptObservedGeneration(i, j *metav1.Condition) bool {
+	return i.Type == j.Type &&
+		i.Status == j.Status &&
+		i.Reason == j.Reason &&
+		i.Message == j.Message
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
If only the generation of an object changed we currently get an additional patch and requeue just to update the ObservedGeneration of the Paused condition.

This PR avoids these additional reconciles

(on the left: this PR, on the right: main)
![image](https://github.com/user-attachments/assets/d8383d80-cdae-4c4b-bf21-23c7b14dc31b)



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->