### PR TITLE
:seedling: [release-1.10] Add 1.33 kind image to mapper.go file

### DIFF
--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -81,6 +81,11 @@ var preBuiltMappings = []Mapping{
 	// TODO: Add pre-built images for newer Kind versions on top
 	// Pre-built images for Kind v0.27.
 	{
+		KubernetesVersion: semver.MustParse("1.33.0"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.33.0@sha256:02f73d6ae3f11ad5d543f16736a2cb2a63a300ad60e81dac22099b0b04784a4e",
+	},
+	{
 		KubernetesVersion: semver.MustParse("1.32.2"),
 		Mode:              Mode0_20,
 		Image:             "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding the kind 0.27 v1.33.0 image to mapper.go so that e2e tests can use v1.33 as a source cluster when testing v1.10. Resolves some todo comments in main's clusterctl_upgrade_test.go file.

/area e2e-testing
