### PR TITLE
✨ migrate Requeue to RequeueAfter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -257,10 +257,6 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: .*\.Deprecated\.V1Beta1.* is deprecated'
-        # CR v0.21 deprecated Result.Requeue, will be fixed incrementally and tracked via https://github.com/kubernetes-sigs/cluster-api/issues/12272
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*(res|result|i|j)\.Requeue is deprecated: Use `RequeueAfter` instead'
       - linters:
           - revive
         text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -58,7 +59,7 @@ func TestKubeadmConfigReconciler(t *testing.T) {
 				},
 			})
 			g.Expect(err).To(Succeed())
-			g.Expect(result.Requeue).To(BeFalse())
+			g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 		})
 	})
 }

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -124,7 +124,6 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfKubeadmConfigIsReady(t *
 	}
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 }
 
@@ -297,7 +296,6 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasDataSecretName
 	actual := &bootstrapv1.KubeadmConfig{}
 	g.Expect(myclient.Get(ctx, client.ObjectKey{Namespace: config.Namespace, Name: config.Name}, actual)).To(Succeed())
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 	assertHasTrueCondition(g, myclient, request, bootstrapv1.KubeadmConfigDataSecretAvailableCondition)
 }
@@ -470,7 +468,6 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueJoiningNodesIfControlPlaneNotI
 
 			result, err := k.Reconcile(ctx, tc.request)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(result.Requeue).To(BeFalse())
 			g.Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 			assertHasFalseCondition(g, myclient, tc.request, bootstrapv1.KubeadmConfigDataSecretAvailableCondition, bootstrapv1.KubeadmConfigDataSecretNotAvailableReason)
 		})
@@ -523,7 +520,6 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 	cfg, err := getKubeadmConfig(myclient, "control-plane-init-cfg", metav1.NamespaceDefault)
@@ -627,7 +623,6 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueIfControlPlaneIsMissingAPIEndp
 	}
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 
 	actualConfig := &bootstrapv1.KubeadmConfig{}
@@ -705,7 +700,6 @@ func TestReconcileIfJoinCertificatesAvailableConditioninNodesAndControlPlaneIsRe
 			}
 			result, err := k.Reconcile(ctx, request)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(result.Requeue).To(BeFalse())
 			g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 			cfg, err := getKubeadmConfig(myclient, rt.configName, metav1.NamespaceDefault)
@@ -783,7 +777,6 @@ func TestReconcileIfJoinNodePoolsAndControlPlaneIsReady(t *testing.T) {
 			}
 			result, err := k.Reconcile(ctx, request)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(result.Requeue).To(BeFalse())
 			g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 			cfg, err := getKubeadmConfig(myclient, rt.configName, metav1.NamespaceDefault)
@@ -991,7 +984,6 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 	cfg, err := getKubeadmConfig(myclient, "worker-join-cfg", metav1.NamespaceDefault)
@@ -1245,7 +1237,6 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	} {
 		result, err := k.Reconcile(ctx, req)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result.Requeue).To(BeFalse())
 		g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 	}
 
@@ -2130,7 +2121,6 @@ func TestKubeadmConfigReconciler_Reconcile_ExactlyOneControlPlaneMachineInitiali
 	}
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 	request = ctrl.Request{
@@ -2141,7 +2131,6 @@ func TestKubeadmConfigReconciler_Reconcile_ExactlyOneControlPlaneMachineInitiali
 	}
 	result, err = k.Reconcile(ctx, request)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(30 * time.Second))
 	confList := &bootstrapv1.KubeadmConfigList{}
 	g.Expect(myclient.List(ctx, confList)).To(Succeed())
@@ -2198,7 +2187,6 @@ func TestKubeadmConfigReconciler_Reconcile_PatchWhenErrorOccurred(t *testing.T) 
 
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).To(HaveOccurred())
-	g.Expect(result.Requeue).To(BeFalse())
 	g.Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
 
 	cfg, err := getKubeadmConfig(myclient, "control-plane-init-cfg", metav1.NamespaceDefault)

