### PR TITLE
🌱 Restructure excludes in KAL linter config

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -72,81 +72,61 @@ linters:
       linters:
         - kubeapilinter
 
-    ## Excludes that can be removed once v1alpha1/v1beta1 apiVersions are dropped
+    ## Excludes for old apiVersions that can be removed once the apiVersions are dropped (we don't want to make any changes to these APIs).
+    - path: "api/addons/v1beta1|api/bootstrap/kubeadm/v1beta1|api/controlplane/kubeadm/v1beta1|api/core/v1beta1|api/ipam/v1beta1|api/ipam/v1alpha1|api/runtime/v1alpha1"
+      linters:
+        - kubeapilinter
 
-    # .status.deprecated.v1beta1.conditions fields are using v1beta1.Condition types, these fields will be removed once v1alpha1/v1beta1 is removed.
-    - path: "api/addons/v1beta2/*|api/bootstrap/kubeadm/v1beta2/*|api/controlplane/kubeadm/v1beta2/*|api/core/v1beta2/*|api/ipam/v1beta2/*|api/runtime/v1beta2/*|api/addons/v1beta1/*|api/bootstrap/kubeadm/v1beta1/*|api/controlplane/kubeadm/v1beta1/*|api/core/v1beta1/*|api/ipam/v1beta1/*|api/ipam/v1alpha1/*|api/runtime/v1alpha1/*"
+    ## Excludes for current apiVersions that can be removed once v1beta1 is removed.
+    # .status.deprecated.v1beta1.conditions fields are using v1beta1.Condition types.
+    - path: "api/addons/v1beta2|api/bootstrap/kubeadm/v1beta2|api/controlplane/kubeadm/v1beta2|api/core/v1beta2|api/ipam/v1beta2|api/runtime/v1beta2"
       text: "Conditions field must be a slice of metav1.Condition"
       linters:
         - kubeapilinter
-    - path: "api/core/v1beta2/*|api/core/v1beta1/*"
+    - path: "api/core/v1beta2"
       text: "field Conditions type Conditions must have a maximum items, add kubebuilder:validation:MaxItems marker"
       linters:
         - kubeapilinter
-    # excludes for v1alpha1/v1beta1 API packages
-    - path: "api/core/v1beta1/*"
-      text: "type ClusterIPFamily should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
-      linters:
-        - kubeapilinter
-    - path: "api/ipam/v1alpha1/*|api/ipam/v1beta1/*"
-      text: "field Prefix should not use an int, int8 or int16. Use int32 or int64 depending on bounding requirements"
-      linters:
-        - kubeapilinter
-    - path: "api/core/v1beta1/*"
-      text: "field Addresses type MachineAddresses must have a maximum items, add kubebuilder:validation:MaxItems marker"
-      linters:
-        - kubeapilinter
-    - path: "api/bootstrap/kubeadm/v1beta1/*"
-      text: "nomaps: APIEndpoints should not use a map type, use a list type with a unique name/identifier instead"
-      linters:
-        - kubeapilinter
-    - path: "api/core/v1beta1/*"
-      text: "nomaps: FailureDomains should not use a map type, use a list type with a unique name/identifier instead"
-      linters:
-        - kubeapilinter
-    - path: "api/addons/v1beta1/*|api/bootstrap/kubeadm/v1beta1/*|api/controlplane/kubeadm/v1beta1/*|api/core/v1beta1/*|api/ipam/v1beta1/*|api/ipam/v1alpha1/*|api/runtime/v1alpha1/*|cmd/clusterctl/api/v1alpha3/*"
-      text: "optionalfields"
-      linters:
-        - kubeapilinter
-    - path: "api/core/v1beta1/clusterclass_types.go"
-      text: "field Ref is marked as required, should not be a pointer"
-      linters:
-        - kubeapilinter
 
-    ## Excludes for clusterctl and Runtime Hooks (can be fixed once we bump their apiVersion)
+    ## Excludes for current clusterctl v1alpha3 and Runtime Hooks v1alpha1 apiVersions (can be fixed once we bump their apiVersion).
     - path: "cmd/clusterctl/api/v1alpha3|api/runtime/hooks/v1alpha1"
-      text: "maxlength"
-      linters:
-        - kubeapilinter
-
-    ## controller-gen does not allow to add MaxItems to Schemaless fields
-    - path: "api/core/v1beta2/*|api/core/v1beta1/*"
-      text: "maxlength: field (AllOf|OneOf|AnyOf) must have a maximum items, add kubebuilder:validation:MaxItems marker"
-      linters:
-        - kubeapilinter
-
-    ## Removal of bool fields of existing types requires further discussion
-    - path: "api/bootstrap/kubeadm/v1beta2/*|api/controlplane/kubeadm/v1beta2/*|api/core/v1beta2/*|api/addons/v1beta2/*|api/bootstrap/kubeadm/v1beta1/*|api/controlplane/kubeadm/v1beta1/*|api/v1alpha1/*|api/core/v1beta1/*|api/addons/v1beta1/*"
-      text: "nobools"
+      text: "optionalfields|maxlength"
       linters:
         - kubeapilinter
 
     ## Excludes for JSONSchemaProps
