### PR TITLE
:bug: Fix validation of worker topology names in Cluster resource

### DIFF
--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -296,8 +296,8 @@ func MachinePoolClassesAreUnique(clusterClass *clusterv1.ClusterClass) field.Err
 	return allErrs
 }
 
-// MachineDeploymentTopologiesAreValidAndDefinedInClusterClass checks that each MachineDeploymentTopology name is not empty
-// and unique, and each class in use is defined in ClusterClass.spec.Workers.MachineDeployments.
+// MachineDeploymentTopologiesAreValidAndDefinedInClusterClass checks that each MachineDeploymentTopology name is not empty,
+// is a valid Kubernetes resource name, is unique, and each class in use is defined in ClusterClass.spec.Workers.MachineDeployments.
 func MachineDeploymentTopologiesAreValidAndDefinedInClusterClass(desired *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
 	var allErrs field.ErrorList
 	if desired.Spec.Topology.Workers == nil {
@@ -310,7 +310,8 @@ func MachineDeploymentTopologiesAreValidAndDefinedInClusterClass(desired *cluste
 	machineDeploymentClasses := mdClassNamesFromWorkerClass(clusterClass.Spec.Workers)
 	names := sets.Set[string]{}
 	for i, md := range desired.Spec.Topology.Workers.MachineDeployments {
-		if errs := validation.IsValidLabelValue(md.Name); len(errs) != 0 {
+		// The Name must be a valid Kubernetes resource name, because it is used to generate the MachineDeployment name.
+		if errs := validation.IsDNS1123Label(md.Name); len(errs) != 0 {
 			for _, err := range errs {
 				allErrs = append(
 					allErrs,
@@ -360,8 +361,8 @@ func MachineDeploymentTopologiesAreValidAndDefinedInClusterClass(desired *cluste
 	return allErrs
 }
 
-// MachinePoolTopologiesAreValidAndDefinedInClusterClass checks that each MachinePoolTopology name is not empty
-// and unique, and each class in use is defined in ClusterClass.spec.Workers.MachinePools.
+// MachinePoolTopologiesAreValidAndDefinedInClusterClass checks that each MachinePoolTopology name is not empty,
+// is a valid Kubernetes resource name, is unique, and each class in use is defined in ClusterClass.spec.Workers.MachinePools.
 func MachinePoolTopologiesAreValidAndDefinedInClusterClass(desired *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
 	var allErrs field.ErrorList
 	if desired.Spec.Topology.Workers == nil {
@@ -374,7 +375,8 @@ func MachinePoolTopologiesAreValidAndDefinedInClusterClass(desired *clusterv1.Cl
 	machinePoolClasses := mpClassNamesFromWorkerClass(clusterClass.Spec.Workers)
 	names := sets.Set[string]{}
 	for i, mp := range desired.Spec.Topology.Workers.MachinePools {
-		if errs := validation.IsValidLabelValue(mp.Name); len(errs) != 0 {
+		// The Name must be a valid Kubernetes resource name, because it is used to generate the MachinePool name.
+		if errs := validation.IsDNS1123Label(mp.Name); len(errs) != 0 {
 			for _, err := range errs {
 				allErrs = append(
 					allErrs,

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1850,6 +1850,34 @@ func TestClusterTopologyValidation(t *testing.T) {
 				Build(),
 		},
 		{
+			name:      "should return error when MachineDeploymentTopology name is not a valid Kubernetes resource name",
+			expectErr: true,
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("under_score").
+							WithClass("aa").
+							Build()).
+					Build()).
+				Build(),
+		},
+		{
+			name:      "should return error when MachinePoolTopology name is not a valid Kubernetes resource name",
+			expectErr: true,
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					WithMachinePool(
+						builder.MachinePoolTopology("under_score").
+							WithClass("aa").
+							Build()).
+					Build()).
+				Build(),
+		},
+		{
 			name:      "should update",
 			expectErr: false,
 			old: builder.Cluster("fooboo", "cluster1").


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The worker topology name is used to generate the name of a Kubernetes resource (MachineDelpoyment or MachinePool), and must therefore be a valid Kubernetes resource name. The existing validation does not ensure this.

The first commit adds tests; without a fix, they fail, as expected.
The second commit fixes the validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12068

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area clusterclass