### PR TITLE
🐛 Fix rendering of *bool values in cloud init

### DIFF
--- a/bootstrap/kubeadm/internal/cloudinit/ntp.go
+++ b/bootstrap/kubeadm/internal/cloudinit/ntp.go
@@ -21,7 +21,7 @@ const (
 {{- if . }}
 ntp:
   {{ if .Enabled -}}
-  enabled: true
+  enabled: {{ .Enabled }}
   {{ end -}}
   servers:{{ range .Servers }}
     - {{ . }}

--- a/bootstrap/kubeadm/internal/cloudinit/users.go
+++ b/bootstrap/kubeadm/internal/cloudinit/users.go
@@ -34,7 +34,7 @@ users:{{ range . }}
     homedir: {{ .HomeDir }}
     {{- end -}}
     {{- if .Inactive }}
-    inactive: true
+    inactive: {{ .Inactive }}
     {{- end -}}
     {{- if .LockPassword }}
     lock_passwd: {{ .LockPassword }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like cloud init go templates are not correct for `dns.enabled` and `users.inactive`, both of type `*bool`

More specifically, even if the value is set to ptr.To(false), the template renders true, which is wrong.
This PR aligns go templates for this two fields to the same format we are using for other `*bool` fields. 

/area provider/bootstrap-kubeadm
