### PR TITLE
🌱 Add validation for Cluster spec.controlPlaneRef, spec.infrastructureRef and spec.topology

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
@@ -37,9 +36,8 @@ func TestKubeadmConfigReconciler(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			cluster := builder.Cluster(ns.Name, "cluster1").
-				WithClusterNetwork(&clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
-				}).
+				WithControlPlane(
+					builder.ControlPlane(ns.Name, "cp1").Build()).
 				Build()
 			g.Expect(env.Create(ctx, cluster)).To(Succeed())
 			machine := newWorkerMachineForCluster(cluster)

--- a/controllers/clustercache/cluster_accessor_test.go
+++ b/controllers/clustercache/cluster_accessor_test.go
@@ -41,6 +41,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
 func TestConnect(t *testing.T) {
@@ -52,8 +53,10 @@ func TestConnect(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -153,8 +156,10 @@ func TestDisconnect(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -207,8 +212,10 @@ func TestHealthCheck(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -323,8 +330,10 @@ func TestWatch(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -47,6 +47,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
 func TestReconcile(t *testing.T) {
@@ -58,8 +59,10 @@ func TestReconcile(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -738,8 +741,10 @@ func createCluster(g Gomega, testCluster testCluster) {
 			Namespace: testCluster.cluster.Namespace,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
 func TestGetMachinesForCluster(t *testing.T) {
@@ -119,8 +120,10 @@ func TestGetWorkloadCluster(t *testing.T) {
 			Namespace: ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.InfrastructureGroupVersion.Group,
+				Kind:     builder.GenericInfrastructureClusterKind,
+				Name:     "infracluster1",
 			},
 		},
 	}

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1206,6 +1206,11 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 			Host: "test.local",
 			Port: 9999,
 		},
+		InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+			APIGroup: builder.InfrastructureGroupVersion.Group,
+			Kind:     builder.GenericInfrastructureClusterKind,
+			Name:     "infracluster1",
+		},
 	}
 	g.Expect(env.Create(ctx, cluster)).To(Succeed())
 	patchHelper, err := patch.NewHelper(cluster, env)
@@ -1423,6 +1428,11 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 			Host: "test.local",
 			Port: 9999,
 		},
+		InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+			APIGroup: builder.InfrastructureGroupVersion.Group,
+			Kind:     builder.GenericInfrastructureClusterKind,
+			Name:     "infracluster1",
+		},
 	}
 
 	caCertificate := &secret.Certificate{
@@ -1457,7 +1467,7 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 
 	genericInfrastructureMachineTemplate := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"kind":       "GenericInfrastructureMachineTemplate",
+			"kind":       builder.GenericInfrastructureMachineTemplateKind,
 			"apiVersion": clusterv1.GroupVersionInfrastructure.String(),
 			"metadata": map[string]interface{}{
 				"name":      "infra-foo",
@@ -1649,8 +1659,10 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 				Name:      "test-cluster",
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.InfrastructureGroupVersion.Group,
+					Kind:     builder.GenericInfrastructureClusterKind,
+					Name:     "infracluster1",
 				},
 			},
 		}

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -1351,9 +1351,8 @@ func TestReconcileMachinePoolMachines(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		cluster := builder.Cluster(ns.Name, clusterName).
-			WithClusterNetwork(&clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
-			}).
+			WithControlPlane(
+				builder.ControlPlane(ns.Name, "cp1").Build()).
 			Build()
 		g.Expect(env.CreateAndWait(ctx, cluster)).To(Succeed())
 
