### PR TITLE
🐛 Fix MachinePool nodeRef UID mismatch after K8s upgrade

### DIFF
--- a/internal/controllers/machinepool/machinepool_controller_noderef.go
+++ b/internal/controllers/machinepool/machinepool_controller_noderef.go
@@ -84,6 +84,7 @@ func (r *Reconciler) reconcileNodeRefs(ctx context.Context, s *scope) (ctrl.Resu
 
 				// If node not found or UID doesn't match, mark as invalid
 				if !exists || foundNode.UID != nodeRef.UID {
+					log.V(1).Info("NodeRefs do not match current Nodes, will reassign")
 					validNodeRefs = false
 					break
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
When a K8s upgrade is performed on a Managed cluster, new nodes will come up with new UIDs. However, the MachinePool controller has an early return condition that only validates the count of NodeRefs but doesn't check if the UIDs are still valid. This leads to MachinePools retaining stale NodeRef UIDs after upgrades, causing UID mismatches that persist until manual intervention.
This PR adds UID validation logic before the early return condition.
- A new name-to-node map with the name nodeNameMap is created.
- We iterate over the mp.Status.NodeRefs and using the above map, get each each Node.
- If the Node doesn't exists or the fetched Node's UID is not matching to the UID in NodeRef, we break and continue with further reconciliation. This will set the correct nodeRef in the Machine Pool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12388 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->