### PR TITLE
:bug: Fix MaxLength of worker topology Name fields

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -686,7 +686,7 @@ type MachineDeploymentTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// failureDomain is the failure domain the machines will be created in.
@@ -797,7 +797,7 @@ type MachinePoolTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// failureDomains is the list of failure domains the machine pool will be created in.

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -686,7 +686,7 @@ type MachineDeploymentTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
 	// failureDomain is the failure domain the machines will be created in.
@@ -797,7 +797,7 @@ type MachinePoolTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
 	// failureDomains is the list of failure domains the machine pool will be created in.

--- a/api/v1beta2/cluster_types.go
+++ b/api/v1beta2/cluster_types.go
@@ -686,7 +686,7 @@ type MachineDeploymentTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// failureDomain is the failure domain the machines will be created in.
@@ -797,7 +797,7 @@ type MachinePoolTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// failureDomains is the list of failure domains the machine pool will be created in.

--- a/api/v1beta2/cluster_types.go
+++ b/api/v1beta2/cluster_types.go
@@ -686,7 +686,7 @@ type MachineDeploymentTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
 	// failureDomain is the failure domain the machines will be created in.
@@ -797,7 +797,7 @@ type MachinePoolTopology struct {
 	// the values are hashed together.
 	// +required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=256
+	// +kubebuilder:validation:MaxLength=64
 	Name string `json:"name"`
 
 	// failureDomains is the list of failure domains the machine pool will be created in.

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1512,7 +1512,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 64
+                              maxLength: 63
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -1793,7 +1793,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 64
+                              maxLength: 63
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -2941,7 +2941,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 64
+                              maxLength: 63
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -3222,7 +3222,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 64
+                              maxLength: 63
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1512,7 +1512,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 256
+                              maxLength: 64
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -1793,7 +1793,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 256
+                              maxLength: 64
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -2941,7 +2941,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachineDeployment's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 256
+                              maxLength: 64
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:
@@ -3222,7 +3222,7 @@ spec:
                                 The value is used with other unique identifiers to create a MachinePool's Name
                                 (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
                                 the values are hashed together.
-                              maxLength: 256
+                              maxLength: 64
                               minLength: 1
                               type: string
                             nodeDeletionTimeout:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Due to existing webhook validation, the effective max length was, and continues to be 63 characters. This updates the annotation (and CRD) to reflect this.

This PR came from a conversation in another PR: https://github.com/kubernetes-sigs/cluster-api/pull/12069#issuecomment-2785764984

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area clusterclass
/area api