### PR TITLE
🐛 ipam: enable conversion in CRDs

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -30,6 +30,8 @@ patches:
 - path: patches/webhook_in_machinehealthchecks.yaml
 - path: patches/webhook_in_clusterresourcesets.yaml
 - path: patches/webhook_in_clusterresourcesetbindings.yaml
+- path: patches/webhook_in_ipaddresses.yaml
+- path: patches/webhook_in_ipaddressclaims.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/webhook_in_ipaddressclaims.yaml
+++ b/config/crd/patches/webhook_in_ipaddressclaims.yaml
@@ -1,0 +1,16 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_ipaddresses.yaml
+++ b/config/crd/patches/webhook_in_ipaddresses.yaml
@@ -1,0 +1,16 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -58,8 +58,6 @@ replacements:
     select:
       kind: CustomResourceDefinition
     reject:
-    - name: ipaddressclaims.ipam.cluster.x-k8s.io
-    - name: ipaddresses.ipam.cluster.x-k8s.io
     - name: extensionconfigs.runtime.cluster.x-k8s.io
 - source:
     fieldPath: .metadata.name
@@ -93,8 +91,6 @@ replacements:
     select:
       kind: CustomResourceDefinition
     reject:
-    - name: ipaddressclaims.ipam.cluster.x-k8s.io
-    - name: ipaddresses.ipam.cluster.x-k8s.io
     - name: extensionconfigs.runtime.cluster.x-k8s.io
 - source:
     fieldPath: .metadata.name

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ import (
 	expv1beta1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta2"
 	expcontrollers "sigs.k8s.io/cluster-api/exp/controllers"
+	ipamv1alpha1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
+	ipamv1beta1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta1"
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1beta2"
 	expipamwebhooks "sigs.k8s.io/cluster-api/exp/ipam/webhooks"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
@@ -158,6 +160,8 @@ func init() {
 
 	_ = runtimev1.AddToScheme(scheme)
 
+	_ = ipamv1alpha1.AddToScheme(scheme)
+	_ = ipamv1beta1.AddToScheme(scheme)
 	_ = ipamv1.AddToScheme(scheme)
 
 	// Register the RuntimeHook types into the catalog.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Conversion was never active for the IPAM api types IPAddressClaim and IPAddress.

This PR enables them

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ipam