### PR TITLE
🌱 Block dependencies to internal packages for the RX implementation

### DIFF
--- a/hack/verify-import-restrictions.sh
+++ b/hack/verify-import-restrictions.sh
@@ -32,6 +32,7 @@ sub_packages=(
   "controlplane/kubeadm/api"
   "api/ipam"
   "api/runtime"
+  "test/extension"
   "test/infrastructure/docker/api"
   "test/infrastructure/docker/exp/api"
   "test/infrastructure/inmemory/api"
@@ -43,7 +44,7 @@ visit() {
   for file in "$1"/* ; do
     if [ -d "$file" ]; then
       visit "$file"
-    elif [ -f "$file" ]; then
+    elif [ -f "$file" ] && [[ "$file" = *.go ]]; then
       ((count += 1))
     fi
   done

--- a/test/extension/.import-restrictions
+++ b/test/extension/.import-restrictions
@@ -1,0 +1,6 @@
+# Enforce that the test extension implementation and its integration tests
+# do not depend on internal packages.
+rules:
+  - selectorRegexp: .*internal.*
+    allowedPrefixes: []
+    forbiddenPrefixes: []


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->