### PR TITLE
⚠️ Remove deprecated ClusterResourceSetBinding.DeleteBinding method 

### DIFF
--- a/api/addons/v1beta2/clusterresourcesetbinding_types.go
+++ b/api/addons/v1beta2/clusterresourcesetbinding_types.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ANCHOR: ResourceBinding
@@ -112,64 +111,6 @@ func (c *ClusterResourceSetBinding) RemoveBinding(clusterResourceSet *ClusterRes
 			break
 		}
 	}
-}
-
-// DeleteBinding removes the ClusterResourceSet from the ClusterResourceSetBinding Bindings list.
-//
-// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
-func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterResourceSet) {
-	for i, binding := range c.Spec.Bindings {
-		if binding.ClusterResourceSetName == clusterResourceSet.Name {
-			copy(c.Spec.Bindings[i:], c.Spec.Bindings[i+1:])
-			c.Spec.Bindings = c.Spec.Bindings[:len(c.Spec.Bindings)-1]
-			break
-		}
-	}
-	c.OwnerReferences = removeOwnerRef(c.GetOwnerReferences(), metav1.OwnerReference{
-		APIVersion: GroupVersion.String(),
-		Kind:       "ClusterResourceSet",
-		Name:       clusterResourceSet.Name,
-	})
-}
-
-// removeOwnerRef returns the slice of owner references after removing the supplied owner ref.
-// Note: removeOwnerRef ignores apiVersion and UID. It will remove the passed ownerReference where it matches Name, Group and Kind.
-//
-// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
-func removeOwnerRef(ownerReferences []metav1.OwnerReference, inputRef metav1.OwnerReference) []metav1.OwnerReference {
-	if index := indexOwnerRef(ownerReferences, inputRef); index != -1 {
-		return append(ownerReferences[:index], ownerReferences[index+1:]...)
-	}
-	return ownerReferences
-}
-
-// indexOwnerRef returns the index of the owner reference in the slice if found, or -1.
-//
-// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
-func indexOwnerRef(ownerReferences []metav1.OwnerReference, ref metav1.OwnerReference) int {
-	for index, r := range ownerReferences {
-		if referSameObject(r, ref) {
-			return index
-		}
-	}
-	return -1
-}
-
-// Returns true if a and b point to the same object based on Group, Kind and Name.
-//
-// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API.
-func referSameObject(a, b metav1.OwnerReference) bool {
-	aGV, err := schema.ParseGroupVersion(a.APIVersion)
-	if err != nil {
-		return false
-	}
-
-	bGV, err := schema.ParseGroupVersion(b.APIVersion)
-	if err != nil {
-		return false
-	}
-
-	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
 }
 
 // +kubebuilder:object:root=true

--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -196,6 +196,10 @@ proposal because most of the changes described below are a consequence of the wo
 - Support for terminal errors has been dropped.
   - `status.failureReason` and `status.failureMessage` will continue to exist temporarily under `status.deprecated.v1beta1`.
   
+### ClusterResourceSetBinding
+
+- Remove deprecated `ClusterResourceSetBinding.DeleteBinding` func
+
 ## Cluster API Contract changes
 
 - v1beta1 version of the Cluster API contract is now deprecated


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12123

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->