### PR TITLE
:book: Add missing space to kustomize build command

### DIFF
--- a/docs/book/src/tasks/using-kustomize.md
+++ b/docs/book/src/tasks/using-kustomize.md
@@ -190,6 +190,6 @@ namePrefix: "blue-"
 nameSuffix: "-dev"
 ```
 
-Running `kustomize build. ` with this configuration would modify the name of all the Cluster API
+Running `kustomize build .` with this configuration would modify the name of all the Cluster API
 objects _and_ the associated referenced objects, adding "blue-" at the beginning and appending "-dev"
 at the end.


### PR DESCRIPTION
**What this PR does / why we need it**:

The `kustomize build .` command needs a space before the dot.

/area documentation
