### PR TITLE
🌱 Bump kustomize to v5.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ get_go_version = $(shell go list -m $1 | awk '{print $$2}')
 # Binaries.
 #
 # Note: Need to use abspath so we can invoke these from subdirectories
-KUSTOMIZE_VER := v5.6.0
+KUSTOMIZE_VER := v5.7.0
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
 KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v5


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `kustomize` tool to [v5.7.0](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.7.0).

**Which issue(s) this PR fixes**:

Refs #12123: "Bump dependencies"
See #11867 for the previous bump.

/area dependency