### PR TITLE
⚠️ Stop using deprecated replica counters in controllers

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -16,9 +16,10 @@ proposal because most of the changes described below are a consequence of the wo
 - v1beta2 API version has been introduced; notable changes are:
   - The transition to the new K8s aligned conditions using `metav1.Conditions` types and the new condition semantic
     has been completed for all Kinds:
-    - `status.conditions` has been replaced with `status.v1beta2.conditions`
-    - the old `status.conditions` will continue to exist temporarily under `status.deprecated.v1beta1` for the sake of
-      down conversions and to provide a temporary option for users willing to continue using old conditions.
+    - `status.conditions` has been replaced with `status.v1beta2.conditions` based on metav1 condition types
+    - the old `status.conditions` based on custom cluster API condition types will continue to exist temporarily 
+      under `status.deprecated.v1beta1.conditions` for the sake of down conversions and to provide a temporary option
+      for users willing to continue using old conditions.
   - Support for terminal errors has been dropped from all Kinds
     - `status.failureReason` and `status.failureMessage` will continue to exist temporarily under `status.deprecated.v1beta1`
       for the sake of down conversions and to provide a temporary option for users willing to continue using old conditions.
@@ -27,7 +28,16 @@ proposal because most of the changes described below are a consequence of the wo
   - All the resources handling machine replicas have now a consistent set of replica counters based on corresponding
     conditions defined at machine level.
     - `status.readyReplicas`, `status.availableReplicas`, `status.upToDateReplicas` on `MachineDeployments`, `MachineSet`
-      and `KubeadmControlPlane`
+      and `KubeadmControlPlane`; please note that
+      - `status.readyReplicas` has now a new semantic based on machine's `Ready` condition
+      - `status.availableReplicas` has now a new semantic based on machine's `Available` condition
+      - `status.upToDateReplicas` has now a new semantic (and name) based on machine's `UpToDate` condition
+      - Temporarily, old replica counters will still be available under the `status.deprecated.v1beta1` struct; more specifically
+        - `status.deprecated.v1beta1.readyReplicas` with old semantic for `MachineDeployments`, `MachineSet` and `KubeadmControlPlane`
+        - `status.deprecated.v1beta1.availableReplicas` with old semantic for `MachineDeployments`, `MachineSet`
+        - `status.deprecated.v1beta1.unavailableReplicas` with old semantic for `MachineDeployments`, `KubeadmControlPlane`
+        - `status.deprecated.v1beta1.updatedReplicas` with old semantic (and name) for `MachineDeployments`, `KubeadmControlPlane`
+        - `status.deprecated.v1beta1.fullyLabeledReplicas` for `MachineSet`
     - The `Cluster` resource reports replica counters for both control plane and worker machines.
 
 ### Cluster API Contract changes
@@ -51,7 +61,14 @@ See [provider contracts](../contracts/overview.md) for more details.
 ### Deprecation
 
 - v1beta1 API version is deprecated and it will be removed tentatively in August 2026 
-  - All the fields under `status.deprecated.v1beta1` in the new v1beta2 API are deprecated and whey will be removed
+  - All the fields under `status.deprecated.v1beta1` in the new v1beta2 API are deprecated and whey will be removed. This includes:
+    - `status.deprecated.v1beta1.conditions` based on custom cluster API condition types
+    - `status.deprecated.v1beta1.failureReason` and `status.failureMessage`
+    - `status.deprecated.v1beta1.readyReplicas` with old semantic for `MachineDeployments`, `MachineSet` and `KubeadmControlPlane`
+    - `status.deprecated.v1beta1.availableReplicas` with old semantic for `MachineDeployments`, `MachineSet`
+    - `status.deprecated.v1beta1.unavailableReplicas` with old semantic for `MachineDeployments`, `KubeadmControlPlane`
+    - `status.deprecated.v1beta1.updatedReplicas` with old semantic (and name) for `MachineDeployments`, `KubeadmControlPlane`
+    - `status.deprecated.v1beta1.fullyLabeledReplicas` for `MachineSet`
 - v1beta1 conditions utils are now deprecated, and will removed as soon as v1beta1 API will be removed
 - v1beta1 support in the patch helper is now deprecated, and will removed as soon as v1beta1 API will be removed
 

