### PR TITLE
🚀 Release v1.10.1

### DIFF
--- a/CHANGELOG/v1.10.1.md
+++ b/CHANGELOG/v1.10.1.md
@@ -1,0 +1,36 @@
+## 👌 Kubernetes version support
+
+- Management Cluster: v1.28.x -> v1.33.x
+- Workload Cluster: v1.26.x -> v1.33.x
+
+[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+## Changes since v1.10.0
+## :chart_with_upwards_trend: Overview
+- 5 new commits merged
+- 1 feature addition ✨
+- 2 bugs fixed 🐛
+
+## :sparkles: New Features
+- Testing: Bump Kubernetes in tests to v1.33.0 and claim support for v1.33 (#12105)
+
+## :bug: Bug Fixes
+- Bootstrap: Make joinConfiguration.discovery.bootstrapToken.token optional (#12136)
+
+## :seedling: Others
+- Dependency: Bump cert-manager to v1.17.1 (#12127)
+
+:book: Additionally, there has been 1 contribution to our documentation and book. (#12124) 
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added release notes of v1.10.1

**Which issue(s) this PR fixes**
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/11656

/area release