### PR TITLE
[release-1.9] :seedling: Add --etcd-client-log-level flag to KCP

### DIFF
--- a/controlplane/kubeadm/controllers/alias.go
+++ b/controlplane/kubeadm/controllers/alias.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -36,6 +37,7 @@ type KubeadmControlPlaneReconciler struct {
 
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
+	EtcdLogger      *zap.Logger
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -54,6 +56,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 		ClusterCache:                 r.ClusterCache,
 		EtcdDialTimeout:              r.EtcdDialTimeout,
 		EtcdCallTimeout:              r.EtcdCallTimeout,
+		EtcdLogger:                   r.EtcdLogger,
 		WatchFilterValue:             r.WatchFilterValue,
 		RemoteConditionsGracePeriod:  r.RemoteConditionsGracePeriod,
 		DeprecatedInfraMachineNaming: r.DeprecatedInfraMachineNaming,

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
@@ -57,6 +58,7 @@ type Management struct {
 	ClusterCache        clustercache.ClusterCache
 	EtcdDialTimeout     time.Duration
 	EtcdCallTimeout     time.Duration
+	EtcdLogger          *zap.Logger
 }
 
 // RemoteClusterConnectionError represents a failure to connect to a remote cluster.
@@ -158,7 +160,7 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 		restConfig:          restConfig,
 		Client:              c,
 		CoreDNSMigrator:     &CoreDNSMigrator{},
-		etcdClientGenerator: NewEtcdClientGenerator(restConfig, tlsConfig, m.EtcdDialTimeout, m.EtcdCallTimeout),
+		etcdClientGenerator: NewEtcdClientGenerator(restConfig, tlsConfig, m.EtcdDialTimeout, m.EtcdCallTimeout, m.EtcdLogger),
 	}, nil
 }
 

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,6 +86,7 @@ type KubeadmControlPlaneReconciler struct {
 
 	EtcdDialTimeout time.Duration
 	EtcdCallTimeout time.Duration
+	EtcdLogger      *zap.Logger
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -147,6 +149,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 			ClusterCache:        r.ClusterCache,
 			EtcdDialTimeout:     r.EtcdDialTimeout,
 			EtcdCallTimeout:     r.EtcdCallTimeout,
+			EtcdLogger:          r.EtcdLogger,
 		}
 	}
 

--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -138,13 +137,8 @@ type ClientConfiguration struct {
 	TLSConfig   *tls.Config
 	DialTimeout time.Duration
 	CallTimeout time.Duration
+	Logger      *zap.Logger
 }
-
-var (
-	// Create the etcdClientLogger only once. Otherwise every call of clientv3.New
-	// would create its own logger which leads to a lot of memory allocations.
-	etcdClientLogger, _ = logutil.CreateDefaultZapLogger(zapcore.InfoLevel)
-)
 
 // NewClient creates a new etcd client with the given configuration.
 func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error) {
@@ -160,7 +154,7 @@ func NewClient(ctx context.Context, config ClientConfiguration) (*Client, error)
 			grpc.WithContextDialer(dialer.DialContextWithAddr),
 		},
 		TLS:    config.TLSConfig,
-		Logger: etcdClientLogger,
+		Logger: config.Logger,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create etcd client")

--- a/controlplane/kubeadm/internal/etcd_client_generator.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -43,7 +44,7 @@ type clientCreator func(ctx context.Context, endpoint string) (*etcd.Client, err
 var errEtcdNodeConnection = errors.New("failed to connect to etcd node")
 
 // NewEtcdClientGenerator returns a new etcdClientGenerator instance.
-func NewEtcdClientGenerator(restConfig *rest.Config, tlsConfig *tls.Config, etcdDialTimeout, etcdCallTimeout time.Duration) *EtcdClientGenerator {
+func NewEtcdClientGenerator(restConfig *rest.Config, tlsConfig *tls.Config, etcdDialTimeout, etcdCallTimeout time.Duration, etcdLogger *zap.Logger) *EtcdClientGenerator {
 	ecg := &EtcdClientGenerator{restConfig: restConfig, tlsConfig: tlsConfig}
 
 	ecg.createClient = func(ctx context.Context, endpoint string) (*etcd.Client, error) {
@@ -59,6 +60,7 @@ func NewEtcdClientGenerator(restConfig *rest.Config, tlsConfig *tls.Config, etcd
 			TLSConfig:   tlsConfig,
 			DialTimeout: etcdDialTimeout,
 			CallTimeout: etcdCallTimeout,
+			Logger:      etcdLogger,
 		})
 	}
 

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -96,6 +98,7 @@ var (
 	clusterCacheConcurrency         int
 	etcdDialTimeout                 time.Duration
 	etcdCallTimeout                 time.Duration
+	etcdLogLevel                    string
 	useDeprecatedInfraMachineNaming bool
 )
 
@@ -183,6 +186,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.DurationVar(&etcdCallTimeout, "etcd-call-timeout-duration", etcd.DefaultCallTimeout,
 		"Duration that the etcd client waits at most for read and write operations to etcd.")
+
+	fs.StringVar(&etcdLogLevel, "etcd-client-log-level", zapcore.InfoLevel.String(),
+		"Logging level for etcd client. Possible values are: debug, info, warn, error, dpanic, panic, fatal.")
 
 	fs.BoolVar(&useDeprecatedInfraMachineNaming, "use-deprecated-infra-machine-naming", false,
 		"Use the deprecated naming convention for infra machines where they are named after the InfraMachineTemplate.")
@@ -389,6 +395,16 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
+	zapLogLevel, err := zapcore.ParseLevel(etcdLogLevel)
+	if err != nil {
+		setupLog.Error(err, "Unable to parse etcd log level")
+		os.Exit(1)
+	}
+	etcdLogger, err := logutil.CreateDefaultZapLogger(zapLogLevel)
+	if err != nil {
+		setupLog.Error(err, "unable to create etcd logger")
+		os.Exit(1)
+	}
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
 		Client:                       mgr.GetClient(),
 		SecretCachingClient:          secretCachingClient,
@@ -396,6 +412,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		WatchFilterValue:             watchFilterValue,
 		EtcdDialTimeout:              etcdDialTimeout,
 		EtcdCallTimeout:              etcdCallTimeout,
+		EtcdLogger:                   etcdLogger,
 		RemoteConditionsGracePeriod:  remoteConditionsGracePeriod,
 		DeprecatedInfraMachineNaming: useDeprecatedInfraMachineNaming,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This is manual backport of #12271 to release-1.9

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->