### PR TITLE
🌱 KCP: Set MinItems=1 on ExternalEtcd.Endpoints

### DIFF
--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -459,6 +459,7 @@ type LocalEtcd struct {
 type ExternalEtcd struct {
 	// endpoints of etcd members. Required for ExternalEtcd.
 	// +required
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=50
 	// +kubebuilder:validation:items:MinLength=1
 	// +kubebuilder:validation:items:MaxLength=512

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -4601,6 +4601,7 @@ spec:
                               minLength: 1
                               type: string
                             maxItems: 50
+                            minItems: 1
                             type: array
                           keyFile:
                             description: |-

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -4482,6 +4482,7 @@ spec:
                                       minLength: 1
                                       type: string
                                     maxItems: 50
+                                    minItems: 1
                                     type: array
                                   keyFile:
                                     description: |-

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -5528,6 +5528,7 @@ spec:
                                   minLength: 1
                                   type: string
                                 maxItems: 50
+                                minItems: 1
                                 type: array
                               keyFile:
                                 description: |-

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -3904,6 +3904,7 @@ spec:
                                           minLength: 1
                                           type: string
                                         maxItems: 50
+                                        minItems: 1
                                         type: array
                                       keyFile:
                                         description: |-

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -428,6 +428,8 @@ func dropOmittableFields(spec *bootstrapv1.KubeadmConfigSpec) {
 		}
 		// NOTE: we are not dropping spec.ClusterConfiguration.Etcd.ExternalEtcd.Endpoints because this field
 		// doesn't have omitempty, so [] array is different from nil when serialized.
+		// But this field is also required and has MinItems=1, so it will
+		// never actually be nil or an empty array so that difference also won't trigger any rollouts.
 		if len(spec.ClusterConfiguration.APIServer.ExtraArgs) == 0 {
 			spec.ClusterConfiguration.APIServer.ExtraArgs = nil
 		}

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -1896,7 +1896,9 @@ func TestOmittableFieldsClusterConfiguration(t *testing.T) {
 						PeerCertSANs:   nil,
 					},
 					External: &bootstrapv1.ExternalEtcd{
-						Endpoints: []string{}, // The field doesn't have omit empty.
+						// The field doesn't have omit empty. It also is required and has MinItems=1, so it will
+						// never actually be nil or an empty array so that difference also won't trigger any rollouts.
+						Endpoints: []string{},
 					},
 				},
 				APIServer: bootstrapv1.APIServer{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
ExternalEtcd.Endpoints is actually a required field, so an empty array should not be valid

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/12402

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->