### PR TITLE
:seedling: Fix e2e test capi-e2e-release-1.8

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -241,6 +241,14 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
 		}, "5s", "100ms").Should(Succeed(), "Failed to assert self-hosted API server stability")
 
+		By("Ensure all machines have NodeRef before doing move")
+		// Ensure all machines have NodeRef before attempting to move.
+		// This prevents clusterctl move failures when machines are still provisioning.
+		framework.WaitForClusterMachineNodeRefs(ctx, framework.WaitForClusterMachineNodeRefsInput{
+			GetLister: input.BootstrapClusterProxy.GetClient(),
+			Cluster:   cluster,
+		}, input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade")...)
+
 		// Get the machines of the workloadCluster before it is moved to become self-hosted to make sure that the move did not trigger
 		// any unexpected rollouts.
 		preMoveMachineList := &unstructured.UnstructuredList{}
@@ -442,6 +450,14 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 				kubeSystem := &corev1.Namespace{}
 				return selfHostedClusterProxy.GetClient().Get(ctx, client.ObjectKey{Name: "kube-system"}, kubeSystem)
 			}, "5s", "100ms").Should(Succeed(), "Failed to assert self-hosted API server stability")
+
+			By("Ensure all machines have NodeRef before doing move back")
+			// Ensure all machines have NodeRef before attempting to move back to bootstrap.
+			// This prevents clusterctl move failures when machines are still provisioning.
+			framework.WaitForClusterMachineNodeRefs(ctx, framework.WaitForClusterMachineNodeRefsInput{
+				GetLister: selfHostedClusterProxy.GetClient(),
+				Cluster:   selfHostedCluster,
+			}, input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade")...)
 
 			By("Moving the cluster back to bootstrap")
 			clusterctl.Move(ctx, clusterctl.MoveInput{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The `clusterctl move` command verifies that all Machines have NodeRef before starting the move operation, but the self-hosted test wasn't checking this condition before attempting the move. This caused failures when machines were still provisioning (I think).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12340 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->