### PR TITLE
🌱 Remove explicit defaulting of MS deletePolicy, MHC maxUnhealthy, KCPTemplate rolloutStrategy

### DIFF
--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate.go
@@ -59,8 +59,6 @@ func (webhook *KubeadmControlPlaneTemplate) Default(_ context.Context, obj runti
 
 	k.Spec.Template.Spec.KubeadmConfigSpec.Default()
 
-	k.Spec.Template.Spec.RolloutStrategy = defaultRolloutStrategy(k.Spec.Template.Spec.RolloutStrategy)
-
 	return nil
 }
 

--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate_test.go
@@ -58,8 +58,6 @@ func TestKubeadmControlPlaneTemplateDefault(t *testing.T) {
 	g.Expect(webhook.Default(ctx, kcpTemplate)).To(Succeed())
 
 	g.Expect(kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.Format).To(Equal(bootstrapv1.CloudConfig))
-	g.Expect(kcpTemplate.Spec.Template.Spec.RolloutStrategy.Type).To(Equal(controlplanev1.RollingUpdateStrategyType))
-	g.Expect(kcpTemplate.Spec.Template.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntVal).To(Equal(int32(1)))
 }
 
 func TestKubeadmControlPlaneTemplateValidationFeatureGateEnabled(t *testing.T) {

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -3297,7 +3297,6 @@ func TestMergeMap(t *testing.T) {
 }
 
 func Test_computeMachineHealthCheck(t *testing.T) {
-	maxUnhealthyValue := intstr.FromString("100%")
 	mhcSpec := &clusterv1.MachineHealthCheckClass{
 		UnhealthyNodeConditions: []clusterv1.UnhealthyNodeCondition{
 			{
@@ -3340,8 +3339,6 @@ func Test_computeMachineHealthCheck(t *testing.T) {
 			Selector: metav1.LabelSelector{MatchLabels: map[string]string{
 				"foo": "bar",
 			}},
-			// MaxUnhealthy is added by defaulting values using MachineHealthCheck.Default()
-			MaxUnhealthy: &maxUnhealthyValue,
 			UnhealthyNodeConditions: []clusterv1.UnhealthyNodeCondition{
 				{
 					Type:           corev1.NodeReady,

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -2279,7 +2279,7 @@ func TestIsAllowedRemediation(t *testing.T) {
 			maxUnhealthy:     nil,
 			expectedMachines: int32(3),
 			currentHealthy:   int32(0),
-			allowed:          false,
+			allowed:          true,
 		},
 		{
 			name:             "when maxUnhealthy is not an int or percentage",
@@ -2365,9 +2365,8 @@ func TestGetMaxUnhealthy(t *testing.T) {
 		{
 			name:                 "when maxUnhealthy is nil",
 			maxUnhealthy:         nil,
-			expectedMaxUnhealthy: 0,
+			expectedMaxUnhealthy: 7,
 			actualMachineCount:   7,
-			expectedErr:          errors.New("spec.maxUnhealthy must be set"),
 		},
 		{
 			name:                 "when maxUnhealthy is not an int or percentage",

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machineset
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
@@ -825,7 +826,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 		}
 		return ctrl.Result{}, r.waitForMachineCreation(ctx, machineList)
 	case diff > 0:
-		log.Info(fmt.Sprintf("MachineSet is scaling down to %d replicas by deleting %d machines", *(ms.Spec.Replicas), diff), "replicas", *(ms.Spec.Replicas), "machineCount", len(machines), "deletePolicy", ms.Spec.DeletePolicy)
+		log.Info(fmt.Sprintf("MachineSet is scaling down to %d replicas by deleting %d machines", *(ms.Spec.Replicas), diff), "replicas", *(ms.Spec.Replicas), "machineCount", len(machines), "deletePolicy", cmp.Or(ms.Spec.DeletePolicy, clusterv1.RandomMachineSetDeletePolicy))
 
 		deletePriorityFunc, err := getDeletePriorityFunc(ms)
 		if err != nil {

--- a/internal/webhooks/machinehealthcheck.go
+++ b/internal/webhooks/machinehealthcheck.go
@@ -77,11 +77,6 @@ func (webhook *MachineHealthCheck) Default(_ context.Context, obj runtime.Object
 	}
 	m.Labels[clusterv1.ClusterNameLabel] = m.Spec.ClusterName
 
-	if m.Spec.MaxUnhealthy == nil {
-		defaultMaxUnhealthy := intstr.FromString("100%")
-		m.Spec.MaxUnhealthy = &defaultMaxUnhealthy
-	}
-
 	if m.Spec.NodeStartupTimeoutSeconds == nil {
 		m.Spec.NodeStartupTimeoutSeconds = &clusterv1.DefaultNodeStartupTimeoutSeconds
 	}

--- a/internal/webhooks/machinehealthcheck_test.go
+++ b/internal/webhooks/machinehealthcheck_test.go
@@ -53,7 +53,6 @@ func TestMachineHealthCheckDefault(t *testing.T) {
 	g.Expect(webhook.Default(ctx, mhc)).To(Succeed())
 
 	g.Expect(mhc.Labels[clusterv1.ClusterNameLabel]).To(Equal(mhc.Spec.ClusterName))
-	g.Expect(mhc.Spec.MaxUnhealthy.String()).To(Equal("100%"))
 	g.Expect(mhc.Spec.NodeStartupTimeoutSeconds).ToNot(BeNil())
 	g.Expect(*mhc.Spec.NodeStartupTimeoutSeconds).To(Equal(int32(10 * 60)))
 }

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -103,10 +103,6 @@ func (webhook *MachineSet) Default(ctx context.Context, obj runtime.Object) erro
 	}
 	m.Spec.Replicas = ptr.To[int32](replicas)
 
-	if m.Spec.DeletePolicy == "" {
-		m.Spec.DeletePolicy = clusterv1.RandomMachineSetDeletePolicy
-	}
-
 	if m.Spec.Selector.MatchLabels == nil {
 		m.Spec.Selector.MatchLabels = make(map[string]string)
 	}

--- a/internal/webhooks/machineset_test.go
+++ b/internal/webhooks/machineset_test.go
@@ -60,7 +60,6 @@ func TestMachineSetDefault(t *testing.T) {
 	g.Expect(webhook.Default(reqCtx, ms)).To(Succeed())
 
 	g.Expect(ms.Labels[clusterv1.ClusterNameLabel]).To(Equal(ms.Spec.ClusterName))
-	g.Expect(ms.Spec.DeletePolicy).To(Equal(clusterv1.RandomMachineSetDeletePolicy))
 	g.Expect(ms.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.MachineSetNameLabel, "test-ms"))
 	g.Expect(ms.Spec.Template.Labels).To(HaveKeyWithValue(clusterv1.MachineSetNameLabel, "test-ms"))
 	g.Expect(ms.Spec.Template.Spec.Version).To(Equal("v1.19.10"))


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
To test our marshalling after recent changes (omitzero etc.) we tried to apply some minimal YAMLs to verify everything works as expected.

While doing that we noticed that we introduce some noise by explicitly defaulting values. Usually in most newer API fields we stopped explicit defaulting to preserve user intent.

This PR drops explicit defaulting from:
* MS deletePolicy
* MHC maxUnhealthy
* KubeadmControlPlaneTemplate rolloutStrategy

In these cases the defaulting doesn't really add additional value as it's not really important to see the default values in the objects:
* MS `deletePolicy Random` doesn't add much
* MHC `maxUnhealthy: 100%` is more confusing than anything else
* KubeadmControlPlaneTemplate: it's not really important that we default the rolloutStrategy on the template, it will still be defaulted on the actual KubeadmControlPlane where it's definitely nice to know

Please note, that we stop defaulting these fields will not lead to any rollouts. There are other fields (KubeadmConfig/..: format & imagePullPolicy) where it's more complicated to stop defaulting. Will try to tackle this in a follow-up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->