### PR TITLE
🐛 test framework: fix e2e config provider's kustomize resource loading using a go getter url 

### DIFF
--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -508,14 +508,9 @@ func (c *E2EConfig) AbsPaths(basePath string) {
 		provider := &c.Providers[i]
 		for j := range provider.Versions {
 			version := &provider.Versions[j]
-			if version.Type != URLSource && version.Value != "" {
-				if !filepath.IsAbs(version.Value) {
-					version.Value = filepath.Join(basePath, version.Value)
-				}
-			} else if version.Type == URLSource && version.Value != "" {
-				// Skip error, will be checked later when loading contents from URL
+			if version.Value != "" {
+				// Skip error, will be checked later when loading contents from URL or file path
 				u, _ := url.Parse(version.Value)
-
 				if u != nil {
 					switch u.Scheme {
 					case "", fileURIScheme:


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes a bug with loading kustomize resources from a go getter url. We only need to append the absolute path to provider.version.value if it's url scheme is file or empty. Removed the extra check for version type to check if it's kustomize or url, because both types can have either folder path or url values. 

**Which issue(s) this PR fixes**:
fixes https://github.com/kubernetes-sigs/cluster-api/issues/12264

/area/e2e-testing