### PR TITLE
:seedling: [release-1.9] Add CVEs to Trivy ignore file

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,4 @@
 # According to govulncheck we are not using code that is affected by CVEs
+CVE-2025-22869
 CVE-2025-22870
+CVE-2025-22872


### PR DESCRIPTION
**What this PR does / why we need it**:

* Add two CVEs to the `.trivyignore` file, as according to govulncheck our code does not call
these vulnerabilities and we don't want to bump the go.mod go version.
* Ignores CVE-2025-22869 and CVE-2025-22872 in the weekly security scan on this branch.

https://github.com/kubernetes-sigs/cluster-api/actions/runs/14835970794

Ref: #12173 is where we decided to ignore these.

/area ci
/area security