### PR TITLE
🌱 Add filename to clusterctl error about bad YAML

### DIFF
--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -157,7 +157,7 @@ func (v *versionChecker) getLatestRelease(ctx context.Context) (*ReleaseInfo, er
 	// NOTE: local state file is ignored if older than 1d.
 	vs, err := readStateFile(v.versionFilePath)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to read version state file")
+		return nil, errors.Wrapf(err, "unable to read version state file %s", v.versionFilePath)
 	}
 	if vs != nil {
 		return &vs.LatestRelease, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the full path of the state.yaml file to the error raised when clusterctl can't parse it as YAML.

**Which issue(s) this PR fixes**:
Fixes #12182

/area clusterctl