### PR TITLE
⚠️ Make clusterName field in ClusterResourceSetBinding required

### DIFF
--- a/api/addons/v1beta2/clusterresourcesetbinding_types.go
+++ b/api/addons/v1beta2/clusterresourcesetbinding_types.go
@@ -200,11 +200,10 @@ type ClusterResourceSetBindingSpec struct {
 	Bindings []*ResourceSetBinding `json:"bindings,omitempty"`
 
 	// clusterName is the name of the Cluster this binding applies to.
-	// Note: this field mandatory in v1beta2.
-	// +optional
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName,omitempty"`
+	ClusterName string `json:"clusterName"`
 }
 
 // ANCHOR_END: ClusterResourceSetBindingSpec

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -398,12 +398,13 @@ spec:
                 maxItems: 100
                 type: array
               clusterName:
-                description: |-
-                  clusterName is the name of the Cluster this binding applies to.
-                  Note: this field mandatory in v1beta2.
+                description: clusterName is the name of the Cluster this binding applies
+                  to.
                 maxLength: 63
                 minLength: 1
                 type: string
+            required:
+            - clusterName
             type: object
         type: object
     served: true


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Makes the clusterName field in CRSB required as documented in the linked issue

This is safe to do because the field has been set by CRS / CRSB controllers since Cluster API v1.4


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8267
Part of #10852

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->