### PR TITLE
✨ Reintroduce KCP/CABPK ClusterConfiguration controlPlaneEndpoint

### DIFF
--- a/api/bootstrap/kubeadm/v1beta1/conversion_test.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion_test.go
@@ -143,7 +143,6 @@ func spokeClusterConfiguration(in *ClusterConfiguration, c randfill.Continue) {
 	in.Networking.PodSubnet = ""
 	in.Networking.DNSDomain = ""
 	in.KubernetesVersion = ""
-	in.ControlPlaneEndpoint = ""
 	in.ClusterName = ""
 }
 

--- a/api/bootstrap/kubeadm/v1beta1/zz_generated.conversion.go
+++ b/api/bootstrap/kubeadm/v1beta1/zz_generated.conversion.go
@@ -652,7 +652,7 @@ func autoConvert_v1beta1_ClusterConfiguration_To_v1beta2_ClusterConfiguration(in
 	}
 	// WARNING: in.Networking requires manual conversion: does not exist in peer-type
 	// WARNING: in.KubernetesVersion requires manual conversion: does not exist in peer-type
-	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta1_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}
@@ -676,6 +676,7 @@ func autoConvert_v1beta2_ClusterConfiguration_To_v1beta1_ClusterConfiguration(in
 	if err := Convert_v1beta2_Etcd_To_v1beta1_Etcd(&in.Etcd, &out.Etcd, s); err != nil {
 		return err
 	}
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta2_APIServer_To_v1beta1_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}

--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -122,6 +122,23 @@ type ClusterConfiguration struct {
 	// +optional
 	Etcd Etcd `json:"etcd,omitempty"`
 
+	// controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+	// can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+	// In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+	// are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+	// the BindPort is used.
+	// Possible usages are:
+	// e.g. In a cluster with more than one control plane instances, this field should be
+	// assigned the address of the external load balancer in front of the
+	// control plane instances.
+	// e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+	// could be used for assigning a stable DNS to the control plane.
+	// NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=512
+	ControlPlaneEndpoint string `json:"controlPlaneEndpoint,omitempty"`
+
 	// apiServer contains extra settings for the API server control plane component
 	// +optional
 	APIServer APIServer `json:"apiServer,omitempty"`

--- a/api/controlplane/kubeadm/v1beta1/conversion_test.go
+++ b/api/controlplane/kubeadm/v1beta1/conversion_test.go
@@ -222,7 +222,6 @@ func spokeClusterConfiguration(in *bootstrapv1beta1.ClusterConfiguration, c rand
 	in.Networking.PodSubnet = ""
 	in.Networking.DNSDomain = ""
 	in.KubernetesVersion = ""
-	in.ControlPlaneEndpoint = ""
 	in.ClusterName = ""
 }
 

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -4350,6 +4350,23 @@ spec:
                     maxLength: 512
                     minLength: 1
                     type: string
+                  controlPlaneEndpoint:
+                    description: |-
+                      controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                      the BindPort is used.
+                      Possible usages are:
+                      e.g. In a cluster with more than one control plane instances, this field should be
+                      assigned the address of the external load balancer in front of the
+                      control plane instances.
+                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                      could be used for assigning a stable DNS to the control plane.
+                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
                   controllerManager:
                     description: controllerManager contains extra settings for the
                       controller manager control plane component

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -4224,6 +4224,23 @@ spec:
                             maxLength: 512
                             minLength: 1
                             type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
                           controllerManager:
                             description: controllerManager contains extra settings
                               for the controller manager control plane component

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -1828,7 +1828,7 @@ func TestKubeadmConfigReconciler_Reconcile_DiscoveryReconcileFailureBehaviors(t 
 }
 
 // Set cluster configuration defaults based on dynamic values from the cluster object.
-func TestKubeadmConfigReconciler_computeClusterConfigurationAdditionalData(t *testing.T) {
+func TestKubeadmConfigReconciler_computeClusterConfigurationAndAdditionalData(t *testing.T) {
 	k := &KubeadmConfigReconciler{}
 
 	testcases := []struct {
@@ -1870,9 +1870,10 @@ func TestKubeadmConfigReconciler_computeClusterConfigurationAdditionalData(t *te
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotData := k.computeClusterConfigurationAdditionalData(tc.cluster, tc.machine, tc.initConfiguration)
+			clusterConfiguration := &bootstrapv1.ClusterConfiguration{}
+			gotData := k.computeClusterConfigurationAndAdditionalData(tc.cluster, tc.machine, clusterConfiguration, tc.initConfiguration)
+			g.Expect(clusterConfiguration.ControlPlaneEndpoint).To(Equal("myControlPlaneEndpoint:6443"))
 			g.Expect(gotData.KubernetesVersion).To(Equal(ptr.To("v1.23.0")))
-			g.Expect(gotData.ControlPlaneEndpoint).To(Equal(ptr.To("myControlPlaneEndpoint:6443")))
 			g.Expect(gotData.ClusterName).To(Equal(ptr.To("mycluster")))
 			g.Expect(gotData.PodSubnet).To(Equal(ptr.To("myPodSubnet")))
 			g.Expect(gotData.ServiceSubnet).To(Equal(ptr.To("myServiceSubnet")))

--- a/bootstrap/kubeadm/types/upstream/upstream.go
+++ b/bootstrap/kubeadm/types/upstream/upstream.go
@@ -35,12 +35,11 @@ type AdditionalDataGetter interface {
 // in different Cluster API objects, like e.g. the Cluster object.
 type AdditionalData struct {
 	// Data from Cluster API's Cluster object.
-	KubernetesVersion    *string
-	ClusterName          *string
-	ControlPlaneEndpoint *string
-	DNSDomain            *string
-	ServiceSubnet        *string
-	PodSubnet            *string
+	KubernetesVersion *string
+	ClusterName       *string
+	DNSDomain         *string
+	ServiceSubnet     *string
+	PodSubnet         *string
 
 	// Data migrated from ClusterConfiguration to InitConfiguration in kubeadm's v1beta4 API version.
 	// Note: Corresponding Cluster API types are aligned with kubeadm's v1beta4 API version.
@@ -52,7 +51,6 @@ func (a *AdditionalData) Clone() *AdditionalData {
 	return &AdditionalData{
 		KubernetesVersion:                       a.KubernetesVersion,
 		ClusterName:                             a.ClusterName,
-		ControlPlaneEndpoint:                    a.ControlPlaneEndpoint,
 		DNSDomain:                               a.DNSDomain,
 		ServiceSubnet:                           a.ServiceSubnet,
 		PodSubnet:                               a.PodSubnet,

--- a/bootstrap/kubeadm/types/upstreamv1beta3/conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/conversion.go
@@ -193,9 +193,6 @@ func (src *ClusterConfiguration) SetAdditionalData(data upstream.AdditionalData)
 	if data.ClusterName != nil {
 		src.ClusterName = *data.ClusterName
 	}
-	if data.ControlPlaneEndpoint != nil {
-		src.ControlPlaneEndpoint = *data.ControlPlaneEndpoint
-	}
 	if data.DNSDomain != nil {
 		src.Networking.DNSDomain = *data.DNSDomain
 	}
@@ -225,9 +222,6 @@ func (src *ClusterConfiguration) GetAdditionalData(data *upstream.AdditionalData
 	}
 	if src.ClusterName != "" {
 		data.ClusterName = ptr.To(src.ClusterName)
-	}
-	if src.ControlPlaneEndpoint != "" {
-		data.ControlPlaneEndpoint = ptr.To(src.ControlPlaneEndpoint)
 	}
 	if src.Networking.DNSDomain != "" {
 		data.DNSDomain = ptr.To(src.Networking.DNSDomain)

--- a/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/conversion_test.go
@@ -108,7 +108,6 @@ func spokeClusterConfigurationFuzzer(in *ClusterConfiguration, c randfill.Contin
 	in.Networking.PodSubnet = ""
 	in.Networking.DNSDomain = ""
 	in.KubernetesVersion = ""
-	in.ControlPlaneEndpoint = ""
 	in.ClusterName = ""
 }
 

--- a/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
@@ -360,7 +360,7 @@ func autoConvert_upstreamv1beta3_ClusterConfiguration_To_v1beta2_ClusterConfigur
 	}
 	// WARNING: in.Networking requires manual conversion: does not exist in peer-type
 	// WARNING: in.KubernetesVersion requires manual conversion: does not exist in peer-type
-	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_upstreamv1beta3_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}
@@ -384,6 +384,7 @@ func autoConvert_v1beta2_ClusterConfiguration_To_upstreamv1beta3_ClusterConfigur
 	if err := Convert_v1beta2_Etcd_To_upstreamv1beta3_Etcd(&in.Etcd, &out.Etcd, s); err != nil {
 		return err
 	}
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta2_APIServer_To_upstreamv1beta3_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion.go
@@ -172,9 +172,6 @@ func (src *ClusterConfiguration) SetAdditionalData(data upstream.AdditionalData)
 	if data.ClusterName != nil {
 		src.ClusterName = *data.ClusterName
 	}
-	if data.ControlPlaneEndpoint != nil {
-		src.ControlPlaneEndpoint = *data.ControlPlaneEndpoint
-	}
 	if data.DNSDomain != nil {
 		src.Networking.DNSDomain = *data.DNSDomain
 	}
@@ -204,9 +201,6 @@ func (src *ClusterConfiguration) GetAdditionalData(data *upstream.AdditionalData
 	}
 	if src.ClusterName != "" {
 		data.ClusterName = ptr.To(src.ClusterName)
-	}
-	if src.ControlPlaneEndpoint != "" {
-		data.ControlPlaneEndpoint = ptr.To(src.ControlPlaneEndpoint)
 	}
 	if src.Networking.DNSDomain != "" {
 		data.DNSDomain = ptr.To(src.Networking.DNSDomain)

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion_test.go
@@ -104,7 +104,6 @@ func spokeClusterConfigurationFuzzer(obj *ClusterConfiguration, c randfill.Conti
 	obj.Networking.PodSubnet = ""
 	obj.Networking.DNSDomain = ""
 	obj.KubernetesVersion = ""
-	obj.ControlPlaneEndpoint = ""
 	obj.ClusterName = ""
 }
 

--- a/bootstrap/kubeadm/types/upstreamv1beta4/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/zz_generated.conversion.go
@@ -411,7 +411,7 @@ func autoConvert_upstreamv1beta4_ClusterConfiguration_To_v1beta2_ClusterConfigur
 	}
 	// WARNING: in.Networking requires manual conversion: does not exist in peer-type
 	// WARNING: in.KubernetesVersion requires manual conversion: does not exist in peer-type
-	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_upstreamv1beta4_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}
@@ -439,6 +439,7 @@ func autoConvert_v1beta2_ClusterConfiguration_To_upstreamv1beta4_ClusterConfigur
 	if err := Convert_v1beta2_Etcd_To_upstreamv1beta4_Etcd(&in.Etcd, &out.Etcd, s); err != nil {
 		return err
 	}
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta2_APIServer_To_upstreamv1beta4_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}

--- a/bootstrap/kubeadm/types/utils_test.go
+++ b/bootstrap/kubeadm/types/utils_test.go
@@ -125,7 +125,6 @@ func TestMarshalClusterConfigurationForVersion(t *testing.T) {
 	data := &upstream.AdditionalData{
 		// KubernetesVersion is going to be set on a test bases.
 		ClusterName:                             ptr.To("mycluster"),
-		ControlPlaneEndpoint:                    ptr.To("myControlPlaneEndpoint:6443"),
 		DNSDomain:                               ptr.To("myDNSDomain"),
 		ServiceSubnet:                           ptr.To("myServiceSubnet"),
 		PodSubnet:                               ptr.To("myPodSubnet"),
@@ -145,7 +144,9 @@ func TestMarshalClusterConfigurationForVersion(t *testing.T) {
 		{
 			name: "Generates a v1beta3 kubeadm configuration",
 			args: args{
-				capiObj: &bootstrapv1.ClusterConfiguration{},
+				capiObj: &bootstrapv1.ClusterConfiguration{
+					ControlPlaneEndpoint: "myControlPlaneEndpoint:6443",
+				},
 				version: semver.MustParse("1.22.0"),
 			},
 			want: "apiServer:\n" +
@@ -168,7 +169,9 @@ func TestMarshalClusterConfigurationForVersion(t *testing.T) {
 		{
 			name: "Generates a v1beta4 kubeadm configuration",
 			args: args{
-				capiObj: &bootstrapv1.ClusterConfiguration{},
+				capiObj: &bootstrapv1.ClusterConfiguration{
+					ControlPlaneEndpoint: "myControlPlaneEndpoint:6443",
+				},
 				version: semver.MustParse("1.31.0"),
 			},
 			want: "apiServer: {}\n" +
@@ -374,14 +377,15 @@ func TestUnmarshalClusterConfiguration(t *testing.T) {
 					"  serviceSubnet: myServiceSubnet\n" +
 					"scheduler: {}\n",
 			},
-			want: &bootstrapv1.ClusterConfiguration{},
+			want: &bootstrapv1.ClusterConfiguration{
+				ControlPlaneEndpoint: "myControlPlaneEndpoint:6443",
+			},
 			wantUpstreamData: &upstream.AdditionalData{
-				KubernetesVersion:    ptr.To("v1.23.1"),
-				ClusterName:          ptr.To("mycluster"),
-				ControlPlaneEndpoint: ptr.To("myControlPlaneEndpoint:6443"),
-				DNSDomain:            ptr.To("myDNSDomain"),
-				ServiceSubnet:        ptr.To("myServiceSubnet"),
-				PodSubnet:            ptr.To("myPodSubnet"),
+				KubernetesVersion: ptr.To("v1.23.1"),
+				ClusterName:       ptr.To("mycluster"),
+				DNSDomain:         ptr.To("myDNSDomain"),
+				ServiceSubnet:     ptr.To("myServiceSubnet"),
+				PodSubnet:         ptr.To("myPodSubnet"),
 			},
 			wantErr: false,
 		},
@@ -405,11 +409,12 @@ func TestUnmarshalClusterConfiguration(t *testing.T) {
 					"  serviceSubnet: myServiceSubnet\n" +
 					"scheduler: {}\n",
 			},
-			want: &bootstrapv1.ClusterConfiguration{},
+			want: &bootstrapv1.ClusterConfiguration{
+				ControlPlaneEndpoint: "myControlPlaneEndpoint:6443",
+			},
 			wantUpstreamData: &upstream.AdditionalData{
 				KubernetesVersion:                       ptr.To("v1.23.1"),
 				ClusterName:                             ptr.To("mycluster"),
-				ControlPlaneEndpoint:                    ptr.To("myControlPlaneEndpoint:6443"),
 				DNSDomain:                               ptr.To("myDNSDomain"),
 				ServiceSubnet:                           ptr.To("myServiceSubnet"),
 				PodSubnet:                               ptr.To("myPodSubnet"),
@@ -436,14 +441,15 @@ func TestUnmarshalClusterConfiguration(t *testing.T) {
 					"proxy: {}\n" +
 					"scheduler: {}\n",
 			},
-			want: &bootstrapv1.ClusterConfiguration{},
+			want: &bootstrapv1.ClusterConfiguration{
+				ControlPlaneEndpoint: "myControlPlaneEndpoint:6443",
+			},
 			wantUpstreamData: &upstream.AdditionalData{
-				KubernetesVersion:    ptr.To("v1.31.1"),
-				ClusterName:          ptr.To("mycluster"),
-				ControlPlaneEndpoint: ptr.To("myControlPlaneEndpoint:6443"),
-				DNSDomain:            ptr.To("myDNSDomain"),
-				ServiceSubnet:        ptr.To("myServiceSubnet"),
-				PodSubnet:            ptr.To("myPodSubnet"),
+				KubernetesVersion: ptr.To("v1.31.1"),
+				ClusterName:       ptr.To("mycluster"),
+				DNSDomain:         ptr.To("myDNSDomain"),
+				ServiceSubnet:     ptr.To("myServiceSubnet"),
+				PodSubnet:         ptr.To("myPodSubnet"),
 			},
 			wantErr: false,
 		},

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -5274,6 +5274,23 @@ spec:
                         maxLength: 512
                         minLength: 1
                         type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
                       controllerManager:
                         description: controllerManager contains extra settings for
                           the controller manager control plane component

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -3642,6 +3642,23 @@ spec:
                                 maxLength: 512
                                 minLength: 1
                                 type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
                               controllerManager:
                                 description: controllerManager contains extra settings
                                   for the controller manager control plane component

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -199,7 +199,7 @@ func TestMatchClusterConfiguration(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(match).To(BeFalse())
 		g.Expect(diff).To(BeComparableTo(`&v1beta2.ClusterConfiguration{
-    ... // 3 identical fields
+    ... // 4 identical fields
     Scheduler:       {},
     DNS:             {},
 -   CertificatesDir: "bar",
@@ -1007,7 +1007,7 @@ func TestMatchesKubeadmBootstrapConfig(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(match).To(BeFalse())
 		g.Expect(reason).To(BeComparableTo(`Machine KubeadmConfig ClusterConfiguration is outdated: diff: &v1beta2.ClusterConfiguration{
-    ... // 3 identical fields
+    ... // 4 identical fields
     Scheduler:       {},
     DNS:             {},
 -   CertificatesDir: "bar",
@@ -1814,7 +1814,7 @@ func TestUpToDate(t *testing.T) {
 			infraConfigs:            defaultInfraConfigs,
 			machineConfigs:          defaultMachineConfigs,
 			expectUptoDate:          false,
-			expectLogMessages:       []string{"Machine KubeadmConfig ClusterConfiguration is outdated: diff: &v1beta2.ClusterConfiguration{\n    ... // 3 identical fields\n    Scheduler:       {},\n    DNS:             {},\n-   CertificatesDir: \"foo\",\n+   CertificatesDir: \"bar\",\n    ImageRepository: \"\",\n    FeatureGates:    nil,\n  }"},
+			expectLogMessages:       []string{"Machine KubeadmConfig ClusterConfiguration is outdated: diff: &v1beta2.ClusterConfiguration{\n    ... // 4 identical fields\n    Scheduler:       {},\n    DNS:             {},\n-   CertificatesDir: \"foo\",\n+   CertificatesDir: \"bar\",\n    ImageRepository: \"\",\n    FeatureGates:    nil,\n  }"},
 			expectConditionMessages: []string{"KubeadmConfig is not up-to-date"},
 		},
 		{

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
@@ -483,6 +483,9 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	unsetEtcdLocal := etcdLocalImageTag.DeepCopy()
 	unsetEtcdLocal.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = nil
 
+	controlPlaneEndpoint := before.DeepCopy()
+	controlPlaneEndpoint.Spec.KubeadmConfigSpec.ClusterConfiguration.ControlPlaneEndpoint = "some control plane endpoint"
+
 	apiServer := before.DeepCopy()
 	apiServer.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer = bootstrapv1.APIServer{
 		ControlPlaneComponent: bootstrapv1.ControlPlaneComponent{
@@ -817,6 +820,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: true,
 			before:    before,
 			kcp:       etcdLocalImageInvalidTag,
+		},
+		{
+			name:      "should fail when making a change to the cluster config's controlPlaneEndpoint",
+			expectErr: true,
+			before:    before,
+			kcp:       controlPlaneEndpoint,
 		},
 		{
 			name:      "should allow changes to the cluster config's apiServer",

--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -318,7 +318,6 @@ proposal because most of the changes described below are a consequence of the wo
   - `networking.podSubnet` (can still be set via `Cluster.spec.clusterNetwork.pods.cidrBlocks`)
   - `networking.dnsDomain` (can still be set via `Cluster.spec.clusterNetwork.serviceDomain`)
   - `kubernetesVersion` (can still be set via `Machine.spec.version`)
-  - `controlPlaneEndpoint` (can still be set via `Cluster.spec.controlPlaneEndpoint`)
   - `clusterName` (can still be set via `Cluster.metadata.name`)
     Note: The ClusterConfiguration fields could previously be used to overwrite the fields from Cluster, now we only use the fields from Cluster.
 - All fields of type Duration in `spec.initConfiguration.bootstrapTokens[]` have
@@ -376,7 +375,6 @@ KubeadmConfigTemplate `spec.template.spec` has been aligned to changes in the [K
   - `networking.podSubnet` (can still be set via `Cluster.spec.clusterNetwork.pods.cidrBlocks`)
   - `networking.dnsDomain` (can still be set via `Cluster.spec.clusterNetwork.serviceDomain`)
   - `kubernetesVersion` (can still be set via `KubeadmControlPlane.spec.version`)
-  - `controlPlaneEndpoint` (can still be set via `Cluster.spec.controlPlaneEndpoint`)
   - `clusterName` (can still be set via `Cluster.metadata.name`)
   Note: The ClusterConfiguration fields could previously be used to overwrite the fields from Cluster, now we only use the fields from Cluster.
 - All fields of type Duration in `spec.kubeadmConfigSpec.initConfiguration.bootstrapTokens[]` have

--- a/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
@@ -153,7 +153,6 @@ func spokeClusterConfiguration(obj *ClusterConfiguration, c randfill.Continue) {
 	obj.Networking.PodSubnet = ""
 	obj.Networking.DNSDomain = ""
 	obj.KubernetesVersion = ""
-	obj.ControlPlaneEndpoint = ""
 	obj.ClusterName = ""
 }
 

--- a/internal/api/bootstrap/kubeadm/v1alpha3/zz_generated.conversion.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha3/zz_generated.conversion.go
@@ -521,7 +521,7 @@ func autoConvert_v1alpha3_ClusterConfiguration_To_v1beta2_ClusterConfiguration(i
 	}
 	// WARNING: in.Networking requires manual conversion: does not exist in peer-type
 	// WARNING: in.KubernetesVersion requires manual conversion: does not exist in peer-type
-	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1alpha3_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}
@@ -546,6 +546,7 @@ func autoConvert_v1beta2_ClusterConfiguration_To_v1alpha3_ClusterConfiguration(i
 	if err := Convert_v1beta2_Etcd_To_v1alpha3_Etcd(&in.Etcd, &out.Etcd, s); err != nil {
 		return err
 	}
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta2_APIServer_To_v1alpha3_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}

--- a/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
@@ -132,7 +132,6 @@ func spokeClusterConfiguration(in *ClusterConfiguration, c randfill.Continue) {
 	in.Networking.PodSubnet = ""
 	in.Networking.DNSDomain = ""
 	in.KubernetesVersion = ""
-	in.ControlPlaneEndpoint = ""
 	in.ClusterName = ""
 }
 

--- a/internal/api/bootstrap/kubeadm/v1alpha4/zz_generated.conversion.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha4/zz_generated.conversion.go
@@ -521,7 +521,7 @@ func autoConvert_v1alpha4_ClusterConfiguration_To_v1beta2_ClusterConfiguration(i
 	}
 	// WARNING: in.Networking requires manual conversion: does not exist in peer-type
 	// WARNING: in.KubernetesVersion requires manual conversion: does not exist in peer-type
-	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1alpha4_APIServer_To_v1beta2_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}
@@ -545,6 +545,7 @@ func autoConvert_v1beta2_ClusterConfiguration_To_v1alpha4_ClusterConfiguration(i
 	if err := Convert_v1beta2_Etcd_To_v1alpha4_Etcd(&in.Etcd, &out.Etcd, s); err != nil {
 		return err
 	}
+	out.ControlPlaneEndpoint = in.ControlPlaneEndpoint
 	if err := Convert_v1beta2_APIServer_To_v1alpha4_APIServer(&in.APIServer, &out.APIServer, s); err != nil {
 		return err
 	}

--- a/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
@@ -185,7 +185,6 @@ func spokeKubeadmClusterConfiguration(obj *bootstrapv1alpha3.ClusterConfiguratio
 	obj.Networking.PodSubnet = ""
 	obj.Networking.DNSDomain = ""
 	obj.KubernetesVersion = ""
-	obj.ControlPlaneEndpoint = ""
 	obj.ClusterName = ""
 }
 

--- a/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
@@ -221,7 +221,6 @@ func spokeClusterConfiguration(in *bootstrapv1alpha4.ClusterConfiguration, c ran
 	in.Networking.PodSubnet = ""
 	in.Networking.DNSDomain = ""
 	in.KubernetesVersion = ""
-	in.ControlPlaneEndpoint = ""
 	in.ClusterName = ""
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/12319#issuecomment-3004553197

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/10852

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->