--- a/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/topologymutation_variable_types.go
@@ -125,7 +125,7 @@ type ControlPlaneBuiltins struct {
 
 	// replicas is the value of the replicas field of the ControlPlane object.
 	// +optional
-	Replicas *int64 `json:"replicas,omitempty"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// machineTemplate is the value of the .spec.machineTemplate field of the ControlPlane object.
 	// +optional

--- a/exp/runtime/hooks/api/v1alpha1/zz_generated.deepcopy.go
+++ b/exp/runtime/hooks/api/v1alpha1/zz_generated.deepcopy.go
@@ -504,7 +504,7 @@ func (in *ControlPlaneBuiltins) DeepCopyInto(out *ControlPlaneBuiltins) {
 	}
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
-		*out = new(int64)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.MachineTemplate != nil {

--- a/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
+++ b/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
@@ -1031,7 +1031,7 @@ func schema_runtime_hooks_api_v1alpha1_ControlPlaneBuiltins(ref common.Reference
 						SchemaProps: spec.SchemaProps{
 							Description: "replicas is the value of the replicas field of the ControlPlane object.",
 							Type:        []string{"integer"},
-							Format:      "int64",
+							Format:      "int32",
 						},
 					},
 					"machineTemplate": {

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -354,7 +354,7 @@ func (g *generator) computeControlPlane(ctx context.Context, s *scope.Scope, inf
 	// NOTE: If the Topology.ControlPlane.replicas value is nil, it is assumed that the control plane controller
 	// does not implement support for this field and the ControlPlane object is generated without the number of Replicas.
 	if s.Blueprint.Topology.ControlPlane.Replicas != nil {
-		if err := contract.ControlPlane().Replicas().Set(controlPlane, int64(*s.Blueprint.Topology.ControlPlane.Replicas)); err != nil {
+		if err := contract.ControlPlane().Replicas().Set(controlPlane, *s.Blueprint.Topology.ControlPlane.Replicas); err != nil {
 			return nil, errors.Wrapf(err, "failed to set %s in the ControlPlane object", contract.ControlPlane().Replicas().Path())
 		}
 	}

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -1859,13 +1859,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 						WithStatus(clusterv1.MachineDeploymentStatus{
 							ObservedGeneration: 2,
 							Replicas:           2,
-							Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-								V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-									ReadyReplicas:     2,
-									UpdatedReplicas:   2,
-									AvailableReplicas: 2,
-								},
-							},
+							ReadyReplicas:      ptr.To[int32](2),
+							UpToDateReplicas:   ptr.To[int32](2),
+							AvailableReplicas:  ptr.To[int32](2),
 						}).
 						Build()
 					mdsState = duplicateMachineDeploymentsState(mdsState)

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -241,7 +241,7 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 // - spec.replicas != status.replicas.
 // - spec.replicas != status.upToDateReplicas.
 // - spec.replicas != status.readyReplicas.
-// - status.unavailableReplicas > 0.
+// - spec.replicas != status.availableReplicas.
 // NOTE: this function is used only in E2E tests.
 func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured, contractVersion string) (bool, error) {
 	desiredReplicas, err := c.Replicas().Get(obj)

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -93,95 +93,49 @@ func (c *ControlPlaneContract) ControlPlaneEndpoint() *ControlPlaneEndpoint {
 // NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
 // do support a field in the type definition from the fact that a field is not set in a given instance.
 // This is why in we are deriving if replicas is required from the ClusterClass in the topology reconciler code.
-func (c *ControlPlaneContract) Replicas() *Int64 {
-	return &Int64{
+func (c *ControlPlaneContract) Replicas() *Int32 {
+	return &Int32{
 		path: []string{"spec", "replicas"},
 	}
 }
 
 // StatusReplicas provide access to the status.replicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-func (c *ControlPlaneContract) StatusReplicas() *Int64 {
-	return &Int64{
+func (c *ControlPlaneContract) StatusReplicas() *Int32 {
+	return &Int32{
 		path: []string{"status", "replicas"},
 	}
 }
 
-// UpdatedReplicas provide access to the status.updatedReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Rename to V1Beta1DeprecatedUpdatedReplicas and make sure we are only using this method for compatibility with old contracts.
-func (c *ControlPlaneContract) UpdatedReplicas(contractVersion string) *Int64 {
-	if contractVersion == "v1beta1" {
-		return &Int64{
-			path: []string{"status", "updatedReplicas"},
-		}
-	}
-
-	return &Int64{
-		path: []string{"status", "deprecated", "v1beta1", "updatedReplicas"},
-	}
-}
-
 // ReadyReplicas provide access to the status.readyReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Rename to V1Beta1DeprecatedReadyReplicas and make sure we are only using this method for compatibility with old contracts.
-func (c *ControlPlaneContract) ReadyReplicas(contractVersion string) *Int64 {
-	if contractVersion == "v1beta1" {
-		return &Int64{
-			path: []string{"status", "readyReplicas"},
-		}
-	}
-
-	return &Int64{
-		path: []string{"status", "deprecated", "v1beta1", "readyReplicas"},
-	}
-}
-
-// UnavailableReplicas provide access to the status.unavailableReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Rename to V1Beta1DeprecatedUnavailableReplicas and make sure we are only using this method for compatibility with old contracts.
-func (c *ControlPlaneContract) UnavailableReplicas(contractVersion string) *Int64 {
-	if contractVersion == "v1beta1" {
-		return &Int64{
-			path: []string{"status", "unavailableReplicas"},
-		}
-	}
-
-	return &Int64{
-		path: []string{"status", "deprecated", "v1beta1", "unavailableReplicas"},
-	}
-}
-
-// V1Beta2ReadyReplicas provide access to the status.readyReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Drop V1Beta2 prefix..
-func (c *ControlPlaneContract) V1Beta2ReadyReplicas(contractVersion string) *Int32 {
-	if contractVersion == "v1beta1" {
-		return &Int32{
-			path: []string{"status", "v1beta2", "readyReplicas"},
-		}
-	}
-
+// NOTE: readyReplicas changed semantic in v1beta2 contract.
+func (c *ControlPlaneContract) ReadyReplicas() *Int32 {
 	return &Int32{
 		path: []string{"status", "readyReplicas"},
 	}
 }
 
-// V1Beta2AvailableReplicas provide access to the status.availableReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Drop V1Beta2 prefix.x.
-func (c *ControlPlaneContract) V1Beta2AvailableReplicas(contractVersion string) *Int32 {
-	if contractVersion == "v1beta1" {
-		return &Int32{
-			path: []string{"status", "v1beta2", "availableReplicas"},
-		}
-	}
-
+// AvailableReplicas provide access to the status.availableReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
+// NOTE: availableReplicas was introduced by the v1beta2 contract; use unavailableReplicas for the v1beta1 contract.
+func (c *ControlPlaneContract) AvailableReplicas() *Int32 {
 	return &Int32{
 		path: []string{"status", "availableReplicas"},
 	}
 }
 
-// V1Beta2UpToDateReplicas provide access to the status.upToDateReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
-// TODO (v1beta2): Drop V1Beta2 prefix.ix.
-func (c *ControlPlaneContract) V1Beta2UpToDateReplicas(contractVersion string) *Int32 {
+// V1Beta1UnavailableReplicas provide access to the status.unavailableReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
+// NOTE: use availableReplicas when working with the v1beta2 contract.
+func (c *ControlPlaneContract) V1Beta1UnavailableReplicas() *Int64 {
+	return &Int64{
+		path: []string{"status", "unavailableReplicas"},
+	}
+}
+
+// UpToDateReplicas provide access to the status.upToDateReplicas field in a ControlPlane object, if any. Applies to implementations using replicas.
+// NOTE: upToDateReplicas was introduced by the v1beta2 contract; code will fall back to updatedReplicas for the v1beta1 contract.
+func (c *ControlPlaneContract) UpToDateReplicas(contractVersion string) *Int32 {
 	if contractVersion == "v1beta1" {
 		return &Int32{
-			path: []string{"status", "v1beta2", "upToDateReplicas"},
+			path: []string{"status", "updatedReplicas"},
 		}
 	}
 
@@ -291,12 +245,8 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured, contractVersion string) (bool, error) {
 	desiredReplicas, err := c.Replicas().Get(obj)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get control plane spec replicas")
+		return false, errors.Wrapf(err, "failed to get control plane %s", c.Replicas().Path().String())
 	}
-
-	// TODO (v1beta2): Add a new code path using v1beta2 replica counters
-	//  note: currently we are still always using v1beta1 counters no matter if they are moved under deprecated
-	//  but we should stop doing this ASAP
 
 	statusReplicas, err := c.StatusReplicas().Get(obj)
 	if err != nil {
@@ -306,10 +256,10 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured, contrac
 			// so that we can block any operations that expect control plane to be stable.
 			return true, nil
 		}
-		return false, errors.Wrap(err, "failed to get control plane status replicas")
+		return false, errors.Wrapf(err, "failed to get control plane %s", c.StatusReplicas().Path().String())
 	}
 
-	updatedReplicas, err := c.UpdatedReplicas(contractVersion).Get(obj)
+	upToDatedReplicas, err := c.UpToDateReplicas(contractVersion).Get(obj)
 	if err != nil {
 		if errors.Is(err, ErrFieldNotFound) {
 			// If updatedReplicas is not set on the control plane
@@ -317,10 +267,10 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured, contrac
 			// we block any operation that expect the control plane to be stable.
 			return true, nil
 		}
-		return false, errors.Wrap(err, "failed to get control plane status updatedReplicas")
+		return false, errors.Wrapf(err, "failed to get control plane %s", c.UpToDateReplicas(contractVersion).Path().String())
 	}
 
-	readyReplicas, err := c.ReadyReplicas(contractVersion).Get(obj)
+	readyReplicas, err := c.ReadyReplicas().Get(obj)
 	if err != nil {
 		if errors.Is(err, ErrFieldNotFound) {
 			// If readyReplicas is not set on the control plane
@@ -328,32 +278,46 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured, contrac
 			// we block any operation that expect the control plane to be stable.
 			return true, nil
 		}
-		return false, errors.Wrap(err, "failed to get control plane status readyReplicas")
+		return false, errors.Wrapf(err, "failed to get control plane %s", c.ReadyReplicas().Path().String())
 	}
 
-	unavailableReplicas, err := c.UnavailableReplicas(contractVersion).Get(obj)
-	if err != nil {
-		if !errors.Is(err, ErrFieldNotFound) {
-			return false, errors.Wrap(err, "failed to get control plane status unavailableReplicas")
+	var availableReplicas *int32
+	if contractVersion == "v1beta1" {
+		unavailableReplicas, err := c.V1Beta1UnavailableReplicas().Get(obj)
+		if err != nil {
+			if !errors.Is(err, ErrFieldNotFound) {
+				return false, errors.Wrapf(err, "failed to get control plane %s", c.V1Beta1UnavailableReplicas().Path().String())
+			}
+			// If unavailableReplicas is not set on the control plane we assume it is 0.
+			// We have to do this as the following happens after clusterctl move with KCP:
+			// * clusterctl move creates the KCP object without status
+			// * the KCP controller won't patch the field to 0 if it doesn't exist
+			//   * This is because the patchHelper marshals before/after object to JSON to calculate a diff
+			//     and as the unavailableReplicas field is not a pointer, not set and 0 are both rendered as 0.
+			//     If before/after of the field is the same (i.e. 0), there is no diff and thus also no patch to set it to 0.
+			unavailableReplicas = ptr.To[int64](0)
 		}
-		// If unavailableReplicas is not set on the control plane we assume it is 0.
-		// We have to do this as the following happens after clusterctl move with KCP:
-		// * clusterctl move creates the KCP object without status
-		// * the KCP controller won't patch the field to 0 if it doesn't exist
-		//   * This is because the patchHelper marshals before/after object to JSON to calculate a diff
-		//     and as the unavailableReplicas field is not a pointer, not set and 0 are both rendered as 0.
-		//     If before/after of the field is the same (i.e. 0), there is no diff and thus also no patch to set it to 0.
-		unavailableReplicas = ptr.To[int64](0)
+		availableReplicas = ptr.To(*desiredReplicas - int32(*unavailableReplicas))
+	} else {
+		availableReplicas, err = c.AvailableReplicas().Get(obj)
+		if err != nil {
+			if errors.Is(err, ErrFieldNotFound) {
+				// If readyReplicas is not set on the control plane
+				// we should consider the control plane to be scaling so that
+				// we block any operation that expect the control plane to be stable.
+				return true, nil
+			}
+			return false, errors.Wrapf(err, "failed to get control plane %s", c.AvailableReplicas().Path().String())
+		}
 	}
 
 	// Control plane is still scaling if:
-	// * .spec.replicas, .status.replicas, .status.updatedReplicas,
-	//   .status.readyReplicas are not equal and
-	// * unavailableReplicas > 0
+	// * .spec.replicas, .status.replicas, .status.upToDateReplicas,
+	//   .status.readyReplicas, .status.availableReplicas are not equal.
 	if *statusReplicas != *desiredReplicas ||
-		*updatedReplicas != *desiredReplicas ||
+		*upToDatedReplicas != *desiredReplicas ||
 		*readyReplicas != *desiredReplicas ||
-		*unavailableReplicas > 0 {
+		*availableReplicas != *desiredReplicas {
 		return true, nil
 	}
 	return false, nil

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -103,200 +103,85 @@ func TestControlPlane(t *testing.T) {
 
 		g.Expect(ControlPlane().Replicas().Path()).To(Equal(Path{"spec", "replicas"}))
 
-		err := ControlPlane().Replicas().Set(obj, int64(3))
+		err := ControlPlane().Replicas().Set(obj, int32(3))
 		g.Expect(err).ToNot(HaveOccurred())
 
 		got, err := ControlPlane().Replicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(3)))
+		g.Expect(*got).To(Equal(int32(3)))
 	})
 	t.Run("Manages status.replicas", func(t *testing.T) {
 		g := NewWithT(t)
 
 		g.Expect(ControlPlane().StatusReplicas().Path()).To(Equal(Path{"status", "replicas"}))
 
-		err := ControlPlane().StatusReplicas().Set(obj, int64(3))
+		err := ControlPlane().StatusReplicas().Set(obj, int32(3))
 		g.Expect(err).ToNot(HaveOccurred())
 
 		got, err := ControlPlane().StatusReplicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(3)))
+		g.Expect(*got).To(Equal(int32(3)))
 	})
-	t.Run("Manages status.updatedreplicas", func(t *testing.T) {
+	t.Run("Manages status.upToDateReplicas", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(ControlPlane().UpdatedReplicas("v1beta1").Path()).To(Equal(Path{"status", "updatedReplicas"}))
+		g.Expect(ControlPlane().UpToDateReplicas("v1beta1").Path()).To(Equal(Path{"status", "updatedReplicas"}))
 
-		err := ControlPlane().UpdatedReplicas("v1beta1").Set(obj, int64(3))
+		err := ControlPlane().UpToDateReplicas("v1beta1").Set(obj, int32(3))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err := ControlPlane().UpdatedReplicas("v1beta1").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(3)))
-
-		g.Expect(ControlPlane().UpdatedReplicas("v1beta2").Path()).To(Equal(Path{"status", "deprecated", "v1beta1", "updatedReplicas"}))
-
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"deprecated": map[string]interface{}{
-					"v1beta1": map[string]interface{}{
-						"updatedReplicas": int64(5),
-					},
-				},
-			},
-		}}
-
-		got, err = ControlPlane().UpdatedReplicas("v1beta2").Get(obj)
+		got, err := ControlPlane().UpToDateReplicas("v1beta1").Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(5)))
+		g.Expect(*got).To(Equal(int32(3)))
+
+		g.Expect(ControlPlane().UpToDateReplicas("v1beta2").Path()).To(Equal(Path{"status", "upToDateReplicas"}))
+
+		err = ControlPlane().UpToDateReplicas("v1beta2").Set(obj, int32(5))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err = ControlPlane().UpToDateReplicas("v1beta2").Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(int32(5)))
 	})
 	t.Run("Manages status.readyReplicas", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(ControlPlane().ReadyReplicas("v1beta1").Path()).To(Equal(Path{"status", "readyReplicas"}))
+		g.Expect(ControlPlane().ReadyReplicas().Path()).To(Equal(Path{"status", "readyReplicas"}))
 
-		err := ControlPlane().ReadyReplicas("v1beta1").Set(obj, int64(3))
+		err := ControlPlane().ReadyReplicas().Set(obj, int32(3))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err := ControlPlane().ReadyReplicas("v1beta1").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(3)))
-
-		g.Expect(ControlPlane().ReadyReplicas("v1beta2").Path()).To(Equal(Path{"status", "deprecated", "v1beta1", "readyReplicas"}))
-
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"deprecated": map[string]interface{}{
-					"v1beta1": map[string]interface{}{
-						"readyReplicas": int64(5),
-					},
-				},
-			},
-		}}
-
-		got, err = ControlPlane().ReadyReplicas("v1beta2").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(5)))
-	})
-	t.Run("Manages status.unavailableReplicas", func(t *testing.T) {
-		g := NewWithT(t)
-
-		g.Expect(ControlPlane().UnavailableReplicas("v1beta1").Path()).To(Equal(Path{"status", "unavailableReplicas"}))
-
-		err := ControlPlane().UnavailableReplicas("v1beta1").Set(obj, int64(3))
-		g.Expect(err).ToNot(HaveOccurred())
-
-		got, err := ControlPlane().UnavailableReplicas("v1beta1").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(3)))
-
-		g.Expect(ControlPlane().UnavailableReplicas("v1beta2").Path()).To(Equal(Path{"status", "deprecated", "v1beta1", "unavailableReplicas"}))
-
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"deprecated": map[string]interface{}{
-					"v1beta1": map[string]interface{}{
-						"unavailableReplicas": int64(5),
-					},
-				},
-			},
-		}}
-
-		got, err = ControlPlane().UnavailableReplicas("v1beta2").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int64(5)))
-	})
-	t.Run("Manages status.readyReplicas for v1beta2 status", func(t *testing.T) {
-		g := NewWithT(t)
-
-		g.Expect(ControlPlane().V1Beta2ReadyReplicas("v1beta1").Path()).To(Equal(Path{"status", "v1beta2", "readyReplicas"}))
-
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"readyReplicas": int64(3),
-				"v1beta2": map[string]interface{}{
-					"readyReplicas": int64(5),
-				},
-			},
-		}}
-
-		got, err := ControlPlane().V1Beta2ReadyReplicas("v1beta1").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int32(5)))
-
-		g.Expect(ControlPlane().V1Beta2ReadyReplicas("v1beta2").Path()).To(Equal(Path{"status", "readyReplicas"}))
-
-		err = ControlPlane().V1Beta2ReadyReplicas("v1beta2").Set(obj, 3)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		got, err = ControlPlane().V1Beta2ReadyReplicas("v1beta2").Get(obj)
+		got, err := ControlPlane().ReadyReplicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(Equal(int32(3)))
 	})
-	t.Run("Manages status.availableReplicas for v1beta2 status", func(t *testing.T) {
+	t.Run("Manages status.V1Beta1UnavailableReplicas", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(ControlPlane().V1Beta2AvailableReplicas("v1beta1").Path()).To(Equal(Path{"status", "v1beta2", "availableReplicas"}))
+		g.Expect(ControlPlane().V1Beta1UnavailableReplicas().Path()).To(Equal(Path{"status", "unavailableReplicas"}))
 
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"availableReplicas": int64(3),
-				"v1beta2": map[string]interface{}{
-					"availableReplicas": int64(5),
-				},
-			},
-		}}
+		err := ControlPlane().V1Beta1UnavailableReplicas().Set(obj, int64(3))
+		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err := ControlPlane().V1Beta2AvailableReplicas("v1beta1").Get(obj)
+		got, err := ControlPlane().V1Beta1UnavailableReplicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int32(5)))
-
-		g.Expect(ControlPlane().V1Beta2AvailableReplicas("v1beta2").Path()).To(Equal(Path{"status", "availableReplicas"}))
-
-		err = ControlPlane().V1Beta2AvailableReplicas("v1beta2").Set(obj, 3)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		got, err = ControlPlane().V1Beta2AvailableReplicas("v1beta2").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int32(3)))
+		g.Expect(*got).To(Equal(int64(3)))
 	})
-	t.Run("Manages status.upToDateReplicas for v1beta2 status", func(t *testing.T) {
+	t.Run("Manages status.availableReplicas", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(ControlPlane().V1Beta2UpToDateReplicas("v1beta1").Path()).To(Equal(Path{"status", "v1beta2", "upToDateReplicas"}))
+		g.Expect(ControlPlane().AvailableReplicas().Path()).To(Equal(Path{"status", "availableReplicas"}))
 
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"upToDateReplicas": int64(3),
-				"v1beta2": map[string]interface{}{
-					"upToDateReplicas": int64(5),
-				},
-			},
-		}}
-
-		got, err := ControlPlane().V1Beta2UpToDateReplicas("v1beta1").Get(obj)
-		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(int32(5)))
-
-		g.Expect(ControlPlane().V1Beta2UpToDateReplicas("v1beta2").Path()).To(Equal(Path{"status", "upToDateReplicas"}))
-
-		err = ControlPlane().V1Beta2UpToDateReplicas("v1beta2").Set(obj, 3)
+		err := ControlPlane().AvailableReplicas().Set(obj, int32(3))
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err = ControlPlane().V1Beta2UpToDateReplicas("v1beta2").Get(obj)
+		got, err := ControlPlane().AvailableReplicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(Equal(int32(3)))

--- a/internal/contract/types.go
+++ b/internal/contract/types.go
@@ -127,8 +127,8 @@ func (i *Int32) Get(obj *unstructured.Unstructured) (*int32, error) {
 
 // Set sets the int32 value in the path.
 // Note: Cluster API should never Set values on external objects owner by providers; however this method is useful for writing tests.
-func (i *Int32) Set(obj *unstructured.Unstructured, value int64) error {
-	if err := unstructured.SetNestedField(obj.UnstructuredContent(), value, i.path...); err != nil {
+func (i *Int32) Set(obj *unstructured.Unstructured, value int32) error {
+	if err := unstructured.SetNestedField(obj.UnstructuredContent(), int64(value), i.path...); err != nil {
 		return errors.Wrapf(err, "failed to set path %s of object %v", "."+strings.Join(i.path, "."), obj.GroupVersionKind())
 	}
 	return nil

--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -159,7 +159,7 @@ func bootstrapConfigReadyFallBackMessage(kind string, ready bool) string {
 	if ready {
 		return ""
 	}
-	return fmt.Sprintf("%s status.ready is %t", kind, ready)
+	return fmt.Sprintf("%s status.initialization.dataSecretCreated is %t", kind, ready)
 }
 
 func setInfrastructureReadyCondition(_ context.Context, machine *clusterv1.Machine, infraMachine *unstructured.Unstructured, infraMachineIsNotFound bool) {
@@ -254,7 +254,7 @@ func infrastructureReadyFallBackMessage(kind string, ready bool) string {
 	if ready {
 		return ""
 	}
-	return fmt.Sprintf("%s status.ready is %t", kind, ready)
+	return fmt.Sprintf("%s status.initialization.provisioned is %t", kind, ready)
 }
 
 func setNodeHealthyAndReadyConditions(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, node *corev1.Node, nodeGetErr error, lastProbeSuccessTime time.Time, remoteConditionsGracePeriod time.Duration) {

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -161,7 +161,7 @@ func TestSetBootstrapReadyCondition(t *testing.T) {
 				Type:    clusterv1.MachineBootstrapConfigReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  clusterv1.MachineBootstrapConfigNotReadyReason,
-				Message: "GenericBootstrapConfig status.ready is false",
+				Message: "GenericBootstrapConfig status.initialization.dataSecretCreated is false",
 			},
 		},
 		{
@@ -385,7 +385,7 @@ func TestSetInfrastructureReadyCondition(t *testing.T) {
 				Type:    clusterv1.MachineInfrastructureReadyCondition,
 				Status:  metav1.ConditionFalse,
 				Reason:  clusterv1.MachineInfrastructureNotReadyReason,
-				Message: "GenericInfrastructureMachine status.ready is false",
+				Message: "GenericInfrastructureMachine status.initialization.provisioned is false",
 			},
 		},
 		{

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -1171,6 +1171,7 @@ func TestMachineConditions(t *testing.T) {
 			infraProvisioned:           false,
 			bootstrapDataSecretCreated: false,
 			conditionsToAssert: []*clusterv1.Condition{
+				// in V1beta1 ready condition summary consumes reason from the infra condition
 				v1beta1conditions.FalseCondition(clusterv1.ReadyV1Beta1Condition, clusterv1.WaitingForInfrastructureFallbackV1Beta1Reason, clusterv1.ConditionSeverityInfo, ""),
 			},
 		},

--- a/internal/controllers/machinedeployment/machinedeployment_rolling_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling_test.go
@@ -367,11 +367,7 @@ func TestReconcileOldMachineSets(t *testing.T) {
 					Replicas: ptr.To[int32](0),
 				},
 				Status: clusterv1.MachineSetStatus{
-					Deprecated: &clusterv1.MachineSetDeprecatedStatus{
-						V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-							AvailableReplicas: 2,
-						},
-					},
+					AvailableReplicas: ptr.To[int32](2),
 				},
 			},
 			oldMachineSets: []*clusterv1.MachineSet{
@@ -384,11 +380,7 @@ func TestReconcileOldMachineSets(t *testing.T) {
 						Replicas: ptr.To[int32](2),
 					},
 					Status: clusterv1.MachineSetStatus{
-						Deprecated: &clusterv1.MachineSetDeprecatedStatus{
-							V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-								AvailableReplicas: 2,
-							},
-						},
+						AvailableReplicas: ptr.To[int32](2),
 					},
 				},
 				{
@@ -400,11 +392,7 @@ func TestReconcileOldMachineSets(t *testing.T) {
 						Replicas: ptr.To[int32](1),
 					},
 					Status: clusterv1.MachineSetStatus{
-						Deprecated: &clusterv1.MachineSetDeprecatedStatus{
-							V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-								AvailableReplicas: 1,
-							},
-						},
+						AvailableReplicas: ptr.To[int32](1),
 					},
 				},
 			},
@@ -438,12 +426,6 @@ func TestReconcileOldMachineSets(t *testing.T) {
 				},
 				Status: clusterv1.MachineSetStatus{
 					Replicas: 5,
-					Deprecated: &clusterv1.MachineSetDeprecatedStatus{
-						V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-							ReadyReplicas:     0,
-							AvailableReplicas: 0,
-						},
-					},
 				},
 			},
 			oldMachineSets: []*clusterv1.MachineSet{
@@ -456,13 +438,9 @@ func TestReconcileOldMachineSets(t *testing.T) {
 						Replicas: ptr.To[int32](8),
 					},
 					Status: clusterv1.MachineSetStatus{
-						Replicas: 10,
-						Deprecated: &clusterv1.MachineSetDeprecatedStatus{
-							V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-								ReadyReplicas:     8,
-								AvailableReplicas: 8,
-							},
-						},
+						Replicas:          10,
+						ReadyReplicas:     ptr.To[int32](8),
+						AvailableReplicas: ptr.To[int32](8),
 					},
 				},
 			},

--- a/internal/controllers/machinedeployment/machinedeployment_status.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status.go
@@ -75,16 +75,16 @@ func (r *Reconciler) updateStatus(ctx context.Context, s *scope) (retErr error) 
 	return retErr
 }
 
-// setReplicas sets replicas in the v1beta2 status.
+// setReplicas sets replicas in status.
 // Note: this controller computes replicas several time during a reconcile, because those counters are
 // used by low level operations to take decisions, but also those decisions might impact the very same the counters
 // e.g. scale up MachinesSet is based on counters and it can change the value on MachineSet's replica number;
 // as a consequence it is required to compute the counters again before calling scale down machine sets,
 // and again to before computing the overall availability of the Machine deployment.
 func setReplicas(machineDeployment *clusterv1.MachineDeployment, machineSets []*clusterv1.MachineSet) {
-	machineDeployment.Status.ReadyReplicas = mdutil.GetV1Beta2ReadyReplicaCountForMachineSets(machineSets)
-	machineDeployment.Status.AvailableReplicas = mdutil.GetV1Beta2AvailableReplicaCountForMachineSets(machineSets)
-	machineDeployment.Status.UpToDateReplicas = mdutil.GetV1Beta2UptoDateReplicaCountForMachineSets(machineSets)
+	machineDeployment.Status.ReadyReplicas = mdutil.GetReadyReplicaCountForMachineSets(machineSets)
+	machineDeployment.Status.AvailableReplicas = mdutil.GetAvailableReplicaCountForMachineSets(machineSets)
+	machineDeployment.Status.UpToDateReplicas = mdutil.GetUptoDateReplicaCountForMachineSets(machineSets)
 }
 
 func setAvailableCondition(_ context.Context, machineDeployment *clusterv1.MachineDeployment, getAndAdoptMachineSetsForDeploymentSucceeded bool) {
@@ -110,13 +110,13 @@ func setAvailableCondition(_ context.Context, machineDeployment *clusterv1.Machi
 		return
 	}
 
-	// Surface if .status.v1beta2.availableReplicas is not yet set.
+	// Surface if .status.availableReplicas is not yet set.
 	if machineDeployment.Status.AvailableReplicas == nil {
 		conditions.Set(machineDeployment, metav1.Condition{
 			Type:    clusterv1.MachineDeploymentAvailableCondition,
 			Status:  metav1.ConditionUnknown,
 			Reason:  clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetReason,
-			Message: "Waiting for status.v1beta2.availableReplicas set",
+			Message: "Waiting for status.availableReplicas set",
 		})
 		return
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_status_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_status_test.go
@@ -120,7 +120,7 @@ func Test_setAvailableCondition(t *testing.T) {
 				Type:    clusterv1.MachineDeploymentAvailableCondition,
 				Status:  metav1.ConditionUnknown,
 				Reason:  clusterv1.MachineDeploymentAvailableWaitingForAvailableReplicasSetReason,
-				Message: "Waiting for status.v1beta2.availableReplicas set",
+				Message: "Waiting for status.availableReplicas set",
 			},
 		},
 		{

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -770,7 +770,7 @@ func TestNewMSNewReplicas(t *testing.T) {
 }
 
 func TestDeploymentComplete(t *testing.T) {
-	deployment := func(desired, current, updated, available, maxUnavailable, maxSurge int32) *clusterv1.MachineDeployment {
+	deployment := func(desired, current, upToDate, available, maxUnavailable, maxSurge int32) *clusterv1.MachineDeployment {
 		return &clusterv1.MachineDeployment{
 			Spec: clusterv1.MachineDeploymentSpec{
 				Replicas: &desired,
@@ -783,13 +783,9 @@ func TestDeploymentComplete(t *testing.T) {
 				},
 			},
 			Status: clusterv1.MachineDeploymentStatus{
-				Replicas: current,
-				Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-					V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-						UpdatedReplicas:   updated,
-						AvailableReplicas: available,
-					},
-				},
+				Replicas:          current,
+				UpToDateReplicas:  ptr.To[int32](upToDate),
+				AvailableReplicas: ptr.To[int32](available),
 			},
 		}
 	}
@@ -935,11 +931,7 @@ func TestAnnotationUtils(t *testing.T) {
 
 	// Test Case 2:  Check if annotations reflect deployments state
 	tMS.Annotations[clusterv1.DesiredReplicasAnnotation] = "1"
-	tMS.Status.Deprecated = &clusterv1.MachineSetDeprecatedStatus{
-		V1Beta1: &clusterv1.MachineSetV1Beta1DeprecatedStatus{
-			AvailableReplicas: 1,
-		},
-	}
+	tMS.Status.AvailableReplicas = ptr.To[int32](1)
 	tMS.Spec.Replicas = new(int32)
 	*tMS.Spec.Replicas = 1
 

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -198,7 +198,12 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string, g *WithT) {
 
 	// Patch the node and make it look like ready.
 	patchNode := client.MergeFrom(node.DeepCopy())
-	node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue})
+	node.Status.Conditions = append(node.Status.Conditions,
+		corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		corev1.NodeCondition{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+		corev1.NodeCondition{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+		corev1.NodeCondition{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+	)
 	g.Expect(env.Status().Patch(ctx, node, patchNode)).To(Succeed())
 
 	// Patch the Machine.

--- a/internal/controllers/machineset/machineset_controller_status.go
+++ b/internal/controllers/machineset/machineset_controller_status.go
@@ -37,12 +37,8 @@ import (
 // updateStatus updates MachineSet's status.
 // Additionally, this func should ensure that the conditions managed by this controller are always set in order to
 // comply with the recommendation in the Kubernetes API guidelines.
-// Note: v1beta1 conditions are not managed by this func.
 func (r *Reconciler) updateStatus(ctx context.Context, s *scope) {
-	// Update the following fields in status from the machines list.
-	// - v1beta2.readyReplicas
-	// - v1beta2.availableReplicas
-	// - v1beta2.upToDateReplicas
+	// Update replica counter fields in status from the machines list.
 	setReplicas(ctx, s.machineSet, s.machines, s.getAndAdoptMachinesForMachineSetSucceeded)
 
 	// Conditions

--- a/internal/controllers/machineset/suite_test.go
+++ b/internal/controllers/machineset/suite_test.go
@@ -208,7 +208,12 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string, g *WithT) {
 
 	// Patch the node and make it look like ready.
 	patchNode := client.MergeFrom(node.DeepCopy())
-	node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue, Reason: "SomeReason"})
+	node.Status.Conditions = append(node.Status.Conditions,
+		corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+		corev1.NodeCondition{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+		corev1.NodeCondition{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+		corev1.NodeCondition{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+	)
 	g.Expect(env.Status().Patch(ctx, node, patchNode)).To(Succeed())
 
 	// Patch the Machine.

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -995,8 +995,8 @@ func assertControlPlaneReconcile(cluster *clusterv1.Cluster) error {
 		}
 
 		// Check for Control Plane replicase if it's set in the Cluster.Spec.Topology
-		if int32(*replicas) != *cluster.Spec.Topology.ControlPlane.Replicas {
-			return fmt.Errorf("replicas %v do not match expected %v", int32(*replicas), *cluster.Spec.Topology.ControlPlane.Replicas)
+		if *replicas != *cluster.Spec.Topology.ControlPlane.Replicas {
+			return fmt.Errorf("replicas %v do not match expected %v", *replicas, *cluster.Spec.Topology.ControlPlane.Replicas)
 		}
 	}
 	clusterClass := &clusterv1.ClusterClass{}

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -276,15 +277,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 							Object: builder.MachineDeployment("ns1", "md0-abc123").
 								WithReplicas(2).
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(1),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(1),
-											ReadyReplicas:       int32(1),
-											AvailableReplicas:   int32(1),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(1),
+									ReadyReplicas:     ptr.To[int32](1),
+									UpToDateReplicas:  ptr.To[int32](1),
+									AvailableReplicas: ptr.To[int32](1),
 								}).
 								Build(),
 						},
@@ -379,15 +375,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 							Object: builder.MachineDeployment("ns1", "md0-abc123").
 								WithReplicas(2).
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(2),
-											ReadyReplicas:       int32(2),
-											AvailableReplicas:   int32(2),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},
@@ -554,15 +545,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								}).
 								WithStatus(clusterv1.MachineDeploymentStatus{
 									// MD is not ready because we don't have 2 updated, ready and available replicas.
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(1),
-											ReadyReplicas:       int32(1),
-											AvailableReplicas:   int32(1),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](1),
+									UpToDateReplicas:  ptr.To[int32](1),
+									AvailableReplicas: ptr.To[int32](1),
 								}).
 								Build(),
 						},
@@ -576,15 +562,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 									},
 								}).
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(2),
-											ReadyReplicas:       int32(2),
-											AvailableReplicas:   int32(2),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},
@@ -720,15 +701,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								WithReplicas(2).
 								WithVersion("v1.22.0").
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(2),
-											ReadyReplicas:       int32(2),
-											AvailableReplicas:   int32(2),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},
@@ -737,15 +713,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								WithReplicas(2).
 								WithVersion("v1.21.2").
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(2),
-											ReadyReplicas:       int32(2),
-											AvailableReplicas:   int32(2),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},
@@ -858,15 +829,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								WithReplicas(2).
 								WithVersion("v1.22.0").
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(1),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(1),
-											ReadyReplicas:       int32(1),
-											AvailableReplicas:   int32(1),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(1),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},
@@ -875,15 +841,10 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								WithReplicas(2).
 								WithVersion("v1.22.0").
 								WithStatus(clusterv1.MachineDeploymentStatus{
-									Replicas: int32(2),
-									Deprecated: &clusterv1.MachineDeploymentDeprecatedStatus{
-										V1Beta1: &clusterv1.MachineDeploymentV1Beta1DeprecatedStatus{
-											UpdatedReplicas:     int32(2),
-											ReadyReplicas:       int32(2),
-											AvailableReplicas:   int32(2),
-											UnavailableReplicas: int32(0),
-										},
-									},
+									Replicas:          int32(2),
+									ReadyReplicas:     ptr.To[int32](2),
+									UpToDateReplicas:  ptr.To[int32](2),
+									AvailableReplicas: ptr.To[int32](2),
 								}).
 								Build(),
 						},

--- a/internal/controllers/topology/cluster/conditions_test.go
+++ b/internal/controllers/topology/cluster/conditions_test.go
@@ -830,9 +830,9 @@ func TestReconcileTopologyReconciledCondition(t *testing.T) {
 								WithVersion("v1.22.0").
 								WithStatus(clusterv1.MachineDeploymentStatus{
 									Replicas:          int32(1),
-									ReadyReplicas:     ptr.To[int32](2),
-									UpToDateReplicas:  ptr.To[int32](2),
-									AvailableReplicas: ptr.To[int32](2),
+									ReadyReplicas:     ptr.To[int32](1),
+									UpToDateReplicas:  ptr.To[int32](1),
+									AvailableReplicas: ptr.To[int32](1),
 								}).
 								Build(),
 						},

--- a/internal/util/tree/tree.go
+++ b/internal/util/tree/tree.go
@@ -285,7 +285,7 @@ func addOtherConditions(prefix string, tbl *tablewriter.Table, objectTree *tree.
 		childrenPipe = pipe
 	}
 
-	negativePolarityConditions := sets.New(
+	negativePolarityConditions := sets.New[string](
 		clusterv1.PausedCondition,
 		clusterv1.DeletingCondition,
 		clusterv1.RollingOutCondition,
@@ -649,13 +649,13 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 				}
 			}
 
-			if c, err := contract.ControlPlane().V1Beta2AvailableReplicas(contractVersion).Get(obj); err == nil && c != nil {
+			if c, err := contract.ControlPlane().AvailableReplicas().Get(obj); err == nil && c != nil {
 				v.availableCounters = fmt.Sprintf("%d", *c)
 			}
-			if c, err := contract.ControlPlane().V1Beta2ReadyReplicas(contractVersion).Get(obj); err == nil && c != nil {
+			if c, err := contract.ControlPlane().ReadyReplicas().Get(obj); err == nil && c != nil {
 				v.readyCounters = fmt.Sprintf("%d", *c)
 			}
-			if c, err := contract.ControlPlane().V1Beta2UpToDateReplicas(contractVersion).Get(obj); err == nil && c != nil {
+			if c, err := contract.ControlPlane().UpToDateReplicas(contractVersion).Get(obj); err == nil && c != nil {
 				v.upToDateCounters = fmt.Sprintf("%d", *c)
 			}
 		}

--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta2"
@@ -44,11 +45,6 @@ func WaitForControlPlaneToBeUpToDate(ctx context.Context, input WaitForControlPl
 		if err := input.Getter.Get(ctx, key, controlplane); err != nil {
 			return 0, err
 		}
-		// TODO (v1beta2) Use new replica counters
-		updatedReplicas := int32(0)
-		if controlplane.Status.Deprecated != nil && controlplane.Status.Deprecated.V1Beta1 != nil {
-			updatedReplicas = controlplane.Status.Deprecated.V1Beta1.UpdatedReplicas
-		}
-		return updatedReplicas, nil
+		return ptr.Deref(controlplane.Status.UpToDateReplicas, 0), nil
 	}, intervals...).Should(Equal(*input.ControlPlane.Spec.Replicas), "Timed waiting for all control plane replicas to be updated")
 }

--- a/test/framework/controlplane_helpers.go
+++ b/test/framework/controlplane_helpers.go
@@ -174,24 +174,17 @@ func WaitForControlPlaneToBeReady(ctx context.Context, input WaitForControlPlane
 
 		desiredReplicas := controlplane.Spec.Replicas
 		statusReplicas := controlplane.Status.Replicas
-		// TODO (v1beta2) Use new replica counters
-		updatedReplicas := int32(0)
-		readyReplicas := int32(0)
-		unavailableReplicas := int32(0)
-		if controlplane.Status.Deprecated != nil && controlplane.Status.Deprecated.V1Beta1 != nil {
-			updatedReplicas = controlplane.Status.Deprecated.V1Beta1.UpdatedReplicas
-			readyReplicas = controlplane.Status.Deprecated.V1Beta1.ReadyReplicas
-			unavailableReplicas = controlplane.Status.Deprecated.V1Beta1.UnavailableReplicas
-		}
+		upToDatedReplicas := ptr.Deref(controlplane.Status.UpToDateReplicas, 0)
+		readyReplicas := ptr.Deref(controlplane.Status.ReadyReplicas, 0)
+		availableReplicas := ptr.Deref(controlplane.Status.AvailableReplicas, 0)
 
 		// Control plane is still rolling out (and thus not ready) if:
-		// * .spec.replicas, .status.replicas, .status.updatedReplicas,
-		//   .status.readyReplicas are not equal and
-		// * unavailableReplicas > 0
+		// * .spec.replicas, .status.replicas, .status.upToDateReplicas,
+		//   .status.readyReplicas, .status.availableReplicas are not equal.
 		if statusReplicas != *desiredReplicas ||
-			updatedReplicas != *desiredReplicas ||
+			upToDatedReplicas != *desiredReplicas ||
 			readyReplicas != *desiredReplicas ||
-			unavailableReplicas > 0 {
+			availableReplicas != *desiredReplicas {
 			return false, nil
 		}
 

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -341,10 +341,8 @@ func UpgradeMachineDeploymentInfrastructureRefAndWait(ctx context.Context, input
 			// MachineSet should be rolled out.
 			g.Expect(newMachineSet.Spec.Replicas).To(Equal(deployment.Spec.Replicas))
 			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.Replicas))
-			g.Expect(*newMachineSet.Status.Deprecated).ToNot(BeNil())
-			g.Expect(*newMachineSet.Status.Deprecated.V1Beta1).ToNot(BeNil())
-			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.Deprecated.V1Beta1.ReadyReplicas))
-			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.Deprecated.V1Beta1.AvailableReplicas))
+			g.Expect(newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.ReadyReplicas))
+			g.Expect(newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.AvailableReplicas))
 
 			// MachineSet should have the same infrastructureRef as the MachineDeployment.
 			g.Expect(newMachineSet.Spec.Template.Spec.InfrastructureRef).To(BeComparableTo(deployment.Spec.Template.Spec.InfrastructureRef))


### PR DESCRIPTION
**What this PR does / why we need it**:
As defined in https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md, stop using Deprecated replica counters in controllers.
Use new replica counters instead

**Which issue(s) this PR fixes**:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/11947

/area cluster
/area machinedeployment
/area machineset
/area machine