### PR TITLE
🌱 clusterclass: improve webhook output to include the names of the clusters blocking a deletion

### DIFF
--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -40,6 +41,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/topology/check"
 	topologynames "sigs.k8s.io/cluster-api/internal/topology/names"
 	"sigs.k8s.io/cluster-api/internal/topology/variables"
+	clog "sigs.k8s.io/cluster-api/util/log"
 )
 
 func (webhook *ClusterClass) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -137,9 +139,11 @@ func (webhook *ClusterClass) ValidateDelete(ctx context.Context, obj runtime.Obj
 	}
 
 	if len(clusters) > 0 {
-		// TODO(killianmuldoon): Improve error here to include the names of some clusters using the clusterClass.
+		clustersList := clog.ListToString(clusters, func(cluster clusterv1.Cluster) string {
+			return klog.KObj(&cluster).String()
+		}, 3)
 		return nil, apierrors.NewForbidden(clusterv1.GroupVersion.WithResource("ClusterClass").GroupResource(), clusterClass.Name,
-			fmt.Errorf("ClusterClass cannot be deleted because it is used by %d Cluster(s)", len(clusters)))
+			fmt.Errorf("ClusterClass cannot be deleted because it is used by Cluster(s): %s", clustersList))
 	}
 	return nil, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Currently we would have the following error:

```
admission webhook "validation.clusterclass.cluster.x-k8s.io" denied the request: ClusterClass.cluster.x-k8s.io "my-cc" is forbidden: ClusterClass cannot be deleted because it is used by 2 Cluster(s)
```

This does not show which cluster's are blocking the deletion.

This fix lists now up to 3 clusters instead and outputs the remaining number if there are more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area topology