### PR TITLE
🌱 e2e: ensure to always preload kindnetd to not hit ImagePullBackoff

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -259,6 +259,11 @@ kind:prepullAdditionalImages () {
   kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.16.3"
   kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.16.3"
   kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.16.3"
+
+  # Pull all images defined in DOCKER_PRELOAD_IMAGES.
+  for IMAGE in $(grep DOCKER_PRELOAD_IMAGES: < "$E2E_CONF_FILE" | sed -E 's/.*\[(.*)\].*/\1/' | tr ',' ' '); do
+    kind::prepullImage "${IMAGE}"
+  done
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -380,6 +380,8 @@ variables:
   DOCKER_POD_CIDRS: "192.168.0.0/16"
   DOCKER_SERVICE_IPV6_CIDRS: "fd00:100:64::/108"
   DOCKER_POD_IPV6_CIDRS: "fd00:100:96::/48"
+  # Needs to be kept in sync the CNI file referenced below for caching purposes.
+  DOCKER_PRELOAD_IMAGES: "[kindest/kindnetd:v20250214-acbabc1a]"
   CNI: "./data/cni/kindnet/kindnet.yaml"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   AUTOSCALER_WORKLOAD: "./data/autoscaler/autoscaler-to-workload-workload.yaml"

--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -1,4 +1,4 @@
-# kindnetd networking manifest
+# source: https://github.com/kubernetes-sigs/kind/blob/v0.27.0/pkg/build/nodeimage/const_cni.go#L28
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -6,19 +6,29 @@ metadata:
   name: kindnet
 rules:
   - apiGroups:
-      - ""
+    - policy
     resources:
-      - nodes
+    - podsecuritypolicies
     verbs:
-      - list
-      - watch
-      - patch
+    - use
+    resourceNames:
+    - kindnet
   - apiGroups:
       - ""
     resources:
-      - configmaps
+      - nodes
+      - pods
+      - namespaces
     verbs:
-      - get
+      - list
+      - watch
+  - apiGroups:
+     - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,9 +39,9 @@ roleRef:
   kind: ClusterRole
   name: kindnet
 subjects:
-  - kind: ServiceAccount
-    name: kindnet
-    namespace: kube-system
+- kind: ServiceAccount
+  name: kindnet
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -60,55 +70,52 @@ spec:
         k8s-app: kindnet
     spec:
       hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
-        - operator: Exists
-          effect: NoSchedule
+      - operator: Exists
       serviceAccountName: kindnet
       containers:
-        - name: kindnet-cni
-          image: kindest/kindnetd:v20230511-dc714da8
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            # We're using the dualstack CIDRs here. The order doesn't matter for kindnet as the loops are run concurrently.
-            # REF: https://github.com/kubernetes-sigs/kind/blob/3dbeb894e3092a336ab4278d3823e73a1d66aff7/images/kindnetd/cmd/kindnetd/main.go#L149-L175
-            - name: POD_SUBNET
-              value: '${DOCKER_POD_CIDRS},${DOCKER_POD_IPV6_CIDRS}'
-          volumeMounts:
-            - name: cni-cfg
-              mountPath: /etc/cni/net.d
-            - name: xtables-lock
-              mountPath: /run/xtables.lock
-              readOnly: false
-            - name: lib-modules
-              mountPath: /lib/modules
-              readOnly: true
-          resources:
-            requests:
-              cpu: "100m"
-              memory: "50Mi"
-            limits:
-              cpu: "100m"
-              memory: "50Mi"
-          securityContext:
-            privileged: false
-            capabilities:
-              add: ["NET_RAW", "NET_ADMIN"]
+      - name: kindnet-cni
+        # Needs to be kept in sync with DOCKER_PRELOAD_IMAGES in test/e2e/config/docker.yaml for caching purposes.
+        image: kindest/kindnetd:v20250214-acbabc1a
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        # We're using the dualstack CIDRs here. The order doesn't matter for kindnet as the loops are run concurrently.
+        # REF: https://github.com/kubernetes-sigs/kind/blob/3dbeb894e3092a336ab4278d3823e73a1d66aff7/images/kindnetd/cmd/kindnetd/main.go#L149-L175
+        - name: POD_SUBNET
+          value: '${DOCKER_POD_CIDRS},${DOCKER_POD_IPV6_CIDRS}'
+        volumeMounts:
+        - name: cni-cfg
+          mountPath: /etc/cni/net.d
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+          readOnly: false
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: false
+          capabilities:
+            add: ["NET_RAW", "NET_ADMIN"]
       volumes:
-        - name: cni-bin
-          hostPath:
-            path: /opt/cni/bin
-            type: DirectoryOrCreate
         - name: cni-cfg
           hostPath:
             path: /etc/cni/net.d
-            type: DirectoryOrCreate
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-remediation/cluster-with-kcp.yaml
@@ -37,7 +37,8 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
-    spec: {}
+    spec:
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmControlPlane referenced by the Cluster
 kind: KubeadmControlPlane

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -114,6 +114,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -125,6 +126,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -137,6 +139,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -582,6 +582,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -602,6 +603,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -623,6 +625,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/cluster-with-kcp.yaml
@@ -43,6 +43,7 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmControlPlane referenced by the Cluster object with
 # - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.

--- a/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.3/bases/md.yaml
@@ -13,6 +13,7 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmConfigTemplate referenced by the MachineDeployment
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/cluster-with-kcp.yaml
@@ -43,6 +43,7 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmControlPlane referenced by the Cluster object with
 # - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.

--- a/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v0.4/bases/md.yaml
@@ -13,6 +13,7 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmConfigTemplate referenced by the MachineDeployment
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4

--- a/test/e2e/data/infrastructure-docker/v1.5/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.5/clusterclass-quick-start.yaml
@@ -417,6 +417,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -437,6 +438,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v1.6/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.6/clusterclass-quick-start.yaml
@@ -564,6 +564,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -584,6 +585,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -605,6 +607,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v1.7/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.7/clusterclass-quick-start.yaml
@@ -570,6 +570,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -590,6 +591,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -611,6 +613,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v1.8/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.8/clusterclass-quick-start.yaml
@@ -582,6 +582,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -602,6 +603,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -623,6 +625,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v1.9/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.9/clusterclass-quick-start.yaml
@@ -582,6 +582,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -602,6 +603,7 @@ spec:
       extraMounts:
       - containerPath: "/var/run/docker.sock"
         hostPath: "/var/run/docker.sock"
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
@@ -623,6 +625,7 @@ spec:
         extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+        preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -161,6 +161,9 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// controller images into the nodes.
 		if hasDockerInfrastructureProvider {
 			images := []string{}
+			if preloadList := strings.TrimSuffix(strings.TrimPrefix(clusterctlVariables["DOCKER_PRELOAD_IMAGES"], "["), "]"); preloadList != "" {
+				images = strings.Split(preloadList, ",")
+			}
 			for _, image := range input.E2EConfig.Images {
 				images = append(images, fmt.Sprintf("%q", image.Name))
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

E2E improvement to ensure startup of a machine does not fail due to imagepullbackoff of kindnetd.
Also reduces the amount of required image pulls from remote and thus should make it faster and reduce costs for the community a bit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing