### PR TITLE
🐛 Add missing API version to NS object

### DIFF
--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -317,7 +317,8 @@ func addNamespaceIfMissing(objs []unstructured.Unstructured, targetNamespace str
 	if !namespaceObjectFound {
 		objs = append(objs, unstructured.Unstructured{
 			Object: map[string]interface{}{
-				"kind": namespaceKind,
+				"apiVersion": "v1",
+				"kind":       namespaceKind,
 				"metadata": map[string]interface{}{
 					"name": targetNamespace,
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

In some specific scenarios, clusterctl components attempt to add missing namespace object causes to appear an error on resource creation. This happens due to namespace object missing `apiVersion`, so `ProviderComponents().Create()` fails to get resource from untyped unstructured object it is represented with.

This PR makes a small fix which prevents this from happening.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl