### PR TITLE
🐛 Fixing failed to install kind for e2e tests

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -43,7 +43,7 @@ verify_kind_version() {
       if ! [ -d "${GOPATH_BIN}" ]; then
         mkdir -p "${GOPATH_BIN}"
       fi
-      curl -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
+      curl --retry 5 --retry-all-errors -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
       chmod +x "${GOPATH_BIN}/kind"
       verify_gopath_bin
     else


### PR DESCRIPTION
**What this PR does / why we need it**:
This Pull Request adds a retry-mechanism for the script `./hack/ensure-kind.sh`.

I added a max retry attempt of 5. 

As seen in the issue #12316 the curl of the kind binary fails. The overall curl command is correct, so the guess is, that the URL did not correctly provided the binary to download at that specific time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12316 