### PR TITLE
:seedling: Bump clusterctl_upgrade_test.go main and 1.10 tests to k8s v1.33.0

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -339,7 +339,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>cu
 			// Note: WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
 			// When picking this version, please check also the list of versions known by the source Cluster API version (rif. test/infrastructure/kind/mapper.go).
 			InitWithKubernetesVersion:   initKubernetesVersion,
-			WorkloadKubernetesVersion:   "v1.32.2", // NOTE: use v1.33 as soon as it is GA
+			WorkloadKubernetesVersion:   "v1.33.0",
 			MgmtFlavor:                  "topology",
 			WorkloadFlavor:              "topology",
 			UseKindForManagementCluster: true,

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -300,8 +300,8 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>cu
 			},
 			// Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
 			// When picking this version, please check also the list of versions known by the source Cluster API version (rif. test/infrastructure/kind/mapper.go).
-			InitWithKubernetesVersion:   "v1.32.2", // NOTE: use v1.33 as soon as it is GA
-			WorkloadKubernetesVersion:   "v1.32.2", // NOTE: use v1.33 as soon as it is GA
+			InitWithKubernetesVersion:   "v1.33.0",
+			WorkloadKubernetesVersion:   "v1.33.0",
 			MgmtFlavor:                  "topology",
 			WorkloadFlavor:              "topology",
 			UseKindForManagementCluster: true,

--- a/test/infrastructure/kind/mapper.go
+++ b/test/infrastructure/kind/mapper.go
@@ -81,6 +81,11 @@ var preBuiltMappings = []Mapping{
 	// TODO: Add pre-built images for newer Kind versions on top
 	// Pre-built images for Kind v0.27.
 	{
+		KubernetesVersion: semver.MustParse("1.33.0"),
+		Mode:              Mode0_20,
+		Image:             "kindest/node:v1.33.0@sha256:02f73d6ae3f11ad5d543f16736a2cb2a63a300ad60e81dac22099b0b04784a4e",
+	},
+	{
 		KubernetesVersion: semver.MustParse("1.32.2"),
 		Mode:              Mode0_20,
 		Image:             "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding the kind 0.27 v1.33.0 image to mapper.go so that e2e tests can use v1.33 as a source cluster when testing v1.10. 
Bumps the e2e tests for main and v1.10 in clusterctl_upgrade_test.go to use v1.33.0 kubernetes.  This resolves some todo comments.

Depends on #12192 

/area e2e-testing
