### PR TITLE
:seedling: clusterctl init: add flag for retrying cert-manager readiness check

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -251,7 +251,7 @@ type fakeCertManagerClient struct {
 
 var _ cluster.CertManagerClient = &fakeCertManagerClient{}
 
-func (p *fakeCertManagerClient) EnsureInstalled(_ context.Context) error {
+func (p *fakeCertManagerClient) EnsureInstalled(_ context.Context, _ bool) error {
 	return nil
 }
 

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -76,6 +76,10 @@ type InitOptions struct {
 	// WaitProviderTimeout sets the timeout per provider wait installation
 	WaitProviderTimeout time.Duration
 
+	// RetryCertManagerReadinessCheck instructs the init command to retry the check for cert-manager readiness
+	// before attempting to install it.
+	RetryCertManagerReadinessCheck bool
+
 	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
 	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
 	skipTemplateProcess bool
@@ -142,7 +146,7 @@ func (c *clusterctlClient) Init(ctx context.Context, options InitOptions) ([]Com
 
 	// Before installing the providers, ensure the cert-manager Webhook is in place.
 	certManager := clusterClient.CertManager()
-	if err := certManager.EnsureInstalled(ctx); err != nil {
+	if err := certManager.EnsureInstalled(ctx, options.RetryCertManagerReadinessCheck); err != nil {
 		return nil, err
 	}
 

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -193,9 +193,11 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
-While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.17.1). See [clusterctl configuration](../configuration.md) for
-available options to customize this operation.
+While doing init, clusterctl checks if there is a version of cert-manager already installed. By default, a single check
+is performed, but users can use `--retry-cert-manager-readiness-check` to ensure that clusterctl keeps retrying
+after initial failure. 
+In case the single check fails (default) or all retry attempts are exhaused, clusterctl will install a default version 
+(currently cert-manager v1.17.1). See [clusterctl configuration](../configuration.md) for available options to customize this operation.
 
 <aside class="note warning">
 

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -583,7 +583,7 @@ func certManagerTask() taskFunction {
 		}
 		cluster := cluster.New(cluster.Kubeconfig{}, config)
 
-		if err := cluster.CertManager().EnsureInstalled(ctx); err != nil {
+		if err := cluster.CertManager().EnsureInstalled(ctx, false); err != nil {
 			errCh <- errors.Wrapf(err, "[%s] failed to install cert-manger", prefix)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

 This introduces a new clusterctl init flag "--retry-cert-manager-readiness-check" that allows to retry the check for an already installed cert-manager, which by default is only attempted once before a new cert-manager installation is started.
    
When enabled, cert-manager readiness check will be retried for the duration specified in clusterctl config file's cert-manager.timeout entry or for a default timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #11960 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area clusterctl