### PR TITLE
📖 Add Harvester Provider to the Infrastructure List

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -44,6 +44,7 @@ source of inspiration and ideas for others.
 - [CoxEdge](https://github.com/coxedge/cluster-api-provider-coxedge)
 - [DigitalOcean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean)
 - [Google Cloud Platform (GCP)](https://cluster-api-gcp.sigs.k8s.io/)
+- [Harvester](https://github.com/rancher-sandbox/cluster-api-provider-harvester)
 - [Hetzner](https://github.com/syself/cluster-api-provider-hetzner)
 - [Hivelocity](https://github.com/hivelocity/cluster-api-provider-hivelocity)
 - [Huawei Cloud](https://github.com/HuaweiCloudDeveloper/cluster-api-provider-huawei)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the Cluster-API Harvester Infrastructure Provider to the List of available Providers in the documentation, found here:

https://cluster-api.sigs.k8s.io/reference/providers


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12286