### PR TITLE
:seedling: Add validation for PREVIOUS_RELEASE_TAG in release-notes-tool

### DIFF
--- a/hack/tools/release/internal/update_providers/provider_issues.go
+++ b/hack/tools/release/internal/update_providers/provider_issues.go
@@ -75,7 +75,7 @@ type IssueResponse struct {
 // releaseDetails is the struct for the release details.
 type releaseDetails struct {
 	ReleaseTag       string
-	BetaTag          string
+	PreReleaseTag    string
 	ReleaseLink      string
 	ReleaseDate      string
 	ReleaseNotesLink string
@@ -83,7 +83,9 @@ type releaseDetails struct {
 
 // Example command:
 //
+//	GITHUB_ISSUE_OPENER_TOKEN="fake" RELEASE_TAG="v1.6.0-alpha.0" RELEASE_DATE="2023-11-28" PROVIDER_ISSUES_DRY_RUN="true" make release-provider-issues-tool
 //	GITHUB_ISSUE_OPENER_TOKEN="fake" RELEASE_TAG="v1.6.0-beta.0" RELEASE_DATE="2023-11-28" PROVIDER_ISSUES_DRY_RUN="true" make release-provider-issues-tool
+//	GITHUB_ISSUE_OPENER_TOKEN="fake" RELEASE_TAG="v1.6.0-rc.0" RELEASE_DATE="2023-11-28" PROVIDER_ISSUES_DRY_RUN="true" make release-provider-issues-tool
 func main() {
 	githubToken, keySet := os.LookupEnv("GITHUB_ISSUE_OPENER_TOKEN")
 	if !keySet || githubToken == "" {
@@ -264,11 +266,11 @@ func getReleaseDetails() (releaseDetails, error) {
 		return releaseDetails{}, errors.New("release tag is a required. Refer to README.md in folder for more information")
 	}
 
-	// allow patterns like v1.7.0-beta.0
-	pattern := `^v\d+\.\d+\.\d+-beta\.\d+$`
+	// allow patterns like v1.7.0-alpha.0, v1.7.0-beta.0, v1.7.0-rc.0
+	pattern := `^v\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$`
 	match, err := regexp.MatchString(pattern, releaseSemVer)
 	if err != nil || !match {
-		return releaseDetails{}, errors.New("release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0")
+		return releaseDetails{}, errors.New("release tag must be in format `^v\\d+\\.\\d+\\.\\d+-(alpha|beta|rc)\\.\\d+$` e.g. v1.7.0-beta.0")
 	}
 
 	major, minor, patch := "", "", ""
@@ -296,14 +298,13 @@ func getReleaseDetails() (releaseDetails, error) {
 
 	majorMinorWithoutPrefixV := fmt.Sprintf("%s.%s", major, minor) // e.g. 1.7 . Note that there is no "v" in the majorMinor
 	releaseTag := fmt.Sprintf("v%s.%s.%s", major, minor, patch)    // e.g. v1.7.0
-	betaTag := fmt.Sprintf("%s%s", releaseTag, "-beta.0")          // e.g. v1.7.0-beta.0
 	releaseLink := fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-%s.md#timeline", majorMinorWithoutPrefixV)
-	releaseNotesLink := fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/releases/tag/%s", betaTag)
+	releaseNotesLink := fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/releases/tag/%s", releaseSemVer)
 
 	return releaseDetails{
 		ReleaseDate:      formattedReleaseDate,
 		ReleaseTag:       releaseTag,
-		BetaTag:          betaTag,
+		PreReleaseTag:    releaseSemVer,
 		ReleaseLink:      releaseLink,
 		ReleaseNotesLink: releaseNotesLink,
 	}, nil
@@ -339,13 +340,13 @@ func formatDate(inputDate string) (string, error) {
 func getIssueBody() *template.Template {
 	// do not indent the body
 	// indenting the body will result in the body being posted as a code snippet
-	issueBody, err := template.New("issue").Parse(`CAPI {{.BetaTag}} has been released and is ready for testing.
+	issueBody, err := template.New("issue").Parse(`CAPI {{.PreReleaseTag}} has been released and is ready for testing.
 Looking forward to your feedback before {{.ReleaseTag}} release!
 
 ## For quick reference
 
 <!-- body -->
-- [CAPI {{.BetaTag}} release notes]({{.ReleaseNotesLink}})
+- [CAPI {{.PreReleaseTag}} release notes]({{.ReleaseNotesLink}})
 - [Shortcut to CAPI git issues](https://github.com/kubernetes-sigs/cluster-api/issues)
 
 ## Following are the planned dates for the upcoming releases
@@ -365,7 +366,7 @@ More details of the upcoming schedule can be seen at [CAPI {{.ReleaseTag}} relea
 
 // getIssueTitle returns the issue title template.
 func getIssueTitle() *template.Template {
-	issueTitle, err := template.New("title").Parse(`CAPI {{.BetaTag}} has been released and is ready for testing`)
+	issueTitle, err := template.New("title").Parse(`CAPI {{.PreReleaseTag}} has been released and is ready for testing`)
 	if err != nil {
 		panic(err)
 	}

--- a/hack/tools/release/internal/update_providers/provider_issues_test.go
+++ b/hack/tools/release/internal/update_providers/provider_issues_test.go
@@ -35,38 +35,71 @@ func Test_GetReleaseDetails(t *testing.T) {
 		err         string
 	}{
 		{
-			name:        "Correct RELEASE_TAG and RELEASE_DATE are set",
+			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for alpha",
+			releaseTag:  "v1.7.0-alpha.0",
+			releaseDate: "2024-04-16",
+			want: releaseDetails{
+				ReleaseDate:      "Tuesday, 16th April 2024",
+				ReleaseTag:       "v1.7.0",
+				PreReleaseTag:    "v1.7.0-alpha.0",
+				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-alpha.0",
+			},
+			expectErr: false,
+		},
+		{
+			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for beta",
 			releaseTag:  "v1.7.0-beta.0",
 			releaseDate: "2024-04-16",
 			want: releaseDetails{
 				ReleaseDate:      "Tuesday, 16th April 2024",
 				ReleaseTag:       "v1.7.0",
-				BetaTag:          "v1.7.0-beta.0",
+				PreReleaseTag:    "v1.7.0-beta.0",
 				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
 				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-beta.0",
 			},
 			expectErr: false,
 		},
 		{
-			name:        "RELEASE_TAG is not in the format ^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$",
+			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for rc",
+			releaseTag:  "v1.7.0-rc.0",
+			releaseDate: "2024-04-16",
+			want: releaseDetails{
+				ReleaseDate:      "Tuesday, 16th April 2024",
+				ReleaseTag:       "v1.7.0",
+				PreReleaseTag:    "v1.7.0-rc.0",
+				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-rc.0",
+			},
+			expectErr: false,
+		},
+		{
+			name:        "RELEASE_TAG is not in the correct format",
 			releaseTag:  "v1.7.0.1",
 			releaseDate: "2024-04-16",
 			expectErr:   true,
-			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-(alpha|beta|rc)\\.\\d+$` e.g. v1.7.0-beta.0",
 		},
 		{
 			name:        "RELEASE_TAG does not have prefix 'v' in its semver",
 			releaseTag:  "1.7.0-beta.0",
 			releaseDate: "2024-04-16",
 			expectErr:   true,
-			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-(alpha|beta|rc)\\.\\d+$` e.g. v1.7.0-beta.0",
 		},
 		{
 			name:        "RELEASE_TAG contains invalid Major.Minor.Patch SemVer",
 			releaseTag:  "v1.x.0-beta.0",
 			releaseDate: "2024-04-16",
 			expectErr:   true,
-			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-beta\\.\\d+$` e.g. v1.7.0-beta.0",
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-(alpha|beta|rc)\\.\\d+$` e.g. v1.7.0-beta.0",
+		},
+		{
+			name:        "RELEASE_TAG contains unsupported pre-release type",
+			releaseTag:  "v1.7.0-gamma.0",
+			releaseDate: "2024-04-16",
+			expectErr:   true,
+			err:         "release tag must be in format `^v\\d+\\.\\d+\\.\\d+-(alpha|beta|rc)\\.\\d+$` e.g. v1.7.0-beta.0",
 		},
 		{
 			name:        "invalid yyyy-dd-mm RELEASE_DATE entered",
@@ -104,7 +137,7 @@ func Test_GetReleaseDetails(t *testing.T) {
 			} else {
 				g.Expect(got.ReleaseDate).To(Equal(tt.want.ReleaseDate))
 				g.Expect(got.ReleaseTag).To(Equal(tt.want.ReleaseTag))
-				g.Expect(got.BetaTag).To(Equal(tt.want.BetaTag))
+				g.Expect(got.PreReleaseTag).To(Equal(tt.want.PreReleaseTag))
 				g.Expect(got.ReleaseLink).To(Equal(tt.want.ReleaseLink))
 			}
 		})

--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -146,7 +146,7 @@ func releaseTypeFromNewTag(newTagConfig string) string {
 		return ""
 	}
 
-	// Only allow alpha, beta and RC releases. More types must be defined here.
+	// Only allow alpha, beta and rc releases. More types must be defined here.
 	// If a new type is not defined, no warning banner will be printed.
 	switch newTag.Pre[0].VersionStr {
 	case preReleaseAlpha:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add a validation logic for `make release-notes`

✅ Now Accepts:
- tags/v1.0.0-alpha.1 (alpha pre-release)
- tags/v1.0.0-beta.1 (beta pre-release)
- tags/v1.0.0-rc.1 (release candidate)

❌ Now Rejects:
- v1.0.0-alpha.1 (missing tags/ prefix)
- tags/v1.0.0 (no pre-release identifier)
- tags/v1.0.0-dev.1 (unsupported pre-release type)
- invalid-version (malformed version)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12278

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release