### PR TITLE
⚠️ Keep using v1beta1 condition in CAPD Docker backend

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -133,8 +133,8 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 			// In this case recover the information from the existing v1beta1 condition, because we do not know if
 			// all commands succeeded.
 			if !conditions.Has(dockerMachine, infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition) {
-				condition := conditions.Get(dockerMachine, infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition)
-				if condition == nil || condition.Status == metav1.ConditionTrue {
+				condition := v1beta1conditions.Get(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition)
+				if condition == nil || condition.Status == corev1.ConditionTrue {
 					conditions.Set(dockerMachine, metav1.Condition{
 						Type:   infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,
 						Status: metav1.ConditionTrue,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

See the [comment](https://github.com/kubernetes-sigs/cluster-api/pull/12438#discussion_r2184878636)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->