### PR TITLE
🐛 Early bind ProviderID

### DIFF
--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -253,6 +253,12 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 	}
 	s.infraMachine = obj
 
+	// early set Spec.ProviderID.
+	var providerID string
+	if err := util.UnstructuredUnmarshalField(s.infraMachine, &providerID, "spec", "providerID"); err == nil && providerID != "" {
+		m.Spec.ProviderID = ptr.To(providerID)
+	}
+
 	// Determine if the infrastructure provider is ready.
 	ready, err := external.IsReady(s.infraMachine)
 	if err != nil {
@@ -283,7 +289,6 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 	}
 
 	// Get Spec.ProviderID from the infrastructure provider.
-	var providerID string
 	if err := util.UnstructuredUnmarshalField(s.infraMachine, &providerID, "spec", "providerID"); err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve Spec.ProviderID from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	} else if providerID == "" {

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -419,7 +419,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
 				g.Expect(m.Status.InfrastructureReady).To(BeFalse())
-				g.Expect(m.Spec.ProviderID).To(BeNil())
+				g.Expect(ptr.Deref(m.Spec.ProviderID, "")).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(BeNil())
 				g.Expect(m.Status.Addresses).To(BeNil())
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The ProviderID appears before the infrastructure is ready, and the node already exists in the cluster. When deleting a machine, the corresponding node should be cleaned up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/7412 https://github.com/aws/eks-anywhere/issues/4708 https://github.com/kubernetes-sigs/cluster-api/issues/7237

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->