### PR TITLE
⚠️ Change ClusterResourceSetBinding Bindings field from []*ResourceSetBinding to []ResourceSetBinding

### DIFF
--- a/api/addons/v1beta1/conversion.go
+++ b/api/addons/v1beta1/conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -103,6 +105,21 @@ func Convert_v1beta1_ClusterResourceSetStatus_To_v1beta2_ClusterResourceSetStatu
 		clusterv1beta1.Convert_v1beta1_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
 	}
 	return nil
+}
+
+func Convert_Pointer_v1beta1_ResourceSetBinding_To_v1beta2_ResourceSetBinding(in **ResourceSetBinding, out *addonsv1.ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || *in == nil {
+		return nil
+	}
+	return autoConvert_v1beta1_ResourceSetBinding_To_v1beta2_ResourceSetBinding(*in, out, s)
+}
+
+func Convert_v1beta2_ResourceSetBinding_To_Pointer_v1beta1_ResourceSetBinding(in *addonsv1.ResourceSetBinding, out **ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || reflect.DeepEqual(*in, addonsv1.ResourceSetBinding{}) {
+		return nil
+	}
+	*out = &ResourceSetBinding{}
+	return autoConvert_v1beta2_ResourceSetBinding_To_v1beta1_ResourceSetBinding(in, *out, s)
 }
 
 // Implement local conversion func because conversion-gen is not aware of conversion func in other packages (see https://github.com/kubernetes/code-generator/issues/94)

--- a/api/addons/v1beta1/conversion_test.go
+++ b/api/addons/v1beta1/conversion_test.go
@@ -39,8 +39,9 @@ func TestFuzzyConversion(t *testing.T) {
 		FuzzerFuncs: []fuzzer.FuzzerFuncs{ClusterResourceSetFuzzFuncs},
 	}))
 	t.Run("for ClusterResourceSetBinding", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
-		Hub:   &addonsv1.ClusterResourceSetBinding{},
-		Spoke: &ClusterResourceSetBinding{},
+		Hub:         &addonsv1.ClusterResourceSetBinding{},
+		Spoke:       &ClusterResourceSetBinding{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{ClusterResourceSetBindingFuzzFuncs},
 	}))
 }
 
@@ -67,6 +68,23 @@ func spokeClusterResourceSetStatus(in *ClusterResourceSetStatus, c randfill.Cont
 	if in.V1Beta2 != nil {
 		if reflect.DeepEqual(in.V1Beta2, &ClusterResourceSetV1Beta2Status{}) {
 			in.V1Beta2 = nil
+		}
+	}
+}
+
+func ClusterResourceSetBindingFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		hubClusterResourceSetStatus,
+		spokeClusterResourceSetBindingSpec,
+	}
+}
+
+func spokeClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	for i, b := range in.Bindings {
+		if b != nil && reflect.DeepEqual(*b, ResourceSetBinding{}) {
+			in.Bindings[i] = nil
 		}
 	}
 }

--- a/api/addons/v1beta1/zz_generated.conversion.go
+++ b/api/addons/v1beta1/zz_generated.conversion.go
@@ -128,6 +128,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((**ResourceSetBinding)(nil), (*v1beta2.ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Pointer_v1beta1_ResourceSetBinding_To_v1beta2_ResourceSetBinding(a.(**ResourceSetBinding), b.(*v1beta2.ResourceSetBinding), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1.Condition)(nil), (*corev1beta1.Condition)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1_Condition_To_v1beta1_Condition(a.(*v1.Condition), b.(*corev1beta1.Condition), scope)
 	}); err != nil {
@@ -145,6 +150,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1beta2.ClusterResourceSetStatus)(nil), (*ClusterResourceSetStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_ClusterResourceSetStatus_To_v1beta1_ClusterResourceSetStatus(a.(*v1beta2.ClusterResourceSetStatus), b.(*ClusterResourceSetStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.ResourceSetBinding)(nil), (**ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_ResourceSetBinding_To_Pointer_v1beta1_ResourceSetBinding(a.(*v1beta2.ResourceSetBinding), b.(**ResourceSetBinding), scope)
 	}); err != nil {
 		return err
 	}
@@ -211,7 +221,17 @@ func Convert_v1beta2_ClusterResourceSetBinding_To_v1beta1_ClusterResourceSetBind
 
 func autoConvert_v1beta1_ClusterResourceSetBindingList_To_v1beta2_ClusterResourceSetBindingList(in *ClusterResourceSetBindingList, out *v1beta2.ClusterResourceSetBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta2.ClusterResourceSetBinding)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta2.ClusterResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_ClusterResourceSetBinding_To_v1beta2_ClusterResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -222,7 +242,17 @@ func Convert_v1beta1_ClusterResourceSetBindingList_To_v1beta2_ClusterResourceSet
 
 func autoConvert_v1beta2_ClusterResourceSetBindingList_To_v1beta1_ClusterResourceSetBindingList(in *v1beta2.ClusterResourceSetBindingList, out *ClusterResourceSetBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterResourceSetBinding)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]ClusterResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_ClusterResourceSetBinding_To_v1beta1_ClusterResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -232,7 +262,17 @@ func Convert_v1beta2_ClusterResourceSetBindingList_To_v1beta1_ClusterResourceSet
 }
 
 func autoConvert_v1beta1_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, out *v1beta2.ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*v1beta2.ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]v1beta2.ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_Pointer_v1beta1_ResourceSetBinding_To_v1beta2_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	out.ClusterName = in.ClusterName
 	return nil
 }
