### PR TITLE
[release-1.8] 🌱 Ignore CVE 2025 22870

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# According to govulncheck we are not using code that is affected by CVEs
+CVE-2025-22870


### PR DESCRIPTION
According to govulncheck we are not using code that is affected by CVE 2025 22870, so ignoring it
/area security