### PR TITLE
🌱 Set minimum=1 on ObservedGeneration and KubeadmConfig APIEndpoint bindPort

### DIFF
--- a/api/addons/v1beta2/clusterresourceset_types.go
+++ b/api/addons/v1beta2/clusterresourceset_types.go
@@ -129,6 +129,7 @@ type ClusterResourceSetStatus struct {
 
 	// observedGeneration reflects the generation of the most recently observed ClusterResourceSet.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -242,6 +242,7 @@ type APIEndpoint struct {
 	// bindPort sets the secure port for the API Server to bind to.
 	// Defaults to 6443.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	BindPort int32 `json:"bindPort,omitempty"`
 }
 

--- a/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
@@ -472,6 +472,7 @@ type KubeadmConfigStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
+++ b/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
@@ -675,6 +675,7 @@ type KubeadmControlPlaneStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// lastRemediation stores info about last remediation performed.

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -996,6 +996,7 @@ type ClusterStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/api/core/v1beta2/clusterclass_types.go
+++ b/api/core/v1beta2/clusterclass_types.go
@@ -1218,6 +1218,7 @@ type ClusterClassStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/api/core/v1beta2/machine_types.go
+++ b/api/core/v1beta2/machine_types.go
@@ -544,6 +544,7 @@ type MachineStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deletion contains information relating to removal of the Machine.

--- a/api/core/v1beta2/machinedeployment_types.go
+++ b/api/core/v1beta2/machinedeployment_types.go
@@ -431,6 +431,7 @@ type MachineDeploymentStatus struct {
 
 	// observedGeneration is the generation observed by the deployment controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// selector is the same as the label selector but in the string format to avoid introspection

--- a/api/core/v1beta2/machinehealthcheck_types.go
+++ b/api/core/v1beta2/machinehealthcheck_types.go
@@ -225,6 +225,7 @@ type MachineHealthCheckStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// targets shows the current list of machines the machine health check is watching

--- a/api/core/v1beta2/machinepool_types.go
+++ b/api/core/v1beta2/machinepool_types.go
@@ -147,6 +147,7 @@ type MachinePoolStatus struct {
 
 	// observedGeneration is the latest generation observed by the controller.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/api/core/v1beta2/machineset_types.go
+++ b/api/core/v1beta2/machineset_types.go
@@ -312,6 +312,7 @@ type MachineSetStatus struct {
 
 	// observedGeneration reflects the generation of the most recently observed MachineSet.
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -5323,6 +5323,7 @@ spec:
                           bindPort sets the secure port for the API Server to bind to.
                           Defaults to 6443.
                         format: int32
+                        minimum: 1
                         type: integer
                     type: object
                   nodeRegistration:
@@ -5562,6 +5563,7 @@ spec:
                               bindPort sets the secure port for the API Server to bind to.
                               Defaults to 6443.
                             format: int32
+                            minimum: 1
                             type: integer
                         type: object
                     type: object
@@ -6313,6 +6315,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
             type: object
         type: object

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -5225,6 +5225,7 @@ spec:
                                   bindPort sets the secure port for the API Server to bind to.
                                   Defaults to 6443.
                                 format: int32
+                                minimum: 1
                                 type: integer
                             type: object
                           nodeRegistration:
@@ -5465,6 +5466,7 @@ spec:
                                       bindPort sets the secure port for the API Server to bind to.
                                       Defaults to 6443.
                                     format: int32
+                                    minimum: 1
                                     type: integer
                                 type: object
                             type: object

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -864,6 +864,7 @@ spec:
                 description: observedGeneration reflects the generation of the most
                   recently observed ClusterResourceSet.
                 format: int64
+                minimum: 1
                 type: integer
             type: object
         type: object

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -4706,6 +4706,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               variables:
                 description: variables is a list of ClusterClassStatusVariable that

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -3516,6 +3516,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               phase:
                 description: phase represents the current phase of cluster actuation.

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -2503,6 +2503,7 @@ spec:
                 description: observedGeneration is the generation observed by the
                   deployment controller.
                 format: int64
+                minimum: 1
                 type: integer
               phase:
                 description: phase represents the current phase of a MachineDeployment

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -1357,6 +1357,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               remediationsAllowed:
                 description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -2186,6 +2186,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               phase:
                 description: phase represents the current phase of cluster actuation.

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -2070,6 +2070,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               phase:
                 description: phase represents the current phase of machine actuation.

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -2190,6 +2190,7 @@ spec:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
                 format: int64
+                minimum: 1
                 type: integer
               readyReplicas:
                 description: readyReplicas is the number of ready replicas for this

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -6259,6 +6259,7 @@ spec:
                               bindPort sets the secure port for the API Server to bind to.
                               Defaults to 6443.
                             format: int32
+                            minimum: 1
                             type: integer
                         type: object
                       nodeRegistration:
@@ -6498,6 +6499,7 @@ spec:
                                   bindPort sets the secure port for the API Server to bind to.
                                   Defaults to 6443.
                                 format: int32
+                                minimum: 1
                                 type: integer
                             type: object
                         type: object
@@ -7598,6 +7600,7 @@ spec:
                 description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
+                minimum: 1
                 type: integer
               readyReplicas:
                 description: readyReplicas is the number of ready replicas for this

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -4661,6 +4661,7 @@ spec:
                                       bindPort sets the secure port for the API Server to bind to.
                                       Defaults to 6443.
                                     format: int32
+                                    minimum: 1
                                     type: integer
                                 type: object
                               nodeRegistration:
@@ -4902,6 +4903,7 @@ spec:
                                           bindPort sets the secure port for the API Server to bind to.
                                           Defaults to 6443.
                                         format: int32
+                                        minimum: 1
                                         type: integer
                                     type: object
                                 type: object


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->