### PR TITLE
🌱 Fix flaky test in extensionconfig_controller_test.go

### DIFF
--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -69,7 +69,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
 	r := &Reconciler{
-		Client:        env.GetClient(),
+		Client:        env.GetAPIReader().(client.Client),
 		APIReader:     env.GetAPIReader(),
 		RuntimeClient: runtimeClient,
 	}
@@ -102,7 +102,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(*testing.T) {
 		// Warm up the registry before trying reconciliation again.
 		warmup := &warmupRunnable{
-			Client:        env.GetClient(),
+			Client:        env.GetAPIReader().(client.Client),
 			APIReader:     env.GetAPIReader(),
 			RuntimeClient: runtimeClient,
 		}

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -119,18 +119,10 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			pausedCondition := conditions.Get(conf, clusterv1.PausedCondition)
 			g.Expect(pausedCondition).ToNot(BeNil())
 			g.Expect(pausedCondition.ObservedGeneration).To(Equal(conf.Generation))
-		}).WithTimeout(15 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
-
-		// Wait for discovery to complete before checking final conditions
-		g.Eventually(func(g Gomega) {
-			updatedConfig := &runtimev1.ExtensionConfig{}
-			g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), updatedConfig)).To(Succeed())
-			v1beta2Conditions := updatedConfig.GetConditions()
-			g.Expect(len(v1beta2Conditions)).To(BeNumerically(">=", 2))
-		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 		config := &runtimev1.ExtensionConfig{}
 		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), config)).To(Succeed())

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -119,10 +119,18 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			pausedCondition := conditions.Get(conf, clusterv1.PausedCondition)
 			g.Expect(pausedCondition).ToNot(BeNil())
 			g.Expect(pausedCondition.ObservedGeneration).To(Equal(conf.Generation))
-		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+		}).WithTimeout(15 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
+
+		// Wait for discovery to complete before checking final conditions
+		g.Eventually(func(g Gomega) {
+			updatedConfig := &runtimev1.ExtensionConfig{}
+			g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), updatedConfig)).To(Succeed())
+			v1beta2Conditions := updatedConfig.GetConditions()
+			g.Expect(len(v1beta2Conditions)).To(BeNumerically(">=", 2))
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 		config := &runtimev1.ExtensionConfig{}
 		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), config)).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does**

Fixed a flaky test - `TestExtensionReconciler_Reconcile` by adding proper sync to wait for both Paused and Discovery conditions to be set before performing assertions

**why we need it**

The `paused.EnsurePausedCondition()` function triggers multiple reconciliation cycles:

1. Sets `PausedV1Beta2Condition` and returns `requeue=true` (early return)
2. Executes discovery logic and sets `ExtensionConfigDiscoveredV1Beta2Condition`

The test assertion `g.Expect(v1beta2Conditions).To(HaveLen(2))` was executed immediately after the second reconcile call, but before the patch containing the Discovery condition was fully applied to the API server (race condition I think).

So we need to `Eventually` block to resolve this race condition

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12311

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->