@@ -243,7 +283,17 @@ func Convert_v1beta1_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSet
 }
 
 func autoConvert_v1beta2_ClusterResourceSetBindingSpec_To_v1beta1_ClusterResourceSetBindingSpec(in *v1beta2.ClusterResourceSetBindingSpec, out *ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]*ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_ResourceSetBinding_To_Pointer_v1beta1_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	out.ClusterName = in.ClusterName
 	return nil
 }

--- a/api/addons/v1beta2/clusterresourcesetbinding_types.go
+++ b/api/addons/v1beta2/clusterresourcesetbinding_types.go
@@ -92,14 +92,14 @@ func (r *ResourceSetBinding) SetBinding(resourceBinding ResourceBinding) {
 // GetOrCreateBinding returns the ResourceSetBinding for a given ClusterResourceSet if exists,
 // otherwise creates one and updates ClusterResourceSet with it.
 func (c *ClusterResourceSetBinding) GetOrCreateBinding(clusterResourceSet *ClusterResourceSet) *ResourceSetBinding {
-	for _, binding := range c.Spec.Bindings {
-		if binding.ClusterResourceSetName == clusterResourceSet.Name {
-			return binding
+	for i := range c.Spec.Bindings {
+		if c.Spec.Bindings[i].ClusterResourceSetName == clusterResourceSet.Name {
+			return &c.Spec.Bindings[i]
 		}
 	}
-	binding := &ResourceSetBinding{ClusterResourceSetName: clusterResourceSet.Name, Resources: []ResourceBinding{}}
+	binding := ResourceSetBinding{ClusterResourceSetName: clusterResourceSet.Name, Resources: []ResourceBinding{}}
 	c.Spec.Bindings = append(c.Spec.Bindings, binding)
-	return binding
+	return &c.Spec.Bindings[len(c.Spec.Bindings)-1]
 }
 
 // RemoveBinding removes the ClusterResourceSet from the ClusterResourceSetBinding Bindings list.
@@ -138,7 +138,7 @@ type ClusterResourceSetBindingSpec struct {
 	// bindings is a list of ClusterResourceSets and their resources.
 	// +optional
 	// +kubebuilder:validation:MaxItems=100
-	Bindings []*ResourceSetBinding `json:"bindings,omitempty"`
+	Bindings []ResourceSetBinding `json:"bindings,omitempty"`
 
 	// clusterName is the name of the Cluster this binding applies to.
 	// +required

--- a/api/addons/v1beta2/zz_generated.deepcopy.go
+++ b/api/addons/v1beta2/zz_generated.deepcopy.go
@@ -116,13 +116,9 @@ func (in *ClusterResourceSetBindingSpec) DeepCopyInto(out *ClusterResourceSetBin
 	*out = *in
 	if in.Bindings != nil {
 		in, out := &in.Bindings, &out.Bindings
-		*out = make([]*ResourceSetBinding, len(*in))
+		*out = make([]ResourceSetBinding, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ResourceSetBinding)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1195,7 +1195,7 @@ func (f *FakeClusterResourceSet) Objs() []client.Object {
 			},
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
 				ClusterName: cluster.Name,
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{
 						ClusterResourceSetName: crs.Name,
 					},
@@ -1219,7 +1219,7 @@ func (f *FakeClusterResourceSet) Objs() []client.Object {
 			ClusterResourceSetName: crs.Name,
 			Resources:              []addonsv1.ResourceBinding{},
 		}
-		binding.Spec.Bindings = append(binding.Spec.Bindings, &resourceSetBinding)
+		binding.Spec.Bindings = append(binding.Spec.Bindings, resourceSetBinding)
 
 		// creates map entries for each cluster/resource of type Secret
 		for _, secret := range f.secrets {

--- a/internal/api/addons/v1alpha3/conversion.go
+++ b/internal/api/addons/v1alpha3/conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -117,6 +119,21 @@ func Convert_v1beta2_ClusterResourceSetBindingSpec_To_v1alpha3_ClusterResourceSe
 func Convert_v1beta2_ClusterResourceSetStatus_To_v1alpha3_ClusterResourceSetStatus(in *addonsv1.ClusterResourceSetStatus, out *ClusterResourceSetStatus, s apimachineryconversion.Scope) error {
 	// V1Beta2 was added in v1beta1
 	return autoConvert_v1beta2_ClusterResourceSetStatus_To_v1alpha3_ClusterResourceSetStatus(in, out, s)
+}
+
+func Convert_Pointer_v1alpha3_ResourceSetBinding_To_v1beta2_ResourceSetBinding(in **ResourceSetBinding, out *addonsv1.ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || *in == nil {
+		return nil
+	}
+	return autoConvert_v1alpha3_ResourceSetBinding_To_v1beta2_ResourceSetBinding(*in, out, s)
+}
+
+func Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha3_ResourceSetBinding(in *addonsv1.ResourceSetBinding, out **ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || reflect.DeepEqual(*in, addonsv1.ResourceSetBinding{}) {
+		return nil
+	}
+	*out = &ResourceSetBinding{}
+	return autoConvert_v1beta2_ResourceSetBinding_To_v1alpha3_ResourceSetBinding(in, *out, s)
 }
 
 // Implement local conversion func because conversion-gen is not aware of conversion func in other packages (see https://github.com/kubernetes/code-generator/issues/94)

--- a/internal/api/addons/v1alpha3/conversion_test.go
+++ b/internal/api/addons/v1alpha3/conversion_test.go
@@ -41,6 +41,7 @@ func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSetBinding", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:   &addonsv1.ClusterResourceSetBinding{},
 		Spoke: &ClusterResourceSetBinding{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{ClusterResourceSetBindingFuzzFuncs},
 	}))
 }
 
@@ -56,6 +57,23 @@ func hubClusterResourceSetStatus(in *addonsv1.ClusterResourceSetStatus, c randfi
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &addonsv1.ClusterResourceSetV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
+		}
+	}
+}
+
+func ClusterResourceSetBindingFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		hubClusterResourceSetStatus,
+		spokeClusterResourceSetBindingSpec,
+	}
+}
+
+func spokeClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	for i, b := range in.Bindings {
+		if b != nil && reflect.DeepEqual(*b, ResourceSetBinding{}) {
+			in.Bindings[i] = nil
 		}
 	}
 }

