### PR TITLE
:seedling: set base branch for release-1.10 markdown link checks

### DIFF
--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -20,4 +20,4 @@ jobs:
         use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json
         check-modified-files-only: 'yes'
-        base-branch: main
+        base-branch: release-1.10


### PR DESCRIPTION
Signed-off-by: cprivitere <23177737+cprivitere@users.noreply.github.com>

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: This is part of the normal release branch creation process. We set the base-branch for the "PR check Markdown links" github action to be itself, namely release-1.10.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci