### PR TITLE
[WIP] 🌱 Run all tests with race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -906,11 +906,7 @@ test-no-race: $(SETUP_ENVTEST) ## Run unit and integration tests
 
 .PHONY: test
 test: $(SETUP_ENVTEST) ## Run unit and integration tests with race detector
-	# Note: Fuzz tests are not executed with race detector because they would just time out.
-	# To achieve that, all files with fuzz tests have the "!race" build tag, to still run fuzz tests
-	# we have an additional `go test` run that focuses on "TestFuzzyConversion".
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -race ./... $(TEST_ARGS)
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -run "^TestFuzzyConversion$$" ./... $(TEST_ARGS)
 
 .PHONY: test-verbose
 test-verbose: ## Run unit and integration tests with race detector and with verbose flag

--- a/api/addons/v1beta1/conversion_test.go
+++ b/api/addons/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/api/v1beta1/conversion_test.go
+++ b/api/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -32,7 +30,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for Cluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/api/v1beta1/conversion_test.go
+++ b/bootstrap/kubeadm/api/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -27,7 +25,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -29,7 +27,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -29,7 +27,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterConfiguration", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -31,7 +29,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion_no_fuzz_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion_no_fuzz_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // This test case has been moved out of conversion_test.go because it should be run with the race detector.
-// Note: The tests in conversion_test.go are disabled when the race detector is enabled (via "//go:build !race") because otherwise the fuzz tests would just time out.
+// Note: The tests in conversion_test.go are disabled when the race detector is enabled (via "") because otherwise the fuzz tests would just time out.
 
 func TestTimeoutForControlPlaneMigration(t *testing.T) {
 	timeout := metav1.Duration{Duration: 10 * time.Second}

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -31,7 +29,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	g := NewWithT(t)

--- a/controlplane/kubeadm/api/v1beta1/conversion_test.go
+++ b/controlplane/kubeadm/api/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -27,7 +25,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/exp/api/v1beta1/conversion_test.go
+++ b/exp/api/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for MachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/exp/ipam/api/v1alpha1/conversion_test.go
+++ b/exp/ipam/api/v1alpha1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -27,7 +25,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for IPAddress", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/exp/ipam/api/v1beta1/conversion_test.go
+++ b/exp/ipam/api/v1beta1/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2025 The Kubernetes Authors.
 
@@ -27,7 +25,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for IPAddress", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/addons/v1alpha3/conversion_test.go
+++ b/internal/apis/addons/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/addons/v1alpha4/conversion_test.go
+++ b/internal/apis/addons/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/bootstrap/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -30,7 +28,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/bootstrap/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/apis/bootstrap/kubeadm/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -34,7 +32,7 @@ const (
 	fakeSecret = "abcdef0123456789"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmConfig", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/controlplane/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -31,7 +29,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/controlplane/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/apis/controlplane/kubeadm/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -38,7 +36,7 @@ const (
 	fakeSecret = "abcdef0123456789"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/v1alpha3/conversion_test.go
+++ b/internal/apis/core/exp/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -30,7 +28,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for MachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/exp/v1alpha4/conversion_test.go
+++ b/internal/apis/core/exp/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for MachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/v1alpha3/conversion_test.go
+++ b/internal/apis/core/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2020 The Kubernetes Authors.
 
@@ -31,7 +29,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for Cluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/internal/apis/core/v1alpha4/conversion_test.go
+++ b/internal/apis/core/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -32,7 +30,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for Cluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/exp/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{

--- a/test/infrastructure/docker/exp/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/conversion_test.go
@@ -1,5 +1,3 @@
-//go:build !race
-
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -25,7 +23,7 @@ import (
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
-// Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
+// Test is disabled when the race detector is enabled (via "" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
 	t.Run("for DockerMachinePool", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Cleanup in the context of https://github.com/kubernetes-sigs/cluster-api/issues/11947

Just a test, not sure if it works

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->