### PR TITLE
⚠️ Stop using v1beta1 status in CAPD controllers

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
@@ -142,8 +142,7 @@ func (r *ClusterBackEndReconciler) ReconcileDelete(ctx context.Context, cluster 
 
 	// Set the LoadBalancerAvailableCondition reporting delete is started, and requeue in order to make
 	// this visible to the users.
-	// TODO (v1beta2): test for v1beta2 conditions
-	if v1beta1conditions.GetReason(dockerCluster, infrav1.LoadBalancerAvailableV1Beta1Condition) != clusterv1.DeletingV1Beta1Reason {
+	if conditions.GetReason(dockerCluster, infrav1.DevClusterDockerLoadBalancerAvailableCondition) != infrav1.DevClusterDockerLoadBalancerDeletingReason {
 		v1beta1conditions.MarkFalse(dockerCluster, infrav1.LoadBalancerAvailableV1Beta1Condition, clusterv1.DeletingV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(dockerCluster, metav1.Condition{
 			Type:   infrav1.DevClusterDockerLoadBalancerAvailableCondition,

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -133,8 +133,8 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 			// In this case recover the information from the existing v1beta1 condition, because we do not know if
 			// all commands succeeded.
 			if !conditions.Has(dockerMachine, infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition) {
-				condition := v1beta1conditions.Get(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition)
-				if condition == nil || condition.Status == corev1.ConditionTrue {
+				condition := conditions.Get(dockerMachine, infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition)
+				if condition == nil || condition.Status == metav1.ConditionTrue {
 					conditions.Set(dockerMachine, metav1.Condition{
 						Type:   infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,
 						Status: metav1.ConditionTrue,
@@ -228,9 +228,8 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 
 	// Update the ContainerProvisioned and BootstrapExecSucceeded condition if not already in the correct state.
-	// TODO (v1beta2): test for v1beta2 conditions
 	requeue := false
-	if !v1beta1conditions.IsTrue(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition) {
+	if !conditions.IsTrue(dockerMachine, infrav1.DevMachineDockerContainerProvisionedCondition) {
 		v1beta1conditions.MarkTrue(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition)
 		conditions.Set(dockerMachine, metav1.Condition{
 			Type:   infrav1.DevMachineDockerContainerProvisionedCondition,
@@ -239,7 +238,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		})
 		requeue = true
 	}
-	if !v1beta1conditions.Has(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition) {
+	if !conditions.Has(dockerMachine, infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition) {
 		v1beta1conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition, infrav1.BootstrappingV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(dockerMachine, metav1.Condition{
 			Type:   infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,
@@ -425,8 +424,7 @@ func (r *MachineBackendReconciler) ReconcileDelete(ctx context.Context, cluster 
 	// this visible to the users.
 	// NB. The operation in docker is fast, so there is the chance the user will not notice the status change;
 	// nevertheless we are issuing a patch so we can test a pattern that will be used by other providers as well
-	// TODO (v1beta2): test for v1beta2 conditions
-	if v1beta1conditions.GetReason(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition) != clusterv1.DeletingV1Beta1Reason {
+	if conditions.GetReason(dockerMachine, infrav1.DevMachineDockerContainerProvisionedCondition) != infrav1.DevMachineDockerContainerDeletingReason {
 		v1beta1conditions.MarkFalse(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition, clusterv1.DeletingV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(dockerCluster, metav1.Condition{
 			Type:   infrav1.DevMachineDockerContainerProvisionedCondition,

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -242,8 +242,7 @@ func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Conte
 
 func (r *MachineBackendReconciler) reconcileNormalNode(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, inMemoryMachine *infrav1.DevMachine) (_ ctrl.Result, retErr error) {
 	// No-op if the VM is not provisioned yet
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.VMProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryVMProvisionedCondition) {
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryNodeProvisionedCondition,
 			Status: metav1.ConditionFalse,
@@ -280,8 +279,7 @@ func (r *MachineBackendReconciler) reconcileNormalNode(ctx context.Context, clus
 		}
 	}
 
-	// TODO (v1beta2): test for v1beta2 conditions
-	start := v1beta1conditions.Get(inMemoryMachine, infrav1.VMProvisionedCondition).LastTransitionTime
+	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryVMProvisionedCondition).LastTransitionTime
 	now := time.Now()
 	if now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.NodeProvisionedCondition, infrav1.NodeWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
@@ -374,8 +372,7 @@ func (r *MachineBackendReconciler) reconcileNormalETCD(ctx context.Context, clus
 	}
 
 	// No-op if the VM is not provisioned yet
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.VMProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryVMProvisionedCondition) {
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryEtcdProvisionedCondition,
 			Status: metav1.ConditionFalse,
@@ -385,8 +382,7 @@ func (r *MachineBackendReconciler) reconcileNormalETCD(ctx context.Context, clus
 	}
 
 	// No-op if the Node is not provisioned yet
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.NodeProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition) {
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryEtcdProvisionedCondition,
 			Status: metav1.ConditionFalse,
@@ -423,8 +419,7 @@ func (r *MachineBackendReconciler) reconcileNormalETCD(ctx context.Context, clus
 		}
 	}
 
-	// TODO (v1beta2): test for v1beta2 conditions
-	start := v1beta1conditions.Get(inMemoryMachine, infrav1.NodeProvisionedCondition).LastTransitionTime
+	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
 	if now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.EtcdProvisionedCondition, infrav1.EtcdWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
@@ -618,8 +613,7 @@ func (r *MachineBackendReconciler) reconcileNormalAPIServer(ctx context.Context,
 	}
 
 	// No-op if the VM is not provisioned yet
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.VMProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryVMProvisionedCondition) {
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryAPIServerProvisionedCondition,
 			Status: metav1.ConditionFalse,
@@ -629,8 +623,7 @@ func (r *MachineBackendReconciler) reconcileNormalAPIServer(ctx context.Context,
 	}
 
 	// No-op if the Node is not provisioned yet
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.NodeProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition) {
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryAPIServerProvisionedCondition,
 			Status: metav1.ConditionFalse,
@@ -667,8 +660,7 @@ func (r *MachineBackendReconciler) reconcileNormalAPIServer(ctx context.Context,
 		}
 	}
 
-	// TODO (v1beta2): test for v1beta2 conditions
-	start := v1beta1conditions.Get(inMemoryMachine, infrav1.NodeProvisionedCondition).LastTransitionTime
+	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
 	if now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.APIServerProvisionedCondition, infrav1.APIServerWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
@@ -775,8 +767,7 @@ func (r *MachineBackendReconciler) reconcileNormalScheduler(ctx context.Context,
 	// specific behaviour for this component because they are not relevant for stress tests.
 	// As a current approximation, we create the scheduler as soon as the API server is provisioned;
 	// also, the scheduler is immediately marked as ready.
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.APIServerProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryAPIServerProvisionedCondition) {
 		return ctrl.Result{}, nil
 	}
 
@@ -823,8 +814,7 @@ func (r *MachineBackendReconciler) reconcileNormalControllerManager(ctx context.
 	// specific behaviour for this component because they are not relevant for stress tests.
 	// As a current approximation, we create the controller manager as soon as the API server is provisioned;
 	// also, the controller manager is immediately marked as ready.
-	// TODO (v1beta2): test for v1beta2 conditions
-	if !v1beta1conditions.IsTrue(inMemoryMachine, infrav1.APIServerProvisionedCondition) {
+	if !conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryAPIServerProvisionedCondition) {
 		return ctrl.Result{}, nil
 	}
 

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -195,6 +195,7 @@ func patchDockerCluster(ctx context.Context, patchHelper *patch.Helper, dockerCl
 }
 
 func dockerClusterToDevCluster(dockerCluster *infrav1.DockerCluster) *infrav1.DevCluster {
+	// Carry over deprecated v1beta1 status if defined.
 	var v1Beta1Status *infrav1.DevClusterDeprecatedStatus
 	if dockerCluster.Status.Deprecated != nil && dockerCluster.Status.Deprecated.V1Beta1 != nil {
 		v1Beta1Status = &infrav1.DevClusterDeprecatedStatus{
@@ -232,6 +233,7 @@ func dockerClusterToDevCluster(dockerCluster *infrav1.DockerCluster) *infrav1.De
 }
 
 func devClusterToDockerCluster(devCluster *infrav1.DevCluster, dockerCluster *infrav1.DockerCluster) {
+	// Carry over deprecated v1beta1 status if defined.
 	var v1Beta1Status *infrav1.DockerClusterDeprecatedStatus
 	if devCluster.Status.Deprecated != nil && devCluster.Status.Deprecated.V1Beta1 != nil {
 		v1Beta1Status = &infrav1.DockerClusterDeprecatedStatus{

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -294,6 +294,7 @@ func patchDockerMachine(ctx context.Context, patchHelper *patch.Helper, dockerMa
 }
 
 func dockerMachineToDevMachine(dockerMachine *infrav1.DockerMachine) *infrav1.DevMachine {
+	// Carry over deprecated v1beta1 status if defined.
 	var v1Beta1Status *infrav1.DevMachineDeprecatedStatus
 	if dockerMachine.Status.Deprecated != nil && dockerMachine.Status.Deprecated.V1Beta1 != nil {
 		v1Beta1Status = &infrav1.DevMachineDeprecatedStatus{
@@ -339,6 +340,7 @@ func dockerMachineToDevMachine(dockerMachine *infrav1.DockerMachine) *infrav1.De
 }
 
 func devMachineToDockerMachine(devMachine *infrav1.DevMachine, dockerMachine *infrav1.DockerMachine) {
+	// Carry over deprecated v1beta1 status if defined.
 	var v1Beta1Status *infrav1.DockerMachineDeprecatedStatus
 	if devMachine.Status.Deprecated != nil && devMachine.Status.Deprecated.V1Beta1 != nil {
 		v1Beta1Status = &infrav1.DockerMachineDeprecatedStatus{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Part of #11947 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->