### PR TITLE
⚠️ KCP tolerates diff not leading to changes on machines

### DIFF
--- a/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
+++ b/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
@@ -325,7 +325,7 @@ func TestNewJoinNodeCommands(t *testing.T) {
 	g.Expect(out).To(ContainSubstring(expectedRunCmd))
 }
 
-func TestOmitableFields(t *testing.T) {
+func TestOmittableFields(t *testing.T) {
 	tests := []struct {
 		name string
 		A    BaseUserData

--- a/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
+++ b/bootstrap/kubeadm/internal/cloudinit/cloudinit_test.go
@@ -324,3 +324,164 @@ func TestNewJoinNodeCommands(t *testing.T) {
 
 	g.Expect(out).To(ContainSubstring(expectedRunCmd))
 }
+
+func TestOmitableFields(t *testing.T) {
+	tests := []struct {
+		name string
+		A    BaseUserData
+		B    BaseUserData
+	}{
+		{
+			name: "No diff between empty or nil additionalFiles", // NOTE: it maps to .Files in the KubeadmConfigSpec
+			A: BaseUserData{
+				AdditionalFiles: []bootstrapv1.File{},
+			},
+			B: BaseUserData{
+				AdditionalFiles: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil diskSetup.partitions",
+			A: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Partitions: []bootstrapv1.Partition{},
+				},
+			},
+			B: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Partitions: nil,
+				},
+			},
+		},
+		{
+			name: "No diff between empty or nil diskSetup.filesystems.extraOpts",
+			A: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: []bootstrapv1.Filesystem{
+						{
+							ExtraOpts: []string{},
+						},
+					},
+				},
+			},
+			B: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: []bootstrapv1.Filesystem{
+						{
+							ExtraOpts: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "No diff between empty or nil diskSetup.filesystems",
+			A: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: []bootstrapv1.Filesystem{},
+				},
+			},
+			B: BaseUserData{
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: nil,
+				},
+			},
+		},
+		{
+			name: "No diff between empty or nil mounts",
+			A: BaseUserData{
+				Mounts: []bootstrapv1.MountPoints{},
+			},
+			B: BaseUserData{
+				Mounts: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil bootCommands",
+			A: BaseUserData{
+				BootCommands: []string{},
+			},
+			B: BaseUserData{
+				BootCommands: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil preKubeadmCommands",
+			A: BaseUserData{
+				PreKubeadmCommands: []string{},
+			},
+			B: BaseUserData{
+				PreKubeadmCommands: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil postKubeadmCommands",
+			A: BaseUserData{
+				PostKubeadmCommands: []string{},
+			},
+			B: BaseUserData{
+				PostKubeadmCommands: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil users",
+			A: BaseUserData{
+				Users: []bootstrapv1.User{},
+			},
+			B: BaseUserData{
+				Users: nil,
+			},
+		},
+		{
+			name: "No diff between empty or nil users.sshAuthorizedKeys",
+			A: BaseUserData{
+				Users: []bootstrapv1.User{
+					{
+						SSHAuthorizedKeys: nil,
+					},
+				},
+			},
+			B: BaseUserData{
+				Users: []bootstrapv1.User{
+					{
+						SSHAuthorizedKeys: []string{},
+					},
+				},
+			},
+		},
+		{
+			name: "No diff between empty or nil ntp.servers",
+			A: BaseUserData{
+				NTP: &bootstrapv1.NTP{
+					Servers: []string{},
+				},
+			},
+			B: BaseUserData{
+				NTP: &bootstrapv1.NTP{
+					Servers: nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			outA, err := NewInitControlPlane(&ControlPlaneInput{BaseUserData: tt.A})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			outB, err := NewInitControlPlane(&ControlPlaneInput{BaseUserData: tt.B})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(string(outA)).To(Equal(string(outB)))
+
+			outA, err = NewJoinControlPlane(&ControlPlaneJoinInput{BaseUserData: tt.A})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			outB, err = NewJoinControlPlane(&ControlPlaneJoinInput{BaseUserData: tt.B})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(string(outA)).To(Equal(string(outB)))
+		})
+	}
+}

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -219,13 +219,18 @@ func matchClusterConfiguration(kcp *controlplanev1.KubeadmControlPlane, machine 
 		machineClusterConfig = &bootstrapv1.ClusterConfiguration{}
 	}
 
-	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration
+	kcpLocalClusterConfiguration := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.DeepCopy()
 	if kcpLocalClusterConfiguration == nil {
 		kcpLocalClusterConfiguration = &bootstrapv1.ClusterConfiguration{}
 	}
 
 	// Skip checking DNS fields because we can update the configuration of the working cluster in place.
 	machineClusterConfig.DNS = kcpLocalClusterConfiguration.DNS
+
+	// Drop differences that do not lead to changes to machines, but that might exist due
+	// changes is how we serialize objects / how webhooks works.
+	dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: kcpLocalClusterConfiguration})
+	dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: machineClusterConfig})
 
 	// Compare and return.
 	match, diff, err := compare.Diff(machineClusterConfig, kcpLocalClusterConfiguration)
