### PR TITLE
🌱 Improve CC RefVersionsUpToDate condition message

### DIFF
--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -463,10 +463,6 @@ func dropFalsePtrBool(in *clusterv1.JSONSchemaProps) *clusterv1.JSONSchemaProps 
 	return ret
 }
 
-func refString(ref *corev1.ObjectReference) string {
-	return fmt.Sprintf("%s %s/%s", ref.GroupVersionKind().String(), ref.Namespace, ref.Name)
-}
-
 func (r *Reconciler) reconcileExternal(ctx context.Context, clusterClass *clusterv1.ClusterClass, ref *corev1.ObjectReference) error {
 	obj, err := external.Get(ctx, r.Client, ref)
 	if err != nil {

--- a/internal/controllers/clusterclass/clusterclass_controller_status.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_status.go
@@ -50,9 +50,12 @@ func setRefVersionsUpToDateCondition(_ context.Context, clusterClass *clusterv1.
 	}
 
 	if len(outdatedRefs) > 0 {
-		var msg []string
+		var msg = []string{
+			"The following templateRefs are not using the latest apiVersion:",
+		}
 		for _, outdatedRef := range outdatedRefs {
-			msg = append(msg, fmt.Sprintf("* templateRef %q should be %q", refString(outdatedRef.Outdated), refString(outdatedRef.UpToDate)))
+			msg = append(msg, fmt.Sprintf("* %s %s: current: %s, latest: %s", outdatedRef.Outdated.Kind, outdatedRef.Outdated.Name,
+				outdatedRef.Outdated.GroupVersionKind().Version, outdatedRef.UpToDate.GroupVersionKind().Version))
 		}
 		v1beta1conditions.Set(clusterClass,
 			v1beta1conditions.FalseCondition(

--- a/internal/controllers/clusterclass/clusterclass_controller_status_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_status_test.go
@@ -81,10 +81,9 @@ func TestSetRefVersionsUpToDateCondition(t *testing.T) {
 				Type:   clusterv1.ClusterClassRefVersionsUpToDateCondition,
 				Status: metav1.ConditionFalse,
 				Reason: clusterv1.ClusterClassRefVersionsNotUpToDateReason,
-				Message: "* templateRef \"controlplane.cluster.x-k8s.io/v1beta2, Kind=KubeadmControlPlaneTemplate default/test-kcp\" should be " +
-					"\"controlplane.cluster.x-k8s.io/v99, Kind=KubeadmControlPlaneTemplate default/test-kcp\"\n" +
-					"* templateRef \"infrastructure.cluster.x-k8s.io/v1beta2, Kind=DockerMachineTemplate default/test-dmt\" should be " +
-					"\"infrastructure.cluster.x-k8s.io/v99, Kind=DockerMachineTemplate default/test-dmt\"",
+				Message: "The following templateRefs are not using the latest apiVersion:\n" +
+					"* KubeadmControlPlaneTemplate test-kcp: current: v1beta2, latest: v99\n" +
+					"* DockerMachineTemplate test-dmt: current: v1beta2, latest: v99",
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The current condition message makes it sound like it's an error to not use the latest apiVersion (which it is not).

So tried to rephrase a bit


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->