### PR TITLE
🌱  Ignore net.ErrClosed error when we already closed lister connection.

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/mux.go
+++ b/test/infrastructure/inmemory/pkg/server/mux.go
@@ -612,7 +612,7 @@ func (m *WorkloadClustersMux) DeleteWorkloadClusterListener(wclName string) erro
 	}
 
 	if wcl.listener != nil {
-		if err := wcl.listener.Close(); err != nil {
+		if err := wcl.listener.Close(); !errors.Is(err, net.ErrClosed) {
 			return errors.Wrapf(err, "failed to stop WorkloadClusterListener %s, %s", wclName, wcl.HostPort())
 		}
 	}
@@ -634,7 +634,7 @@ func (m *WorkloadClustersMux) Shutdown(ctx context.Context) error {
 	}
 
 	// NOTE: this closes all the listeners
-	if err := m.muxServer.Shutdown(ctx); err != nil {
+	if err := m.muxServer.Shutdown(ctx); !errors.Is(err, net.ErrClosed) {
 		return errors.Wrap(err, "failed to shutdown the mux server")
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

TestMux is flaky since if the wcl.lister has already been closed, Close return net.ErrClosed.
This flaky depends on the timing of Serve.
So I made these ignore the error if the server is already closed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area test
/kind bug