### PR TITLE
⚠️ Partially revert: Remove DefaulterRemoveUnknownOrOmitableFields mutating webhook option

### DIFF
--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfig.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfig.go
@@ -33,7 +33,7 @@ import (
 func (webhook *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&bootstrapv1.KubeadmConfig{}).
-		WithDefaulter(webhook).
+		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
 		WithValidator(webhook).
 		Complete()
 }

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate.go
@@ -32,7 +32,7 @@ import (
 func (webhook *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&bootstrapv1.KubeadmConfigTemplate{}).
-		WithDefaulter(webhook).
+		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
 		WithValidator(webhook).
 		Complete()
 }

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -47,7 +47,7 @@ import (
 func (webhook *KubeadmControlPlane) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&controlplanev1.KubeadmControlPlane{}).
-		WithDefaulter(webhook).
+		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
 		WithValidator(webhook).
 		Complete()
 }

--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
@@ -36,7 +36,7 @@ import (
 func (webhook *KubeadmControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&controlplanev1.KubeadmControlPlaneTemplate{}).
-		WithDefaulter(webhook).
+		WithDefaulter(webhook, admission.DefaulterRemoveUnknownOrOmitableFields).
 		WithValidator(webhook).
 		Complete()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Partially revert of:

- #12231

Reverts above PR for kubeadm control plane and kubeadm bootstrap providers, as it could lead to unintentional rollouts (e.g. workers via topology controllers) or even infinite rollouts (e.g. for KCP).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area api