### PR TITLE
🌱 e2e: only run DescribeCluster if v1beta2 Cluster CRD is there

### DIFF
--- a/test/framework/cluster_helpers.go
+++ b/test/framework/cluster_helpers.go
@@ -403,6 +403,19 @@ func DescribeAllCluster(ctx context.Context, input DescribeAllClusterInput) {
 	Expect(input.LogFolder).ToNot(BeEmpty(), "Invalid argument. input.LogFolder can't be empty when calling DescribeAllCluster")
 	Expect(input.Namespace).ToNot(BeNil(), "Invalid argument. input.Namespace can't be nil when calling DescribeAllCluster")
 
+	types := getClusterAPITypes(ctx, input.Lister)
+	clusterAPIVersion := ""
+	for t := range types {
+		if t.Kind == "Cluster" {
+			clusterAPIVersion = t.APIVersion
+			break
+		}
+	}
+	if clusterAPIVersion != clusterv1.GroupVersion.String() {
+		log.Logf("Skipping DescribeCluster because detected Cluster CR in APIVersion %q but require %q", clusterAPIVersion, clusterv1.GroupVersion.String())
+		return
+	}
+
 	clusters := &clusterv1.ClusterList{}
 	Eventually(func() error {
 		return input.Lister.List(ctx, clusters, client.InNamespace(input.Namespace))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

DescribeCluster may fail when doing clusterctl upgrade e2e tests, if target version is not yet deployed.

This also leads to not dumping any yamls for the cluster objects, which might be required to debug the job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing