### PR TITLE
⚠️ Remove deprecated Cluster.spec.topology.rolloutAfter field

### DIFF
--- a/api/core/v1beta1/conversion_test.go
+++ b/api/core/v1beta1/conversion_test.go
@@ -76,6 +76,7 @@ func TestFuzzyConversion(t *testing.T) {
 func ClusterFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubClusterStatus,
+		spokeClusterTopology,
 		spokeClusterStatus,
 		spokeClusterVariable,
 	}
@@ -96,6 +97,13 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c fuzz.Continue) {
 			in.Initialization = nil
 		}
 	}
+}
+
+func spokeClusterTopology(in *Topology, c fuzz.Continue) {
+	c.FuzzNoCustom(in)
+
+	// RolloutAfter was unused and has been removed in v1beta2.
+	in.RolloutAfter = nil
 }
 
 func spokeClusterStatus(in *ClusterStatus, c fuzz.Continue) {

--- a/api/core/v1beta1/zz_generated.conversion.go
+++ b/api/core/v1beta1/zz_generated.conversion.go
@@ -3735,7 +3735,7 @@ func autoConvert_v1beta1_Topology_To_v1beta2_Topology(in *Topology, out *v1beta2
 	// WARNING: in.Class requires manual conversion: does not exist in peer-type
 	// WARNING: in.ClassNamespace requires manual conversion: does not exist in peer-type
 	out.Version = in.Version
-	out.RolloutAfter = (*v1.Time)(unsafe.Pointer(in.RolloutAfter))
+	// WARNING: in.RolloutAfter requires manual conversion: does not exist in peer-type
 	if err := Convert_v1beta1_ControlPlaneTopology_To_v1beta2_ControlPlaneTopology(&in.ControlPlane, &out.ControlPlane, s); err != nil {
 		return err
 	}
@@ -3765,7 +3765,6 @@ func autoConvert_v1beta1_Topology_To_v1beta2_Topology(in *Topology, out *v1beta2
 func autoConvert_v1beta2_Topology_To_v1beta1_Topology(in *v1beta2.Topology, out *Topology, s conversion.Scope) error {
 	// WARNING: in.ClassRef requires manual conversion: does not exist in peer-type
 	out.Version = in.Version
-	out.RolloutAfter = (*v1.Time)(unsafe.Pointer(in.RolloutAfter))
 	if err := Convert_v1beta2_ControlPlaneTopology_To_v1beta1_ControlPlaneTopology(&in.ControlPlane, &out.ControlPlane, s); err != nil {
 		return err
 	}

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -548,14 +548,6 @@ type Topology struct {
 	// +kubebuilder:validation:MaxLength=256
 	Version string `json:"version"`
 
-	// rolloutAfter performs a rollout of the entire cluster one component at a time,
-	// control plane first and then machine deployments.
-	//
-	// Deprecated: This field has no function and is going to be removed in the next apiVersion.
-	//
-	// +optional
-	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
-
 	// controlPlane describes the cluster control plane.
 	// +optional
 	ControlPlane ControlPlaneTopology `json:"controlPlane,omitempty"`

--- a/api/core/v1beta2/zz_generated.deepcopy.go
+++ b/api/core/v1beta2/zz_generated.deepcopy.go
@@ -3097,10 +3097,6 @@ func (in *RemediationStrategy) DeepCopy() *RemediationStrategy {
 func (in *Topology) DeepCopyInto(out *Topology) {
 	*out = *in
 	out.ClassRef = in.ClassRef
-	if in.RolloutAfter != nil {
-		in, out := &in.RolloutAfter, &out.RolloutAfter
-		*out = (*in).DeepCopy()
-	}
 	in.ControlPlane.DeepCopyInto(&out.ControlPlane)
 	if in.Workers != nil {
 		in, out := &in.Workers, &out.Workers

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -5280,12 +5280,6 @@ func schema_cluster_api_api_core_v1beta2_Topology(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
-					"rolloutAfter": {
-						SchemaProps: spec.SchemaProps{
-							Description: "rolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.\n\nDeprecated: This field has no function and is going to be removed in the next apiVersion.",
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
-						},
-					},
 					"controlPlane": {
 						SchemaProps: spec.SchemaProps{
 							Description: "controlPlane describes the cluster control plane.",
@@ -5326,7 +5320,7 @@ func schema_cluster_api_api_core_v1beta2_Topology(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Time", "sigs.k8s.io/cluster-api/api/core/v1beta2.ClusterClassRef", "sigs.k8s.io/cluster-api/api/core/v1beta2.ClusterVariable", "sigs.k8s.io/cluster-api/api/core/v1beta2.ControlPlaneTopology", "sigs.k8s.io/cluster-api/api/core/v1beta2.WorkersTopology"},
+			"sigs.k8s.io/cluster-api/api/core/v1beta2.ClusterClassRef", "sigs.k8s.io/cluster-api/api/core/v1beta2.ClusterVariable", "sigs.k8s.io/cluster-api/api/core/v1beta2.ControlPlaneTopology", "sigs.k8s.io/cluster-api/api/core/v1beta2.WorkersTopology"},
 	}
 }
 

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -2690,14 +2690,6 @@ spec:
                             x-kubernetes-list-type: map
                         type: object
                     type: object
-                  rolloutAfter:
-                    description: |-
-                      rolloutAfter performs a rollout of the entire cluster one component at a time,
-                      control plane first and then machine deployments.
-
-                      Deprecated: This field has no function and is going to be removed in the next apiVersion.
-                    format: date-time
-                    type: string
                   variables:
                     description: |-
                       variables can be used to customize the Cluster through

--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -91,6 +91,7 @@ proposal because most of the changes described below are a consequence of the wo
 - See changes that apply to [all CRDs](#all-crds)
 - The `spec.topology.class` field has been renamed to `spec.topology.classRef.name`
 - The `spec.topology.classNamespace` field has been renamed to `spec.topology.classRef.namespace`
+- The `spec.topology.rolloutAfter` field has been removed (the corresponding functionality was never implemented)
 - The `definitionFrom` field (deprecated since CAPI v1.8) has been removed from
   - `spec.topology.variables`
   - `spec.topology.controlPlane.variables.overrides`

--- a/internal/apis/core/v1alpha4/conversion_test.go
+++ b/internal/apis/core/v1alpha4/conversion_test.go
@@ -109,6 +109,7 @@ func ClusterFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		hubClusterVariable,
 		hubClusterStatus,
+		spokeClusterTopology,
 	}
 }
 
@@ -134,6 +135,13 @@ func hubClusterVariable(in *clusterv1.ClusterVariable, c fuzz.Continue) {
 
 	// Not every random byte array is valid JSON, e.g. a string without `""`,so we're setting a valid value.
 	in.Value = apiextensionsv1.JSON{Raw: []byte("\"test-string\"")}
+}
+
+func spokeClusterTopology(in *Topology, c fuzz.Continue) {
+	c.FuzzNoCustom(in)
+
+	// RolloutAfter was unused and has been removed in v1beta2.
+	in.RolloutAfter = nil
 }
 
 func ClusterClassFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {

--- a/internal/apis/core/v1alpha4/zz_generated.conversion.go
+++ b/internal/apis/core/v1alpha4/zz_generated.conversion.go
@@ -2034,7 +2034,7 @@ func Convert_v1beta2_ObjectMeta_To_v1alpha4_ObjectMeta(in *v1beta2.ObjectMeta, o
 func autoConvert_v1alpha4_Topology_To_v1beta2_Topology(in *Topology, out *v1beta2.Topology, s conversion.Scope) error {
 	// WARNING: in.Class requires manual conversion: does not exist in peer-type
 	out.Version = in.Version
-	out.RolloutAfter = (*v1.Time)(unsafe.Pointer(in.RolloutAfter))
+	// WARNING: in.RolloutAfter requires manual conversion: does not exist in peer-type
 	if err := Convert_v1alpha4_ControlPlaneTopology_To_v1beta2_ControlPlaneTopology(&in.ControlPlane, &out.ControlPlane, s); err != nil {
 		return err
 	}
@@ -2053,7 +2053,6 @@ func autoConvert_v1alpha4_Topology_To_v1beta2_Topology(in *Topology, out *v1beta
 func autoConvert_v1beta2_Topology_To_v1alpha4_Topology(in *v1beta2.Topology, out *Topology, s conversion.Scope) error {
 	// WARNING: in.ClassRef requires manual conversion: does not exist in peer-type
 	out.Version = in.Version
-	out.RolloutAfter = (*v1.Time)(unsafe.Pointer(in.RolloutAfter))
 	if err := Convert_v1beta2_ControlPlaneTopology_To_v1alpha4_ControlPlaneTopology(&in.ControlPlane, &out.ControlPlane, s); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Note: The corresponding functionality was never implemented!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/12123

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->