--- a/internal/api/addons/v1alpha3/zz_generated.conversion.go
+++ b/internal/api/addons/v1alpha3/zz_generated.conversion.go
@@ -128,6 +128,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((**ResourceSetBinding)(nil), (*v1beta2.ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Pointer_v1alpha3_ResourceSetBinding_To_v1beta2_ResourceSetBinding(a.(**ResourceSetBinding), b.(*v1beta2.ResourceSetBinding), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1.Condition)(nil), (*corev1alpha3.Condition)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1_Condition_To_v1alpha3_Condition(a.(*v1.Condition), b.(*corev1alpha3.Condition), scope)
 	}); err != nil {
@@ -145,6 +150,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1beta2.ClusterResourceSetStatus)(nil), (*ClusterResourceSetStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_ClusterResourceSetStatus_To_v1alpha3_ClusterResourceSetStatus(a.(*v1beta2.ClusterResourceSetStatus), b.(*ClusterResourceSetStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.ResourceSetBinding)(nil), (**ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha3_ResourceSetBinding(a.(*v1beta2.ResourceSetBinding), b.(**ResourceSetBinding), scope)
 	}); err != nil {
 		return err
 	}
@@ -252,7 +262,17 @@ func Convert_v1beta2_ClusterResourceSetBindingList_To_v1alpha3_ClusterResourceSe
 }
 
 func autoConvert_v1alpha3_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, out *v1beta2.ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*v1beta2.ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]v1beta2.ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_Pointer_v1alpha3_ResourceSetBinding_To_v1beta2_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	return nil
 }
 
