### PR TITLE
📖 ci-signal: clarified timing for dropping n-3 release support in setup steps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -66,6 +66,7 @@ Week 18:
 * [ ] [Release Lead] Organize release retrospective
 * [ ] [Communications Manager] [Change production branch in Netlify to the new release branch](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/communications#change-production-branch-in-netlify-to-the-new-release-branch)
 * [ ] [Communications Manager] [Update clusterctl links in the quickstart](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/communications#update-clusterctl-links-in-the-quickstart)
+* [ ] [CI Manager] [Post-release cleanup](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/ci-signal#post-release-cleanup)
 
 Continuously:
 * [Release lead] [Maintain the GitHub release milestone](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/release-lead#continuously-maintain-the-github-release-milestone)

--- a/docs/release/role-handbooks/ci-signal/README.md
+++ b/docs/release/role-handbooks/ci-signal/README.md
@@ -12,6 +12,7 @@
   - [Setup jobs and dashboards for a new release branch](#setup-jobs-and-dashboards-for-a-new-release-branch)
   - [[Continuously] Monitor CI signal](#continuously-monitor-ci-signal)
   - [[Continuously] Reduce the amount of flaky tests](#continuously-reduce-the-amount-of-flaky-tests)
+  - [Post-release cleanup](#post-release-cleanup)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -37,7 +38,7 @@ While we add test coverage for the new release branch we will also drop the test
     2. Modify the following at the `release-1.8` branch entry:
             * Change intervals (let's use the same as for `release-1.7`).
 2. Create a new dashboard for the new branch in: `test-infra/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml` (`dashboard_groups` and `dashboards`).
-3. Remove old release branches and unused versions from the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/) according to our policy documented in [Support and guarantees](../../../../CONTRIBUTING.md#support-and-guarantees). As we just added `release-1.8`, then we can now drop test coverage for the `release-1.5` branch.
+3. Do not remove old release branches during this setup phase.
 4. Review the templates and modify/remove any outdated logic in the templates.  For example, when `release-1.7` is dropped from support, it can be removed from [this if statement](https://github.com/kubernetes/test-infra/blob/fa895d9f204e912e2bf0bd42221017a6dedf6065/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl#L42).
 5. Regenerate the prowjob configuration running `make generate-test-infra-prowjobs` command from cluster-api repository. Before running this command, ensure to export the `TEST_INFRA_DIR` variable, specifying the location of the [test-infra](https://github.com/kubernetes/test-infra/) repository in your environment. For further information, refer to this [link](https://github.com/kubernetes-sigs/cluster-api/pull/9937).
 
@@ -84,3 +85,11 @@ To reduce the amount of flakes please periodically:
 2. Open issues using an appropriate template (flaking-test) for occurring flakes and ideally fix them or find someone who can.
 
    **Note**: Given resource limitations in the Prow cluster it might not be possible to fix all flakes. Let's just try to pragmatically keep the amount of flakes pretty low.
+
+### Post-release cleanup
+Once the new minor release (e.g., `v1.8.0`) has been officially cut, perform the following cleanup:
+
+- Remove old release branches and unused versions from the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/) according to our policy documented in [Support and guarantees](https://cluster-api.sigs.k8s.io/reference/versions#cluster-api-release-support)
+
+We can now drop test coverage for branches out of support (e.g. `release-1.5`).
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR updates the CI Signal handbook to clarify the timing for dropping support for n-3 release branches during the new release setup process.

Previously, the instructions implied that support for n-3 (e.g., release-1.7 during the v1.10 cycle) should be removed during the setup phase. However, during the v1.10 release, the team aligned on delaying this step until after the new minor release (e.g., v1.10.0) has been officially cut.

This update ensures consistency with current team practices and avoids premature removal of test coverage for supported versions.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [#12025](https://github.com/kubernetes-sigs/cluster-api/issues/12025)

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->