+    # controller-gen does not allow to add MaxItems to Schemaless fields
+    - path: "api/core/v1beta2/clusterclass_types.go"
+      text: "maxlength: field (AllOf|OneOf|AnyOf) must have a maximum items, add kubebuilder:validation:MaxItems marker"
+      linters:
+        - kubeapilinter
     # We want to align to the JSON tags of the CustomResourceDefinition fields.
-    - path: "api/core/v1beta2/*|api/core/v1beta1/*"
+    - path: "api/core/v1beta2/clusterclass_types"
       text: "field (XPreserveUnknownFields|XPreserveUnknownFields|XValidations|XMetadata|XIntOrString) json tag does not match pattern"
       linters:
         - kubeapilinter
     # We want to align Properties to the corresponding field in CustomResourceDefinitions.
-    - path: "api/core/v1beta2/*|api/core/v1beta1/*"
+    - path: "api/core/v1beta2/clusterclass_types"
       text: "Properties should not use a map type, use a list type with a unique name/identifier instead"
+      linters:
+        - kubeapilinter
+
+    ## Removal of bool fields of existing types requires further discussion
+    - path: "api/bootstrap/kubeadm/v1beta2|api/controlplane/kubeadm/v1beta2|api/core/v1beta2|api/addons/v1beta2"
+      text: "nobools"
       linters:
         - kubeapilinter
 
     ## Excludes for kubeadm types
     # We want to align the FeatureGates field to the FeatureGates field in kubeadm.
-    - path: "api/bootstrap/kubeadm/v1beta2/*|api/bootstrap/kubeadm/v1beta1/*"
+    - path: "api/bootstrap/kubeadm/v1beta2/kubeadm_types.go"
       text: "nomaps: FeatureGates should not use a map type, use a list type with a unique name/identifier instead"
+      linters:
+        - kubeapilinter
+    # Note: Maybe this has to stay a pointer for marshalling reasons.
+    # TODO: we should eventually remove the pointer: https://github.com/kubernetes-sigs/cluster-api/issues/10852
+    - path: "api/bootstrap/kubeadm/v1beta2/kubeadm_types.go"
+      text: "field Token is marked as required, should not be a pointer"
       linters:
         - kubeapilinter
 
@@ -156,35 +136,24 @@ linters:
       text: "optionalfields: field (Bootstrap) is optional and (should be a pointer|should have the omitempty tag|has a valid zero value)"
       linters:
         - kubeapilinter
+
+    # TODO: Excludes that should be removed once the corresponding issues in KAL are fixed
     # KAL incorrectly reports that the Taints field doesn't have to be a pointer (it has to be to preserve []).
+    # See: https://github.com/kubernetes-sigs/kube-api-linter/issues/116
     - path: "api/bootstrap/kubeadm/v1beta2/kubeadm_types.go"
       text: "optionalfields: field Taints is optional but the underlying type does not need to be a pointer. The pointer should be removed."
       linters:
         - kubeapilinter
-
-    ## TODO: The following rules are disabled until we migrate to the new API.
-    # Note: Maybe this has to stay a pointer for marshalling reasons.
-    - path: "api/bootstrap/kubeadm/v1beta2/kubeadm_types.go|api/bootstrap/kubeadm/v1beta1/kubeadm_types.go"
-      text: "field Token is marked as required, should not be a pointer"
-      linters:
-        - kubeapilinter
-
-    # Audit the entire hook types + builtins from a serialization point of view when bumping the API (this is not a CRD)
-    - path: "api/runtime/hooks/v1alpha1/*"
-      text: "optionalfields"
-      linters:
-        - kubeapilinter
-
     # KAL does not handle omitzero correctly yet: https://github.com/kubernetes-sigs/kube-api-linter/pull/115
     - path: "api/.*"
       text: "optionalfields: field Status is optional and should (be a pointer|have the omitempty tag)"
       linters:
         - kubeapilinter
-    - path: "api/bootstrap/kubeadm/v1beta2/*"
+    - path: "api/bootstrap/kubeadm/v1beta2"
       text: "optionalfields: field (Spec|NodeRegistration|LocalAPIEndpoint|Etcd|APIServer|ControllerManager|Scheduler|DNS|Discovery|ObjectMeta) is optional and should (be a pointer|have the omitempty tag)"
       linters:
         - kubeapilinter
-    - path: "api/controlplane/kubeadm/v1beta2/*"
+    - path: "api/controlplane/kubeadm/v1beta2"
       text: "optionalfields: field (Spec|ObjectMeta|KubeadmConfigSpec) is optional and should (be a pointer|have the omitempty tag)"
       linters:
         - kubeapilinter
@@ -200,12 +169,12 @@ linters:
       text: "optionalfields: field AddressRef is optional and should (be a pointer|have the omitempty tag)"
       linters:
         - kubeapilinter
-
-      # KAL does not handle enum markers on enum types yet: https://github.com/kubernetes-sigs/kube-api-linter/issues/113
+    # KAL does not handle enum markers on enum types yet: https://github.com/kubernetes-sigs/kube-api-linter/issues/113
     - path: ".*"
       text: "optionalfields: field (Format|Encoding|Type|DeletePolicy) is optional and (should be a pointer|has a valid zero value)"
       linters:
         - kubeapilinter
+
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Restructured the config a bit so the actual relevant findings can be more easily maintained

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->