### PR TITLE
🌱 Make infrastructure and controlPlane required in ClusterClass

### DIFF
--- a/api/core/v1beta2/clusterclass_types.go
+++ b/api/core/v1beta2/clusterclass_types.go
@@ -89,7 +89,6 @@ type ClusterClass struct {
 }
 
 // ClusterClassSpec describes the desired state of the ClusterClass.
-// +kubebuilder:validation:MinProperties=1
 type ClusterClassSpec struct {
 	// availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
 	//
@@ -103,12 +102,12 @@ type ClusterClassSpec struct {
 
 	// infrastructure is a reference to a local struct that holds the details
 	// for provisioning the infrastructure cluster for the Cluster.
-	// +optional
+	// +required
 	Infrastructure InfrastructureClass `json:"infrastructure,omitempty,omitzero"`
 
 	// controlPlane is a reference to a local struct that holds the details
 	// for provisioning the Control Plane for the Cluster.
-	// +optional
+	// +required
 	ControlPlane ControlPlaneClass `json:"controlPlane,omitempty,omitzero"`
 
 	// workers describes the worker nodes for the cluster.

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -574,6 +574,7 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassSpec(ref common.ReferenceCa
 						},
 					},
 				},
+				Required: []string{"infrastructure", "controlPlane"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -2847,7 +2847,6 @@ spec:
             type: object
           spec:
             description: spec is the desired state of ClusterClass.
-            minProperties: 1
             properties:
               availabilityGates:
                 description: |-
@@ -4568,6 +4567,9 @@ spec:
                     - class
                     x-kubernetes-list-type: map
                 type: object
+            required:
+            - controlPlane
+            - infrastructure
             type: object
           status:
             description: status is the observed state of ClusterClass.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
While infrastructure / controlplane are somehwat optional in Cluster, ClusterClass today only works if both of them are specified. We can consider making infrastructure optional once the Cluster topology controller supports it (CP is always mandatory with ClusterClass as it heavily relies on the ControlPlane object)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->