### PR TITLE
:bug: Fix second rolling update for MD rolloutAfter

### DIFF
--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -499,9 +499,9 @@ func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*cluste
 		return matchingMachineSets[0], "", nil
 	}
 
-	// Pick the first matching MachineSet that has been created after RolloutAfter.
+	// Pick the first matching MachineSet that has been created at RolloutAfter or later.
 	for _, ms := range matchingMachineSets {
-		if ms.CreationTimestamp.After(deployment.Spec.RolloutAfter.Time) {
+		if ms.CreationTimestamp.Sub(deployment.Spec.RolloutAfter.Time) >= 0 {
 			return ms, "", nil
 		}
 	}

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -423,6 +423,9 @@ func TestFindNewMachineSet(t *testing.T) {
 	msCreatedAfterRolloutAfter := generateMS(deployment)
 	msCreatedAfterRolloutAfter.CreationTimestamp = oneAfterRolloutAfter
 
+	msCreatedExactlyInRolloutAfter := generateMS(deployment)
+	msCreatedExactlyInRolloutAfter.CreationTimestamp = rolloutAfter
+
 	tests := []struct {
 		Name               string
 		deployment         clusterv1.MachineDeployment
@@ -484,6 +487,14 @@ func TestFindNewMachineSet(t *testing.T) {
 			msList:             []*clusterv1.MachineSet{&msCreatedAfterRolloutAfter, &msCreatedTwoBeforeRolloutAfter},
 			reconciliationTime: &twoAfterRolloutAfter,
 			expected:           &msCreatedAfterRolloutAfter,
+		},
+		{
+			// https://github.com/kubernetes-sigs/cluster-api/issues/12260
+			Name:               "Get MachineSet created exactly in RolloutAfter if reconciliationTime > rolloutAfter",
+			deployment:         *deploymentWithRolloutAfter,
+			msList:             []*clusterv1.MachineSet{&msCreatedExactlyInRolloutAfter, &msCreatedTwoBeforeRolloutAfter},
+			reconciliationTime: &oneAfterRolloutAfter,
+			expected:           &msCreatedExactlyInRolloutAfter,
 		},
 		{
 			Name:               "Get MachineSet created after RolloutAfter if reconciliationTime is > rolloutAfter (inverse order in ms list)",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes secondary MS creation if the previous one was created in the same second as `.spec.rolloutAfter`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12260

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machinedeployment