### PR TITLE
🌱 Ensure Cluster.status.failureDomains are alphabetically sorted

### DIFF
--- a/api/core/v1beta1/conversion.go
+++ b/api/core/v1beta1/conversion.go
@@ -19,6 +19,9 @@ package v1beta1
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"sort"
 	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
@@ -700,7 +703,10 @@ func Convert_v1beta1_ClusterStatus_To_v1beta2_ClusterStatus(in *ClusterStatus, o
 	// Move FailureDomains
 	if in.FailureDomains != nil {
 		out.FailureDomains = []clusterv1.FailureDomain{}
-		for name, fd := range in.FailureDomains {
+		domainNames := slices.Collect(maps.Keys(in.FailureDomains))
+		sort.Strings(domainNames)
+		for _, name := range domainNames {
+			fd := in.FailureDomains[name]
 			out.FailureDomains = append(out.FailureDomains, clusterv1.FailureDomain{
 				Name:         name,
 				ControlPlane: fd.ControlPlane,

--- a/internal/api/core/v1alpha3/conversion.go
+++ b/internal/api/core/v1alpha3/conversion.go
@@ -19,6 +19,9 @@ package v1alpha3
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"sort"
 	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
@@ -701,7 +704,10 @@ func Convert_v1alpha3_ClusterStatus_To_v1beta2_ClusterStatus(in *ClusterStatus, 
 	// Move FailureDomains
 	if in.FailureDomains != nil {
 		out.FailureDomains = []clusterv1.FailureDomain{}
-		for name, fd := range in.FailureDomains {
+		domainNames := slices.Collect(maps.Keys(in.FailureDomains))
+		sort.Strings(domainNames)
+		for _, name := range domainNames {
+			fd := in.FailureDomains[name]
 			out.FailureDomains = append(out.FailureDomains, clusterv1.FailureDomain{
 				Name:         name,
 				ControlPlane: fd.ControlPlane,

--- a/internal/api/core/v1alpha3/conversion_test.go
+++ b/internal/api/core/v1alpha3/conversion_test.go
@@ -21,6 +21,7 @@ package v1alpha3
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -342,6 +343,25 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c randfill.Continue) {
 		if reflect.DeepEqual(in.Initialization, &clusterv1.ClusterInitializationStatus{}) {
 			in.Initialization = nil
 		}
+	}
+
+	if len(in.FailureDomains) > 0 {
+		in.FailureDomains = nil // Remove all pre-existing potentially invalid FailureDomains
+		for i := range c.Int31n(20) {
+			in.FailureDomains = append(in.FailureDomains,
+				clusterv1.FailureDomain{
+					Name:         fmt.Sprintf("%d-%s", i, c.String(255)), // Ensure valid unique non-empty names.
+					ControlPlane: c.Bool(),
+				},
+			)
+		}
+		// The Cluster controller always ensures alphabetic sorting when writing this field.
+		slices.SortFunc(in.FailureDomains, func(a, b clusterv1.FailureDomain) int {
+			if a.Name < b.Name {
+				return -1
+			}
+			return 1
+		})
 	}
 }
 

--- a/internal/api/core/v1alpha4/conversion.go
+++ b/internal/api/core/v1alpha4/conversion.go
@@ -19,6 +19,9 @@ package v1alpha4
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"sort"
 	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
@@ -916,7 +919,10 @@ func Convert_v1alpha4_ClusterStatus_To_v1beta2_ClusterStatus(in *ClusterStatus, 
 	// Move FailureDomains
 	if in.FailureDomains != nil {
 		out.FailureDomains = []clusterv1.FailureDomain{}
-		for name, fd := range in.FailureDomains {
+		domainNames := slices.Collect(maps.Keys(in.FailureDomains))
+		sort.Strings(domainNames)
+		for _, name := range domainNames {
+			fd := in.FailureDomains[name]
 			out.FailureDomains = append(out.FailureDomains, clusterv1.FailureDomain{
 				Name:         name,
 				ControlPlane: fd.ControlPlane,

--- a/internal/api/core/v1alpha4/conversion_test.go
+++ b/internal/api/core/v1alpha4/conversion_test.go
@@ -21,6 +21,7 @@ package v1alpha4
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -224,6 +225,25 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c randfill.Continue) {
 		if reflect.DeepEqual(in.Initialization, &clusterv1.ClusterInitializationStatus{}) {
 			in.Initialization = nil
 		}
+	}
+
+	if len(in.FailureDomains) > 0 {
+		in.FailureDomains = nil // Remove all pre-existing potentially invalid FailureDomains
+		for i := range c.Int31n(20) {
+			in.FailureDomains = append(in.FailureDomains,
+				clusterv1.FailureDomain{
+					Name:         fmt.Sprintf("%d-%s", i, c.String(255)), // Ensure valid unique non-empty names.
+					ControlPlane: c.Bool(),
+				},
+			)
+		}
+		// The Cluster controller always ensures alphabetic sorting when writing this field.
+		slices.SortFunc(in.FailureDomains, func(a, b clusterv1.FailureDomain) int {
+			if a.Name < b.Name {
+				return -1
+			}
+			return 1
+		})
 	}
 }
 

--- a/internal/contract/infrastructure_cluster.go
+++ b/internal/contract/infrastructure_cluster.go
@@ -190,6 +190,15 @@ func (d *FailureDomains) Get(obj *unstructured.Unstructured) ([]clusterv1.Failur
 		return nil, errors.Wrapf(err, "failed to unmarshal field at %s to json", "."+strings.Join(d.path, "."))
 	}
 
+	// Sort the failureDomains to ensure deterministic order even if the failureDomains field
+	// on the InfraCluster is not sorted.
+	slices.SortFunc(domains, func(a, b clusterv1.FailureDomain) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		return 1
+	})
+
 	return domains, nil
 }
 

--- a/internal/contract/infrastructure_cluster_test.go
+++ b/internal/contract/infrastructure_cluster_test.go
@@ -174,10 +174,17 @@ func TestInfrastructureCluster(t *testing.T) {
 			"status": map[string]interface{}{
 				"failureDomains": []interface{}{
 					map[string]interface{}{
-						"name":         "newdomain",
+						"name":         "oldDomain",
 						"controlPlane": true,
 						"attributes": map[string]interface{}{
 							"attribute1": "value1",
+						},
+					},
+					map[string]interface{}{
+						"name":         "newdomain",
+						"controlPlane": true,
+						"attributes": map[string]interface{}{
+							"attribute2": "value2",
 						},
 					},
 				},
@@ -186,9 +193,17 @@ func TestInfrastructureCluster(t *testing.T) {
 		got, err = InfrastructureCluster().FailureDomains("v1beta2").Get(infraClusterV1Beta2)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
+		// Note: Also validates the failureDomains are sorted.
 		g.Expect(got).To(BeComparableTo([]clusterv1.FailureDomain{
 			{
 				Name:         "newdomain",
+				ControlPlane: true,
+				Attributes: map[string]string{
+					"attribute2": "value2",
+				},
+			},
+			{
+				Name:         "oldDomain",
 				ControlPlane: true,
 				Attributes: map[string]string{
 					"attribute1": "value1",


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

We have to ensure Cluster.status.failureDomains are always alphabetically sorted. We already did this before when reading from an InfraCluster that was still implementing the v1beta1 contract, this PR adds:
* Alphabetic sorting when reading from an InfraCluster that implements the v1beta2 contract
* conversions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->