@@ -1724,8 +1723,10 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller_test.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
 const (
@@ -112,8 +113,10 @@ metadata:
 				Namespace: ns.Name,
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -239,8 +239,10 @@ func TestGetNode(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -387,8 +389,10 @@ func TestNodeLabelSync(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	builder "sigs.k8s.io/cluster-api/util/test/builder"
 )
 
 func TestSetBootstrapReadyCondition(t *testing.T) {
@@ -1906,8 +1907,10 @@ func TestReconcileMachinePhases(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -105,8 +105,10 @@ func TestWatches(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -263,6 +265,11 @@ func TestWatchesDelete(t *testing.T) {
 			// This avoids going through reconcileExternal, which adds watches
 			// for the provider machine and the bootstrap config objects.
 			Paused: ptr.To(true),
+			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.InfrastructureGroupVersion.Group,
+				Kind:     builder.GenericInfrastructureClusterKind,
+				Name:     "infracluster1",
+			},
 		},
 	}
 
@@ -425,8 +432,10 @@ func TestMachine_Reconcile(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}
@@ -3081,8 +3090,10 @@ func TestNodeToMachine(t *testing.T) {
 			Namespace:    ns.Name,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -61,8 +61,10 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 				Name:      "test-cluster",
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}
@@ -509,8 +511,10 @@ func TestMachineDeploymentReconciler_CleanUpManagedFieldsForSSAAdoption(t *testi
 				Name:      "test-cluster",
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -2444,8 +2444,10 @@ func createCluster(g *WithT, namespaceName string) *clusterv1.Cluster {
 			Namespace:    namespaceName,
 		},
 		Spec: clusterv1.ClusterSpec{
-			ClusterNetwork: &clusterv1.ClusterNetwork{
-				ServiceDomain: "service.domain",
+			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
 			},
 		},
 	}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -71,8 +71,10 @@ func TestMachineSetReconciler(t *testing.T) {
 				Name:      testClusterName,
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}
@@ -1095,8 +1097,10 @@ func TestMachineSetReconciler_syncMachines(t *testing.T) {
 				Name:      testClusterName,
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -48,6 +49,7 @@ import (
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	"sigs.k8s.io/cluster-api/exp/topology/desiredstate"
 	"sigs.k8s.io/cluster-api/exp/topology/scope"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/structuredmerge"
 	"sigs.k8s.io/cluster-api/internal/hooks"
@@ -1091,11 +1093,18 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 }
 
 func TestReconcileCluster(t *testing.T) {
+	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
+
 	cluster1 := builder.Cluster(metav1.NamespaceDefault, "cluster1").
-		WithClusterNetwork(&clusterv1.ClusterNetwork{
-			ServiceDomain: "service.domain",
+		WithTopology(&clusterv1.Topology{
+			ClassRef: clusterv1.ClusterClassRef{
+				Name: "class1",
+			},
+			Version: "v1.30.0",
 		}).
 		Build()
+	// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
+	cluster1.Spec.Paused = ptr.To(true)
 	cluster1WithReferences := builder.Cluster(metav1.NamespaceDefault, "cluster1").
 		WithInfrastructureCluster(builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").
 			Build()).
@@ -1144,6 +1153,16 @@ func TestReconcileCluster(t *testing.T) {
 				tt.current = prepareCluster(tt.current, namespace.GetName())
 			}
 
+			ict := builder.TestInfrastructureClusterTemplate(namespace.GetName(), "infra1").Build()
+			cpt := builder.TestControlPlaneTemplate(namespace.GetName(), "cp1").Build()
+			clusterClass := builder.ClusterClass(namespace.GetName(), "class1").
+				WithInfrastructureClusterTemplate(ict).
+				WithControlPlaneTemplate(cpt).
+				Build()
+			g.Expect(env.CreateAndWait(ctx, ict)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, cpt)).To(Succeed())
+			g.Expect(env.CreateAndWait(ctx, clusterClass)).To(Succeed())
+
 			if tt.current != nil {
 				// NOTE: it is ok to use create given that the Cluster are created by user.
 				g.Expect(env.CreateAndWait(ctx, tt.current)).To(Succeed())
@@ -1175,6 +1194,7 @@ func TestReconcileCluster(t *testing.T) {
 			if tt.current != nil {
 				g.Expect(env.CleanupAndWait(ctx, tt.current)).To(Succeed())
 			}
+			g.Expect(env.CleanupAndWait(ctx, clusterClass, ict, cpt)).To(Succeed())
 		})
 	}
 }
@@ -3451,16 +3471,28 @@ func TestReconcileMachineDeploymentMachineHealthCheck(t *testing.T) {
 }
 
 func TestReconcileState(t *testing.T) {
+	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
+
+	ict := builder.TestInfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()
+	cpt := builder.TestControlPlaneTemplate(metav1.NamespaceDefault, "cp1").Build()
+	clusterClass := builder.ClusterClass(metav1.NamespaceDefault, "class1").
+		WithInfrastructureClusterTemplate(ict).
+		WithControlPlaneTemplate(cpt).
+		Build()
+
 	t.Run("Cluster get reconciled with infrastructure Ref only when reconcileInfrastructureCluster pass and reconcileControlPlane fails ", func(t *testing.T) {
 		g := NewWithT(t)
 
 		currentCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
-			WithClusterNetwork(
-				&clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
 				},
-			).
+				Version: "v1.30.0",
+			}).
 			Build()
+		// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
+		currentCluster.Spec.Paused = ptr.To(true)
 
 		infrastructureCluster := builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Build()
 		controlPlane := builder.TestControlPlane(metav1.NamespaceDefault, "controlplane-cluster1").Build()
@@ -3468,6 +3500,10 @@ func TestReconcileState(t *testing.T) {
 			WithInfrastructureCluster(infrastructureCluster).
 			WithControlPlane(controlPlane).
 			Build()
+
+		g.Expect(env.CreateAndWait(ctx, ict.DeepCopy())).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, cpt.DeepCopy())).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, clusterClass.DeepCopy())).To(Succeed())
 
 		// cluster requires a UID because reconcileClusterShim will create a cluster shim
 		// which has the cluster set as Owner in an OwnerReference.
@@ -3505,18 +3541,21 @@ func TestReconcileState(t *testing.T) {
 		g.Expect(got.Spec.InfrastructureRef).ToNot(BeNil())
 		g.Expect(got.Spec.ControlPlaneRef).To(BeNil())
 
-		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, currentCluster)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, currentCluster, clusterClass, ict, cpt)).To(Succeed())
 	})
 	t.Run("Cluster get reconciled with both infrastructure Ref and control plane ref when both reconcileInfrastructureCluster and reconcileControlPlane pass", func(t *testing.T) {
 		g := NewWithT(t)
 
 		currentCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
-			WithClusterNetwork(
-				&clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
 				},
-			).
+				Version: "v1.30.0",
+			}).
 			Build()
