### PR TITLE
🌱 Enforce skip upgrade policy in clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -370,7 +370,7 @@ func (u *providerUpgrader) doUpgrade(ctx context.Context, upgradePlan *UpgradePl
 	for _, upgradeItem := range upgradePlan.Providers {
 		if !(upgradeItem.Type == string(clusterctlv1.CoreProviderType) ||
 			(upgradeItem.Type == string(clusterctlv1.BootstrapProviderType) && upgradeItem.ProviderName == config.KubeadmBootstrapProviderName) ||
-			(upgradeItem.Type == string(clusterctlv1.ControlPlaneProviderType) && upgradeItem.ProviderName == config.KubeadmBootstrapProviderName)) {
+			(upgradeItem.Type == string(clusterctlv1.ControlPlaneProviderType) && upgradeItem.ProviderName == config.KubeadmControlPlaneProviderName)) {
 			continue
 		}
 
@@ -388,7 +388,7 @@ func (u *providerUpgrader) doUpgrade(ctx context.Context, upgradePlan *UpgradePl
 			return errors.Wrapf(err, "failed to parse next version for %s provider", upgradeItem.InstanceName())
 		}
 
-		if nextVersion.Minor >= currentVersion.Minor+3 {
+		if nextVersion.Minor > currentVersion.Minor+3 {
 			return errors.Errorf("upgrade for %s provider can't skip more than 3 versions", upgradeItem.InstanceName())
 		}
 	}

--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -77,19 +77,10 @@ clusterctl upgrade apply \
 
 <aside class="note warning">
 
-<h1>Clusterctl upgrade test coverage</h1>
+<h1>Skip upgrades</h1>
 
-Cluster API only tests a subset of possible clusterctl upgrade paths as otherwise the test matrix would be overwhelming.
-Untested upgrade paths are not blocked by clusterctl and should work in general, but users
-intending to perform an upgrade path not tested by us should do their own validation to ensure the operation works correctly.
-
-The following is an example of the tested upgrade paths for v1.10:
-
-| From | To    | Note                          |
-|------|-------|-------------------------------|
-| v1.7 | v1.10 | n-3 --> n (v1.7 is v1.10 - 3) |
-| v1.8 | v1.10 | n-2 --> n (v1.8 is v1.10 - 2) |
-| v1.9 | v1.10 | n-1 --> n (v1.9 is v1.10 - 1) |
+Please check providers documentation before performing skip upgrades (skip minor versions).
+Not supported skip upgrades might lead to non functional management clusters. 
 
 </aside>
 

--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -82,6 +82,9 @@ clusterctl upgrade apply \
 Please check providers documentation before performing skip upgrades (skip minor versions).
 Not supported skip upgrades might lead to non functional management clusters. 
 
+For Core provider, Kubeadm bootstrap provider, Kubeadm control plane provider and Docker infrastructure provider
+please look at [skip upgrades](../../reference/versions.md#skip-upgrades) rules.
+
 </aside>
 
 <aside class="note warning">


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently improved CAPI version support policies clarifying that we support only n-3 skip upgrades, and we are now using this assumption as a cornerstone to plan API removal activities in https://github.com/kubernetes-sigs/cluster-api/issues/11919 and https://github.com/kubernetes-sigs/cluster-api/issues/11920

However, I noticed that in the clusterctl upgrade doc we were stating something slightly different, so I removed this inconsistency, but then I started thinking about the fact that clusterctl can help users preventing issue.

So I extended a little bit this PR adding a first version of skip upgrade policy check.
For now this check is hardcoded and limited to core CAPI and providers in the core repo; if there is interest we can consider extending the clustectl contract so any provider can declare it's own skip upgrade rules and enforce them via clusterctl 

/area clusterctl
