### PR TITLE
:seedling: Add default registry in kubevirt tilt file

### DIFF
--- a/docs/book/src/developer/core/tilt.md
+++ b/docs/book/src/developer/core/tilt.md
@@ -114,6 +114,7 @@ enable_providers:
 {{#tab KubeVirt}}
 
 ```yaml
+default_registry: gcr.io/your-project-name-here
 enable_providers:
 - kubevirt
 - kubeadm-bootstrap


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

If we blindly follow the [Developing Cluster API with Tilt](https://cluster-api.sigs.k8s.io/developer/core/tilt#developing-cluster-api-with-tilt) in CAPI book for Kubevirt provider references and use the given tilt file content, we hit the following error
```
ERROR: Traceback (most recent call last):
  /root/cluster-api/Tiltfile:46:13: in <toplevel>
Error in fail: default_registry is required when not using a local registry, please add it to your tilt-settings.yaml/json
```

This PR would add the `default_registry` key into the tilt file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->