+		// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
+		currentCluster.Spec.Paused = ptr.To(true)
 
 		infrastructureCluster := builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Build()
 		controlPlane := builder.TestControlPlane(metav1.NamespaceDefault, "controlplane-cluster1").Build()
@@ -3524,6 +3563,10 @@ func TestReconcileState(t *testing.T) {
 			WithInfrastructureCluster(infrastructureCluster).
 			WithControlPlane(controlPlane).
 			Build()
+
+		g.Expect(env.CreateAndWait(ctx, ict.DeepCopy())).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, cpt.DeepCopy())).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, clusterClass.DeepCopy())).To(Succeed())
 
 		// cluster requires a UID because reconcileClusterShim will create a cluster shim
 		// which has the cluster set as Owner in an OwnerReference.
@@ -3558,7 +3601,7 @@ func TestReconcileState(t *testing.T) {
 		g.Expect(got.Spec.InfrastructureRef).ToNot(BeNil())
 		g.Expect(got.Spec.ControlPlaneRef).ToNot(BeNil())
 
-		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, controlPlane, currentCluster)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, controlPlane, currentCluster, clusterClass, ict, cpt)).To(Succeed())
 	})
 	t.Run("Cluster does not get reconciled when reconcileControlPlane fails and infrastructure Ref is set", func(t *testing.T) {
 		g := NewWithT(t)
@@ -3569,6 +3612,8 @@ func TestReconcileState(t *testing.T) {
 		currentCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
 			WithInfrastructureCluster(infrastructureCluster).
 			Build()
+		// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
+		currentCluster.Spec.Paused = ptr.To(true)
 
 		desiredCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
 			WithInfrastructureCluster(infrastructureCluster).

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -195,6 +195,17 @@ func (webhook *Cluster) validate(ctx context.Context, oldCluster, newCluster *cl
 		)
 	}
 
+	if newCluster.Spec.ControlPlaneRef == nil && newCluster.Spec.InfrastructureRef == nil &&
+		newCluster.Spec.Topology == nil {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				specPath,
+				"one of spec.controlPlaneRef, spec.infrastructureRef or spec.topology must be set",
+			),
+		)
+	}
+
 	if newCluster.Spec.ControlPlaneRef == nil && oldCluster != nil && oldCluster.Spec.ControlPlaneRef != nil {
 		allErrs = append(
 			allErrs,
@@ -204,6 +215,7 @@ func (webhook *Cluster) validate(ctx context.Context, oldCluster, newCluster *cl
 			),
 		)
 	}
+
 	if newCluster.Spec.ClusterNetwork != nil {
 		// Ensure that the CIDR blocks defined under ClusterNetwork are valid.
 		if newCluster.Spec.ClusterNetwork.Pods != nil {

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -179,8 +179,10 @@ func TestPatchHelper(t *testing.T) {
 					Namespace:    ns.Name,
 				},
 				Spec: clusterv1.ClusterSpec{
-					ClusterNetwork: &clusterv1.ClusterNetwork{
-						ServiceDomain: "service.domain",
+					ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: builder.ControlPlaneGroupVersion.Group,
+						Kind:     builder.GenericControlPlaneKind,
+						Name:     "cp1",
 					},
 				},
 			}
@@ -527,8 +529,10 @@ func TestPatchHelper(t *testing.T) {
 				Namespace:    ns.Name,
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}
@@ -965,8 +969,10 @@ func TestPatchHelper(t *testing.T) {
 				Namespace:    ns.Name,
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 		}
@@ -1018,8 +1024,10 @@ func TestPatchHelper(t *testing.T) {
 				Finalizers: []string{"block-deletion"},
 			},
 			Spec: clusterv1.ClusterSpec{
-				ClusterNetwork: &clusterv1.ClusterNetwork{
-					ServiceDomain: "service.domain",
+				ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+					APIGroup: builder.ControlPlaneGroupVersion.Group,
+					Kind:     builder.GenericControlPlaneKind,
+					Name:     "cp1",
 				},
 			},
 			Status: clusterv1.ClusterStatus{},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to a recent discussion around these fields


Cluster API today only supports the following cases:

| spec.topology | spec.controlPlaneRef | spec.infrastructureRef | Supported? |
|---------------|----------------------|------------------------|:-----------|
| -             | -                    | -                      | No, No idea how a cluster without Infra/CP would work         |
| -             | -                    | x                      | Yes        |
| -             | x                    | -                      | Yes        |
| -             | x                    | x                      | Yes        |
| x             | - / x                | - / x                  | Yes        |

In other words either one of `spec.controlPlaneRef` or ``spec.infrastructureRef` or `spec.topology` must be set.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->