### PR TITLE
🌱 add mboersma and richardcase as MachinePool reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -125,3 +125,11 @@ aliases:
   - mboersma
   - shecodesmagic
   - tsuzu
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for release-team
+  # -----------------------------------------------------------
+
+  cluster-api-machinepool-reviewers:
+  - mboersma
+  - richardcase

--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
-	machinepool "sigs.k8s.io/cluster-api/exp/internal/controllers"
+	"sigs.k8s.io/cluster-api/exp/internal/controllers/machinepool"
 )
 
 // MachinePoolReconciler reconciles a MachinePool object.
@@ -38,7 +38,7 @@ type MachinePoolReconciler struct {
 }
 
 func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	return (&machinepool.MachinePoolReconciler{
+	return (&machinepool.Reconciler{
 		Client:           r.Client,
 		APIReader:        r.APIReader,
 		ClusterCache:     r.ClusterCache,

--- a/exp/internal/controllers/machinepool/OWNERS
+++ b/exp/internal/controllers/machinepool/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-maintainers
+
+reviewers:
+  - cluster-api-reviewers
+  - cluster-api-machinepool-reviewers

--- a/exp/internal/controllers/machinepool/doc.go
+++ b/exp/internal/controllers/machinepool/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package machinepool implements machinepool controllers.
+package machinepool

--- a/exp/internal/controllers/machinepool/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool/machinepool_controller_noderef.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machinepool
 
 import (
 	"context"
@@ -48,7 +48,7 @@ type getNodeReferencesResult struct {
 	ready      int
 }
 
-func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, s *scope) (ctrl.Result, error) {
+func (r *Reconciler) reconcileNodeRefs(ctx context.Context, s *scope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	cluster := s.cluster
 	mp := s.machinePool
@@ -140,7 +140,7 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, s *scope)
 // deleteRetiredNodes deletes nodes that don't have a corresponding ProviderID in Spec.ProviderIDList.
 // A MachinePool infrastructure provider indicates an instance in the set has been deleted by
 // removing its ProviderID from the slice.
-func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client.Client, nodeRefs []corev1.ObjectReference, providerIDList []string) error {
+func (r *Reconciler) deleteRetiredNodes(ctx context.Context, c client.Client, nodeRefs []corev1.ObjectReference, providerIDList []string) error {
 	log := ctrl.LoggerFrom(ctx, "providerIDList", len(providerIDList))
 	nodeRefsMap := make(map[string]*corev1.Node, len(nodeRefs))
 	for _, nodeRef := range nodeRefs {
@@ -172,7 +172,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 	return nil
 }
 
-func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, providerIDList []string, minReadySeconds int32, nodeRefsMap map[string]*corev1.Node) (getNodeReferencesResult, error) {
+func (r *Reconciler) getNodeReferences(ctx context.Context, providerIDList []string, minReadySeconds int32, nodeRefsMap map[string]*corev1.Node) (getNodeReferencesResult, error) {
 	log := ctrl.LoggerFrom(ctx, "providerIDList", len(providerIDList))
 
 	var ready, available int
@@ -206,7 +206,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, providerI
 }
 
 // patchNodes patches the nodes with the cluster name and cluster namespace annotations.
-func (r *MachinePoolReconciler) patchNodes(ctx context.Context, c client.Client, references []corev1.ObjectReference, mp *expv1.MachinePool) error {
+func (r *Reconciler) patchNodes(ctx context.Context, c client.Client, references []corev1.ObjectReference, mp *expv1.MachinePool) error {
 	log := ctrl.LoggerFrom(ctx)
 	for _, nodeRef := range references {
 		node := &corev1.Node{}

--- a/exp/internal/controllers/machinepool/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool/machinepool_controller_noderef_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machinepool
 
 import (
 	"testing"
@@ -31,7 +31,7 @@ import (
 )
 
 func TestMachinePoolGetNodeReference(t *testing.T) {
-	r := &MachinePoolReconciler{
+	r := &Reconciler{
 		Client:   fake.NewClientBuilder().Build(),
 		recorder: record.NewFakeRecorder(32),
 	}
@@ -306,7 +306,7 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 }
 
 func TestMachinePoolPatchNodes(t *testing.T) {
-	r := &MachinePoolReconciler{
+	r := &Reconciler{
 		Client:   fake.NewClientBuilder().Build(),
 		recorder: record.NewFakeRecorder(32),
 	}

--- a/exp/internal/controllers/machinepool/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool/machinepool_controller_phases_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machinepool
 
 import (
 	"fmt"
@@ -132,7 +132,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		infraConfig := defaultInfra.DeepCopy()
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -175,7 +175,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
 
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -215,7 +215,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -271,7 +271,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -343,7 +343,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -393,7 +393,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -446,7 +446,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -516,7 +516,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -592,7 +592,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Finalizers = []string{expv1.MachinePoolFinalizer}
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -666,7 +666,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinePool.Status.Replicas = ptr.To(int32(1))
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinePool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -762,7 +762,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinePool.Status.Replicas = ptr.To(int32(1))
 
 		fakeClient := fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinePool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			externalTracker: external.ObjectTracker{
@@ -1105,7 +1105,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
 			fakeClient := fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client: fakeClient,
 				externalTracker: external.ObjectTracker{
 					Controller:      externalfake.Controller{},
@@ -1317,7 +1317,7 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 
 			infraConfig := &unstructured.Unstructured{Object: tc.infraConfig}
 			fakeClient := fake.NewClientBuilder().WithObjects(tc.machinepool, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:       fakeClient,
 				ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 				externalTracker: external.ObjectTracker{
@@ -1406,7 +1406,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 			}
 			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:   env,
 				ssaCache: ssa.NewCache(testController),
 				externalTracker: external.ObjectTracker{
@@ -1475,7 +1475,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 			}
 			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:   env,
 				ssaCache: ssa.NewCache(testController),
 				externalTracker: external.ObjectTracker{
@@ -1540,7 +1540,7 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 			}
 			g.Expect(env.CreateAndWait(ctx, &unstructured.Unstructured{Object: infraConfig})).To(Succeed())
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:   env,
 				ssaCache: ssa.NewCache(testController),
 			}
@@ -1701,7 +1701,7 @@ func TestInfraMachineToMachinePoolMapper(t *testing.T) {
 				objs = append(objs, mp.DeepCopy())
 			}
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
 			}
 
@@ -1841,7 +1841,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
@@ -1909,7 +1909,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
@@ -1960,7 +1960,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
@@ -2007,7 +2007,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			recorder:     record.NewFakeRecorder(32),
 			ClusterCache: clustercache.NewFakeClusterCache(fakeClient, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
@@ -2076,7 +2076,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		fakeClient := fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build()
-		r := &MachinePoolReconciler{
+		r := &Reconciler{
 			Client:       fakeClient,
 			ClusterCache: clustercache.NewFakeClusterCache(env.GetClient(), client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			recorder:     record.NewFakeRecorder(32),
@@ -2308,7 +2308,7 @@ func TestMachinePoolReconciler_getNodeRefMap(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:   fake.NewClientBuilder().Build(),
 				recorder: record.NewFakeRecorder(32),
 			}

--- a/exp/internal/controllers/machinepool/machinepool_controller_test.go
+++ b/exp/internal/controllers/machinepool/machinepool_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machinepool
 
 import (
 	"context"
@@ -124,7 +124,7 @@ func TestMachinePoolFinalizer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			mr := &MachinePoolReconciler{
+			mr := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(
 					clusterCorrectMeta,
 					machinePoolValidCluster,
@@ -258,7 +258,7 @@ func TestMachinePoolOwnerReference(t *testing.T) {
 				machinePoolValidCluster,
 				machinePoolValidMachinePool,
 			).WithStatusSubresource(&expv1.MachinePool{}).Build()
-			mr := &MachinePoolReconciler{
+			mr := &Reconciler{
 				Client:    fakeClient,
 				APIReader: fakeClient,
 			}
@@ -606,7 +606,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 				},
 			}).WithObjects(trackerObjects...).Build()
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:       clientFake,
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(trackerClientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
@@ -725,7 +725,7 @@ func TestMachinePoolNodeDeleteTimeoutPassed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			timeoutPassed := (&MachinePoolReconciler{}).isMachinePoolNodeDeleteTimeoutPassed(tc.machinePool)
+			timeoutPassed := (&Reconciler{}).isMachinePoolNodeDeleteTimeoutPassed(tc.machinePool)
 			g.Expect(timeoutPassed).To(Equal(tc.want))
 		})
 	}
@@ -837,7 +837,7 @@ func TestReconcileMachinePoolDeleteExternal(t *testing.T) {
 				objs = append(objs, infraConfig)
 			}
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
 			}
 
@@ -893,7 +893,7 @@ func TestRemoveMachinePoolFinalizerAfterDeleteReconcile(t *testing.T) {
 	}
 	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
 	clientFake := fake.NewClientBuilder().WithObjects(testCluster, m).WithStatusSubresource(&expv1.MachinePool{}).Build()
-	mr := &MachinePoolReconciler{
+	mr := &Reconciler{
 		Client:       clientFake,
 		ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 	}
@@ -1184,7 +1184,7 @@ func TestMachinePoolConditions(t *testing.T) {
 				builder.TestInfrastructureMachineTemplateCRD,
 			).WithStatusSubresource(&expv1.MachinePool{}).Build()
 
-			r := &MachinePoolReconciler{
+			r := &Reconciler{
 				Client:       clientFake,
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),

--- a/exp/internal/controllers/machinepool/suite_test.go
+++ b/exp/internal/controllers/machinepool/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machinepool
 
 import (
 	"context"
@@ -74,7 +74,7 @@ func TestMain(m *testing.M) {
 			clusterCache.(interface{ Shutdown() }).Shutdown()
 		}()
 
-		if err := (&MachinePoolReconciler{
+		if err := (&Reconciler{
 			Client:       mgr.GetClient(),
 			APIReader:    mgr.GetAPIReader(),
 			ClusterCache: clusterCache,

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
-	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers"
+	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers/machinepool"
 )
 
 // DockerMachinePoolReconciler reconciles a DockerMachinePool object.

--- a/test/infrastructure/docker/exp/internal/controllers/machinepool/OWNERS
+++ b/test/infrastructure/docker/exp/internal/controllers/machinepool/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-maintainers
+
+reviewers:
+  - cluster-api-reviewers
+  - cluster-api-machinepool-reviewers

--- a/test/infrastructure/docker/exp/internal/controllers/machinepool/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/machinepool/dockermachinepool_controller.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controllers implements controller functionality.
-package controllers
+// Package machinepool implements machinepool controller functionality.
+package machinepool
 
 import (
 	"context"

--- a/test/infrastructure/docker/exp/internal/controllers/machinepool/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/exp/internal/controllers/machinepool/dockermachinepool_controller_phases.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package controllers implements controller functionality.
-package controllers
+// Package machinepool implements controller functionality.
+package machinepool
 
 import (
 	"context"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR reorganizes the MachinePool controller code organizations to match other controllers (e.g., `Machine`) in order to better tag @mboersma and @richardcase as reviewers as we work on the v1beta2 MachinePool efforts:

- https://github.com/kubernetes-sigs/cluster-api/issues/12178

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->