### PR TITLE
📖 Fix broken link to cluster-api-provider-nested

### DIFF
--- a/docs/release/role-handbooks/communications/README.md
+++ b/docs/release/role-handbooks/communications/README.md
@@ -191,7 +191,7 @@ We should inform at least the following providers via a new issue on their respe
 * Kubevirt: https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/new
 * IBMCloud: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/new
 * Metal3: https://github.com/metal3-io/cluster-api-provider-metal3/issues/new
-* Nested: https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/new
+* Nested (read-only): https://github.com/kubernetes-retired/cluster-api-provider-nested/issues
 * OCI: https://github.com/oracle/cluster-api-provider-oci/issues/new
 * Openstack: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/new
 * Operator: https://github.com/kubernetes-sigs/cluster-api-operator/issues/new


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

cluster-api-provider-nested has already been archived. I fixed broken link to it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->