### PR TITLE
:seedling: Avoid large number of connection error traces in kubeadm controlplane controller

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -216,7 +216,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err := r.updateStatus(ctx, controlPlane); err != nil {
 			var connFailure *internal.RemoteClusterConnectionError
 			if errors.As(err, &connFailure) {
-				log.Error(err, "Could not connect to workload cluster to fetch status")
+				log.Info(fmt.Sprintf("Could not connect to workload cluster to fetch status: %s", err.Error()))
 			} else {
 				reterr = kerrors.NewAggregate([]error{reterr, errors.Wrap(err, "failed to update KubeadmControlPlane status")})
 			}
@@ -225,7 +225,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err := r.updateV1Beta1Status(ctx, controlPlane); err != nil {
 			var connFailure *internal.RemoteClusterConnectionError
 			if errors.As(err, &connFailure) {
-				log.Error(err, "Could not connect to workload cluster to fetch deprecated v1beta1 status")
+				log.Info(fmt.Sprintf("Could not connect to workload cluster to fetch deprecated v1beta1 status: %s", err.Error()))
 			} else {
 				reterr = kerrors.NewAggregate([]error{reterr, errors.Wrap(err, "failed to update KubeadmControlPlane deprecated v1beta1 status")})
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This small fix removes large number of stack traces of the workload cluster connection error while it's not ready. The logs spams with predictable stack trace on each reconcile loop with full stack trace instead connection is not ready info. 
```bash
2025-04-16T19:50:59+03:00	INFO	Reconcile KubeadmControlPlane	{"controller": "kubeadmcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "KubeadmControlPlane", "KubeadmControlPlane": {"name":"test-mgmt-control-plane","namespace":"default"}, "namespace": "default", "name": "test-mgmt-control-plane", "reconcileID": "b5b5f0e9-e0a5-46eb-925a-9536fb144e23", "Cluster": {"name":"test-mgmt","namespace":"default"}}
2025-04-16T19:50:59+03:00	INFO	Scaling up control plane	{"controller": "kubeadmcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "KubeadmControlPlane", "KubeadmControlPlane": {"name":"test-mgmt-control-plane","namespace":"default"}, "namespace": "default", "name": "test-mgmt-control-plane", "reconcileID": "b5b5f0e9-e0a5-46eb-925a-9536fb144e23", "Cluster": {"name":"test-mgmt","namespace":"default"}, "desired": 3, "existing": 1}
2025-04-16T19:50:59+03:00	INFO	Waiting for control plane to pass preflight checks	{"controller": "kubeadmcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "KubeadmControlPlane", "KubeadmControlPlane": {"name":"test-mgmt-control-plane","namespace":"default"}, "namespace": "default", "name": "test-mgmt-control-plane", "reconcileID": "b5b5f0e9-e0a5-46eb-925a-9536fb144e23", "Cluster": {"name":"test-mgmt","namespace":"default"}, "failures": "Machine test-mgmt-control-plane-pqh7s does not have a corresponding Node yet (Machine.status.nodeRef not set)"}
2025-04-16T19:50:59+03:00	DEBUG	events	Waiting for control plane to pass preflight checks to continue reconciliation: Machine test-mgmt-control-plane-pqh7s does not have a corresponding Node yet (Machine.status.nodeRef not set)	{"type": "Warning", "object": {"kind":"KubeadmControlPlane","namespace":"default","name":"test-mgmt-control-plane","uid":"06538869-e95e-40e4-8a90-f602672391e5","apiVersion":"controlplane.cluster.x-k8s.io/v1beta1","resourceVersion":"742"}, "reason": "ControlPlaneUnhealthy"}
2025-04-16T19:50:59+03:00	ERROR	Could not connect to workload cluster to fetch status	{"controller": "kubeadmcontrolplane", "controllerGroup": "controlplane.cluster.x-k8s.io", "controllerKind": "KubeadmControlPlane", "KubeadmControlPlane": {"name":"test-mgmt-control-plane","namespace":"default"}, "namespace": "default", "name": "test-mgmt-control-plane", "reconcileID": "b5b5f0e9-e0a5-46eb-925a-9536fb144e23", "Cluster": {"name":"test-mgmt","namespace":"default"}, "error": "failed to create remote cluster client: default/test-mgmt: failed to get REST config: failed to create cluster accessor: error creating http client and mapper for remote cluster \"default/test-mgmt\": error creating client for remote cluster \"default/test-mgmt\": cluster is not reachable: Get \"https://10.0.180.10:6443/?timeout=5s\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")", "errorVerbose": "default/test-mgmt: failed to get REST config: failed to create cluster accessor: error creating http client and mapper for remote cluster \"default/test-mgmt\": error creating client for remote cluster \"default/test-mgmt\": cluster is not reachable: Get \"https://10.0.180.10:6443/?timeout=5s\": tls: failed to verify certificate: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")\nfailed to create remote cluster client\nsigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers.(*KubeadmControlPlaneReconciler).updateStatus\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/cluster-api@v1.8.11/controlplane/kubeadm/internal/controllers/status.go:89\nsigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers.(*KubeadmControlPlaneReconciler).Reconcile.func1\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/cluster-api@v1.8.11/controlplane/kubeadm/internal/controllers/controller.go:206\nsigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers.(*KubeadmControlPlaneReconciler).Reconcile\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/cluster-api@v1.8.11/controlplane/kubeadm/internal/controllers/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:222\nruntime.goexit\n\t/home/dvolodin/sdk/go1.23.5/src/runtime/asm_amd64.s:1700"}
sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers.(*KubeadmControlPlaneReconciler).Reconcile.func1
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/cluster-api@v1.8.11/controlplane/kubeadm/internal/controllers/controller.go:209
sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/controllers.(*KubeadmControlPlaneReconciler).Reconcile
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/cluster-api@v1.8.11/controlplane/kubeadm/internal/controllers/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:261
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/home/dvolodin/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/internal/controller/controller.go:222
```

Another fix can be implemented with validation `controlPlane.Cluster.Status.InfrastructureReady` before connection to avoid connection problems and large number of noisy stack traces. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area control-plane