### PR TITLE
🌱 Add validation to ensure ClusterName fields are equal in MD/MS/MP

### DIFF
--- a/exp/internal/webhooks/machinepool.go
+++ b/exp/internal/webhooks/machinepool.go
@@ -174,6 +174,17 @@ func (webhook *MachinePool) validate(oldObj, newObj *clusterv1.MachinePool) erro
 		)
 	}
 
+	if newObj.Spec.ClusterName != newObj.Spec.Template.Spec.ClusterName {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("clusterName"),
+				newObj.Spec.ClusterName,
+				"spec.clusterName and spec.template.spec.clusterName must be set to the same value",
+			),
+		)
+	}
+
 	if newObj.Spec.Template.Spec.Version != "" {
 		if !version.KubeSemver.MatchString(newObj.Spec.Template.Spec.Version) {
 			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), newObj.Spec.Template.Spec.Version, "must be a valid semantic version"))

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -241,6 +241,17 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 		)
 	}
 
+	if newMD.Spec.ClusterName != newMD.Spec.Template.Spec.ClusterName {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("clusterName"),
+				newMD.Spec.ClusterName,
+				"spec.clusterName and spec.template.spec.clusterName must be set to the same value",
+			),
+		)
+	}
+
 	if newMD.Spec.Strategy != nil && newMD.Spec.Strategy.RollingUpdate != nil {
 		total := 1
 		if newMD.Spec.Replicas != nil {

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -209,6 +209,17 @@ func (webhook *MachineSet) validate(oldMS, newMS *clusterv1.MachineSet) error {
 		)
 	}
 
+	if newMS.Spec.ClusterName != newMS.Spec.Template.Spec.ClusterName {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("clusterName"),
+				newMS.Spec.ClusterName,
+				"spec.clusterName and spec.template.spec.clusterName must be set to the same value",
+			),
+		)
+	}
+
 	if newMS.Spec.Template.Spec.Version != "" {
 		if !version.KubeSemver.MatchString(newMS.Spec.Template.Spec.Version) {
 			allErrs = append(


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Ideally we would want to remove the spec.template.spec.clusterName field. Unforunately we don't have the time to stop embedding the MachineSpec field in MD/MS/MP for v1beta2. For now we'll enforce at least that the values are set consistently

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->