### PR TITLE
🐛 Allow transition of KubeadmControlPlaneTemplate from defaulted rolloutStrategy to unset

### DIFF
--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -88,23 +88,19 @@ func defaultKubeadmControlPlaneSpec(s *controlplanev1.KubeadmControlPlaneSpec) {
 }
 
 func defaultRolloutStrategy(rolloutStrategy *controlplanev1.RolloutStrategy) *controlplanev1.RolloutStrategy {
-	ios1 := intstr.FromInt(1)
-
 	if rolloutStrategy == nil {
 		rolloutStrategy = &controlplanev1.RolloutStrategy{}
 	}
 
 	// Enforce RollingUpdate strategy and default MaxSurge if not set.
-	if rolloutStrategy != nil {
-		if len(rolloutStrategy.Type) == 0 {
-			rolloutStrategy.Type = controlplanev1.RollingUpdateStrategyType
+	if len(rolloutStrategy.Type) == 0 {
+		rolloutStrategy.Type = controlplanev1.RollingUpdateStrategyType
+	}
+	if rolloutStrategy.Type == controlplanev1.RollingUpdateStrategyType {
+		if rolloutStrategy.RollingUpdate == nil {
+			rolloutStrategy.RollingUpdate = &controlplanev1.RollingUpdate{}
 		}
-		if rolloutStrategy.Type == controlplanev1.RollingUpdateStrategyType {
-			if rolloutStrategy.RollingUpdate == nil {
-				rolloutStrategy.RollingUpdate = &controlplanev1.RollingUpdate{}
-			}
-			rolloutStrategy.RollingUpdate.MaxSurge = intstr.ValueOrDefault(rolloutStrategy.RollingUpdate.MaxSurge, ios1)
-		}
+		rolloutStrategy.RollingUpdate.MaxSurge = intstr.ValueOrDefault(rolloutStrategy.RollingUpdate.MaxSurge, intstr.FromInt32(1))
 	}
 
 	return rolloutStrategy
@@ -422,8 +418,8 @@ func validateRolloutStrategy(rolloutStrategy *controlplanev1.RolloutStrategy, re
 		)
 	}
 
-	ios1 := intstr.FromInt(1)
-	ios0 := intstr.FromInt(0)
+	ios1 := intstr.FromInt32(1)
+	ios0 := intstr.FromInt32(0)
 
 	if rolloutStrategy.RollingUpdate.MaxSurge.IntValue() == ios0.IntValue() && (replicas != nil && *replicas < int32(3)) {
 		allErrs = append(

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -719,7 +719,7 @@ func TestNewMSNewReplicas(t *testing.T) {
 		strategyType  clusterv1.MachineDeploymentStrategyType
 		depReplicas   int32
 		newMSReplicas int32
-		maxSurge      int
+		maxSurge      int32
 		expected      int32
 	}{
 		{
@@ -745,14 +745,8 @@ func TestNewMSNewReplicas(t *testing.T) {
 			*(newDeployment.Spec.Replicas) = test.depReplicas
 			newDeployment.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{Type: test.strategyType}
 			newDeployment.Spec.Strategy.RollingUpdate = &clusterv1.MachineRollingUpdateDeployment{
-				MaxUnavailable: func(i int) *intstr.IntOrString {
-					x := intstr.FromInt(i)
-					return &x
-				}(1),
-				MaxSurge: func(i int) *intstr.IntOrString {
-					x := intstr.FromInt(i)
-					return &x
-				}(test.maxSurge),
+				MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+				MaxSurge:       ptr.To(intstr.FromInt32(test.maxSurge)),
 			}
 			*(newRC.Spec.Replicas) = test.newMSReplicas
 			ms, err := NewMSNewReplicas(&newDeployment, []*clusterv1.MachineSet{&rs5}, *newRC.Spec.Replicas)
@@ -769,8 +763,8 @@ func TestDeploymentComplete(t *testing.T) {
 				Replicas: &desired,
 				Strategy: &clusterv1.MachineDeploymentStrategy{
 					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
-						MaxUnavailable: func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxUnavailable)),
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxSurge)),
+						MaxUnavailable: ptr.To(intstr.FromInt32(maxUnavailable)),
+						MaxSurge:       ptr.To(intstr.FromInt32(maxSurge)),
 					},
 					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
 				},
@@ -847,7 +841,7 @@ func TestMaxUnavailable(t *testing.T) {
 				Replicas: func(i int32) *int32 { return &i }(replicas),
 				Strategy: &clusterv1.MachineDeploymentStrategy{
 					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1)),
+						MaxSurge:       ptr.To(intstr.FromInt32(1)),
 						MaxUnavailable: &maxUnavailable,
 					},
 					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
@@ -862,22 +856,22 @@ func TestMaxUnavailable(t *testing.T) {
 	}{
 		{
 			name:       "maxUnavailable less than replicas",
-			deployment: deployment(10, intstr.FromInt(5)),
+			deployment: deployment(10, intstr.FromInt32(5)),
 			expected:   int32(5),
 		},
 		{
 			name:       "maxUnavailable equal replicas",
-			deployment: deployment(10, intstr.FromInt(10)),
+			deployment: deployment(10, intstr.FromInt32(10)),
 			expected:   int32(10),
 		},
 		{
 			name:       "maxUnavailable greater than replicas",
-			deployment: deployment(5, intstr.FromInt(10)),
+			deployment: deployment(5, intstr.FromInt32(10)),
 			expected:   int32(5),
 		},
 		{
 			name:       "maxUnavailable with replicas is 0",
-			deployment: deployment(0, intstr.FromInt(10)),
+			deployment: deployment(0, intstr.FromInt32(10)),
 			expected:   int32(0),
 		},
 		{
@@ -938,8 +932,8 @@ func TestAnnotationUtils(t *testing.T) {
 func TestComputeMachineSetAnnotations(t *testing.T) {
 	deployment := generateDeployment("nginx")
 	deployment.Spec.Replicas = ptr.To[int32](3)
-	maxSurge := intstr.FromInt(1)
-	maxUnavailable := intstr.FromInt(0)
+	maxSurge := intstr.FromInt32(1)
+	maxUnavailable := intstr.FromInt32(0)
 	deployment.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{
 		Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
 		RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -148,7 +148,7 @@ func TestMain(m *testing.M) {
 
 func intOrStrPtr(i int32) *intstr.IntOrString {
 	// FromInt takes an int that must not be greater than int32...
-	res := intstr.FromInt(int(i))
+	res := intstr.FromInt32(i)
 	return &res
 }
 

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -122,11 +122,11 @@ func (webhook *MachineDeployment) Default(ctx context.Context, obj runtime.Objec
 			m.Spec.Strategy.RollingUpdate = &clusterv1.MachineRollingUpdateDeployment{}
 		}
 		if m.Spec.Strategy.RollingUpdate.MaxSurge == nil {
-			ios1 := intstr.FromInt(1)
+			ios1 := intstr.FromInt32(1)
 			m.Spec.Strategy.RollingUpdate.MaxSurge = &ios1
 		}
 		if m.Spec.Strategy.RollingUpdate.MaxUnavailable == nil {
-			ios0 := intstr.FromInt(0)
+			ios0 := intstr.FromInt32(0)
 			m.Spec.Strategy.RollingUpdate.MaxUnavailable = &ios0
 		}
 	}

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -354,9 +354,9 @@ func TestMachineDeploymentValidation(t *testing.T) {
 	goodMaxUnavailablePercentage := intstr.FromString("0%")
 	goodMaxInFlightPercentage := intstr.FromString("20%")
 
-	goodMaxSurgeInt := intstr.FromInt(1)
-	goodMaxUnavailableInt := intstr.FromInt(0)
-	goodMaxInFlightInt := intstr.FromInt(5)
+	goodMaxSurgeInt := intstr.FromInt32(1)
+	goodMaxUnavailableInt := intstr.FromInt32(0)
+	goodMaxInFlightInt := intstr.FromInt32(5)
 	tests := []struct {
 		name                  string
 		md                    *clusterv1.MachineDeployment


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
See: https://github.com/kubernetes-sigs/cluster-api/pull/12464#discussion_r2194800457

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->