### PR TITLE
🐛 Fix rollout when init configuration in KCP is empty

### DIFF
--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -309,6 +309,9 @@ func matchInitOrJoinConfiguration(machineConfig *bootstrapv1.KubeadmConfig, kcp 
 
 	// takes the KubeadmConfigSpec from KCP and applies the transformations required
 	// to allow a comparison with the KubeadmConfig referenced from the machine.
+	if kcp.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+		kcp.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+	}
 	kcpConfig := getAdjustedKcpConfig(kcp, machineConfig)
 
 	// Default both KubeadmConfigSpecs before comparison.

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -544,6 +544,57 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 			Spec: controlplanev1.KubeadmControlPlaneSpec{
 				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
 					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
+					InitConfiguration:    nil,
+					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
+				},
+			},
+		}
+		m := &clusterv1.Machine{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KubeadmConfig",
+				APIVersion: clusterv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test",
+			},
+			Spec: clusterv1.MachineSpec{
+				Bootstrap: clusterv1.Bootstrap{
+					ConfigRef: &corev1.ObjectReference{
+						Kind:       "KubeadmConfig",
+						Namespace:  "default",
+						Name:       "test",
+						APIVersion: bootstrapv1.GroupVersion.String(),
+					},
+				},
+			},
+		}
+		machineConfigs := map[string]*bootstrapv1.KubeadmConfig{
+			m.Name: {
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KubeadmConfig",
+					APIVersion: bootstrapv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					InitConfiguration: &bootstrapv1.InitConfiguration{},
+				},
+			},
+		}
+		match, diff, err := matchInitOrJoinConfiguration(machineConfigs[m.Name], kcp)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(match).To(BeTrue())
+		g.Expect(diff).To(BeEmpty())
+	})
+	t.Run("returns true if InitConfiguration is equal", func(t *testing.T) {
+		g := NewWithT(t)
+		kcp := &controlplanev1.KubeadmControlPlane{
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
 					InitConfiguration:    &bootstrapv1.InitConfiguration{},
 					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
While testing I saw an unexpected behaviour in KCP rolling out machines after initial provisioning.
After digging into, I found that the issue happens when InitConfiguration in KCP is empty, which is not a common use case (I was using the in-memory provider, so my config was very minimal because I'm not running a real K8s cluster)

/area provider/control-plane-kubeadm
