### PR TITLE
📖 Add Cluster API release-1.11 timeline document

### DIFF
--- a/docs/release/releases/release-1.11.md
+++ b/docs/release/releases/release-1.11.md
@@ -1,0 +1,42 @@
+# Cluster API v1.11
+
+## Timeline
+
+The following table shows the preliminary dates for the `v1.11` release cycle.
+
+| **What**                                              | **Who**       | **When**                    | **Week** |
+|-------------------------------------------------------|---------------|-----------------------------|----------|
+| Start of Release Cycle                                | Release Lead  | Monday 28th April 2025      | week 1   |
+| Schedule finalized                                    | Release Lead  | Monday 28th April 2025      | week 1   |
+| Team finalized                                        | Release Lead  | Monday 28th April 2025      | week 1   |
+| *v1.10.x released (tentative)*                        | Release Lead  | Tuesday 29th April 2025     | week 1   |
+| *v1.9.x & v1.10.x released*                           | Release Lead  | Tuesday 20th May 2025       | week 4   |
+| v1.11.0-alpha.0 released                              | Release Lead  | Tuesday 28th May 2025       | week 5   |
+| Communicate alpha to providers                        | Comms Mgr     | Tuesday 28th May 2025       | week 5   |
+| *v1.9.x & v1.10.x released*                           | Release Lead  | Tuesday 17th June 2025      | week 8   |
+| v1.11.0-alpha.1 released (to be confirmed)            | Release Lead  | Tuesday 17th June 2025      | week 8   |
+| v1.11.0-alpha.2 released  (to be confirmed)           | Release Lead  | Tuesday 1st July 2025       | week 10  |
+| *v1.9.x & v1.10.x released*                           | Release Lead  | Tuesday 15th July 2025      | week 12  |
+| v1.11.0-beta.0 released                               | Release Lead  | Tuesday 15th July 2025      | week 12  |
+| Communicate beta to providers                         | Comms Mgr     | Tuesday 15th July 2025      | week 12  |
+| Communicate upcoming code freeze to the community     | Comms Mgr     | Tuesday 15th July 2025      | week 12  |
+| v1.11.0-beta.x released                               | Release Lead  | Tuesday 22nd July 2025      | week 13  |
+| release-1.11 branch created (**Begin [Code Freeze]**) | Release Lead  | Tuesday 29th July 2025      | week 14  |
+| v1.11.0-rc.0 released                                 | Release Lead  | Tuesday 29th July 2025      | week 14  |
+| release-1.11 jobs created                             | CI Mgr        | Tuesday 29th July 2025      | week 14  |
+| v1.11.0-rc.1 released                                 | Release Lead  | Tuesday 5th August 2025     | week 15  |
+| **v1.11.0 released**                                  | Release Lead  | Tuesday 12th August 2025    | week 16  |
+| *v1.9.x & v1.10.x released*                           | Release Lead  | Tuesday 12th August 2025    | week 16  |
+| Organize release retrospective                        | Release Lead  | TBC                         | week 16  |
+| *v1.11.1 released (tentative)*                        | Release Lead  | Tuesday 19th August 2025    | week 17  |
+
+
+## Release team
+
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
+| Release Lead                              | Chris Privitere ([@cprivitere](https://github.com/cprivitere) / `@Chris Privitere`) | |
+| Communications/Docs/Release Notes Manager | Chandan Kumar ([@chandankumar4](https://github.com/chandankumar4) / `@Chandan Kumar`) | |
+| CI Signal/Bug Triage/Automation Manager   | Matt Boersma ([@mboersma](https://github.com/mboersma) / `@mboersma`) | |
+| Emeritus Advisor                          | TBD | TBD |
+| Maintainer                                | TBD | TBD |


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds the release-1.11 cycle schedule document with preliminary dates and release team members.

Part of: #11656

/area release
/kind documentation