### PR TITLE
🌱 Move contract version & GetCompatibleVersions to contract package

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
+	"sigs.k8s.io/cluster-api/internal/contract"
 )
 
 // Client is exposes the clusterctl high-level client library.
@@ -178,8 +179,8 @@ func New(ctx context.Context, path string, options ...Option) (Client, error) {
 
 func newClusterctlClient(ctx context.Context, path string, options ...Option) (*clusterctlClient, error) {
 	client := &clusterctlClient{
-		currentContractVersion:        cluster.CurrentContractVersion,
-		getCompatibleContractVersions: cluster.GetCompatibleContractVersions,
+		currentContractVersion:        contract.Version,
+		getCompatibleContractVersions: contract.GetCompatibleVersions,
 	}
 	for _, o := range options {
 		o(client)

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -24,30 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	yaml "sigs.k8s.io/cluster-api/cmd/clusterctl/client/yamlprocessor"
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/internal/contract"
 )
-
-var (
-	// CurrentContractVersion is the contract version supported by this Cluster API version.
-	// Note: Each Cluster API version supports one contract version, and by convention the contract version matches the current API version.
-	CurrentContractVersion = clusterv1.GroupVersion.Version
-)
-
-// GetCompatibleContractVersions return the list of contract version compatible with a given contract version.
-// NOTE: A contract version might be temporarily compatible with older contract versions e.g. to allow users time to transition to the new API.
-// NOTE: The return value must include also the contract version received in input.
-func GetCompatibleContractVersions(contract string) sets.Set[string] {
-	compatibleContracts := sets.New(contract)
-	// v1beta2 contract is temporarily be compatible with v1beta1 (until v1beta1 is EOL).
-	if contract == "v1beta2" {
-		compatibleContracts.Insert("v1beta1")
-	}
-	return compatibleContracts
-}
 
 // Kubeconfig is a type that specifies inputs related to the actual
 // kubeconfig.
@@ -233,8 +215,8 @@ func newClusterClient(kubeconfig Kubeconfig, configClient config.Client, options
 		configClient:                  configClient,
 		kubeconfig:                    kubeconfig,
 		processor:                     yaml.NewSimpleProcessor(),
-		currentContractVersion:        CurrentContractVersion,
-		getCompatibleContractVersions: GetCompatibleContractVersions,
+		currentContractVersion:        contract.Version,
+		getCompatibleContractVersions: contract.GetCompatibleVersions,
 	}
 	for _, o := range options {
 		o(client)

--- a/internal/contract/version.go
+++ b/internal/contract/version.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	// Version is the contract version supported by this Cluster API version.
+	// Note: Each Cluster API version supports one contract version, and by convention the contract version matches the current API version.
+	Version = clusterv1.GroupVersion.Version
+)
+
+// GetCompatibleVersions return the list of contract version compatible with a given contract version.
+// NOTE: A contract version might be temporarily compatible with older contract versions e.g. to allow users time to transition to the new API.
+// NOTE: The return value must include also the contract version received in input.
+func GetCompatibleVersions(contract string) sets.Set[string] {
+	compatibleContracts := sets.New(contract)
+	// v1beta2 contract is temporarily be compatible with v1beta1 (until v1beta1 is EOL).
+	if contract == "v1beta2" {
+		compatibleContracts.Insert("v1beta1")
+	}
+	return compatibleContracts
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We will use the contract version types also from our controllers. Also in general it seems more appropriate to have the contract versions in the contract package

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->