### PR TITLE
🌱 e2e: write clusterctl describe to ginkgowriter on failure

### DIFF
--- a/test/framework/cluster_helpers.go
+++ b/test/framework/cluster_helpers.go
@@ -381,6 +381,9 @@ func DescribeCluster(ctx context.Context, input DescribeClusterInput) {
 
 	w := bufio.NewWriter(f)
 	cmdtree.PrintObjectTreeV1Beta2(tree, w)
+	if CurrentSpecReport().Failed() {
+		cmdtree.PrintObjectTreeV1Beta2(tree, GinkgoWriter)
+	}
 	Expect(w.Flush()).To(Succeed(), "Failed to save clusterctl describe output")
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Write `clusterctl describe` output also to ginkgowriter in case of errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing