### PR TITLE
:seedling: Use github.base_ref in markdown-link-check

### DIFF
--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -20,4 +20,4 @@ jobs:
         use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json
         check-modified-files-only: 'yes'
-        base-branch: main
+        base-branch: ${{ github.base_ref }}

--- a/docs/release/role-handbooks/ci-signal/README.md
+++ b/docs/release/role-handbooks/ci-signal/README.md
@@ -45,7 +45,6 @@ While we add test coverage for the new release branch we will also drop the test
   TEST_INFRA_DIR=../../k8s.io/test-infra make generate-test-infra-prowjobs
   ```
 6. Verify the jobs and dashboards a day later by taking a look at: `https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-1.8`
-7. Update the [PR markdown link checker](https://github.com/kubernetes-sigs/cluster-api/blob/main/.github/workflows/pr-md-link-check.yaml) accordingly (e.g. `main` -> `release-1.8`).
 
 Prior art:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

- Use `github.base_ref ` instead of `main` or `release-XX` in markdown-link-check

**Which issue(s) this PR fixes** 

Fixes #12010 

/area release
/kind cleanup