@@ -306,6 +311,7 @@ func matchInitOrJoinConfiguration(machineConfig *bootstrapv1.KubeadmConfig, kcp 
 		// This is a safety precaution to avoid rolling out machines if the client or the api-server is misbehaving.
 		return true, "", nil
 	}
+	machineConfig = machineConfig.DeepCopy()
 
 	// takes the KubeadmConfigSpec from KCP and applies the transformations required
 	// to allow a comparison with the KubeadmConfig referenced from the machine.
@@ -390,5 +396,201 @@ func cleanupConfigFields(kcpConfig *bootstrapv1.KubeadmConfigSpec, machineConfig
 	if kcpConfig.JoinConfiguration != nil && reflect.DeepEqual(kcpConfig.JoinConfiguration.NodeRegistration, emptyNodeRegistration) &&
 		machineConfig.Spec.JoinConfiguration != nil {
 		machineConfig.Spec.JoinConfiguration.NodeRegistration = emptyNodeRegistration
+	}
+
+	// Drop differences that do not lead to changes to machines, but that might exist due
+	// changes is how we serialize objects / how webhooks works.
+	dropOmitableFields(kcpConfig)
+	dropOmitableFields(&machineConfig.Spec)
+}
+
+// dropOmitableFields makes the comparison tolerant to omitable fields being set in the go struct. It applies to:
+// - empty array vs nil
+// - empty map vs nil
+// - empty struct vs nil (when struct is pointer and there are only omitable fields in the struct).
+// Note: for the part of the KubeadmConfigSpec that is rendered using go templates, consideration might be a little bit different.
+func dropOmitableFields(spec *bootstrapv1.KubeadmConfigSpec) {
+	// When rendered to kubeadm config files there is no diff between nil and empty array or map.
+	if spec.ClusterConfiguration != nil {
+		if spec.ClusterConfiguration.Etcd.Local != nil {
+			if len(spec.ClusterConfiguration.Etcd.Local.ExtraArgs) == 0 {
+				spec.ClusterConfiguration.Etcd.Local.ExtraArgs = nil
+			}
+			if len(spec.ClusterConfiguration.Etcd.Local.ExtraEnvs) == 0 {
+				spec.ClusterConfiguration.Etcd.Local.ExtraEnvs = nil
+			}
+			if len(spec.ClusterConfiguration.Etcd.Local.ServerCertSANs) == 0 {
+				spec.ClusterConfiguration.Etcd.Local.ServerCertSANs = nil
+			}
+			if len(spec.ClusterConfiguration.Etcd.Local.PeerCertSANs) == 0 {
+				spec.ClusterConfiguration.Etcd.Local.PeerCertSANs = nil
+			}
+		}
+		if len(spec.ClusterConfiguration.APIServer.ExtraArgs) == 0 {
+			spec.ClusterConfiguration.APIServer.ExtraArgs = nil
+		}
+		if len(spec.ClusterConfiguration.APIServer.ExtraEnvs) == 0 {
+			spec.ClusterConfiguration.APIServer.ExtraEnvs = nil
+		}
+		if len(spec.ClusterConfiguration.APIServer.ExtraVolumes) == 0 {
+			spec.ClusterConfiguration.APIServer.ExtraVolumes = nil
+		}
+		if len(spec.ClusterConfiguration.APIServer.CertSANs) == 0 {
+			spec.ClusterConfiguration.APIServer.CertSANs = nil
+		}
+		if len(spec.ClusterConfiguration.ControllerManager.ExtraArgs) == 0 {
+			spec.ClusterConfiguration.ControllerManager.ExtraArgs = nil
+		}
+		if len(spec.ClusterConfiguration.ControllerManager.ExtraEnvs) == 0 {
+			spec.ClusterConfiguration.ControllerManager.ExtraEnvs = nil
+		}
+		if len(spec.ClusterConfiguration.ControllerManager.ExtraVolumes) == 0 {
+			spec.ClusterConfiguration.ControllerManager.ExtraVolumes = nil
+		}
+		if len(spec.ClusterConfiguration.Scheduler.ExtraArgs) == 0 {
+			spec.ClusterConfiguration.Scheduler.ExtraArgs = nil
+		}
+		if len(spec.ClusterConfiguration.Scheduler.ExtraEnvs) == 0 {
+			spec.ClusterConfiguration.Scheduler.ExtraEnvs = nil
+		}
+		if len(spec.ClusterConfiguration.Scheduler.ExtraVolumes) == 0 {
+			spec.ClusterConfiguration.Scheduler.ExtraVolumes = nil
+		}
+		if len(spec.ClusterConfiguration.FeatureGates) == 0 {
+			spec.ClusterConfiguration.FeatureGates = nil
+		}
+	}
+	if spec.InitConfiguration != nil {
+		if len(spec.InitConfiguration.BootstrapTokens) == 0 {
+			spec.InitConfiguration.BootstrapTokens = nil
+		}
+		for i, token := range spec.InitConfiguration.BootstrapTokens {
+			if len(token.Usages) == 0 {
+				token.Usages = nil
+			}
+			if len(token.Groups) == 0 {
+				token.Groups = nil
+			}
+			spec.InitConfiguration.BootstrapTokens[i] = token
+		}
+		if len(spec.InitConfiguration.NodeRegistration.KubeletExtraArgs) == 0 {
+			spec.InitConfiguration.NodeRegistration.KubeletExtraArgs = nil
+		}
+		if len(spec.InitConfiguration.NodeRegistration.IgnorePreflightErrors) == 0 {
+			spec.InitConfiguration.NodeRegistration.IgnorePreflightErrors = nil
+		}
+		if len(spec.InitConfiguration.SkipPhases) == 0 {
+			spec.InitConfiguration.SkipPhases = nil
+		}
+	}
+	if spec.JoinConfiguration != nil {
+		if spec.JoinConfiguration.Discovery.BootstrapToken != nil {
+			if len(spec.JoinConfiguration.Discovery.BootstrapToken.CACertHashes) == 0 {
+				spec.JoinConfiguration.Discovery.BootstrapToken.CACertHashes = nil
+			}
+		}
+		if spec.JoinConfiguration.Discovery.File != nil && spec.JoinConfiguration.Discovery.File.KubeConfig != nil {
+			if spec.JoinConfiguration.Discovery.File.KubeConfig.Cluster != nil {
+				if len(spec.JoinConfiguration.Discovery.File.KubeConfig.Cluster.CertificateAuthorityData) == 0 {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.Cluster.CertificateAuthorityData = nil
+				}
+				if reflect.DeepEqual(spec.JoinConfiguration.Discovery.File.KubeConfig.Cluster, &bootstrapv1.KubeConfigCluster{}) {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.Cluster = nil
+				}
+			}
+			if spec.JoinConfiguration.Discovery.File.KubeConfig.User.AuthProvider != nil {
+				if len(spec.JoinConfiguration.Discovery.File.KubeConfig.User.AuthProvider.Config) == 0 {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.User.AuthProvider.Config = nil
+				}
+				if reflect.DeepEqual(spec.JoinConfiguration.Discovery.File.KubeConfig.User.AuthProvider, &bootstrapv1.KubeConfigAuthProvider{}) {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.User.AuthProvider = nil
+				}
+			}
+			if spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec != nil {
+				if len(spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec.Args) == 0 {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec.Args = nil
+				}
+				if len(spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec.Env) == 0 {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec.Env = nil
+				}
+				if reflect.DeepEqual(spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec, &bootstrapv1.KubeConfigAuthExec{}) {
+					spec.JoinConfiguration.Discovery.File.KubeConfig.User.Exec = nil
+				}
+			}
+			if reflect.DeepEqual(spec.JoinConfiguration.Discovery.File.KubeConfig, &bootstrapv1.FileDiscoveryKubeConfig{}) {
+				spec.JoinConfiguration.Discovery.File.KubeConfig = nil
+			}
+		}
+		if len(spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs) == 0 {
+			spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = nil
+		}
+		if len(spec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors) == 0 {
+			spec.JoinConfiguration.NodeRegistration.IgnorePreflightErrors = nil
+		}
+		if len(spec.JoinConfiguration.SkipPhases) == 0 {
+			spec.JoinConfiguration.SkipPhases = nil
+		}
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty files.
+	if len(spec.Files) == 0 {
+		spec.Files = nil
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty diskSetup.filesystems.
+	// When rendered to cloud init, there is no diff between nil and empty diskSetup.filesystems[].extraOpts.
+	// When rendered to cloud init, there is no diff between nil and empty diskSetup.partitions.
+	if spec.DiskSetup != nil {
+		if len(spec.DiskSetup.Filesystems) == 0 {
+			spec.DiskSetup.Filesystems = nil
+		}
+		for i, fs := range spec.DiskSetup.Filesystems {
+			if len(fs.ExtraOpts) == 0 {
+				fs.ExtraOpts = nil
+			}
+			spec.DiskSetup.Filesystems[i] = fs
+		}
+		if len(spec.DiskSetup.Partitions) == 0 {
+			spec.DiskSetup.Partitions = nil
+		}
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty Mounts.
+	if len(spec.Mounts) == 0 {
+		spec.Mounts = nil
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty BootCommands.
+	if len(spec.BootCommands) == 0 {
+		spec.BootCommands = nil
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty PreKubeadmCommands.
+	if len(spec.PreKubeadmCommands) == 0 {
+		spec.PreKubeadmCommands = nil
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty PostKubeadmCommands.
+	if len(spec.PostKubeadmCommands) == 0 {
+		spec.PostKubeadmCommands = nil
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty Users.
+	// When rendered to cloud init, there is no diff between nil and empty Users[].SSHAuthorizedKeys.
+	if len(spec.Users) == 0 {
+		spec.Users = nil
+	}
+	for i, user := range spec.Users {
+		if len(user.SSHAuthorizedKeys) == 0 {
+			user.SSHAuthorizedKeys = nil
+		}
+		spec.Users[i] = user
+	}
+
+	// When rendered to cloud init, there is no diff between nil and empty ntp.servers.
+	if spec.NTP != nil {
+		if len(spec.NTP.Servers) == 0 {
+			spec.NTP.Servers = nil
+		}
 	}
 }

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -208,7 +208,7 @@ func TestMatchClusterConfiguration(t *testing.T) {
     FeatureGates:    nil,
   }`))
 	})
-	t.Run("Return true if only omitable fields are changed", func(t *testing.T) {
+	t.Run("Return true if only omittable fields are changed", func(t *testing.T) {
 		g := NewWithT(t)
 		kcp := &controlplanev1.KubeadmControlPlane{
 			Spec: controlplanev1.KubeadmControlPlaneSpec{
@@ -467,7 +467,7 @@ func TestCleanupConfigFields(t *testing.T) {
 		g.Expect(kcpConfig.JoinConfiguration).ToNot(BeNil())
 		g.Expect(machineConfig.Spec.JoinConfiguration.NodeRegistration).To(BeComparableTo(bootstrapv1.NodeRegistrationOptions{}))
 	})
-	t.Run("drops omitable fields", func(t *testing.T) {
+	t.Run("drops omittable fields", func(t *testing.T) {
 		g := NewWithT(t)
 		kcpConfig := &bootstrapv1.KubeadmConfigSpec{
 			JoinConfiguration: &bootstrapv1.JoinConfiguration{
@@ -511,7 +511,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -561,7 +561,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -611,7 +611,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -665,7 +665,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -733,7 +733,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -787,7 +787,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -842,7 +842,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
     ... // 9 identical fields
   }`))
 	})
-	t.Run("returns true if returns true if only omitable configurations are not equal", func(t *testing.T) {
+	t.Run("returns true if returns true if only omittable configurations are not equal", func(t *testing.T) {
 		g := NewWithT(t)
 		kcp := &controlplanev1.KubeadmControlPlane{
 			Spec: controlplanev1.KubeadmControlPlaneSpec{
@@ -850,13 +850,13 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
 					InitConfiguration:    &bootstrapv1.InitConfiguration{},
 					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
-					Files:                []bootstrapv1.File{}, // This is a change, but it is an omitable field and the diff between nil and empty array is not relevant.
+					Files:                []bootstrapv1.File{}, // This is a change, but it is an omittable field and the diff between nil and empty array is not relevant.
 				},
 			},
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -901,13 +901,13 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
 					InitConfiguration:    &bootstrapv1.InitConfiguration{},
 					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
-					Files:                []bootstrapv1.File{{}}, // This is a change
+					Files:                []bootstrapv1.File{{Path: "/tmp/foo"}}, // This is a change
 				},
 			},
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -947,7 +947,7 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
     InitConfiguration:    &{NodeRegistration: {ImagePullPolicy: "IfNotPresent"}},
     JoinConfiguration:    nil,
 -   Files:                nil,
-+   Files:                []v1beta2.File{{}},
++   Files:                []v1beta2.File{{Path: "/tmp/foo"}},
     DiskSetup:            nil,
     Mounts:               nil,
     ... // 8 identical fields
@@ -1029,7 +1029,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1083,7 +1083,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1151,7 +1151,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1205,7 +1205,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1260,7 +1260,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
     ... // 9 identical fields
   }`))
 	})
-	t.Run("returns true if only omitable configurations are not equal", func(t *testing.T) {
+	t.Run("returns true if only omittable configurations are not equal", func(t *testing.T) {
 		g := NewWithT(t)
 		kcp := &controlplanev1.KubeadmControlPlane{
 			Spec: controlplanev1.KubeadmControlPlaneSpec{
@@ -1268,13 +1268,13 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
 					InitConfiguration:    &bootstrapv1.InitConfiguration{},
 					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
-					Files:                []bootstrapv1.File{}, // This is a change, but it is an omitable field and the diff between nil and empty array is not relevant.
+					Files:                []bootstrapv1.File{}, // This is a change, but it is an omittable field and the diff between nil and empty array is not relevant.
 				},
 			},
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1319,13 +1319,13 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 					ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
 					InitConfiguration:    &bootstrapv1.InitConfiguration{},
 					JoinConfiguration:    &bootstrapv1.JoinConfiguration{},
-					Files:                []bootstrapv1.File{{}}, // This is a change
+					Files:                []bootstrapv1.File{{Path: "/tmp/foo"}}, // This is a change
 				},
 			},
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1365,7 +1365,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
     InitConfiguration:    &{NodeRegistration: {ImagePullPolicy: "IfNotPresent"}},
     JoinConfiguration:    nil,
 -   Files:                nil,
-+   Files:                []v1beta2.File{{}},
++   Files:                []v1beta2.File{{Path: "/tmp/foo"}},
     DiskSetup:            nil,
     Mounts:               nil,
     ... // 8 identical fields
@@ -1393,7 +1393,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		}
 		m := &clusterv1.Machine{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KubeadmConfig",
+				Kind:       "Machine",
 				APIVersion: clusterv1.GroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -1847,14 +1847,14 @@ func TestUpToDate(t *testing.T) {
 	}
 }
 
-func TestOmitableFieldsClusterConfiguration(t *testing.T) {
+func TestOmittableFieldsClusterConfiguration(t *testing.T) {
 	tests := []struct {
 		name string
 		A    *bootstrapv1.ClusterConfiguration
 		B    *bootstrapv1.ClusterConfiguration
 	}{
 		{
-			name: "Test omitable fields",
+			name: "Test omittable fields",
 			A: &bootstrapv1.ClusterConfiguration{
 				Etcd: bootstrapv1.Etcd{
 					Local: &bootstrapv1.LocalEtcd{
@@ -1896,7 +1896,7 @@ func TestOmitableFieldsClusterConfiguration(t *testing.T) {
 						PeerCertSANs:   nil,
 					},
 					External: &bootstrapv1.ExternalEtcd{
-						Endpoints: []string{}, // Required
+						Endpoints: []string{}, // The field doesn't have omit empty.
 					},
 				},
 				APIServer: bootstrapv1.APIServer{
@@ -1925,29 +1925,29 @@ func TestOmitableFieldsClusterConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotA, err := kubeadmtypes.MarshalClusterConfigurationForVersion(tt.A, semver.MustParse("1.33.0"), &upstream.AdditionalData{})
+			gotA, err := kubeadmtypes.MarshalClusterConfigurationForVersion(tt.A, semver.MustParse("1.99.0"), &upstream.AdditionalData{}) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
-			gotB, err := kubeadmtypes.MarshalClusterConfigurationForVersion(tt.B, semver.MustParse("1.33.0"), &upstream.AdditionalData{})
+			gotB, err := kubeadmtypes.MarshalClusterConfigurationForVersion(tt.B, semver.MustParse("1.99.0"), &upstream.AdditionalData{}) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(gotA).To(Equal(gotB), cmp.Diff(gotA, gotB))
 
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: tt.A})
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: tt.B})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: tt.A})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{ClusterConfiguration: tt.B})
 			g.Expect(tt.A).To(Equal(tt.B))
 		})
 	}
 }
 
-func TestOmitableFieldsInitConfiguration(t *testing.T) {
+func TestOmittableFieldsInitConfiguration(t *testing.T) {
 	tests := []struct {
 		name string
 		A    *bootstrapv1.InitConfiguration
 		B    *bootstrapv1.InitConfiguration
 	}{
 		{
-			name: "Test omitable fields",
+			name: "Test omittable fields",
 			A: &bootstrapv1.InitConfiguration{
 				BootstrapTokens: []bootstrapv1.BootstrapToken{},
 				NodeRegistration: bootstrapv1.NodeRegistrationOptions{
@@ -1968,7 +1968,7 @@ func TestOmitableFieldsInitConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "Test omitable fields in BootstrapToken",
+			name: "Test omittable fields in BootstrapToken",
 			A: &bootstrapv1.InitConfiguration{
 				BootstrapTokens: []bootstrapv1.BootstrapToken{
 					{
@@ -1991,29 +1991,29 @@ func TestOmitableFieldsInitConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotA, err := kubeadmtypes.MarshalInitConfigurationForVersion(tt.A, semver.MustParse("1.33.0"))
+			gotA, err := kubeadmtypes.MarshalInitConfigurationForVersion(tt.A, semver.MustParse("1.99.0")) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
-			gotB, err := kubeadmtypes.MarshalInitConfigurationForVersion(tt.B, semver.MustParse("1.33.0"))
+			gotB, err := kubeadmtypes.MarshalInitConfigurationForVersion(tt.B, semver.MustParse("1.99.0")) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(gotA).To(Equal(gotB), cmp.Diff(gotA, gotB))
 
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{InitConfiguration: tt.A})
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{InitConfiguration: tt.B})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{InitConfiguration: tt.A})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{InitConfiguration: tt.B})
 			g.Expect(tt.A).To(Equal(tt.B))
 		})
 	}
 }
 
-func TestOmitableFieldsJoinConfiguration(t *testing.T) {
+func TestOmittableFieldsJoinConfiguration(t *testing.T) {
 	tests := []struct {
 		name string
 		A    *bootstrapv1.JoinConfiguration
 		B    *bootstrapv1.JoinConfiguration
 	}{
 		{
-			name: "Test omitable fields",
+			name: "Test omittable fields",
 			A: &bootstrapv1.JoinConfiguration{
 				NodeRegistration: bootstrapv1.NodeRegistrationOptions{
 					Taints:                []corev1.Taint{},
@@ -2046,8 +2046,8 @@ func TestOmitableFieldsJoinConfiguration(t *testing.T) {
 			B: &bootstrapv1.JoinConfiguration{
 				NodeRegistration: bootstrapv1.NodeRegistrationOptions{
 					Taints:                []corev1.Taint{},
-					KubeletExtraArgs:      []bootstrapv1.Arg{},
-					IgnorePreflightErrors: []string{},
+					KubeletExtraArgs:      nil,
+					IgnorePreflightErrors: nil,
 				},
 				Discovery: bootstrapv1.Discovery{
 					BootstrapToken: &bootstrapv1.BootstrapTokenDiscovery{
@@ -2074,7 +2074,7 @@ func TestOmitableFieldsJoinConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "Test omitable struct",
+			name: "Test omittable struct",
 			A: &bootstrapv1.JoinConfiguration{
 				Discovery: bootstrapv1.Discovery{
 					File: &bootstrapv1.FileDiscovery{
@@ -2104,7 +2104,7 @@ func TestOmitableFieldsJoinConfiguration(t *testing.T) {
 			},
 		},
 		{
-			name: "Test omitable struct",
+			name: "Test omittable struct",
 			A: &bootstrapv1.JoinConfiguration{
 				Discovery: bootstrapv1.Discovery{
 					File: &bootstrapv1.FileDiscovery{
@@ -2125,16 +2125,16 @@ func TestOmitableFieldsJoinConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotA, err := kubeadmtypes.MarshalJoinConfigurationForVersion(tt.A, semver.MustParse("1.33.0"))
+			gotA, err := kubeadmtypes.MarshalJoinConfigurationForVersion(tt.A, semver.MustParse("1.99.0")) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
-			gotB, err := kubeadmtypes.MarshalJoinConfigurationForVersion(tt.B, semver.MustParse("1.33.0"))
+			gotB, err := kubeadmtypes.MarshalJoinConfigurationForVersion(tt.B, semver.MustParse("1.99.0")) // we want to test with latest kubeadm API version.
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(gotA).To(Equal(gotB), cmp.Diff(gotA, gotB))
 
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{JoinConfiguration: tt.A})
-			dropOmitableFields(&bootstrapv1.KubeadmConfigSpec{JoinConfiguration: tt.B})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{JoinConfiguration: tt.A})
+			dropOmittableFields(&bootstrapv1.KubeadmConfigSpec{JoinConfiguration: tt.B})
 			g.Expect(tt.A).To(Equal(tt.B))
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As of today KCP perform a verbatin comparison between current and desired state of machines, and in case of diffs it triggers a rollout.

With this PR we are making the comparison smarter and ignore diff that are not leading to actual changes on machines.
e.g. `files: []` or `files: nill` are different from a golang point of view, but they lead to the same cloud-init file on the machine, so KCP should not rollout in this case.

Please note that this change will also fix infinite rollouts that might be introduced when we drop the DefaulterRemoveUnknownOrOmitableFields from web hooks

Also, note that in a follow up iteration I would like to move tests currently implemented in the cloudinit package near to the new feature in kcp, but this is not in the critical path to unblock work on optional/required & last changed in webhook option.

/area provider/control-plane-kubeadm

Part of https://github.com/kubernetes-sigs/cluster-api/issues/10852