### PR TITLE
🚀 Release v1.10.0-beta.1

### DIFF
--- a/CHANGELOG/v1.10.0-beta.1.md
+++ b/CHANGELOG/v1.10.0-beta.1.md
@@ -1,0 +1,451 @@
+🚨 This is a BETA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
+
+:warning: **BETA RELEASE NOTES** :warning:
+
+
+## Highlights
+
+- Bumped to controller-runtime v0.20, k8s.io/* v0.32, controller-gen v0.17
+- Features:
+  - ClusterResourceSet was promoted to GA (#11365)
+  - PriorityQueue was added as an alpha feature (see kubernetes-sigs/controller-runtime#2374 for more details) (#11698)
+- API: Added additional validation to our CRDs (#11834)
+- API: Various improvements to v1beta2 conditions
+- ClusterClass: Support referencing ClusterClasses across namespaces (#11352 #11395 #11649)
+- ClusterClass: Add NamingStrategy for InfraCluster (#11898)
+- Machine: Add MachineDrainRule behavior "WaitCompleted" (#11545)
+- Machine: Add --additional-sync-machine-labels flag to allow syncing additional labels to Nodes (#11650)
+- Machine: Sync Machine annotations to Nodes (#11813)
+- MachineSet/MachineDeployment: Add NamingStrategy to MachineDeployment (#11172)
+- MachineSet/KCP: Improve preflight checks (#11927 #11941 #11928)
+- CRD migration: Add CRD migrator (#11889 #11991)
+- Metrics: Add ClusterCache (#11789) and SSA cache (#11635) metrics
+- Merged CAPIM in CAPD (see [From CAPD(docker) to CAPD(dev)](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20250124-From%20CAPD(docker)%20to%20CAPD(dev)%20.md) for more details)
+- As usual, significantly improved e2e test framework & coverage (e.g. #11667 #11884 #11966 #9620 #11983)
+- New providers in clusterctl:
+  - Addon providers: fleet (#11806)
+  - Infrastructure providers: OpenNebula (#11835), Harvester (#11477), Huawei Cloud (#11861)
+
+## Deprecation and Removals Warning
+
+- KCP/MachineSet: Removed deprecated flag for old infra machine naming (#11679)
+- MD/MS/MP/KCP: Deprecated status replica counters planned for removal (#11516)
+- MachineDeployment: Deprecated spec.progressDeadlineSeconds (#11472)
+- CRD migration: Deprecated clusterctl upgrade CRD storage version migration for providers (#11889)
+- ClusterResourceSet was promoted to GA, feature flag is now deprecated (#11741)
+
+## Changes since v1.10.0-beta.0
+## :chart_with_upwards_trend: Overview
+- 14 new commits merged
+- 1 feature addition ✨
+- 6 bugs fixed 🐛
+
+## :sparkles: New Features
+- Runtime SDK/ClusterClass: Extend Cluster builtin to include metadata (#12021)
+
+## :bug: Bug Fixes
+- CABPK: Make KubeadmConfig FileSystem.Label optional (#12023)
+- CAPD: Fix worker machine count in CAPD template (#12029)
+- CAPIM: Fix CAPD in-memory templates (#12016)
+- clusterctl: Clusterctl upgrade hangs for a time on CRD migration when new version contains a number of new CRDs (#12002)
+- e2e: Stop overwriting ExtraPortMappings if WithDockerSockMount option is used (#12022)
+- util: CRD migration: Fix cases where update validation fails (#12001)
+
+## :seedling: Others
+- CI: set base branch for release-1.10 markdown link checks (#11994)
+
+:book: Additionally, there has been 1 contribution to our documentation and book. (#11999)
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- github.com/onsi/ginkgo/v2: [v2.23.0 → v2.23.3](https://github.com/onsi/ginkgo/compare/v2.23.0...v2.23.3)
+- github.com/onsi/gomega: [v1.36.2 → v1.36.3](https://github.com/onsi/gomega/compare/v1.36.2...v1.36.3)
+- go.etcd.io/etcd/api/v3: v3.5.19 → v3.5.20
+- go.etcd.io/etcd/client/pkg/v3: v3.5.19 → v3.5.20
+- go.etcd.io/etcd/client/v3: v3.5.19 → v3.5.20
+- google.golang.org/protobuf: v1.36.1 → v1.36.5
+- sigs.k8s.io/controller-runtime: v0.20.3 → v0.20.4
+
+### Removed
+_Nothing has changed._
+
+<details>
+<summary>More details about the release</summary>
+
+## Changes since v1.9.0
+## :chart_with_upwards_trend: Overview
+- 295 new commits merged
+- 8 breaking changes :warning:
+- 22 feature additions ✨
+- 32 bugs fixed 🐛
+
+## :memo: Proposals
+- Community meeting: :sparkles: :people_holding_hands: add proposal for Node Bootstrapping working group (#11407)
+
+## :warning: Breaking Changes
+- API: Add MaxItems markers to API fields (#11934)
+- API: Add MaxLength & MinLength markers (#11949)
+- API: Deprecate replica counters planned for removal (#11516)
+- ClusterResourceSet: Deprecate the ClusterResourceSet feature flag (#11741)
+- Dependency: Bump to controller-runtime v0.20 & controller-tools v0.17 (#11633)
+- MachineDeployment: Deprecate MD.Spec.ProgressDeadlineSeconds (#11472)
+- CAPD/e2e/CAPIM: CAPD DevCluster and Machine (#11819)
+- KCP/MachineSet: Remove deprecated flag for old infra machine naming (#11679)
+
+## :sparkles: New Features
+- CABPK: Add bootCommands to cloud-idit file generation (#11271)
+- ClusterClass: Add Availability and ReadinessGates to ClusterClass (#11868)
+- ClusterClass: Add classNamespace to topology (#11352)
+- ClusterClass: Add e2e tests & clusterctl changes for cross-ns CC ref (#11395)
+- ClusterClass: Clusterctl move support for a cross namespace ClusterClass reference (#11649)
+- clusterctl: Add addon provider fleet to registry (#11806)
+- clusterctl: Add OpenNebula infrastructure provider to clusterctl (#11835)
+- clusterctl: Add support for clusterctl gitlab auth (#11792)
+- ClusterResourceSet: Integrate CRS code into regular code structure (#11943)
+- Controller-runtime: Add PriorityQueue feature gate (#11698)
+- e2e: Extend scale test and make ExtensionConfig name in RuntimeSDK test configurable (#11667)
+- e2e: Test n-3 clusterctl upgrade (#11884)
+- KCP: Add preflight check for pending version upgrade from topology (#11927)
+- Machine: Add MachineDrainRule "WaitCompleted" (#11545)
+- Machine: Sync machine annotations to nodes (#11813)
+- MachineSet: Add ControlPlaneVersionSkew MS preflight check & preflight check cmd line flag (#11941)
+- MachineSet: Extend ControlPlaneIsStable preflight check to check for a pending topology based ControlPlane version upgrade (#11928)
+- API/Documentation/ClusterResourceSet: Promote feature CRS to GA (#11365)
+- Runtime SDK/ClusterClass: Extend Cluster builtin to include metadata (#12014)
+- Runtime SDK/Topology: implement BeforeClusterUpgrade annotation hook (#11922)
+- Testing: Bump Kubernetes in tests to v1.32.0 and claim support for v1.32 (#11563)
+- util: Add CRD migrator, deprecate clusterctl upgrade CRD storage version migration (#11889)
+
+## :bug: Bug Fixes
+- Bootstrap: Recreate bootstrap token if it was cleaned up (#11520)
+- CABPK: Ensure kubeadm controller always sets all v1beta2 conditions (#11948)
+- CABPK: Make KubeadmConfig FileSystem.Label optional (#12019)
+- CAPD: Fix worker machine count in CAPD template (#12028)
+- CAPIM: Fix CAPD in-memory templates (#12013)
+- CAPIM: Fix periodic resync in in-memory provider (#11663)
+- CI: downgrade Kind binary to v0.24.0 to fix building node images for <= v1.30 (#11482)
+- Cluster: Modify calling agg cluster conditions (#11952)
+- Clustercache: Increase timeout for informer List+Watch calls from 10s to 11m (#11757)
+- Clustercache: Prevent concurrent map read/write when creating a cache (#11707)
+- ClusterClass: Don't allow concurrent patch upgrades (#11940)
+- ClusterClass: Ensure Cluster topology controller is not stuck when MDs are stuck in deletion (#11771)
+- ClusterClass: Export runtime.Client interface and cache package (#11611)
+- clusterctl: Clusterctl upgrade hangs for a time on CRD migration when new version contains a number of new CRDs (#11984)
+- clusterctl: Fix multiline Ready condition in clusterctl describe for v1beta2 (#11781)
+- clusterctl: send delete request before removing finalizers (#11814)
+- Conditions: Avoid redundant reconciles if only generation of Paused condition changed (#11972)
+- e2e: Properly display the namespace name in scale test (#11547)
+- e2e: Stop overwriting ExtraPortMappings if WithDockerSockMount option is used (#12012)
+- Machine: Sort list of pre-drain hooks for stable condition messages (#11624)
+- Machine: Use correct APIVersion for KCP related exclude (#11490)
+- MachineDeployment: Remove disableMachineCreate annotation from new machinesets during rolling machine deployment reconciliation (#11415)
+- MachineHealthCheck: fix flaky test (#11471)
+- MachinePool: Check machinepool feature-flag before watching in cluster controller (#11776)
+- Release: Fix broken links in release team handbooks (#11652)
+- Release: Use release branch for v1.10 alpha and beta releases (#11979)
+- Testing: Default to topology flavor in NodeDrainTimeoutSpec (#11727)
+- Testing: Fix flake TestMachineSetReconciler test (#11728)
+- Testing: Fix flaky TestExtensionReconciler_Reconcile test (#11903)
+- Testing: Fix MDR unit test (#11874)
+- util: Also patch external refs if the UID differs (#11688)
+- CRD migration: Fix cases where update validation fails (#11991)
+
+## :seedling: Others
+- API: Add KAL linter for linting API conventions (#11733)
+- API: Enable integers lint of KAL (#11887)
+- API: Enable maxlength linter (#11906)
+- API: Enable nobools linter (#11911)
+- API: Enable nofloats linter (#11910)
+- API: Enable optionalorrequired linter (#11909)
+- API: Enable requiredfields linter (#11908)
+- API: Enable statussubresource linter (#11907)
+- CAPD: Add v1beta2 conditions to DevMachine and DevCluster with Docker backend (#11923)
+- CAPD: Add v1beta2 conditions to DevMachines with InMemory backend (#11901)
+- CAPD: Disable image garbage collection in kubelet to align with kind (#11904)
+- CAPIM: fix watch to continue serving based on resourceVersion parameter (#11695)
+- CI: Bump github-action-markdown-link-check to 1.0.15 (#11594)
+- CI: bump Govulncheck to v1.1.4 (#11713)
+- CI: Default building kind node-images depending on KIND_BUILD_IMAGES env variable instead of ginkgo magic regexes (#11784)
+- CI: downgrade gh-release action (#11588)
+- CI: Drop 1.0->current upgrade test (#11755)
+- CI: Enable the conditions rule from KAL (#11847)
+- CI: fix checking out k/k release branch (#11836)
+- CI: update branches for weekly actions (#11578)
+- CI: Update golangci-lint to v1.63.4 (#11740)
+- CI: Update version matrix for github workflows for release-1.10 (#11992)
+- Cluster: Improve waiting for CP / InfraCluster deletion logs (#11823)
+- Cluster: Reconcile topology only when necessary (#11605)
+- Cluster: Validate that infrastructureRef and controlPlaneRef cannot be unset (#11969)
+- Clustercache: Add clustercache metrics (#11789)
+- Clustercache: Do not use RequeueAfter when hitting ErrClusterNotConnected (#11736)
+- ClusterClass: Add Namingstrategy to InfraCluster (#11898)
+- ClusterClass: Consider IsProvisioning to determine if ControlPlane is stable (#11939)
+- ClusterClass: Deprecate old ClusterClass index (#11744)
+- ClusterClass: fix godoc for LocalObjectTemplatesAreCompatible (#11732)
+- clusterctl: Add Infrastructure provider Harvester (#11477)
+- clusterctl: Add support infrastructure provider for Huawei Cloud (#11861)
+- clusterctl: Bump cert-manager to v1.16.3 (#11699)
+- clusterctl: Change k0smotron repo location (#11872)
+- clusterctl: Enforce skip upgrade policy in clusterctl (#12017)
+- clusterctl: Fix fallback to overrides directory in home when there is no overrides directory in XDG directory (#11824)
+- clusterctl: Properly indent multiline lists in clusterctl describe (#11508)
+- clusterctl: Remove OCNE providers (#11830)
+- ClusterResourceSet: Cleanup after CRS move (#11968)
+- Conditions: Allow readiness and availability gates with negative polarity (#11918)
+- Conditions: Drop unused v1beta2 conditions and reasons (#11518)
+- Conditions: Fix formatting of blocking lifecycle hook condition message (#11661)
+- Conditions: Fix log messages in Cluster set status code + some minor unit test fixes (#11629)
+- Conditions: Handle "waiting for completion" in KCP, MD, MS and Machine conditions (#11811)
+- Conditions: Refine v1beta2 summary (#11498)
+- Conditions: Refine v1beta2 UpToDate and Rollout conditions (#11503)
+- Conditions: Rename v1beta2 test types (#11832)
+- Conditions: Set merge operation (#11990)
+- Conditions: Small improvements to v1beta2 conditions godoc (#11521)
+- Conditions: sort list of hooks for stable condition messages (#11487)
+- Controller-runtime: Bump to controller-runtime v0.20.1 (#11747)
+- Dependency: Bump controller-gen to v0.17.2 (#11866)
+- Dependency: Bump conversion-gen to v0.32.2 (#11869)
+- Dependency: Bump envtest to v1.32.0 (#11632)
+- Dependency: Bump github.com/coredns/corefile-migration to v1.0.25 (#11651)
+- Dependency: Bump go to v1.22.10 (#11534)
+- Dependency: Bump go to v1.23.5 (#11714)
+- Dependency: Bump go to v1.23.6 (#11803)
+- Dependency: Bump go to v1.23.7 (#11981)
+- Dependency: Bump golang.org/x/crypto (#11579)
+- Dependency: Bump kustomize to v5.6.0 (#11867)
+- Dependency: Bump sigs.k8s.io/kind to v0.26.0 (#11586)
+- Dependency: Bump sigs.k8s.io/kind to v0.27.0 (#11891)
+- Dependency: Bump to controller-runtime v0.19.4 (#11643)
+- Dependency: Bump to controller-runtime v0.20.2 (#11850)
+- Dependency: Bump to controller-runtime v0.20.3 (#11946)
+- Dependency/Conditions: Update controller-runtime to v0.19.3 (#11524)
+- Devtools: Add enable_core_provider option support in tilt-settings.yaml|json file (#11879)
+- Devtools: Add KubeVirt support to Tilt dev workflow (#11697)
+- Devtools: Add Runtime Extension dashboard (#11571)
+- Devtools: Bump CAPI Visualizer to v1.4.0 (#11546)
+- Devtools: Bump kpromo to 5ab0dbc74b0228c22a93d240596dff77464aee8f (#11593)
+- Devtools: Disable TLS verification for Podman pushes inside of Tilt (#11977)
+- Devtools: Fix reconcile extensions dashboard (#11607)
+- Devtools: Remove dependency to envsubst binary (#11783)
+- Devtools: Update dev observability stack to latest versions (#11905)
+- Devtools: Use port 3000 instead of 3001 for Grafana (#11902)
+- e2e: Add clusterctl describe to E2E artifacts (#11966)
+- e2e: Add ginkgo labels to e2e tests (#11686)
+- e2e: Add log command line flags to e2e test binary (#11662)
+- e2e: Add optional ClusterctlVariables to QuickStartSpecInput (#11780)
+- e2e: add options for additional resources and verify volume detach to node drain test (#11526)
+- e2e: Add retry to clusterctl `UpgradeWithBinary` (#11478)
+- e2e: Adopt e2e labels usage (#11763)
+- e2e: Allow e2e scalability test to have custom deletion timeout (#11558)
+- e2e: Attempt older version upgrades twice to work around flake with the docker controller (#11759)
+- e2e: Bump default kind image to v1.32.0 (#11568)
+- e2e: Bump kubernetes release to v1.32.0-rc.1 (#11538)
+- e2e: Bump Kubernetes version used for testing to v1.32.0-rc.0 (#11483)
+- e2e: Bump Kubernetes version used for testing to v1.33.0-beta.0 (#11958)
+- e2e: Create ExtensionConfig including name in settings and create one… (#11956)
+- e2e: Drop v1.24 skip for runtime sdk test (#11791)
+- e2e: Ensure node-drain with real volume detachments can get deleted without race conditions (#11838)
+- e2e: Ensure to always preload kindnetd to not hit ImagePullBackoff (#11986)
+- e2e: make coredns and etcd upgrade variables optional (#11798)
+- e2e: order ginkgo flags, add --fail-on-pending --fail-on-empty, increase timeout to 3h (#11800)
+- e2e: Rename GetVariable functions (#11743)
+- e2e: Use Kubernetes 1.33 for CI latest E2E test (#11496)
+- e2e: Use latest kind image for K8s1.31 in E2E tests (#11484)
+- e2e: Write clusterctl describe to ginkgowriter on failure (#11983)
+- IPAM: Add v1beta2 conditions to IPAddressClaim (#11971)
+- KCP: Call etcd member list and alarms once in KCP's updateManagedEtcdConditions (#11815)
+- KCP: Drop MemberUpdate from etcd client in KCP (#11795)
+- KCP: Drop retry when computing KCP conditions (#11515)
+- KCP: Drop retry when ready KCP conditions (#11797)
+- KCP: Drop unnecessary etcd call from KCP (#11489)
+- KCP: Improve KCP remediation of multiple failures (#11716)
+- KCP: Improve KCP scale up when using failure domains (#11598)
+- KCP: make EtcdMemberHealthy less verbose on client creation failures (#11502)
+- KCP: Read etcd alarm list once per reconcile in KCP (#11796)
+- KCP: Refine KCP's Available, ControlPlaneComponentsHealthy, EtcdClusterHealthy v1beta2 conditions (#11504)
+- KCP: Stop recreating logger for etcd client (#11664)
+- KCP/MachineSet: Prioritize Machine with remediate-machine anotation when selecting the next machine to be remediated (#11495)
+- Logging: Log version directly on controller startup (#11957)
+- Logging: Reduce log level of noisy logs in ExtensionConfig and Cluster controller (#11660)
+- Machine: Add --additional-sync-machine-labels to allow syncing additional labels to Nodes (#11650)
+- Machine: Improve Machine create and delete logs (#11693)
+- Machine: Move MDR unique validations to CEL (#11852)
+- Machine: Refine v1beta2 NodeHealthy condition (#11494)
+- Machine: Remove solved todo comment (#11566)
+- MachineDeployment: Improve MachineSet create and delete logs (#11751)
+- MachineDeployment: Refine MachineDeployment v1beta2 available condition (#11501)
+- MachineHealthCheck: Improve Machine remediation logs (#11692)
+- MachineSet: delete Bootstrap object when creating InfraMachine object failed (#11211)
+- MachineSet/MachineDeployment: Add NamingStrategy to MachineDeployment (#11172)
+- Misc: Enable commentstart lint of KAL (#11936)
+- Misc: Enable jsontags lint of KAL (#11890)
+- Misc: Remove labels.includeSelectors from config/crd/kustomization.yaml (#11753)
+- Misc: Remove redundant pagination with cached clients (#11873)
+- Misc: Use context.WithTimeoutCause and context.WithCancelCause for better readability (#11705)
+- Misc: Use std API instead of exp API (#11790)
+- Observability: bump helm charts to newer versions (#11601)
+- Observability: improvements to grafana and loki (#11685)
+- Observability: split up grafana configmap to not exceed the size limits on reoccuring apply (#11769)
+- PatchHelper: call toUnstructured only if necessary (#11665)
+- Release: Align release 1.10 job creation with the new code freeze (#11799)
+- Release: Follow up of 11647 (#11659)
+- Release: Prepare main branch for v1.10 development (#11647)
+- Release: Prepare main for v1.11 development (#12000)
+- Release: Release notes `v1.9.0-rc.1` fix (#11530)
+- Runtime SDK: add cluster to logger to co-relate requests to clusters in tests (#11938)
+- Runtime SDK: Add v1beta2 conditions to ExtensionConfig (#11848)
+- Runtime SDK: Cache DiscoveryVariables calls (#11592)
+- Runtime SDK: Sync Cache configuration in tests (#11768)
+- Testing: Set MachinePool feature gates in tests correctly with testutil (#11921)
+- Testing: Test BYO certificates (#10681)
+- Testing: Use inCluster kubeconfig if empty var provided (#11865)
+- Tilt: use unique names for local_resources and buttons (#11871)
+- util: Add SSA cache metrics (#11635)
+- util: Add TypedAll, ResourceIsUnchanged and TypedResourceIsUnchanged predicates (#11597)
+- util: Call patchHelper only if necessary when reconciling external refs (#11666)
+
+:book: Additionally, there have been 36 contributions to our documentation and book. (#11479, #11486, #11491, #11543, #11557, #11559, #11575, #11581, #11584, #11596, #11623, #11628, #11648, #11696, #11702, #11703, #11723, #11731, #11734, #11735, #11752, #11754, #11774, #11786, #11807, #11810, #11817, #11870, #11875, #11878, #11883, #11914, #11929, #11931, #11998, #12004) 
+
+## Dependencies
+
+### Added
+- cloud.google.com/go/auth/oauth2adapt: v0.2.6
+- cloud.google.com/go/auth: v0.13.0
+- cloud.google.com/go/monitoring: v1.21.2
+- github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp: [v1.25.0](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/detectors/gcp/v1.25.0)
+- github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric: [v0.48.1](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/exporter/metric/v0.48.1)
+- github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping: [v0.48.1](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/internal/resourcemapping/v0.48.1)
+- github.com/go-viper/mapstructure/v2: [v2.2.1](https://github.com/go-viper/mapstructure/tree/v2.2.1)
+- github.com/planetscale/vtprotobuf: [0393e58](https://github.com/planetscale/vtprotobuf/tree/0393e58)
+- go.opentelemetry.io/contrib/detectors/gcp: v1.29.0
+- go.opentelemetry.io/otel/sdk/metric: v1.29.0
+
+### Changed
+- cel.dev/expr: v0.15.0 → v0.18.0
+- cloud.google.com/go/compute/metadata: v0.3.0 → v0.6.0
+- cloud.google.com/go/iam: v1.1.5 → v1.2.2
+- cloud.google.com/go/storage: v1.35.1 → v1.49.0
+- cloud.google.com/go: v0.112.1 → v0.116.0
+- github.com/Azure/go-ansiterm: [d185dfc → 306776e](https://github.com/Azure/go-ansiterm/compare/d185dfc...306776e)
+- github.com/cncf/xds/go: [555b57e → b4127c9](https://github.com/cncf/xds/compare/555b57e...b4127c9)
+- github.com/coredns/corefile-migration: [v1.0.24 → v1.0.25](https://github.com/coredns/corefile-migration/compare/v1.0.24...v1.0.25)
+- github.com/cpuguy83/go-md2man/v2: [v2.0.4 → v2.0.6](https://github.com/cpuguy83/go-md2man/compare/v2.0.4...v2.0.6)
+- github.com/emicklei/go-restful/v3: [v3.12.1 → v3.12.2](https://github.com/emicklei/go-restful/compare/v3.12.1...v3.12.2)
+- github.com/envoyproxy/go-control-plane: [v0.12.0 → v0.13.1](https://github.com/envoyproxy/go-control-plane/compare/v0.12.0...v0.13.1)
+- github.com/envoyproxy/protoc-gen-validate: [v1.0.4 → v1.1.0](https://github.com/envoyproxy/protoc-gen-validate/compare/v1.0.4...v1.1.0)
+- github.com/evanphx/json-patch/v5: [v5.9.0 → v5.9.11](https://github.com/evanphx/json-patch/compare/v5.9.0...v5.9.11)
+- github.com/fsnotify/fsnotify: [v1.7.0 → v1.8.0](https://github.com/fsnotify/fsnotify/compare/v1.7.0...v1.8.0)
+- github.com/go-openapi/jsonpointer: [v0.19.6 → v0.21.0](https://github.com/go-openapi/jsonpointer/compare/v0.19.6...v0.21.0)
+- github.com/go-openapi/swag: [v0.22.4 → v0.23.0](https://github.com/go-openapi/swag/compare/v0.22.4...v0.23.0)
+- github.com/golang/glog: [v1.2.1 → v1.2.2](https://github.com/golang/glog/compare/v1.2.1...v1.2.2)
+- github.com/google/btree: [v1.0.1 → v1.1.3](https://github.com/google/btree/compare/v1.0.1...v1.1.3)
+- github.com/google/cel-go: [v0.20.1 → v0.22.0](https://github.com/google/cel-go/compare/v0.20.1...v0.22.0)
+- github.com/google/go-cmp: [v0.6.0 → v0.7.0](https://github.com/google/go-cmp/compare/v0.6.0...v0.7.0)
+- github.com/google/pprof: [d1b30fe → 40e02aa](https://github.com/google/pprof/compare/d1b30fe...40e02aa)
+- github.com/google/s2a-go: [v0.1.7 → v0.1.8](https://github.com/google/s2a-go/compare/v0.1.7...v0.1.8)
+- github.com/googleapis/enterprise-certificate-proxy: [v0.3.2 → v0.3.4](https://github.com/googleapis/enterprise-certificate-proxy/compare/v0.3.2...v0.3.4)
+- github.com/googleapis/gax-go/v2: [v2.12.3 → v2.14.1](https://github.com/googleapis/gax-go/compare/v2.12.3...v2.14.1)
+- github.com/gorilla/websocket: [v1.5.0 → v1.5.3](https://github.com/gorilla/websocket/compare/v1.5.0...v1.5.3)
+- github.com/gregjones/httpcache: [9cad4c3 → 901d907](https://github.com/gregjones/httpcache/compare/9cad4c3...901d907)
+- github.com/hashicorp/golang-lru: [v0.5.4 → v0.5.1](https://github.com/hashicorp/golang-lru/compare/v0.5.4...v0.5.1)
+- github.com/jessevdk/go-flags: [v1.4.0 → v1.6.1](https://github.com/jessevdk/go-flags/compare/v1.4.0...v1.6.1)
+- github.com/jonboulle/clockwork: [v0.2.2 → v0.4.0](https://github.com/jonboulle/clockwork/compare/v0.2.2...v0.4.0)
+- github.com/moby/spdystream: [v0.4.0 → v0.5.0](https://github.com/moby/spdystream/compare/v0.4.0...v0.5.0)
+- github.com/onsi/ginkgo/v2: [v2.22.0 → v2.23.3](https://github.com/onsi/ginkgo/compare/v2.22.0...v2.23.3)
+- github.com/onsi/gomega: [v1.36.0 → v1.36.3](https://github.com/onsi/gomega/compare/v1.36.0...v1.36.3)
+- github.com/pelletier/go-toml/v2: [v2.2.2 → v2.2.3](https://github.com/pelletier/go-toml/compare/v2.2.2...v2.2.3)
+- github.com/pkg/sftp: [v1.13.6 → v1.13.7](https://github.com/pkg/sftp/compare/v1.13.6...v1.13.7)
+- github.com/sagikazarmark/locafero: [v0.4.0 → v0.7.0](https://github.com/sagikazarmark/locafero/compare/v0.4.0...v0.7.0)
+- github.com/spf13/afero: [v1.11.0 → v1.12.0](https://github.com/spf13/afero/compare/v1.11.0...v1.12.0)
+- github.com/spf13/cast: [v1.7.0 → v1.7.1](https://github.com/spf13/cast/compare/v1.7.0...v1.7.1)
+- github.com/spf13/cobra: [v1.8.1 → v1.9.1](https://github.com/spf13/cobra/compare/v1.8.1...v1.9.1)
+- github.com/spf13/pflag: [v1.0.5 → v1.0.6](https://github.com/spf13/pflag/compare/v1.0.5...v1.0.6)
+- github.com/spf13/viper: [v1.19.0 → v1.20.0](https://github.com/spf13/viper/compare/v1.19.0...v1.20.0)
+- github.com/stoewer/go-strcase: [v1.2.0 → v1.3.0](https://github.com/stoewer/go-strcase/compare/v1.2.0...v1.3.0)
+- github.com/stretchr/objx: [v0.5.2 → v0.5.0](https://github.com/stretchr/objx/compare/v0.5.2...v0.5.0)
+- github.com/stretchr/testify: [v1.9.0 → v1.10.0](https://github.com/stretchr/testify/compare/v1.9.0...v1.10.0)
+- github.com/xiang90/probing: [43a291a → a49e3df](https://github.com/xiang90/probing/compare/43a291a...a49e3df)
+- go.etcd.io/bbolt: v1.3.9 → v1.3.11
+- go.etcd.io/etcd/api/v3: v3.5.17 → v3.5.20
+- go.etcd.io/etcd/client/pkg/v3: v3.5.17 → v3.5.20
+- go.etcd.io/etcd/client/v2: v2.305.13 → v2.305.16
+- go.etcd.io/etcd/client/v3: v3.5.17 → v3.5.20
+- go.etcd.io/etcd/pkg/v3: v3.5.13 → v3.5.16
+- go.etcd.io/etcd/raft/v3: v3.5.13 → v3.5.16
+- go.etcd.io/etcd/server/v3: v3.5.13 → v3.5.16
+- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc: v0.53.0 → v0.54.0
+- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: v0.53.0 → v0.54.0
+- go.opentelemetry.io/otel/metric: v1.28.0 → v1.29.0
+- go.opentelemetry.io/otel/sdk: v1.28.0 → v1.29.0
+- go.opentelemetry.io/otel/trace: v1.28.0 → v1.29.0
+- go.opentelemetry.io/otel: v1.28.0 → v1.29.0
+- golang.org/x/crypto: v0.29.0 → v0.36.0
+- golang.org/x/mod: v0.21.0 → v0.23.0
+- golang.org/x/net: v0.31.0 → v0.37.0
+- golang.org/x/oauth2: v0.24.0 → v0.28.0
+- golang.org/x/sync: v0.9.0 → v0.12.0
+- golang.org/x/sys: v0.27.0 → v0.31.0
+- golang.org/x/term: v0.26.0 → v0.30.0
+- golang.org/x/text: v0.20.0 → v0.23.0
+- golang.org/x/time: v0.5.0 → v0.8.0
+- golang.org/x/tools: v0.26.0 → v0.30.0
+- golang.org/x/xerrors: 04be3eb → 5ec99f8
+- gomodules.xyz/jsonpatch/v2: v2.4.0 → v2.5.0
+- google.golang.org/api: v0.171.0 → v0.215.0
+- google.golang.org/appengine: v1.6.8 → v1.6.7
+- google.golang.org/genproto/googleapis/api: 5315273 → e6fa225
+- google.golang.org/genproto/googleapis/rpc: f6361c8 → 3abc09e
+- google.golang.org/genproto: 012b6fc → e639e21
+- google.golang.org/grpc: v1.65.1 → v1.67.3
+- google.golang.org/protobuf: v1.35.1 → v1.36.5
+- k8s.io/api: v0.31.3 → v0.32.3
+- k8s.io/apiextensions-apiserver: v0.31.3 → v0.32.3
+- k8s.io/apimachinery: v0.31.3 → v0.32.3
+- k8s.io/apiserver: v0.31.3 → v0.32.3
+- k8s.io/client-go: v0.31.3 → v0.32.3
+- k8s.io/cluster-bootstrap: v0.31.3 → v0.32.3
+- k8s.io/code-generator: v0.31.3 → v0.32.3
+- k8s.io/component-base: v0.31.3 → v0.32.3
+- k8s.io/gengo/v2: 51d4e06 → 2b36238
+- k8s.io/kms: v0.31.3 → v0.32.3
+- k8s.io/kube-openapi: 70dd376 → 32ad38e
+- k8s.io/utils: 18e509b → 3ea5e8c
+- sigs.k8s.io/apiserver-network-proxy/konnectivity-client: v0.30.3 → v0.31.0
+- sigs.k8s.io/controller-runtime: v0.19.3 → v0.20.4
+- sigs.k8s.io/json: bc3834c → 9aa6b5e
+- sigs.k8s.io/structured-merge-diff/v4: v4.4.1 → v4.4.2
+
+### Removed
+- cloud.google.com/go/compute: v1.24.0
+- cloud.google.com/go/firestore: v1.15.0
+- cloud.google.com/go/longrunning: v0.5.5
+- github.com/armon/go-metrics: [v0.4.1](https://github.com/armon/go-metrics/tree/v0.4.1)
+- github.com/googleapis/google-cloud-go-testing: [1c9a4c6](https://github.com/googleapis/google-cloud-go-testing/tree/1c9a4c6)
+- github.com/hashicorp/consul/api: [v1.28.2](https://github.com/hashicorp/consul/tree/api/v1.28.2)
+- github.com/hashicorp/errwrap: [v1.1.0](https://github.com/hashicorp/errwrap/tree/v1.1.0)
+- github.com/hashicorp/go-cleanhttp: [v0.5.2](https://github.com/hashicorp/go-cleanhttp/tree/v0.5.2)
+- github.com/hashicorp/go-hclog: [v1.5.0](https://github.com/hashicorp/go-hclog/tree/v1.5.0)
+- github.com/hashicorp/go-immutable-radix: [v1.3.1](https://github.com/hashicorp/go-immutable-radix/tree/v1.3.1)
+- github.com/hashicorp/go-multierror: [v1.1.1](https://github.com/hashicorp/go-multierror/tree/v1.1.1)
+- github.com/hashicorp/go-rootcerts: [v1.0.2](https://github.com/hashicorp/go-rootcerts/tree/v1.0.2)
+- github.com/hashicorp/hcl: [v1.0.0](https://github.com/hashicorp/hcl/tree/v1.0.0)
+- github.com/hashicorp/serf: [v0.10.1](https://github.com/hashicorp/serf/tree/v0.10.1)
+- github.com/imdario/mergo: [v0.3.13](https://github.com/imdario/mergo/tree/v0.3.13)
+- github.com/klauspost/compress: [v1.17.2](https://github.com/klauspost/compress/tree/v1.17.2)
+- github.com/magiconair/properties: [v1.8.7](https://github.com/magiconair/properties/tree/v1.8.7)
+- github.com/mitchellh/go-homedir: [v1.1.0](https://github.com/mitchellh/go-homedir/tree/v1.1.0)
+- github.com/mitchellh/mapstructure: [v1.5.0](https://github.com/mitchellh/mapstructure/tree/v1.5.0)
+- github.com/nats-io/nats.go: [v1.34.0](https://github.com/nats-io/nats.go/tree/v1.34.0)
+- github.com/nats-io/nkeys: [v0.4.7](https://github.com/nats-io/nkeys/tree/v0.4.7)
+- github.com/nats-io/nuid: [v1.0.1](https://github.com/nats-io/nuid/tree/v1.0.1)
+- github.com/sagikazarmark/crypt: [v0.19.0](https://github.com/sagikazarmark/crypt/tree/v0.19.0)
+- github.com/sagikazarmark/slog-shim: [v0.1.0](https://github.com/sagikazarmark/slog-shim/tree/v0.1.0)
+- gopkg.in/ini.v1: v1.67.0
+
+</details>
+<br/>
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
**What this PR does / why we need it**:

Release notes for CAPI v1.10.0-beta.1.

**Which issue(s) this PR fixes**:

Refs #11656

/area release
