### PR TITLE
🌱 Add DropEmptyStruct to ssa patch helper

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -68,8 +68,9 @@ func dryRunSSAPatch(ctx context.Context, dryRunCtx *dryRunSSAPatchInput) (bool, 
 	// For dry run we use the same options as for the intent but with adding metadata.managedFields
 	// to ensure that changes to ownership are detected.
 	filterObjectInput := &ssa.FilterObjectInput{
-		AllowedPaths: append(dryRunCtx.helperOptions.AllowedPaths, []string{"metadata", "managedFields"}),
-		IgnorePaths:  dryRunCtx.helperOptions.IgnorePaths,
+		AllowedPaths:    append(dryRunCtx.helperOptions.AllowedPaths, []string{"metadata", "managedFields"}),
+		IgnorePaths:     dryRunCtx.helperOptions.IgnorePaths,
+		DropEmptyStruct: dryRunCtx.helperOptions.DropEmptyStruct,
 	}
 
 	// Add TopologyDryRunAnnotation to notify validation webhooks to skip immutability checks.

--- a/internal/util/ssa/filterintent_test.go
+++ b/internal/util/ssa/filterintent_test.go
@@ -199,3 +199,49 @@ func Test_filterIgnoredPaths(t *testing.T) {
 		})
 	}
 }
+
+func Test_filterDropEmptyStruct(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctx       *FilterIntentInput
+		wantValue map[string]interface{}
+	}{
+		{
+			name: "Cleanup empty maps",
+			ctx: &FilterIntentInput{
+				Path: contract.Path{},
+				Value: map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+				DropEmptyStruct: true,
+			},
+			wantValue: map[string]interface{}{
+				// we are filtering out spec.foo and then spec given that it is an empty map
+			},
+		},
+		{
+			name: "Cleanup empty nested maps",
+			ctx: &FilterIntentInput{
+				Path: contract.Path{},
+				Value: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"bar": map[string]interface{}{},
+					},
+				},
+				DropEmptyStruct: true,
+			},
+			wantValue: map[string]interface{}{
+				// we are filtering out spec.bar.foo and then spec given that it is an empty map
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			FilterIntent(tt.ctx)
+
+			g.Expect(tt.ctx.Value).To(BeComparableTo(tt.wantValue))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With v1beta2 we are going to start using omitzero to avoid serialization issues when we have a non-pointer field of type struct, all top-level fields in the struct are optional, and the struct has MinProperties=1 (the zero value is not valid).

However, looks like DefaultUnstructuredConverter does not handle omitzero yet, so with this PR we are handling this in CAPI ssa patch helper for now

/area clusterclass