@@ -262,7 +282,17 @@ func Convert_v1alpha3_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSe
 }
 
 func autoConvert_v1beta2_ClusterResourceSetBindingSpec_To_v1alpha3_ClusterResourceSetBindingSpec(in *v1beta2.ClusterResourceSetBindingSpec, out *ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]*ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha3_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	// WARNING: in.ClusterName requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/internal/api/addons/v1alpha4/conversion.go
+++ b/internal/api/addons/v1alpha4/conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha4
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -118,6 +120,21 @@ func Convert_v1beta2_ClusterResourceSetBindingSpec_To_v1alpha4_ClusterResourceSe
 func Convert_v1beta2_ClusterResourceSetStatus_To_v1alpha4_ClusterResourceSetStatus(in *addonsv1.ClusterResourceSetStatus, out *ClusterResourceSetStatus, s apimachineryconversion.Scope) error {
 	// V1Beta2 was added in v1beta1
 	return autoConvert_v1beta2_ClusterResourceSetStatus_To_v1alpha4_ClusterResourceSetStatus(in, out, s)
+}
+
+func Convert_Pointer_v1alpha4_ResourceSetBinding_To_v1beta2_ResourceSetBinding(in **ResourceSetBinding, out *addonsv1.ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || *in == nil {
+		return nil
+	}
+	return autoConvert_v1alpha4_ResourceSetBinding_To_v1beta2_ResourceSetBinding(*in, out, s)
+}
+
+func Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha4_ResourceSetBinding(in *addonsv1.ResourceSetBinding, out **ResourceSetBinding, s apimachineryconversion.Scope) error {
+	if in == nil || reflect.DeepEqual(*in, addonsv1.ResourceSetBinding{}) {
+		return nil
+	}
+	*out = &ResourceSetBinding{}
+	return autoConvert_v1beta2_ResourceSetBinding_To_v1alpha4_ResourceSetBinding(in, *out, s)
 }
 
 // Implement local conversion func because conversion-gen is not aware of conversion func in other packages (see https://github.com/kubernetes/code-generator/issues/94)

--- a/internal/api/addons/v1alpha4/conversion_test.go
+++ b/internal/api/addons/v1alpha4/conversion_test.go
@@ -41,6 +41,7 @@ func TestFuzzyConversion(t *testing.T) {
 	t.Run("for ClusterResourceSetBinding", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
 		Hub:   &addonsv1.ClusterResourceSetBinding{},
 		Spoke: &ClusterResourceSetBinding{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{ClusterResourceSetBindingFuzzFuncs},
 	}))
 }
 
@@ -56,6 +57,23 @@ func hubClusterResourceSetStatus(in *addonsv1.ClusterResourceSetStatus, c randfi
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &addonsv1.ClusterResourceSetV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
+		}
+	}
+}
+
+func ClusterResourceSetBindingFuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
+	return []interface{}{
+		hubClusterResourceSetStatus,
+		spokeClusterResourceSetBindingSpec,
+	}
+}
+
+func spokeClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, c randfill.Continue) {
+	c.FillNoCustom(in)
+
+	for i, b := range in.Bindings {
+		if b != nil && reflect.DeepEqual(*b, ResourceSetBinding{}) {
+			in.Bindings[i] = nil
 		}
 	}
 }

--- a/internal/api/addons/v1alpha4/zz_generated.conversion.go
+++ b/internal/api/addons/v1alpha4/zz_generated.conversion.go
@@ -128,6 +128,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((**ResourceSetBinding)(nil), (*v1beta2.ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_Pointer_v1alpha4_ResourceSetBinding_To_v1beta2_ResourceSetBinding(a.(**ResourceSetBinding), b.(*v1beta2.ResourceSetBinding), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1.Condition)(nil), (*corev1alpha4.Condition)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1_Condition_To_v1alpha4_Condition(a.(*v1.Condition), b.(*corev1alpha4.Condition), scope)
 	}); err != nil {
@@ -145,6 +150,11 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*v1beta2.ClusterResourceSetStatus)(nil), (*ClusterResourceSetStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta2_ClusterResourceSetStatus_To_v1alpha4_ClusterResourceSetStatus(a.(*v1beta2.ClusterResourceSetStatus), b.(*ClusterResourceSetStatus), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta2.ResourceSetBinding)(nil), (**ResourceSetBinding)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha4_ResourceSetBinding(a.(*v1beta2.ResourceSetBinding), b.(**ResourceSetBinding), scope)
 	}); err != nil {
 		return err
 	}
