### PR TITLE
🐛 ipam: revert condition func changes for IPAddressClaim v1beta1

### DIFF
--- a/exp/ipam/api/v1beta1/ipaddressclaim_types.go
+++ b/exp/ipam/api/v1beta1/ipaddressclaim_types.go
@@ -86,26 +86,26 @@ type IPAddressClaim struct {
 	Status IPAddressClaimStatus `json:"status,omitempty"`
 }
 
-// GetV1Beta1Conditions returns the set of conditions for this object.
-func (m *IPAddressClaim) GetV1Beta1Conditions() clusterv1beta1.Conditions {
+// GetConditions returns the set of conditions for this object.
+func (m *IPAddressClaim) GetConditions() clusterv1beta1.Conditions {
 	return m.Status.Conditions
 }
 
-// SetV1Beta1Conditions sets the conditions on this object.
-func (m *IPAddressClaim) SetV1Beta1Conditions(conditions clusterv1beta1.Conditions) {
+// SetConditions sets the conditions on this object.
+func (m *IPAddressClaim) SetConditions(conditions clusterv1beta1.Conditions) {
 	m.Status.Conditions = conditions
 }
 
-// GetConditions returns the set of conditions for this object.
-func (m *IPAddressClaim) GetConditions() []metav1.Condition {
+// GetV1Beta2Conditions returns the set of conditions for this object.
+func (m *IPAddressClaim) GetV1Beta2Conditions() []metav1.Condition {
 	if m.Status.V1Beta2 == nil {
 		return nil
 	}
 	return m.Status.V1Beta2.Conditions
 }
 
-// SetConditions sets conditions for an API object.
-func (m *IPAddressClaim) SetConditions(conditions []metav1.Condition) {
+// SetV1Beta2Conditions sets conditions for an API object.
+func (m *IPAddressClaim) SetV1Beta2Conditions(conditions []metav1.Condition) {
 	if m.Status.V1Beta2 == nil {
 		m.Status.V1Beta2 = &IPAddressClaimV1Beta2Status{}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Allows providers to have a smoother v1beta2 migration.
The v1beta2 IPAddressClaim fulfills the v1beta2 condition signature.
V1beta1 should keep the old one.

Was changed in:
- #12098

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ipam