### PR TITLE
⚠️ Add Minimum=0 marker to all MinReadySeconds fields

### DIFF
--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -739,6 +739,7 @@ type MachineDeploymentTopology struct {
 	// Defaults to 0 (machine will be considered available as soon as it
 	// is ready)
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
@@ -842,6 +843,7 @@ type MachinePoolTopology struct {
 	// Defaults to 0 (machine will be considered available as soon as it
 	// is ready)
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// replicas is the number of nodes belonging to this pool.

--- a/api/core/v1beta2/clusterclass_types.go
+++ b/api/core/v1beta2/clusterclass_types.go
@@ -327,6 +327,7 @@ type MachineDeploymentClass struct {
 	// is ready)
 	// NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
@@ -497,6 +498,7 @@ type MachinePoolClass struct {
 	// is ready)
 	// NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 }
 

--- a/api/core/v1beta2/machine_types.go
+++ b/api/core/v1beta2/machine_types.go
@@ -427,6 +427,7 @@ type MachineSpec struct {
 	// minReadySeconds is the minimum number of seconds for which a Machine should be ready before considering it available.
 	// Defaults to 0 (Machine will be considered available as soon as the Machine is ready)
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
 	// readinessGates specifies additional conditions to include when evaluating Machine Ready condition.

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -4054,6 +4054,7 @@ spec:
                             is ready)
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
                           format: int32
+                          minimum: 0
                           type: integer
                         namingStrategy:
                           description: namingStrategy allows changing the naming pattern
@@ -4396,6 +4397,7 @@ spec:
                             is ready)
                             NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
                           format: int32
+                          minimum: 0
                           type: integer
                         namingStrategy:
                           description: namingStrategy allows changing the naming pattern

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -2906,6 +2906,7 @@ spec:
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
                               format: int32
+                              minimum: 0
                               type: integer
                             name:
                               description: |-
@@ -3187,6 +3188,7 @@ spec:
                                 Defaults to 0 (machine will be considered available as soon as it
                                 is ready)
                               format: int32
+                              minimum: 0
                               type: integer
                             name:
                               description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -2223,6 +2223,7 @@ spec:
                           minReadySeconds is the minimum number of seconds for which a Machine should be ready before considering it available.
                           Defaults to 0 (Machine will be considered available as soon as the Machine is ready)
                         format: int32
+                        minimum: 0
                         type: integer
                       nodeDeletionTimeoutSeconds:
                         description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1832,6 +1832,7 @@ spec:
                           minReadySeconds is the minimum number of seconds for which a Machine should be ready before considering it available.
                           Defaults to 0 (Machine will be considered available as soon as the Machine is ready)
                         format: int32
+                        minimum: 0
                         type: integer
                       nodeDeletionTimeoutSeconds:
                         description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1627,6 +1627,7 @@ spec:
                   minReadySeconds is the minimum number of seconds for which a Machine should be ready before considering it available.
                   Defaults to 0 (Machine will be considered available as soon as the Machine is ready)
                 format: int32
+                minimum: 0
                 type: integer
               nodeDeletionTimeoutSeconds:
                 description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1887,6 +1887,7 @@ spec:
                           minReadySeconds is the minimum number of seconds for which a Machine should be ready before considering it available.
                           Defaults to 0 (Machine will be considered available as soon as the Machine is ready)
                         format: int32
+                        minimum: 0
                         type: integer
                       nodeDeletionTimeoutSeconds:
                         description: |-


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->