### PR TITLE
:seedling:Add an option to override custom node image name for kind cluster

### DIFF
--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -57,12 +57,16 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 
 	// ExtraPortMappings specifies the port forward configuration of the kind node.
 	ExtraPortMappings []kindv1.PortMapping
+
+	// CustomNodeImage is the custom node image used for creating the kind node
+	CustomNodeImage string
 }
 
 // CreateKindBootstrapClusterAndLoadImages returns a new Kubernetes cluster with pre-loaded images.
 func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKindBootstrapClusterAndLoadImagesInput) ClusterProvider {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for CreateKindBootstrapClusterAndLoadImages")
 	Expect(input.Name).ToNot(BeEmpty(), "Invalid argument. Name can't be empty when calling CreateKindBootstrapClusterAndLoadImages")
+	Expect(input.KubernetesVersion != "" && input.CustomNodeImage != "").To(BeFalse(), "Invalid input. Either KubernetesVersion or CustomNodeImage should be passed")
 
 	log.Logf("Creating a kind cluster with name %q", input.Name)
 
@@ -88,6 +92,9 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	}
 	if input.LogFolder != "" {
 		options = append(options, LogFolder(input.LogFolder))
+	}
+	if input.CustomNodeImage != "" {
+		options = append(options, WithNodeImage(input.CustomNodeImage))
 	}
 	options = append(options, WithExtraPortMappings(input.ExtraPortMappings))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds a field to override custom node image name for kind cluster creation in e2e framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->