--- a/controlplane/kubeadm/internal/controllers/consts.go
+++ b/controlplane/kubeadm/internal/controllers/consts.go
@@ -30,4 +30,10 @@ const (
 	// dependentCertRequeueAfter is how long to wait before checking again to see if
 	// dependent certificates have been created.
 	dependentCertRequeueAfter = 30 * time.Second
+
+	// scaleRequeueAfter is how long to wait before scaling up/down again after a scale operation has been requested.
+	scaleRequeueAfter = 15 * time.Second
+
+	// initializationRequeueAfter is how long to wait before checking again to see if the initialization has been completed.
+	initializationRequeueAfter = 15 * time.Second
 )

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -191,8 +191,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Initialize the patch helper.
 	patchHelper, err := patch.NewHelper(kcp, r.Client)
 	if err != nil {
-		log.Error(err, "Failed to configure the patch helper")
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, errors.Wrap(err, "failed to configure the patch helper")
 	}
 
 	if isPaused, requeue, err := paused.EnsurePausedCondition(ctx, r.Client, cluster, kcp); err != nil || isPaused || requeue {
@@ -503,8 +502,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, controlPl
 	// Get the workload cluster client.
 	workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
 	if err != nil {
-		log.V(2).Info("cannot get remote client to workload cluster, will requeue", "cause", err)
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, errors.Wrapf(err, "cannot get remote client to workload cluster for KubeadmControlPlane %s/%s", controlPlane.KCP.Namespace, controlPlane.KCP.Name)
 	}
 
 	// Ensure kubeadm role bindings for v1.18+
@@ -521,7 +519,6 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, controlPl
 
 	// Update kube-proxy daemonset.
 	if err := workloadCluster.UpdateKubeProxyImageInfo(ctx, controlPlane.KCP, parsedVersion); err != nil {
-		log.Error(err, "Failed to update kube-proxy daemonset")
 		return ctrl.Result{}, err
 	}
 

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -480,7 +480,7 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 	result, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 	g.Expect(err).ToNot(HaveOccurred())
 	// TODO: this should stop to re-queue as soon as we have a proper remote cluster cache in place.
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: false, RequeueAfter: 20 * time.Second}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: 20 * time.Second}))
 	g.Expect(r.Client.Get(ctx, util.ObjectKey(kcp), kcp)).To(Succeed())
 
 	// Always expect that the Finalizer is set on the passed in resource

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -368,7 +368,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		controlplanev1.RemediationInProgressAnnotation: remediationInProgressValue,
 	})
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: time.Second * 20}, nil
 }
 
 // Gets the machine to be remediated, which is the "most broken" among the unhealthy machines, determined as the machine

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -70,7 +70,7 @@ func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Conte
 			newMachine.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(newMachine.Spec.Bootstrap.ConfigRef.Namespace, newMachine.Spec.Bootstrap.ConfigRef.Name))
 
 	// Requeue the control plane, in case there are additional operations to perform
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: initializationRequeueAfter}, nil
 }
 
 func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context, controlPlane *internal.ControlPlane) (ctrl.Result, error) {
@@ -111,7 +111,7 @@ func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context,
 			newMachine.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(newMachine.Spec.Bootstrap.ConfigRef.Namespace, newMachine.Spec.Bootstrap.ConfigRef.Name))
 
 	// Requeue the control plane, in case there are other operations to perform
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: scaleRequeueAfter}, nil
 }
 
 func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
@@ -167,7 +167,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 		Info("Deleting Machine (scale down)", "Machine", klog.KObj(machineToDelete))
 
 	// Requeue the control plane, in case there are additional operations to perform
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{RequeueAfter: scaleRequeueAfter}, nil
 }
 
 // preflightChecks checks if the control plane is stable before proceeding with a scale up/scale down operation,

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -80,7 +80,7 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 	}
 
 	result, err := r.initializeControlPlane(ctx, controlPlane)
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: initializationRequeueAfter}))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	machineList := &clusterv1.MachineList{}
@@ -162,7 +162,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		}
 
 		result, err := r.scaleUpControlPlane(ctx, controlPlane)
-		g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+		g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 		g.Expect(err).ToNot(HaveOccurred())
 
 		controlPlaneMachines := clusterv1.MachineList{}
@@ -286,7 +286,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+		g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 
 		controlPlaneMachines := clusterv1.MachineList{}
 		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())
@@ -328,7 +328,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+		g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 
 		controlPlaneMachines := clusterv1.MachineList{}
 		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())

