### PR TITLE
🐛 Relax minLength for bootstrap.dataSecretName to 0

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -669,7 +669,7 @@ type Bootstrap struct {
 	// dataSecretName is the name of the secret that stores the bootstrap data script.
 	// If nil, the Machine should remain in the Pending state.
 	// +optional
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=253
 	DataSecretName *string `json:"dataSecretName,omitempty"`
 }

--- a/api/v1beta2/machine_types.go
+++ b/api/v1beta2/machine_types.go
@@ -696,7 +696,7 @@ type Bootstrap struct {
 	// dataSecretName is the name of the secret that stores the bootstrap data script.
 	// If nil, the Machine should remain in the Pending state.
 	// +optional
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=253
 	DataSecretName *string `json:"dataSecretName,omitempty"`
 }

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1444,7 +1444,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:
@@ -2200,7 +2200,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1182,7 +1182,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:
@@ -1789,7 +1789,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -941,7 +941,7 @@ spec:
                       dataSecretName is the name of the secret that stores the bootstrap data script.
                       If nil, the Machine should remain in the Pending state.
                     maxLength: 253
-                    minLength: 1
+                    minLength: 0
                     type: string
                 type: object
               clusterName:
@@ -1563,7 +1563,7 @@ spec:
                       dataSecretName is the name of the secret that stores the bootstrap data script.
                       If nil, the Machine should remain in the Pending state.
                     maxLength: 253
-                    minLength: 1
+                    minLength: 0
                     type: string
                 type: object
               clusterName:

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1196,7 +1196,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:
@@ -1844,7 +1844,7 @@ spec:
                               dataSecretName is the name of the secret that stores the bootstrap data script.
                               If nil, the Machine should remain in the Pending state.
                             maxLength: 253
-                            minLength: 1
+                            minLength: 0
                             type: string
                         type: object
                       clusterName:


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the validation for Machine spec's `bootstrap.dataSecretName` to `// +kubebuilder:validation:MinLength=0`. This allows an empty string, which is an existing use case for managed MachinePools.

**Which issue(s) this PR fixes**:

Fixes #12161

/area bootstrap
