### PR TITLE
:bug: Fix potential panic if ClusterResourceSetStrategy is not defined or incorrect

### DIFF
--- a/internal/controllers/clusterresourceset/clusterresourceset_scope.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_scope.go
@@ -58,7 +58,7 @@ func reconcileScopeForResource(
 		return nil, err
 	}
 
-	return newResourceReconcileScope(crs, resourceRef, resourceSetBinding, normalizedData, objs), nil
+	return newResourceReconcileScope(crs, resourceRef, resourceSetBinding, normalizedData, objs)
 }
 
 func newResourceReconcileScope(
@@ -67,7 +67,7 @@ func newResourceReconcileScope(
 	resourceSetBinding *addonsv1.ResourceSetBinding,
 	normalizedData [][]byte,
 	objs []unstructured.Unstructured,
-) resourceReconcileScope {
+) (resourceReconcileScope, error) {
 	base := baseResourceReconcileScope{
 		clusterResourceSet: clusterResourceSet,
 		resourceRef:        resourceRef,
@@ -79,11 +79,11 @@ func newResourceReconcileScope(
 
 	switch addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy) {
 	case addonsv1.ClusterResourceSetStrategyApplyOnce:
-		return &reconcileApplyOnceScope{base}
+		return &reconcileApplyOnceScope{base}, nil
 	case addonsv1.ClusterResourceSetStrategyReconcile:
-		return &reconcileStrategyScope{base}
+		return &reconcileStrategyScope{base}, nil
 	default:
-		return nil
+		return nil, errors.Errorf("unsupported or empty resource strategy: %q", clusterResourceSet.Spec.Strategy)
 	}
 }
 
@@ -173,7 +173,7 @@ func (r *reconcileApplyOnceScope) applyObj(ctx context.Context, c client.Client,
 
 type applyObj func(ctx context.Context, c client.Client, obj *unstructured.Unstructured) error
 
-// apply reconciles unstructured objects using applyObj and aggreates the error if present.
+// apply reconciles unstructured objects using applyObj and aggregates the error if present.
 func apply(ctx context.Context, c client.Client, applyObj applyObj, objs []unstructured.Unstructured) error {
 	errList := []error{}
 	for i := range objs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This is small fix which prevents potential situation when `resourceScope` and `error` values could be `nil` simalteniously.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->