### PR TITLE
:bug: Bug fix to set machinedeployment AvailableReplicas

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -492,7 +492,7 @@ func (r *Reconciler) syncDeploymentStatus(allMSs []*clusterv1.MachineSet, newMS 
 		// NOTE: The structure of calculateV1Beta1Status() does not allow us to update the machinedeployment directly, we can only update the status obj it returns. Ideally, we should change calculateV1Beta1Status() --> updateStatus() to be consistent with the rest of the code base, until then, we update conditions here.
 		v1beta1conditions.MarkTrue(md, clusterv1.MachineDeploymentAvailableV1Beta1Condition)
 	} else {
-		v1beta1conditions.MarkFalse(md, clusterv1.MachineDeploymentAvailableV1Beta1Condition, clusterv1.WaitingForAvailableMachinesV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Minimum availability requires %d replicas, current %d available", minReplicasNeeded, md.Status.AvailableReplicas)
+		v1beta1conditions.MarkFalse(md, clusterv1.MachineDeploymentAvailableV1Beta1Condition, clusterv1.WaitingForAvailableMachinesV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Minimum availability requires %d replicas, current %d available", minReplicasNeeded, ptr.Deref[int32](md.Status.AvailableReplicas, 0))
 	}
 
 	if newMS != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

while setting machine-deployment status, AvailableReplicas field was not deferred to set the actual value, Because of this on each reconciliation the status was updated and it was causing aggressive/repeated reconciliation.

```
I0626 08:53:46.421877      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="6129cb51-fe99-462c-8263-1b1fe509a47a" Cluster="default/ibm-powervs-1"
I0626 08:53:46.521349      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="166ca54f-28ae-4966-b3db-e37168e05bce" Cluster="default/ibm-powervs-1"
I0626 08:53:46.621543      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="3d443243-da5d-4611-aa77-783481f6f91e" Cluster="default/ibm-powervs-1"
I0626 08:53:46.720159      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="40e437a1-6d9f-43c2-a71f-0c796676b13c" Cluster="default/ibm-powervs-1"
I0626 08:53:46.820255      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="eb7a2f09-9c5f-4a44-924a-f715a4353b1b" Cluster="default/ibm-powervs-1"
I0626 08:53:46.921383      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="0ae188a7-baa4-4428-8dd9-dcc31d22faad" Cluster="default/ibm-powervs-1"
I0626 08:53:47.021249      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="644ae6d7-ad42-46b5-b25c-068d1d315655" Cluster="default/ibm-powervs-1"
I0626 08:53:47.120684      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="cb0b5005-3c9b-4755-87e9-96f793cceb70" Cluster="default/ibm-powervs-1"
I0626 08:53:47.221367      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="aa007af9-c74b-4533-8392-bdc1c3c24a98" Cluster="default/ibm-powervs-1"
I0626 08:53:47.320932      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="a01f3e10-dc9b-4051-8cbd-2262d8a0201d" Cluster="default/ibm-powervs-1"
I0626 08:53:47.420404      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="c595b459-1812-4031-85b1-52b67fda781f" Cluster="default/ibm-powervs-1"
I0626 08:53:47.519674      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="bdc00188-bf4d-40c3-9eca-a029c1c6279e" Cluster="default/ibm-powervs-1"
I0626 08:53:47.619009      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="a5d975da-3c51-46d0-9f3f-727cb2922ac5" Cluster="default/ibm-powervs-1"
I0626 08:53:47.721728      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="11525951-8419-4dbe-b14d-83dfa1d4587c" Cluster="default/ibm-powervs-1"
I0626 08:53:47.818521      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="278a43a0-9b73-4336-a0f8-36f1b619821e" Cluster="default/ibm-powervs-1"
I0626 08:53:47.918246      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="032e750a-e3c1-4a3a-b33c-c82a65f7eb89" Cluster="default/ibm-powervs-1"
I0626 08:53:48.017799      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="71751958-94e5-4ae3-9e25-e3c4cefebd3d" Cluster="default/ibm-powervs-1"
I0626 08:53:48.120221      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="aac82bd8-4b96-4fac-9a9a-78bbff183c32" Cluster="default/ibm-powervs-1"
I0626 08:53:48.223057      14 machinedeployment_controller.go:234] "Reconcile MachineDeployment" controller="machinedeployment" controllerGroup="cluster.x-k8s.io" controllerKind="MachineDeployment" MachineDeployment="default/ibm-powervs-1-md-0" namespace="default" name="ibm-powervs-1-md-0" reconcileID="2a5c8796-7ced-4917-9444-3a3e697a0ce1" Cluster="default/ibm-powervs-1"
```

```
% kubectl get md -o json | jq .items | jq '.[0].status'
{
  "availableReplicas": 0,
  "conditions": [
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "0 available replicas, at least 1 required (spec.strategy.rollout.maxUnavailable is 0, spec.replicas is 1)",
      "observedGeneration": 1,
      "reason": "NotAvailable",
      "status": "False",
      "type": "Available"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotRollingOut",
      "status": "False",
      "type": "RollingOut"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotRemediating",
      "status": "False",
      "type": "Remediating"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotScalingDown",
      "status": "False",
      "type": "ScalingDown"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:41Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotScalingUp",
      "status": "False",
      "type": "ScalingUp"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:41Z",
      "message": "* Machine ibm-powervs-1-md-0-phjrv-rmzpp:\n  * BootstrapConfigReady:\n    * DataSecretAvailable: Waiting for Cluster control plane to be initialized\n    * CertificatesAvailable: Condition not yet reported\n  * InfrastructureReady:\n    * InstanceReady: WaitingForControlPlaneInitialized\n  * NodeHealthy: Waiting for Cluster control plane to be initialized",
      "observedGeneration": 1,
      "reason": "NotReady",
      "status": "False",
      "type": "MachinesReady"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "UpToDate",
      "status": "True",
      "type": "MachinesUpToDate"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotPaused",
      "status": "False",
      "type": "Paused"
    },
    {
      "lastTransitionTime": "2025-06-26T09:55:39Z",
      "message": "",
      "observedGeneration": 1,
      "reason": "NotDeleting",
      "status": "False",
      "type": "Deleting"
    }
  ],
  "deprecated": {
    "v1beta1": {
      "availableReplicas": 0,
      "conditions": [
        {
          "lastTransitionTime": "2025-06-26T10:25:08Z",
          "message": "Minimum availability requires 1 replicas, current 274906884264 available",
          "reason": "WaitingForAvailableMachines",
          "severity": "Warning",
          "status": "False",
          "type": "Ready"
        },
        {
          "lastTransitionTime": "2025-06-26T10:25:08Z",
          "message": "Minimum availability requires 1 replicas, current 274906884264 available",
          "reason": "WaitingForAvailableMachines",
          "severity": "Warning",
          "status": "False",
          "type": "Available"
        },
        {
          "lastTransitionTime": "2025-06-26T09:55:41Z",
          "message": "Scaling up MachineSet to 1 replicas (actual 0)",
          "reason": "ScalingUp",
          "severity": "Warning",
          "status": "False",
          "type": "MachineSetReady"
        }
      ],
      "readyReplicas": 0,
      "unavailableReplicas": 1,
      "updatedReplicas": 1
    }
  },
  "observedGeneration": 1,
  "phase": "Running",
  "readyReplicas": 0,
  "replicas": 1,
  "selector": "cluster.x-k8s.io/cluster-name=ibm-powervs-1,cluster.x-k8s.io/deployment-name=ibm-powervs-1-md-0",
  "upToDateReplicas": 1
}
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the issue reported in https://github.com/kubernetes-sigs/cluster-api/issues/12334#issuecomment-3005387044

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->