@@ -252,7 +262,17 @@ func Convert_v1beta2_ClusterResourceSetBindingList_To_v1alpha4_ClusterResourceSe
 }
 
 func autoConvert_v1alpha4_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSetBindingSpec(in *ClusterResourceSetBindingSpec, out *v1beta2.ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*v1beta2.ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]v1beta2.ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_Pointer_v1alpha4_ResourceSetBinding_To_v1beta2_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	return nil
 }
 
@@ -262,7 +282,17 @@ func Convert_v1alpha4_ClusterResourceSetBindingSpec_To_v1beta2_ClusterResourceSe
 }
 
 func autoConvert_v1beta2_ClusterResourceSetBindingSpec_To_v1alpha4_ClusterResourceSetBindingSpec(in *v1beta2.ClusterResourceSetBindingSpec, out *ClusterResourceSetBindingSpec, s conversion.Scope) error {
-	out.Bindings = *(*[]*ResourceSetBinding)(unsafe.Pointer(&in.Bindings))
+	if in.Bindings != nil {
+		in, out := &in.Bindings, &out.Bindings
+		*out = make([]*ResourceSetBinding, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta2_ResourceSetBinding_To_Pointer_v1alpha4_ResourceSetBinding(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Bindings = nil
+	}
 	// WARNING: in.ClusterName requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/internal/controllers/clusterresourceset/clusterresourceset_helpers_test.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_helpers_test.go
@@ -51,7 +51,7 @@ func TestGetorCreateClusterResourceSetBinding(t *testing.T) {
 			Name:      testClusterWithBinding.Name,
 		},
 		Spec: addonsv1.ClusterResourceSetBindingSpec{
-			Bindings: []*addonsv1.ResourceSetBinding{
+			Bindings: []addonsv1.ResourceSetBinding{
 				{
 					ClusterResourceSetName: "test-clusterResourceSet",
 					Resources: []addonsv1.ResourceBinding{

--- a/test/framework/clusterresourceset_helpers.go
+++ b/test/framework/clusterresourceset_helpers.go
@@ -169,7 +169,7 @@ func getResourceSetBindingForClusterResourceSet(
 	}
 	for _, binding := range clusterResourceSetBinding.Spec.Bindings {
 		if binding.ClusterResourceSetName == clusterResourceSet.Name {
-			return binding
+			return &binding
 		}
 	}
 	return nil

--- a/test/framework/clusterresourceset_helpers_test.go
+++ b/test/framework/clusterresourceset_helpers_test.go
@@ -51,7 +51,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with no matching bindings",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "bar"},
 				},
 			},
@@ -62,7 +62,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with single matching bindings",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "foo"},
 				},
 			},
@@ -73,7 +73,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with multiple bindings with match at index 0",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "foo"},
 					{ClusterResourceSetName: "bar"},
 				},
@@ -85,7 +85,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with multiple bindings with match at index 1",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "bar"},
 					{ClusterResourceSetName: "foo"},
 				},
@@ -97,7 +97,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with multiple bindings with match at middle index",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "bar"},
 					{ClusterResourceSetName: "foo"},
 					{ClusterResourceSetName: "baz"},
@@ -110,7 +110,7 @@ func Test_getResourceSetBindingForClusterResourceSet(t *testing.T) {
 		name: "CRSB with multiple bindings with match at last index",
 		inputCRSB: &addonsv1.ClusterResourceSetBinding{
 			Spec: addonsv1.ClusterResourceSetBindingSpec{
-				Bindings: []*addonsv1.ResourceSetBinding{
+				Bindings: []addonsv1.ResourceSetBinding{
 					{ClusterResourceSetName: "bar"},
 					{ClusterResourceSetName: "baz"},
 					{ClusterResourceSetName: "foo"},


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
One of the more interesting conversion PRs..


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->