### PR TITLE
[release-1.10] ✨ Bump Kubernetes in tests to v1.33.0 and claim support for v1.33

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -238,7 +238,6 @@ See [Cluster API release support](#cluster-api-release-support) and [Kubernetes 
 
 |                  | v1.8, _Maintenance Mode_ | v1.9              | v1.10             |
 |------------------|--------------------------|-------------------|-------------------|
-| Kubernetes v1.24 |                          |                   |                   |
 | Kubernetes v1.25 | ✓ (only workload)        |                   |                   |
 | Kubernetes v1.26 | ✓ (only workload)        | ✓ (only workload) |                   |
 | Kubernetes v1.27 | ✓                        | ✓ (only workload) | ✓ (only workload) |
@@ -247,6 +246,7 @@ See [Cluster API release support](#cluster-api-release-support) and [Kubernetes 
 | Kubernetes v1.30 | ✓                        | ✓                 | ✓                 |
 | Kubernetes v1.31 | ✓ >= v1.8.1              | ✓                 | ✓                 |
 | Kubernetes v1.32 |                          | ✓ >= v1.9.1       | ✓                 |
+| Kubernetes v1.33 |                          |                   | ✓ >= v1.10.1      |
 
 See also [Kubernetes version specific notes](#kubernetes-version-specific-notes).
 
@@ -267,7 +267,6 @@ using the [kubeadm API](https://kubernetes.io/docs/setup/production-environment/
 
 |                  | kubeadm API Version                                                                |
 |------------------|------------------------------------------------------------------------------------|
-| Kubernetes v1.24 | [v1beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) |
 | Kubernetes v1.25 | [v1beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) |
 | Kubernetes v1.26 | [v1beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) |
 | Kubernetes v1.27 | [v1beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) |
@@ -276,6 +275,7 @@ using the [kubeadm API](https://kubernetes.io/docs/setup/production-environment/
 | Kubernetes v1.30 | [v1beta3](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/) |
 | Kubernetes v1.31 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
 | Kubernetes v1.32 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
+| Kubernetes v1.33 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
 
 ### Kubeadm Control Plane provider (`kubeadm-control-plane-controller`)
 

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -367,10 +367,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0-rc.1"
-  KUBERNETES_VERSION: "v1.33.0-rc.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0"
+  KUBERNETES_VERSION: "v1.33.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.2"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0-rc.1"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.33"
   ETCD_VERSION_UPGRADE_TO: "3.5.21-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.12.0"

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.33.0-rc.1
+  version: v1.33.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -77,7 +77,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.33.0-rc.1
+      version: v1.33.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.33.0-rc.1
+  version: v1.33.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -87,7 +87,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.33.0-rc.1
+      version: v1.33.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.33.0-rc.1
+  version: v1.33.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -76,7 +76,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.33.0-rc.1
+      version: v1.33.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.33.0-rc.1
+  version: v1.33.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.33.0-rc.1
+      version: v1.33.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/11642

/area testing