--- a/controlplane/kubeadm/internal/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade_test.go
@@ -106,7 +106,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	controlPlane.InjectTestManagementCluster(r.managementCluster)
 
 	result, err := r.initializeControlPlane(ctx, controlPlane)
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: initializationRequeueAfter}))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// initial setup
@@ -128,7 +128,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	needingUpgrade := collections.FromMachineList(initialMachine)
 	controlPlane.Machines = needingUpgrade
 	result, err = r.upgradeControlPlane(ctx, controlPlane, needingUpgrade)
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 	g.Expect(err).ToNot(HaveOccurred())
 	bothMachines := &clusterv1.MachineList{}
 	g.Eventually(func(g Gomega) {
@@ -171,7 +171,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	// run upgrade the second time, expect we scale down
 	result, err = r.upgradeControlPlane(ctx, controlPlane, machinesRequireUpgrade)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 	finalMachine := &clusterv1.MachineList{}
 	g.Eventually(func(g Gomega) {
 		g.Expect(env.List(ctx, finalMachine, client.InNamespace(cluster.Namespace))).To(Succeed())
@@ -262,7 +262,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleDown(t *testing.T) {
 	controlPlane.Machines = needingUpgrade
 
 	result, err = r.upgradeControlPlane(ctx, controlPlane, needingUpgrade)
-	g.Expect(result).To(BeComparableTo(ctrl.Result{Requeue: true}))
+	g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: scaleRequeueAfter}))
 	g.Expect(err).ToNot(HaveOccurred())
 	remainingMachines := &clusterv1.MachineList{}
 	g.Expect(fakeClient.List(ctx, remainingMachines, client.InNamespace(cluster.Namespace))).To(Succeed())

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -149,7 +149,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -192,7 +192,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhasePending))
@@ -232,7 +232,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioning))
@@ -288,7 +288,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -360,7 +360,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -410,7 +410,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioned))
@@ -463,7 +463,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -533,7 +533,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -609,7 +609,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseDeleting))
@@ -683,7 +683,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -703,7 +703,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		// Reconcile again. The new bootstrap config should be used.
 		res, err = r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data-new"))
@@ -779,7 +779,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -803,7 +803,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Controller should wait until bootstrap provider reports ready bootstrap config
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 
@@ -1859,7 +1859,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -1927,7 +1927,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -1978,7 +1978,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -2025,7 +2025,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -2094,7 +2094,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := r.reconcile(ctx, scope)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -112,10 +113,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	var errs []error
 	log := ctrl.LoggerFrom(ctx)
 
-	// Requeue events when the registry is not ready.
+	// RequeueAfter events when the registry is not ready.
 	// The registry will become ready after it is 'warmed up' by warmupRunnable.
 	if !r.RuntimeClient.IsReady() {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
 	extensionConfig := &runtimev1.ExtensionConfig{}

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -95,8 +95,8 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		// Attempt to reconcile. This will be an error as the registry has not been warmed up at this point.
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
-		// If the registry isn't warm the reconcile loop will return Requeue: True
-		g.Expect(res.Requeue).To(BeTrue())
+		// If the registry isn't warm the reconcile loop will return RequeueAfter is 5 seconds.
+		g.Expect(res.RequeueAfter).To(Equal(time.Second * 5))
 	})
 
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(*testing.T) {

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -321,7 +321,8 @@ func (r *Reconciler) reconcile(ctx context.Context, logger logr.Logger, cluster 
 		if len(errList) > 0 {
 			return ctrl.Result{}, kerrors.NewAggregate(errList)
 		}
-		return reconcile.Result{Requeue: true}, nil
+		minNextCheck := minDuration(nextCheckTimes)
+		return reconcile.Result{RequeueAfter: minNextCheck}, nil
 	}
 
 	if m.Spec.UnhealthyRange == nil {

--- a/util/util.go
+++ b/util/util.go
@@ -726,9 +726,10 @@ func LowestNonZeroResult(i, j ctrl.Result) ctrl.Result {
 		return j
 	case j.IsZero():
 		return i
-	case i.Requeue:
+	// The Requeue filed is already deprecated, but we keep it for backward compatibility.
+	case i.Requeue: //nolint:staticcheck
 		return i
-	case j.Requeue:
+	case j.Requeue: //nolint:staticcheck
 		return j
 	case i.RequeueAfter < j.RequeueAfter:
 		return i


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12272 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->