### PR TITLE
[WIP] Race Condition where controller marks provisioned

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -424,6 +424,7 @@ func (r *MachineBackendReconciler) reconcileNormalETCD(ctx context.Context, clus
 	// TODO (v1beta2): test for v1beta2 conditions
 	start := v1beta1conditions.Get(inMemoryMachine, infrav1.NodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
+	klog.Infof("ETCD check: now=%v, start=%v, provisioningDuration=%v, until=%v", now, start, provisioningDuration, start.Add(provisioningDuration))
 	if now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.EtcdProvisionedCondition, infrav1.EtcdWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
@@ -668,6 +669,7 @@ func (r *MachineBackendReconciler) reconcileNormalAPIServer(ctx context.Context,
 	// TODO (v1beta2): test for v1beta2 conditions
 	start := v1beta1conditions.Get(inMemoryMachine, infrav1.NodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
+	klog.Infof("APIServer check: now=%v, start=%v, provisioningDuration=%v, until=%v", now, start, provisioningDuration, start.Add(provisioningDuration))
 	if now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.APIServerProvisionedCondition, infrav1.APIServerWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
If res is equal to 0 then reconciliation will not be requeued, but it should be requeued and equal to 0. 
if now < until then not res != 0 and we requeue
if now >= until then res = 0 and we do not requeue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12301

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->