### PR TITLE
🌱 framework: Watch logs from init containers

### DIFF
--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -251,7 +251,7 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 		return
 	}
 
-	for _, container := range pod.Spec.Containers {
+	for _, container := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 		log.Logf("Creating log watcher for controller %s, pod %s, container %s", klog.KRef(eh.input.Namespace, eh.input.ManagingResourceName), pod.Name, container.Name)
 
 		// Create log metadata file.


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the framework watch/collect logs from init containers also. Previously, it only collected the normal container logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12207 

/area testing