### PR TITLE
✨ From 1.10 use GetStableReleaseOfMinor instead of GetLatestReleaseOfMinor

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -278,7 +278,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.9=>cur
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>current) [ClusterClass]", Label("ClusterClass"), func() {
 	// Get n-1 latest stable release
 	version := "1.10"
-	stableRelease, err := GetLatestReleaseOfMinor(ctx, version) // NOTE: use GetStableReleaseOfMinor as soon as v1.10 is GA
+	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version)
 	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
 		return ClusterctlUpgradeSpecInput{
@@ -313,7 +313,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>cu
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>current) on K8S latest ci mgmt cluster [ClusterClass]", Label("ClusterClass"), func() {
 	// Get n-1 latest stable release
 	version := "1.10"
-	stableRelease, err := GetLatestReleaseOfMinor(ctx, version) // NOTE: use GetStableReleaseOfMinor as soon as v1.10 is GA
+	stableRelease, err := GetStableReleaseOfMinor(ctx, version)
 	Expect(err).ToNot(HaveOccurred(), "Failed to get stable version for minor release : %s", version)
 	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
 		initKubernetesVersion, err := kubernetesversions.ResolveVersion(ctx, e2eConfig.MustGetVariable("KUBERNETES_VERSION_LATEST_CI"))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: [Per the 1.10 Release Tasks](https://github.com/kubernetes-sigs/cluster-api/issues/11656), we need to:
"Fix clusterctl upgrade tests starting from 1.10 to use GetStableReleaseOfMinor instead of GetLatestReleaseOfMinor"

I believe the correct procedure is to commit this to main and then cherry pick to 1.10, but let me know if that's not the case and I'll resubmit corrected PRs.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing