### PR TITLE
🌱 Remove redundant check in verifyV1Beta2ConditionsTrueV1Beta1

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -832,19 +832,17 @@ func verifyV1Beta2ConditionsTrueV1Beta1(ctx context.Context, c client.Client, cl
 				clusterv1.ClusterNameLabel: clusterName,
 			})
 	}, 3*time.Minute, 3*time.Second).Should(Succeed(), "Failed to list Machines for Cluster %s", klog.KObj(cluster))
-	if cluster.Status.V1Beta2 != nil && len(cluster.Status.V1Beta2.Conditions) > 0 {
-		for _, machine := range machineList.Items {
-			if machine.Status.V1Beta2 == nil || len(machine.Status.V1Beta2.Conditions) == 0 {
-				continue
-			}
-			for _, conditionType := range v1beta2conditionTypes {
-				for _, condition := range machine.Status.V1Beta2.Conditions {
-					if condition.Type != conditionType {
-						continue
-					}
-					Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The v1beta2 condition %q on the Machine %q should be set to true", conditionType, machine.Name)
-					Expect(condition.Message).To(BeEmpty(), "The v1beta2 condition %q on the Machine %q should have an empty message", conditionType, machine.Name)
+	for _, machine := range machineList.Items {
+		if machine.Status.V1Beta2 == nil || len(machine.Status.V1Beta2.Conditions) == 0 {
+			continue
+		}
+		for _, conditionType := range v1beta2conditionTypes {
+			for _, condition := range machine.Status.V1Beta2.Conditions {
+				if condition.Type != conditionType {
+					continue
 				}
+				Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The v1beta2 condition %q on the Machine %q should be set to true", conditionType, machine.Name)
+				Expect(condition.Message).To(BeEmpty(), "The v1beta2 condition %q on the Machine %q should have an empty message", conditionType, machine.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Small follow-up to #12100


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->