### PR TITLE
✨ clusterctl: dump `metadata.yaml` at `-v=10` to aid debugging

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -494,6 +494,24 @@ func (g *gitHubRepository) downloadFilesFromRelease(ctx context.Context, release
 		return nil, retryError
 	}
 
+	// If this is a metadata.yaml file and verbose logging is enabled (-v=10), dump the content to logs
+	if filepath.Base(fileName) == "metadata.yaml" {
+		log := logf.Log
+		verboseLog := log.V(10)
+
+		// Get version from release tag
+		version := ""
+		if release.TagName != nil {
+			version = *release.TagName
+		}
+
+		verboseLog.Info("Dumping metadata.yaml via downloadFilesFromRelease", "provider", g.providerConfig.Name(), "fileName", fileName)
+		providerID := fmt.Sprintf("%s/%s", g.providerConfig.Name(), version)
+		verboseLog.Info("metadata.yaml content",
+			"providerID", providerID,
+			"content", string(content))
+	}
+
 	return content, nil
 }
 


### PR DESCRIPTION
## PR Description

### What this PR does / why we need it  
Implements the feature proposed in [#12248](https://github.com/kubernetes-sigs/cluster-api/issues/12248).

* When `clusterctl` is executed with `-v=10`, the raw `metadata.yaml` for each GitHub-hosted provider release is logged.  

This extra visibility helps both users and maintainers troubleshoot provider-specific issues without requiring custom binaries or guesswork.

### Observed error before this PR  
The snippet below shows a real failure that is now self-contained in the verbose log thanks to the new dump.  
Without the `metadata.yaml` dump, users only saw the final error; with the dump they can copy the entire block when opening issues.

```console
$ GOPROXY=off clusterctl init --bootstrap k0sproject-k0smotron --target-namespace k0smotron -v=10
No default config file available
Fetching providers
Dumping metadata.yaml via downloadFilesFromRelease provider="cluster-api" fileName="metadata.yaml"
metadata.yaml content providerID="cluster-api/v1.10.1" content="# maps release series of major.minor to cluster-api contract version\n# the contract version may change between minor or major versions, but *not*\n# b
etween patch versions.\n#\n# update this file only when a new major or minor version is released\napiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\nkind: Metadata\nreleaseSeries:\n  - major: 1\n    minor: 10\n    co
ntract: v1beta1\n  - major: 1\n    minor: 9\n    contract: v1beta1\n  - major: 1\n    minor: 8\n    contract: v1beta1\n  - major: 1\n    minor: 7\n    contract: v1beta1\n  - major: 1\n    minor: 6\n    contract: v1b
eta1\n  - major: 1\n    minor: 5\n    contract: v1beta1\n  - major: 1\n    minor: 4\n    contract: v1beta1\n  - major: 1\n    minor: 3\n    contract: v1beta1\n  - major: 1\n    minor: 2\n    contract: v1beta1\n  - m
ajor: 1\n    minor: 1\n    contract: v1beta1\n  - major: 1\n    minor: 0\n    contract: v1beta1\n"
Potential override file searchFile="/Users/xxxx/Library/Application Support/cluster-api/overrides/cluster-api/v1.10.1/core-components.yaml" provider="cluster-api" version="v1.10.1"
Fetching file="core-components.yaml" provider="cluster-api" type="CoreProvider" version="v1.10.1"
Dumping metadata.yaml via downloadFilesFromRelease provider="k0sproject-k0smotron" fileName="metadata.yaml"
metadata.yaml content providerID="k0sproject-k0smotron/v1.5.2" content="{\"url\":\"https://api.github.com/repos/k0sproject/k0smotron/releases/assets/249358839\",\"id\":249358839,\"node_id\":\"RA_kwDOJL1V3M4O3On3\",\
"name\":\"metadata.yaml\",\"label\":\"\",\"uploader\":{\"login\":\"github-actions[bot]\",\"id\":41898282,\"node_id\":\"MDM6Qm90NDE4OTgyODI=\",\"avatar_url\":\"https://avatars.githubusercontent.com/in/15368?v=4\",\"g
ravatar_id\":\"\",\"url\":\"https://api.github.com/users/github-actions%5Bbot%5D\",\"html_url\":\"https://github.com/apps/github-actions\",\"followers_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/fol
lowers\",\"following_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}\",\"starred_url\":\"htt
ps://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/subscriptions\",\"organizations_url\":\"https://api.github.com/
users/github-actions%5Bbot%5D/orgs\",\"repos_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/repos\",\"events_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}\",\"received_e
vents_url\":\"https://api.github.com/users/github-actions%5Bbot%5D/received_events\",\"type\":\"Bot\",\"user_view_type\":\"public\",\"site_admin\":false},\"content_type\":\"application/octet-stream\",\"state\":\"upl
oaded\",\"size\":644,\"download_count\":1709,\"created_at\":\"2025-04-25T06:04:21Z\",\"updated_at\":\"2025-04-25T06:04:21Z\",\"browser_download_url\":\"https://github.com/k0sproject/k0smotron/releases/download/v1.5.
2/metadata.yaml\"}"
Potential override file searchFile="/Users/xxxx/Library/Application Support/cluster-api/overrides/bootstrap-k0sproject-k0smotron/v1.5.2/bootstrap-components.yaml" provider="bootstrap-k0sproject-k0smotron" version=
"v1.5.2"
Fetching file="bootstrap-components.yaml" provider="k0sproject-k0smotron" type="BootstrapProvider" version="v1.5.2"
Potential override file searchFile="/Users/xxxx/Library/Application Support/cluster-api/overrides/control-plane-kubeadm/v1.10.1/control-plane-components.yaml" provider="control-plane-kubeadm" version="v1.10.1"
Fetching file="control-plane-components.yaml" provider="kubeadm" type="ControlPlaneProvider" version="v1.10.1"
Potential override file searchFile="/Users/xxxx/Library/Application Support/cluster-api/overrides/cluster-api/v1.10.1/metadata.yaml" provider="cluster-api" version="v1.10.1"
Fetching file="metadata.yaml" provider="cluster-api" type="CoreProvider" version="v1.10.1"
Potential override file searchFile="/Users/xxxx/Library/Application Support/cluster-api/overrides/bootstrap-k0sproject-k0smotron/v1.5.2/metadata.yaml" provider="bootstrap-k0sproject-k0smotron" version="v1.5.2"
Fetching file="metadata.yaml" provider="k0sproject-k0smotron" type="BootstrapProvider" version="v1.5.2"
Error: invalid provider metadata: version v1.5.2 for the provider k0smotron/bootstrap-k0sproject-k0smotron does not match any release series
sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster.(*providerInstaller).getProviderContract
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/client/cluster/installer.go:321
sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster.(*providerInstaller).Validate
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/client/cluster/installer.go:211
sigs.k8s.io/cluster-api/cmd/clusterctl/client.(*clusterctlClient).Init
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/client/init.go:136
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.runInit
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/cmd/init.go:149
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.init.func13
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/cmd/init.go:89
github.com/spf13/cobra.(*Command).execute
        /Users/xxxx/go/1.23.2/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /Users/xxxx/go/1.23.2/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /Users/xxxx/go/1.23.2/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
sigs.k8s.io/cluster-api/cmd/clusterctl/cmd.Execute
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/cmd/root.go:113
main.main
        /Users/xxxx/ghq/github.com/kubernetes-sigs/cluster-api/cmd/clusterctl/main.go:27
runtime.main
        /Users/xxxx/.goenv/versions/1.23.2/src/runtime/proc.go:272
runtime.goexit
        /Users/xxxx/.goenv/versions/1.23.2/src/runtime/asm_arm64.s:1223
```

The dumped content pinpoints the offending metadata entry (`v1.5.2`) and lets reporters paste everything into the issue template.

### Implementation details
* During `downloadFilesFromRelease`, if the file is `metadata.yaml` and `log.V(10)` is enabled:  
  * Emit the content with contextual fields (`providerID`, `content`).

### Which issue(s) this PR fixes
Fixes #12248

### Release note
```release-note
clusterctl now dumps provider metadata.yaml at -v=10 to simplify debugging and improve issue reports.
```

/kind feature  
/area clusterctl