### PR TITLE
✨ Remove pointer, add omitzero & MinProperties for initialization fields/structs

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -159,7 +159,7 @@ linters:
         - kubeapilinter
     # KAL does not handle omitzero correctly yet: https://github.com/kubernetes-sigs/kube-api-linter/pull/115
     - path: "api/.*"
-      text: "optionalfields: field Status is optional and should (be a pointer|have the omitempty tag)"
+      text: "optionalfields: field (Status|Initialization) is optional and should (be a pointer|have the omitempty tag)"
       linters:
         - kubeapilinter
     - path: "api/bootstrap/kubeadm/v1beta2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -168,6 +168,10 @@ linters:
         # CAPI utils
         - pkg: sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1
           alias: v1beta1conditions
+        - pkg: sigs.k8s.io/cluster-api/util/conditions
+          alias: ""
+        - pkg: sigs.k8s.io/cluster-api/util/patch
+          alias: ""
         - pkg: sigs.k8s.io/cluster-api/internal/topology/names
           alias: topologynames
         # CAPD

--- a/api/bootstrap/kubeadm/v1beta1/conversion.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion.go
@@ -47,13 +47,10 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := bootstrapv1.KubeadmConfigInitializationStatus{}
-	var restoredBootstrapDataSecretCreated *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.DataSecretCreated
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.DataSecretCreated
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Ready, ok, restoredBootstrapDataSecretCreated, &initialization.DataSecretCreated)
 	if !reflect.DeepEqual(initialization, bootstrapv1.KubeadmConfigInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 	if err := RestoreBoolIntentKubeadmConfigSpec(&src.Spec, &dst.Spec, ok, &restored.Spec); err != nil {
 		return err
@@ -363,9 +360,7 @@ func Convert_v1beta2_KubeadmConfigStatus_To_v1beta1_KubeadmConfigStatus(in *boot
 	}
 
 	// Move initialization to old fields
-	if in.Initialization != nil {
-		out.Ready = ptr.Deref(in.Initialization.DataSecretCreated, false)
-	}
+	out.Ready = ptr.Deref(in.Initialization.DataSecretCreated, false)
 
 	// Move new conditions (v1beta2) to the v1beta2 field.
 	if in.Conditions == nil {

--- a/api/bootstrap/kubeadm/v1beta1/conversion_test.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion_test.go
@@ -102,13 +102,6 @@ func hubKubeadmConfigStatus(in *bootstrapv1.KubeadmConfigStatus, c randfill.Cont
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &bootstrapv1.KubeadmConfigV1Beta1DeprecatedStatus{}
 	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &bootstrapv1.KubeadmConfigInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func hubKubeadmConfigSpec(in *bootstrapv1.KubeadmConfigSpec, c randfill.Continue) {

--- a/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
@@ -470,7 +470,7 @@ type KubeadmConfigStatus struct {
 	// initialization provides observations of the KubeadmConfig initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
 	// +optional
-	Initialization *KubeadmConfigInitializationStatus `json:"initialization,omitempty"`
+	Initialization KubeadmConfigInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// dataSecretName is the name of the secret that stores the bootstrap data script.
 	// +optional
@@ -489,6 +489,7 @@ type KubeadmConfigStatus struct {
 }
 
 // KubeadmConfigInitializationStatus provides observations of the KubeadmConfig initialization process.
+// +kubebuilder:validation:MinProperties=1
 type KubeadmConfigInitializationStatus struct {
 	// dataSecretCreated is true when the Machine's boostrap secret is created.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.

--- a/api/bootstrap/kubeadm/v1beta2/zz_generated.deepcopy.go
+++ b/api/bootstrap/kubeadm/v1beta2/zz_generated.deepcopy.go
@@ -957,11 +957,7 @@ func (in *KubeadmConfigStatus) DeepCopyInto(out *KubeadmConfigStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(KubeadmConfigInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.Deprecated != nil {
 		in, out := &in.Deprecated, &out.Deprecated
 		*out = new(KubeadmConfigDeprecatedStatus)

--- a/api/controlplane/kubeadm/v1beta1/conversion.go
+++ b/api/controlplane/kubeadm/v1beta1/conversion.go
@@ -65,13 +65,10 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := controlplanev1.KubeadmControlPlaneInitializationStatus{}
-	var restoredControlPlaneInitialized *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Initialized, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	if !reflect.DeepEqual(initialization, controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	if err := bootstrapv1beta1.RestoreBoolIntentKubeadmConfigSpec(&src.Spec.KubeadmConfigSpec, &dst.Spec.KubeadmConfigSpec, ok, &restored.Spec.KubeadmConfigSpec); err != nil {
@@ -201,9 +198,7 @@ func Convert_v1beta2_KubeadmControlPlaneStatus_To_v1beta1_KubeadmControlPlaneSta
 	}
 
 	// Move initialized to ControlPlaneInitialized, rebuild ready
-	if in.Initialization != nil {
-		out.Initialized = ptr.Deref(in.Initialization.ControlPlaneInitialized, false)
-	}
+	out.Initialized = ptr.Deref(in.Initialization.ControlPlaneInitialized, false)
 	out.Ready = out.ReadyReplicas > 0
 
 	// Move new conditions (v1beta2) and replica counter to the v1beta2 field.

--- a/api/controlplane/kubeadm/v1beta1/conversion_test.go
+++ b/api/controlplane/kubeadm/v1beta1/conversion_test.go
@@ -174,13 +174,6 @@ func hubKubeadmControlPlaneStatus(in *controlplanev1.KubeadmControlPlaneStatus, 
 		in.Deprecated.V1Beta1 = &controlplanev1.KubeadmControlPlaneV1Beta1DeprecatedStatus{}
 	}
 
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
-
 	// nil becomes &0 after hub => spoke => hub conversion
 	// This is acceptable as usually Replicas is set and controllers using older apiVersions are not writing MachineSet status.
 	if in.Replicas == nil {

--- a/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
+++ b/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
@@ -637,7 +637,7 @@ type KubeadmControlPlaneStatus struct {
 	// initialization provides observations of the KubeadmControlPlane initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
 	// +optional
-	Initialization *KubeadmControlPlaneInitializationStatus `json:"initialization,omitempty"`
+	Initialization KubeadmControlPlaneInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// selector is the label selector in string format to avoid introspection
 	// by clients, and is used to provide the CRD-based integration for the
@@ -688,6 +688,7 @@ type KubeadmControlPlaneStatus struct {
 }
 
 // KubeadmControlPlaneInitializationStatus provides observations of the KubeadmControlPlane initialization process.
+// +kubebuilder:validation:MinProperties=1
 type KubeadmControlPlaneInitializationStatus struct {
 	// controlPlaneInitialized is true when the KubeadmControlPlane provider reports that the Kubernetes control plane is initialized;
 	// A control plane is considered initialized when it can accept requests, no matter if this happens before

--- a/api/controlplane/kubeadm/v1beta2/zz_generated.deepcopy.go
+++ b/api/controlplane/kubeadm/v1beta2/zz_generated.deepcopy.go
@@ -219,11 +219,7 @@ func (in *KubeadmControlPlaneStatus) DeepCopyInto(out *KubeadmControlPlaneStatus
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(KubeadmControlPlaneInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.Replicas != nil {
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)

--- a/api/core/v1beta1/conversion.go
+++ b/api/core/v1beta1/conversion.go
@@ -77,15 +77,12 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 	clusterv1.Convert_bool_To_Pointer_bool(src.Spec.Paused, ok, restored.Spec.Paused, &dst.Spec.Paused)
 
 	initialization := clusterv1.ClusterInitializationStatus{}
-	var restoredControlPlaneInitialized, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.ControlPlaneReady, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.ClusterInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 	return nil
 }
@@ -381,15 +378,12 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachineInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachineInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	// Recover other values.
@@ -553,15 +547,12 @@ func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachinePoolInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachinePoolInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	return nil
@@ -917,10 +908,8 @@ func Convert_v1beta2_ClusterStatus_To_v1beta1_ClusterStatus(in *clusterv1.Cluste
 	}
 
 	// Move initialization to old fields
-	if in.Initialization != nil {
-		out.ControlPlaneReady = ptr.Deref(in.Initialization.ControlPlaneInitialized, false)
-		out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
-	}
+	out.ControlPlaneReady = ptr.Deref(in.Initialization.ControlPlaneInitialized, false)
+	out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
 
 	// Move FailureDomains
 	if in.FailureDomains != nil {
@@ -1316,10 +1305,8 @@ func Convert_v1beta2_MachineStatus_To_v1beta1_MachineStatus(in *clusterv1.Machin
 	}
 
 	// Move initialization to old fields
-	if in.Initialization != nil {
-		out.BootstrapReady = ptr.Deref(in.Initialization.BootstrapDataSecretCreated, false)
-		out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
-	}
+	out.BootstrapReady = ptr.Deref(in.Initialization.BootstrapDataSecretCreated, false)
+	out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
 
 	// Move new conditions (v1beta2) to the v1beta2 field.
 	if in.Conditions == nil {
@@ -1436,10 +1423,8 @@ func Convert_v1beta2_MachinePoolStatus_To_v1beta1_MachinePoolStatus(in *clusterv
 	}
 
 	// Move initialization to old fields
-	if in.Initialization != nil {
-		out.BootstrapReady = ptr.Deref(in.Initialization.BootstrapDataSecretCreated, false)
-		out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
-	}
+	out.BootstrapReady = ptr.Deref(in.Initialization.BootstrapDataSecretCreated, false)
+	out.InfrastructureReady = ptr.Deref(in.Initialization.InfrastructureProvisioned, false)
 
 	// Move new conditions (v1beta2) and replica counters to the v1beta2 field.
 	if in.Conditions == nil && in.ReadyReplicas == nil && in.AvailableReplicas == nil && in.UpToDateReplicas == nil {

--- a/api/core/v1beta1/conversion_test.go
+++ b/api/core/v1beta1/conversion_test.go
@@ -136,13 +136,6 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c randfill.Continue) {
 		}
 	}
 
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.ClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
-
 	if len(in.FailureDomains) > 0 {
 		in.FailureDomains = nil // Remove all pre-existing potentially invalid FailureDomains
 		for i := range c.Int31n(20) {
@@ -456,13 +449,6 @@ func hubMachineStatus(in *clusterv1.MachineStatus, c randfill.Continue) {
 			in.Deprecated = nil
 		}
 	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachineInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func spokeMachine(in *Machine, c randfill.Continue) {
@@ -701,13 +687,6 @@ func hubMachinePoolStatus(in *clusterv1.MachinePoolStatus, c randfill.Continue) 
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachinePoolInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 
 	// nil becomes &0 after hub => spoke => hub conversion

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -976,7 +976,7 @@ type ClusterStatus struct {
 	// initialization provides observations of the Cluster initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
 	// +optional
-	Initialization *ClusterInitializationStatus `json:"initialization,omitempty"`
+	Initialization ClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// controlPlane groups all the observations about Cluster's ControlPlane current state.
 	// +optional
@@ -1011,6 +1011,7 @@ type ClusterStatus struct {
 
 // ClusterInitializationStatus provides observations of the Cluster initialization process.
 // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
+// +kubebuilder:validation:MinProperties=1
 type ClusterInitializationStatus struct {
 	// infrastructureProvisioned is true when the infrastructure provider reports that Cluster's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate provisioning.

--- a/api/core/v1beta2/machine_types.go
+++ b/api/core/v1beta2/machine_types.go
@@ -513,7 +513,7 @@ type MachineStatus struct {
 	// initialization provides observations of the Machine initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
 	// +optional
-	Initialization *MachineInitializationStatus `json:"initialization,omitempty"`
+	Initialization MachineInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// nodeRef will point to the corresponding Node if it exists.
 	// +optional
@@ -571,6 +571,7 @@ type MachineNodeReference struct {
 
 // MachineInitializationStatus provides observations of the Machine initialization process.
 // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+// +kubebuilder:validation:MinProperties=1
 type MachineInitializationStatus struct {
 	// infrastructureProvisioned is true when the infrastructure provider reports that Machine's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate provisioning.

--- a/api/core/v1beta2/machinepool_types.go
+++ b/api/core/v1beta2/machinepool_types.go
@@ -120,7 +120,7 @@ type MachinePoolStatus struct {
 	// initialization provides observations of the MachinePool initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial MachinePool provisioning.
 	// +optional
-	Initialization *MachinePoolInitializationStatus `json:"initialization,omitempty"`
+	Initialization MachinePoolInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// nodeRefs will point to the corresponding Nodes if it they exist.
 	// +optional
@@ -161,6 +161,7 @@ type MachinePoolStatus struct {
 
 // MachinePoolInitializationStatus provides observations of the MachinePool initialization process.
 // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial MachinePool provisioning.
+// +kubebuilder:validation:MinProperties=1
 type MachinePoolInitializationStatus struct {
 	// infrastructureProvisioned is true when the infrastructure provider reports that MachinePool's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate provisioning.

--- a/api/core/v1beta2/zz_generated.deepcopy.go
+++ b/api/core/v1beta2/zz_generated.deepcopy.go
@@ -633,11 +633,7 @@ func (in *ClusterStatus) DeepCopyInto(out *ClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(ClusterInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.ControlPlane != nil {
 		in, out := &in.ControlPlane, &out.ControlPlane
 		*out = new(ClusterControlPlaneStatus)
@@ -2486,11 +2482,7 @@ func (in *MachinePoolStatus) DeepCopyInto(out *MachinePoolStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(MachinePoolInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.NodeRefs != nil {
 		in, out := &in.NodeRefs, &out.NodeRefs
 		*out = make([]corev1.ObjectReference, len(*in))
@@ -2915,11 +2907,7 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(MachineInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.NodeRef != nil {
 		in, out := &in.NodeRef, &out.NodeRef
 		*out = new(MachineNodeReference)

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -1215,6 +1215,7 @@ func schema_cluster_api_api_core_v1beta2_ClusterStatus(ref common.ReferenceCallb
 					"initialization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "initialization provides observations of the Cluster initialization process. NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/core/v1beta2.ClusterInitializationStatus"),
 						},
 					},
@@ -4374,6 +4375,7 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolStatus(ref common.ReferenceC
 					"initialization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "initialization provides observations of the MachinePool initialization process. NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial MachinePool provisioning.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/core/v1beta2.MachinePoolInitializationStatus"),
 						},
 					},
@@ -5190,6 +5192,7 @@ func schema_cluster_api_api_core_v1beta2_MachineStatus(ref common.ReferenceCallb
 					"initialization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "initialization provides observations of the Machine initialization process. NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/core/v1beta2.MachineInitializationStatus"),
 						},
 					},

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -6365,6 +6365,7 @@ spec:
                 description: |-
                   initialization provides observations of the KubeadmConfig initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                minProperties: 1
                 properties:
                   dataSecretCreated:
                     description: |-

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -95,12 +95,12 @@ func TestKubeadmConfigReconciler_MachineToBootstrapMapFuncReturn(t *testing.T) {
 func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfKubeadmConfigIsReady(t *testing.T) {
 	g := NewWithT(t)
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	machine := builder.Machine(metav1.NamespaceDefault, "m1").WithClusterName("cluster1").Build()
 	config := newKubeadmConfig(metav1.NamespaceDefault, "cfg")
 	addKubeadmConfigToMachine(config, machine)
 
-	config.Status.Initialization = &bootstrapv1.KubeadmConfigInitializationStatus{DataSecretCreated: ptr.To(true)}
+	config.Status.Initialization.DataSecretCreated = ptr.To(true)
 
 	objects := []client.Object{
 		cluster,
@@ -155,7 +155,7 @@ func TestKubeadmConfigReconciler_TestSecretOwnerReferenceReconciliation(t *testi
 		},
 		Type: corev1.SecretTypeBootstrapToken,
 	}
-	config.Status.Initialization = &bootstrapv1.KubeadmConfigInitializationStatus{DataSecretCreated: ptr.To(true)}
+	config.Status.Initialization.DataSecretCreated = ptr.To(true)
 
 	objects := []client.Object{
 		config,
@@ -264,7 +264,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfReferencedMachineIsNotFoun
 func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasDataSecretName(t *testing.T) {
 	g := NewWithT(t)
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 	machine := builder.Machine(metav1.NamespaceDefault, "machine").
 		WithVersion("v1.23.1").
@@ -315,7 +315,7 @@ func TestKubeadmConfigReconciler_ReturnEarlyIfClusterInfraNotReady(t *testing.T)
 	addKubeadmConfigToMachine(config, machine)
 
 	// cluster infra not ready
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(false)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(false)
 
 	objects := []client.Object{
 		cluster,
@@ -412,7 +412,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfAssociatedClusterIsNotFoun
 // If the control plane isn't initialized then there is no cluster for either a worker or control plane node to join.
 func TestKubeadmConfigReconciler_Reconcile_RequeueJoiningNodesIfControlPlaneNotInitialized(t *testing.T) {
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 	workerMachine := newWorkerMachineForCluster(cluster)
 	workerJoinConfig := newWorkerJoinKubeadmConfig(metav1.NamespaceDefault, "worker-join-cfg")
@@ -484,7 +484,7 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 	configName := "control-plane-init-cfg"
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "validhost", Port: 6443}
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 
 	controlPlaneInitMachine := newControlPlaneMachine(cluster, "control-plane-init-machine")
@@ -528,7 +528,6 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 
 	cfg, err := getKubeadmConfig(myclient, "control-plane-init-cfg", metav1.NamespaceDefault)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 	g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -548,7 +547,7 @@ func TestKubeadmConfigReconciler_Reconcile_ErrorIfJoiningControlPlaneHasInvalidC
 	g := NewWithT(t)
 	// TODO: extract this kind of code into a setup function that puts the state of objects into an initialized controlplane (implies secrets exist)
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 	controlPlaneInitMachine := newControlPlaneMachine(cluster, "control-plane-init-machine")
@@ -594,7 +593,7 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueIfControlPlaneIsMissingAPIEndp
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	controlPlaneInitMachine := newControlPlaneMachine(cluster, "control-plane-init-machine")
 	controlPlaneInitConfig := newControlPlaneInitKubeadmConfig(controlPlaneInitMachine.Namespace, "control-plane-init-cfg")
@@ -640,7 +639,7 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueIfControlPlaneIsMissingAPIEndp
 
 func TestReconcileIfJoinCertificatesAvailableConditioninNodesAndControlPlaneIsReady(t *testing.T) {
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -710,7 +709,6 @@ func TestReconcileIfJoinCertificatesAvailableConditioninNodesAndControlPlaneIsRe
 
 			cfg, err := getKubeadmConfig(myclient, rt.configName, metav1.NamespaceDefault)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 			g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 			g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 			g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -728,7 +726,7 @@ func TestReconcileIfJoinNodePoolsAndControlPlaneIsReady(t *testing.T) {
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -788,7 +786,6 @@ func TestReconcileIfJoinNodePoolsAndControlPlaneIsReady(t *testing.T) {
 
 			cfg, err := getKubeadmConfig(myclient, rt.configName, metav1.NamespaceDefault)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 			g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 			g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 			g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -839,7 +836,7 @@ func TestBootstrapDataFormat(t *testing.T) {
 			g := NewWithT(t)
 
 			cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-			cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+			cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 			cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 			if tc.clusterInitialized {
 				cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
@@ -890,7 +887,6 @@ func TestBootstrapDataFormat(t *testing.T) {
 			// Verify the KubeadmConfig resource state is correct.
 			cfg, err := getKubeadmConfig(myclient, configName, metav1.NamespaceDefault)
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 			g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 			g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 
@@ -933,7 +929,7 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -996,7 +992,6 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 
 	cfg, err := getKubeadmConfig(myclient, "worker-join-cfg", metav1.NamespaceDefault)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 	g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1006,7 +1001,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -1051,7 +1046,6 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 
 	cfg, err := getKubeadmConfig(myclient, "worker-join-cfg", metav1.NamespaceDefault)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 	g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1068,7 +1062,6 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 
 	cfg, err = getKubeadmConfig(myclient, "control-plane-join-cfg", metav1.NamespaceDefault)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 	g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1161,16 +1154,12 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 
 	patchHelper, err := patch.NewHelper(workerMachine, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	workerMachine.Status.Initialization = &clusterv1.MachineInitializationStatus{
-		InfrastructureProvisioned: ptr.To(true),
-	}
+	workerMachine.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(patchHelper.Patch(ctx, workerMachine)).To(Succeed())
 
 	patchHelper, err = patch.NewHelper(controlPlaneJoinMachine, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	controlPlaneJoinMachine.Status.Initialization = &clusterv1.MachineInitializationStatus{
-		InfrastructureProvisioned: ptr.To(true),
-	}
+	controlPlaneJoinMachine.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(patchHelper.Patch(ctx, controlPlaneJoinMachine)).To(Succeed())
 
 	for _, req := range []ctrl.Request{
@@ -1259,7 +1248,7 @@ func TestBootstrapTokenRotationMachinePool(t *testing.T) {
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -1299,7 +1288,6 @@ func TestBootstrapTokenRotationMachinePool(t *testing.T) {
 
 	cfg, err := getKubeadmConfig(myclient, "workerpool-join-cfg", metav1.NamespaceDefault)
 	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 	g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1362,7 +1350,7 @@ func TestBootstrapTokenRotationMachinePool(t *testing.T) {
 
 	patchHelper, err := patch.NewHelper(workerMachinePool, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
-	workerMachinePool.Status.Initialization = &clusterv1.MachinePoolInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	workerMachinePool.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(patchHelper.Patch(ctx, workerMachinePool, patch.WithStatusObservedGeneration{})).To(Succeed())
 
 	result, err = k.Reconcile(ctx, request)
@@ -1452,7 +1440,7 @@ func TestBootstrapTokenRefreshIfTokenSecretCleaned(t *testing.T) {
 		g := NewWithT(t)
 
 		cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 		cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -1492,7 +1480,6 @@ func TestBootstrapTokenRefreshIfTokenSecretCleaned(t *testing.T) {
 
 		cfg, err := getKubeadmConfig(myclient, "worker-join-cfg", metav1.NamespaceDefault)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 		g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 		g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 		g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1526,7 +1513,7 @@ func TestBootstrapTokenRefreshIfTokenSecretCleaned(t *testing.T) {
 		g := NewWithT(t)
 
 		cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
 		cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{Host: "100.105.150.1", Port: 6443}
 
@@ -1566,7 +1553,6 @@ func TestBootstrapTokenRefreshIfTokenSecretCleaned(t *testing.T) {
 
 		cfg, err := getKubeadmConfig(myclient, "workerpool-join-cfg", metav1.NamespaceDefault)
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(cfg.Status.Initialization).ToNot(BeNil())
 		g.Expect(ptr.Deref(cfg.Status.Initialization.DataSecretCreated, false)).To(BeTrue())
 		g.Expect(cfg.Status.DataSecretName).NotTo(BeEmpty())
 		g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
@@ -1889,7 +1875,7 @@ func TestKubeadmConfigReconciler_Reconcile_AlwaysCheckCAVerificationUnlessReques
 	clusterName := "my-cluster"
 	cluster := builder.Cluster(metav1.NamespaceDefault, clusterName).Build()
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
 		Host: "example.com",
 		Port: 6443,
@@ -2029,7 +2015,7 @@ func TestKubeadmConfigReconciler_Reconcile_DoesNotFailIfCASecretsAlreadyExist(t 
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "my-cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	m := newControlPlaneMachine(cluster, "control-plane-machine")
 	configName := "my-config"
 	c := newControlPlaneInitKubeadmConfig(m.Namespace, configName)
@@ -2061,7 +2047,7 @@ func TestKubeadmConfigReconciler_Reconcile_ExactlyOneControlPlaneMachineInitiali
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 	controlPlaneInitMachineFirst := newControlPlaneMachine(cluster, "control-plane-init-machine-first")
 	controlPlaneInitConfigFirst := newControlPlaneInitKubeadmConfig(controlPlaneInitMachineFirst.Namespace, "control-plane-init-cfg-first")
@@ -2124,7 +2110,7 @@ func TestKubeadmConfigReconciler_Reconcile_PatchWhenErrorOccurred(t *testing.T) 
 	g := NewWithT(t)
 
 	cluster := builder.Cluster(metav1.NamespaceDefault, "cluster").Build()
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 	controlPlaneInitMachine := newControlPlaneMachine(cluster, "control-plane-init-machine")
 	controlPlaneInitConfig := newControlPlaneInitKubeadmConfig(controlPlaneInitMachine.Namespace, "control-plane-init-cfg")
@@ -2722,7 +2708,7 @@ func TestKubeadmConfigReconciler_Reconcile_v1beta2_conditions(t *testing.T) {
 	clusterName := "my-cluster"
 	cluster := builder.Cluster(metav1.NamespaceDefault, clusterName).Build()
 	cluster.Status.Conditions = []metav1.Condition{{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue}}
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	cluster.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
 		Host: "example.com",
 		Port: 6443,
@@ -2759,7 +2745,7 @@ func TestKubeadmConfigReconciler_Reconcile_v1beta2_conditions(t *testing.T) {
 			name: "conditions should be true after upgrading to v1beta2",
 			config: func() *bootstrapv1.KubeadmConfig {
 				c := kubeadmConfig.DeepCopy()
-				c.Status.Initialization = &bootstrapv1.KubeadmConfigInitializationStatus{DataSecretCreated: ptr.To(true)}
+				c.Status.Initialization.DataSecretCreated = ptr.To(true)
 				return c
 			}(),
 			machine: machine.DeepCopy(),

--- a/bootstrap/util/configowner_test.go
+++ b/bootstrap/util/configowner_test.go
@@ -57,7 +57,7 @@ func TestGetConfigOwner(t *testing.T) {
 					Version: "v1.19.6",
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 				},
@@ -109,7 +109,7 @@ func TestGetConfigOwner(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachinePoolStatus{
-					Initialization: &clusterv1.MachinePoolInitializationStatus{
+					Initialization: clusterv1.MachinePoolInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 				},
@@ -218,7 +218,7 @@ func TestHasNodeRefs(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Status: clusterv1.MachineStatus{
-				Initialization: &clusterv1.MachineInitializationStatus{
+				Initialization: clusterv1.MachineInitializationStatus{
 					InfrastructureProvisioned: ptr.To(true),
 				},
 				NodeRef: &clusterv1.MachineNodeReference{

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -241,7 +241,7 @@ func (o *objectMover) checkProvisioningCompleted(ctx context.Context, graph *obj
 			return err
 		}
 
-		if clusterObj.Status.Initialization == nil || !ptr.Deref(clusterObj.Status.Initialization.InfrastructureProvisioned, false) {
+		if !ptr.Deref(clusterObj.Status.Initialization.InfrastructureProvisioned, false) {
 			errList = append(errList, errors.Errorf("cannot start the move operation while %q %s/%s is still provisioning the infrastructure", clusterObj.GroupVersionKind(), clusterObj.GetNamespace(), clusterObj.GetName()))
 			continue
 		}
@@ -252,7 +252,7 @@ func (o *objectMover) checkProvisioningCompleted(ctx context.Context, graph *obj
 			continue
 		}
 
-		if clusterObj.Spec.ControlPlaneRef != nil && (clusterObj.Status.Initialization == nil || !ptr.Deref(clusterObj.Status.Initialization.ControlPlaneInitialized, false)) {
+		if clusterObj.Spec.ControlPlaneRef != nil && !ptr.Deref(clusterObj.Status.Initialization.ControlPlaneInitialized, false) {
 			errList = append(errList, errors.Errorf("cannot start the move operation while the control plane for %q %s/%s is not yet initialized", clusterObj.GroupVersionKind(), clusterObj.GetNamespace(), clusterObj.GetName()))
 			continue
 		}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -1461,7 +1461,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							Name:      "cluster1",
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(false)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(false)},
 							Conditions: []metav1.Condition{
 								{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue},
 							},
@@ -1485,7 +1485,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							Name:      "cluster1",
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 						},
 					},
 				},
@@ -1506,7 +1506,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							Name:      "cluster1",
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 							Conditions: []metav1.Condition{
 								{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionFalse},
 							},
@@ -1533,7 +1533,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{},
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 							Conditions: []metav1.Condition{
 								{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue},
 							},
@@ -1558,7 +1558,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							UID:       "cluster1",
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 							Conditions: []metav1.Condition{
 								{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue},
 							},
@@ -1604,7 +1604,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 							UID:       "cluster1",
 						},
 						Status: clusterv1.ClusterStatus{
-							Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true), ControlPlaneInitialized: ptr.To(true)},
+							Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true), ControlPlaneInitialized: ptr.To(true)},
 							Conditions: []metav1.Condition{
 								{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue},
 							},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -3506,6 +3506,7 @@ spec:
                 description: |-
                   initialization provides observations of the Cluster initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
+                minProperties: 1
                 properties:
                   controlPlaneInitialized:
                     description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -2125,6 +2125,7 @@ spec:
                 description: |-
                   initialization provides observations of the MachinePool initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial MachinePool provisioning.
+                minProperties: 1
                 properties:
                   bootstrapDataSecretCreated:
                     description: |-

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1971,6 +1971,7 @@ spec:
                 description: |-
                   initialization provides observations of the Machine initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                minProperties: 1
                 properties:
                   bootstrapDataSecretCreated:
                     description: |-

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -438,7 +438,7 @@ func (cc *clusterCache) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	// Return if infrastructure is not ready yet to avoid trying to open a connection when it cannot succeed.
 	// Requeue is not needed as there will be a new reconcile.Request when Cluster.status.initialization.infrastructureProvisioned is set.
-	if cluster.Status.Initialization == nil || !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+	if !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 		log.V(6).Info("Can't connect yet, Cluster infrastructure is not provisioned")
 		return reconcile.Result{}, nil
 	}

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -107,7 +107,7 @@ func TestReconcile(t *testing.T) {
 
 	// Set Cluster.Status.InfrastructureReady == true
 	patch := client.MergeFrom(testCluster.DeepCopy())
-	testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, testCluster, patch)).To(Succeed())
 
 	// Reconcile, kubeconfig Secret doesn't exist
@@ -765,7 +765,7 @@ func createCluster(g Gomega, testCluster testCluster) {
 	}
 
 	patch := client.MergeFrom(cluster.DeepCopy())
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 }
 

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -7621,6 +7621,7 @@ spec:
                 description: |-
                   initialization provides observations of the KubeadmControlPlane initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                minProperties: 1
                 properties:
                   controlPlaneInitialized:
                     description: |-

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -134,7 +134,7 @@ func TestGetWorkloadCluster(t *testing.T) {
 
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 	patch := client.MergeFrom(cluster.DeepCopy())
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 	// Create kubeconfig secret

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -414,7 +414,7 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 	g := NewWithT(t)
 
 	cluster := newCluster(&types.NamespacedName{Name: "foo", Namespace: metav1.NamespaceDefault})
-	cluster.Status = clusterv1.ClusterStatus{Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -496,7 +496,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		cluster, kcp, tmpl := createClusterWithControlPlane(metav1.NamespaceDefault)
 		cluster.Spec.ControlPlaneEndpoint.Host = "bar"
 		cluster.Spec.ControlPlaneEndpoint.Port = 6443
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		kcp.Spec.Version = version
 
 		fmc := &fakeManagementCluster{
@@ -564,7 +564,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		cluster, kcp, tmpl := createClusterWithControlPlane(metav1.NamespaceDefault)
 		cluster.Spec.ControlPlaneEndpoint.Host = "validhost"
 		cluster.Spec.ControlPlaneEndpoint.Port = 6443
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		kcp.Spec.Version = version
 
 		fmc := &fakeManagementCluster{
@@ -673,7 +673,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		cluster, kcp, tmpl := createClusterWithControlPlane(metav1.NamespaceDefault)
 		cluster.Spec.ControlPlaneEndpoint.Host = "nodomain.example.com1"
 		cluster.Spec.ControlPlaneEndpoint.Port = 6443
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		kcp.Spec.Version = version
 
 		now := metav1.Now()
@@ -742,7 +742,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		cluster, kcp, tmpl := createClusterWithControlPlane(metav1.NamespaceDefault)
 		cluster.Spec.ControlPlaneEndpoint.Host = "nodomain.example.com2"
 		cluster.Spec.ControlPlaneEndpoint.Port = 6443
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		kcp.Spec.Version = "v1.17.0"
 
 		fmc := &fakeManagementCluster{
@@ -800,7 +800,7 @@ func TestKubeadmControlPlaneReconciler_ensureOwnerReferences(t *testing.T) {
 	cluster, kcp, tmpl := createClusterWithControlPlane(metav1.NamespaceDefault)
 	cluster.Spec.ControlPlaneEndpoint.Host = "bar"
 	cluster.Spec.ControlPlaneEndpoint.Port = 6443
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	kcp.Spec.Version = "v1.21.0"
 	key, err := certs.NewPrivateKey()
 	g.Expect(err).ToNot(HaveOccurred())
@@ -974,7 +974,7 @@ func TestReconcileCertificateExpiries(t *testing.T) {
 	cluster := newCluster(&types.NamespacedName{Name: "foo", Namespace: metav1.NamespaceDefault})
 	kcp := &controlplanev1.KubeadmControlPlane{
 		Status: controlplanev1.KubeadmControlPlaneStatus{
-			Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 				ControlPlaneInitialized: ptr.To(true),
 			},
 		},
@@ -1215,7 +1215,7 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	g.Expect(env.Create(ctx, cluster)).To(Succeed())
 	patchHelper, err := patch.NewHelper(cluster, env)
 	g.Expect(err).ToNot(HaveOccurred())
-	cluster.Status = clusterv1.ClusterStatus{Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(patchHelper.Patch(ctx, cluster)).To(Succeed())
 
 	genericInfrastructureMachineTemplate := &unstructured.Unstructured{
@@ -1460,7 +1460,7 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 	g.Expect(env.Create(ctx, cluster)).To(Succeed())
 	patchHelper, err := patch.NewHelper(cluster, env)
 	g.Expect(err).ToNot(HaveOccurred())
-	cluster.Status = clusterv1.ClusterStatus{Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(patchHelper.Patch(ctx, cluster)).To(Succeed())
 
 	g.Expect(env.CreateAndWait(ctx, certSecret)).To(Succeed())
@@ -2137,7 +2137,7 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 			Version: "v1.31.0",
 		},
 		Status: controlplanev1.KubeadmControlPlaneStatus{
-			Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 				ControlPlaneInitialized: ptr.To(true),
 			},
 			Conditions: []metav1.Condition{
@@ -2165,7 +2165,7 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 			controlPlane: &internal.ControlPlane{
 				KCP: func() *controlplanev1.KubeadmControlPlane {
 					kcp := defaultKCP.DeepCopy()
-					kcp.Status.Initialization = &controlplanev1.KubeadmControlPlaneInitializationStatus{ControlPlaneInitialized: ptr.To(false)}
+					kcp.Status.Initialization.ControlPlaneInitialized = ptr.To(false)
 					conditions.Set(kcp, metav1.Condition{
 						Type:   controlplanev1.KubeadmControlPlaneInitializedCondition,
 						Status: metav1.ConditionFalse,

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -115,7 +115,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 	}
 
 	var initialized bool
-	if controlPlane.KCP.Status.Initialization != nil && ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
+	if ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
 		initialized = true
 	}
 	log = log.WithValues("Machine", klog.KObj(machineToBeRemediated), "initialized", initialized)
@@ -207,7 +207,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		return ctrl.Result{}, nil
 	}
 
-	if controlPlane.KCP.Status.Initialization != nil && ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
+	if ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
 		// Executes checks that apply only if the control plane is already initialized; in this case KCP can
 		// remediate only if it can safely assume that the operation preserves the operation state of the
 		// existing cluster (or at least it doesn't make it worse).

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -293,7 +293,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -575,7 +575,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -607,7 +607,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Replicas: utilptr.To[int32](3),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -639,7 +639,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Replicas: utilptr.To(int32(3)),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -672,7 +672,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Replicas: utilptr.To(int32(3)),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -705,7 +705,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Replicas: utilptr.To[int32](3),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -752,7 +752,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Replicas: utilptr.To[int32](5),
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -799,7 +799,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(false),
 					},
 				},
@@ -851,7 +851,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(false),
 					},
 				},
@@ -945,7 +945,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1000,7 +1000,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1055,7 +1055,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1111,7 +1111,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1167,7 +1167,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1223,7 +1223,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1270,7 +1270,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(false),
 					},
 				},
@@ -1380,7 +1380,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 					Version:  "v1.19.1",
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(false),
 					},
 				},
@@ -1493,7 +1493,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 					},
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},
@@ -1609,7 +1609,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 					},
 				},
 				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 						ControlPlaneInitialized: utilptr.To(true),
 					},
 				},

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -204,7 +204,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		cluster.UID = types.UID(util.RandomString(10))
 		cluster.Spec.ControlPlaneEndpoint.Host = "nodomain.example.com"
 		cluster.Spec.ControlPlaneEndpoint.Port = 6443
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 		beforeMachines := collections.New()
 		for i := range 2 {

--- a/controlplane/kubeadm/internal/controllers/status.go
+++ b/controlplane/kubeadm/internal/controllers/status.go
@@ -154,7 +154,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, contro
 // this is considered a proxy information about the API Server being up and running and kubeadm init successfully completed.
 // Note: This only gets initialized once and does not change if the kubeadm config map goes away.
 func setControlPlaneInitialized(ctx context.Context, controlPlane *internal.ControlPlane) error {
-	if controlPlane.KCP.Status.Initialization == nil || !ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
+	if !ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false) {
 		workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to create remote cluster client")
@@ -165,9 +165,6 @@ func setControlPlaneInitialized(ctx context.Context, controlPlane *internal.Cont
 		}
 
 		if status.HasKubeadmConfig {
-			if controlPlane.KCP.Status.Initialization == nil {
-				controlPlane.KCP.Status.Initialization = &controlplanev1.KubeadmControlPlaneInitializationStatus{}
-			}
 			controlPlane.KCP.Status.Initialization.ControlPlaneInitialized = ptr.To(true)
 		}
 	}
@@ -195,7 +192,7 @@ func setReplicas(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, mac
 }
 
 func setInitializedCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane) {
-	if kcp.Status.Initialization != nil && ptr.Deref(kcp.Status.Initialization.ControlPlaneInitialized, false) {
+	if ptr.Deref(kcp.Status.Initialization.ControlPlaneInitialized, false) {
 		conditions.Set(kcp, metav1.Condition{
 			Type:   controlplanev1.KubeadmControlPlaneInitializedCondition,
 			Status: metav1.ConditionTrue,
@@ -514,7 +511,7 @@ func setDeletingCondition(_ context.Context, kcp *controlplanev1.KubeadmControlP
 }
 
 func setAvailableCondition(_ context.Context, kcp *controlplanev1.KubeadmControlPlane, etcdIsManaged bool, etcdMembers []*etcd.Member, etcdMembersAndMachinesAreMatching bool, machines collections.Machines) {
-	if kcp.Status.Initialization == nil || !ptr.Deref(kcp.Status.Initialization.ControlPlaneInitialized, false) {
+	if !ptr.Deref(kcp.Status.Initialization.ControlPlaneInitialized, false) {
 		conditions.Set(kcp, metav1.Condition{
 			Type:    controlplanev1.KubeadmControlPlaneAvailableCondition,
 			Status:  metav1.ConditionFalse,

--- a/controlplane/kubeadm/internal/controllers/status_test.go
+++ b/controlplane/kubeadm/internal/controllers/status_test.go
@@ -58,7 +58,7 @@ func TestKubeadmControlPlaneReconciler_setControlPlaneInitialized(t *testing.T) 
 		err := setControlPlaneInitialized(ctx, controlPlane)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(controlPlane.KCP.Status.Initialization).To(BeNil())
+		g.Expect(ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false)).To(BeFalse())
 
 		setInitializedCondition(ctx, controlPlane.KCP)
 		c := conditions.Get(controlPlane.KCP, controlplanev1.KubeadmControlPlaneInitializedCondition)
@@ -86,7 +86,6 @@ func TestKubeadmControlPlaneReconciler_setControlPlaneInitialized(t *testing.T) 
 		err := setControlPlaneInitialized(ctx, controlPlane)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		g.Expect(controlPlane.KCP.Status.Initialization).ToNot(BeNil())
 		g.Expect(ptr.Deref(controlPlane.KCP.Status.Initialization.ControlPlaneInitialized, false)).To(BeTrue())
 
 		setInitializedCondition(ctx, controlPlane.KCP)
@@ -162,7 +161,7 @@ func Test_setInitializedCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 					},
@@ -970,7 +969,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1002,7 +1001,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1062,7 +1061,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{
@@ -1091,7 +1090,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{
@@ -1120,7 +1119,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 					},
@@ -1141,7 +1140,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1191,7 +1190,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1243,7 +1242,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1294,7 +1293,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1334,7 +1333,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1395,7 +1394,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1458,7 +1457,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1519,7 +1518,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1570,7 +1569,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1634,7 +1633,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1674,7 +1673,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1725,7 +1724,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1773,7 +1772,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1818,7 +1817,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						},
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -1859,7 +1858,7 @@ func Test_setAvailableCondition(t *testing.T) {
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesNotReady},
@@ -1898,7 +1897,7 @@ func Test_setAvailableCondition(t *testing.T) {
 						DeletionTimestamp: ptr.To(metav1.Now()),
 					},
 					Status: controlplanev1.KubeadmControlPlaneStatus{
-						Initialization: &controlplanev1.KubeadmControlPlaneInitializationStatus{
+						Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
 							ControlPlaneInitialized: ptr.To(true),
 						},
 						Conditions: []metav1.Condition{certificatesReady},
@@ -2157,7 +2156,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 	g.Expect(kcp.Status.Deprecated.V1Beta1.UnavailableReplicas).To(BeEquivalentTo(3))
 	g.Expect(kcp.Status.Deprecated.V1Beta1.FailureMessage).To(BeNil())
 	g.Expect(kcp.Status.Deprecated.V1Beta1.FailureReason).To(BeEquivalentTo(""))
-	g.Expect(kcp.Status.Initialization).To(BeNil())
+	g.Expect(ptr.Deref(kcp.Status.Initialization.ControlPlaneInitialized, false)).To(BeFalse())
 }
 
 func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T) {

--- a/controlplane/kubeadm/internal/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/internal/controllers/upgrade_test.go
@@ -74,7 +74,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	cluster.UID = types.UID(util.RandomString(10))
 	cluster.Spec.ControlPlaneEndpoint.Host = Host
 	cluster.Spec.ControlPlaneEndpoint.Port = 6443
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	kcp.UID = types.UID(util.RandomString(10))
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
 	kcp.Spec.Replicas = ptr.To[int32](1)

--- a/docs/book/src/developer/providers/contracts/bootstrap-config.md
+++ b/docs/book/src/developer/providers/contracts/bootstrap-config.md
@@ -238,13 +238,14 @@ type FooConfigStatus struct {
     // initialization provides observations of the FooConfig initialization process.
     // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
     // +optional
-    Initialization *FooConfigInitializationStatus `json:"initialization,omitempty"`
+    Initialization FooConfigInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // See other rules for more details about mandatory/optional fields in BootstrapConfig status.
     // Other fields SHOULD be added based on the needs of your provider.
 }
 
 // FooConfigInitializationStatus provides observations of the FooConfig initialization process.
+// +kubebuilder:validation:MinProperties=1
 type FooConfigInitializationStatus struct {
     // dataSecretCreated is true when the Machine's boostrap secret is created.
     // NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -554,13 +554,14 @@ type FooControlPlaneStatus struct {
     // initialization provides observations of the FooControlPlane initialization process.
     // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
     // +optional
-    Initialization *FooControlPlaneInitializationStatus `json:"initialization,omitempty"`
+    Initialization FooControlPlaneInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // See other rules for more details about mandatory/optional fields in ControlPlane status.
     // Other fields SHOULD be added based on the needs of your provider.
 }
 
 // FooControlPlaneInitializationStatus provides observations of the FooControlPlane initialization process.
+// +kubebuilder:validation:MinProperties=1
 type FooControlPlaneInitializationStatus struct {
     // controlPlaneInitialized is true when the control plane provider reports that the Kubernetes control plane is initialized; 
     // usually a control plane is considered initialized when it can accept requests, no matter if this happens before 

--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -332,13 +332,14 @@ type FooClusterStatus struct {
     // initialization provides observations of the FooCluster initialization process.
     // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
     // +optional
-    Initialization *FooClusterInitializationStatus `json:"initialization,omitempty"`
+    Initialization FooClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // See other rules for more details about mandatory/optional fields in InfraCluster status.
     // Other fields SHOULD be added based on the needs of your provider.
 }
 
 // FooClusterInitializationStatus provides observations of the FooCluster initialization process.
+// +kubebuilder:validation:MinProperties=1
 type FooClusterInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Cluster's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Cluster provisioning.

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -297,13 +297,14 @@ type FooMachineStatus struct {
     // initialization provides observations of the FooMachine initialization process.
     // NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
     // +optional
-    Initialization *FooMachineInitializationStatus `json:"initialization,omitempty"`
+    Initialization FooMachineInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // See other rules for more details about mandatory/optional fields in InfraMachine status.
     // Other fields SHOULD be added based on the needs of your provider.
 }
 
 // FooMachineInitializationStatus provides observations of the FooMachine initialization process.
+// +kubebuilder:validation:MinProperties=1
 type FooMachineInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Machine's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.

--- a/docs/proposals/20240916-improve-status-in-CAPI-resources.md
+++ b/docs/proposals/20240916-improve-status-in-CAPI-resources.md
@@ -288,7 +288,7 @@ type MachineStatus struct {
     // The value of those fields is never updated after provisioning is completed.
     // Use conditions to monitor the operational state of the Machine.
     // +optional
-    Initialization *MachineInitializationStatus `json:"initialization,omitempty"`
+    Initialization MachineInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // Conditions represent the observations of a Machine's current state.
     // +optional
@@ -302,6 +302,7 @@ type MachineStatus struct {
 }
 
 // MachineInitializationStatus provides observations of the Machine initialization process.
+// +kubebuilder:validation:MinProperties=1
 type MachineInitializationStatus struct {
 
     // BootstrapDataSecretCreated is true when the bootstrap provider reports that the Machine's boostrap secret is created.
@@ -731,7 +732,7 @@ type ClusterStatus struct {
     // The value of those fields is never updated after provisioning is completed.
     // Use conditions to monitor the operational state of the Cluster's BootstrapSecret.
     // +optional
-    Initialization *ClusterInitializationStatus `json:"initialization,omitempty"`
+    Initialization ClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // Represents the observations of a Cluster's current state.
     // +optional
@@ -752,6 +753,7 @@ type ClusterStatus struct {
 }
 
 // ClusterInitializationStatus provides observations of the Cluster initialization process.
+// +kubebuilder:validation:MinProperties=1
 type ClusterInitializationStatus struct {
 
     // InfrastructureProvisioned is true when the infrastructure provider reports that Cluster's infrastructure is fully provisioned.
@@ -1109,7 +1111,7 @@ type MachinePoolStatus struct {
     // The value of those fields is never updated after provisioning is completed.
     // Use conditions to monitor the operational state of the MachinePool.
     // +optional
-    Initialization *MachinePoolInitializationStatus `json:"initialization,omitempty"`
+    Initialization MachinePoolInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // Conditions represent the observations of a MachinePool's current state.
     // +optional
@@ -1123,6 +1125,7 @@ type MachinePoolStatus struct {
 }
 
 // MachinePoolInitializationStatus provides observations of the MachinePool initialization process.
+// +kubebuilder:validation:MinProperties=1
 type MachinePoolInitializationStatus struct {
 
     // BootstrapDataSecretCreated is true when the bootstrap provider reports that the MachinePool's boostrap data secret is created.
@@ -1372,7 +1375,7 @@ type KubeadmControlPlaneStatus struct {
     // The value of those fields is never updated after provisioning is completed.
     // Use conditions to monitor the operational state of the Cluster.
     // +optional
-    Initialization *KubeadmControlPlaneInitializationStatus `json:"initialization,omitempty"`
+    Initialization KubeadmControlPlaneInitializationStatus `json:"initialization,omitempty,omitzero"`
     
     // Conditions represent the observations of a ControlPlane's current state.
     // +optional
@@ -1398,6 +1401,7 @@ type KubeadmControlPlaneStatus struct {
 }
 
 // KubeadmControlPlaneInitializationStatus provides observations of the ControlPlane initialization process.
+// +kubebuilder:validation:MinProperties=1
 type KubeadmControlPlaneInitializationStatus struct {
 	
     // controlPlaneInitialized is true when the control plane provider reports that the Kubernetes control plane is initialized; 

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -58,7 +58,7 @@ func (r *MachinePoolReconciler) reconcilePhase(mp *clusterv1.MachinePool) {
 	}
 
 	// Set the phase to "provisioning" if bootstrap is ready and the infrastructure isn't.
-	if mp.Status.Initialization != nil && ptr.Deref(mp.Status.Initialization.BootstrapDataSecretCreated, false) && !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
+	if ptr.Deref(mp.Status.Initialization.BootstrapDataSecretCreated, false) && !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
 		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseProvisioning)
 	}
 
@@ -73,12 +73,12 @@ func (r *MachinePoolReconciler) reconcilePhase(mp *clusterv1.MachinePool) {
 	if mp.Status.Deprecated != nil && mp.Status.Deprecated.V1Beta1 != nil {
 		readyReplicas = mp.Status.Deprecated.V1Beta1.ReadyReplicas
 	}
-	if mp.Status.Initialization != nil && ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas == readyReplicas {
+	if ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas == readyReplicas {
 		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseRunning)
 	}
 
 	// Set the appropriate phase in response to the MachinePool replica count being greater than the observed infrastructure replicas.
-	if mp.Status.Initialization != nil && ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas > readyReplicas {
+	if ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas > readyReplicas {
 		// If we are being managed by an external autoscaler and can't predict scaling direction, set to "Scaling".
 		if annotations.ReplicasManagedByExternalAutoscaler(mp) {
 			mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseScaling)
@@ -89,7 +89,7 @@ func (r *MachinePoolReconciler) reconcilePhase(mp *clusterv1.MachinePool) {
 	}
 
 	// Set the appropriate phase in response to the MachinePool replica count being less than the observed infrastructure replicas.
-	if mp.Status.Initialization != nil && ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas < readyReplicas {
+	if ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) && mp.Spec.Replicas != nil && *mp.Spec.Replicas < readyReplicas {
 		// If we are being managed by an external autoscaler and can't predict scaling direction, set to "Scaling".
 		if annotations.ReplicasManagedByExternalAutoscaler(mp) {
 			mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseScaling)
@@ -220,9 +220,6 @@ func (r *MachinePoolReconciler) reconcileBootstrap(ctx context.Context, s *scope
 
 		if !dataSecretCreated {
 			log.Info("Waiting for bootstrap provider to generate data secret and report status.ready", bootstrapConfig.GetKind(), klog.KObj(bootstrapConfig))
-			if m.Status.Initialization == nil {
-				m.Status.Initialization = &clusterv1.MachinePoolInitializationStatus{}
-			}
 			m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(dataSecretCreated)
 			return ctrl.Result{}, nil
 		}
@@ -236,18 +233,12 @@ func (r *MachinePoolReconciler) reconcileBootstrap(ctx context.Context, s *scope
 		}
 
 		m.Spec.Template.Spec.Bootstrap.DataSecretName = secretName
-		if m.Status.Initialization == nil {
-			m.Status.Initialization = &clusterv1.MachinePoolInitializationStatus{}
-		}
 		m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 		return ctrl.Result{}, nil
 	}
 
 	// If dataSecretName is set without a ConfigRef, this means the user brought their own bootstrap data.
 	if m.Spec.Template.Spec.Bootstrap.DataSecretName != nil {
-		if m.Status.Initialization == nil {
-			m.Status.Initialization = &clusterv1.MachinePoolInitializationStatus{}
-		}
 		m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 		v1beta1conditions.MarkTrue(m, clusterv1.BootstrapReadyV1Beta1Condition)
 		return ctrl.Result{}, nil
@@ -267,7 +258,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, s *
 	if err != nil {
 		if apierrors.IsNotFound(errors.Cause(err)) {
 			log.Error(err, "infrastructure reference could not be found")
-			if mp.Status.Initialization != nil && ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
+			if ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
 				// Infra object went missing after the machine pool was up and running
 				log.Error(err, "infrastructure reference has been deleted after being ready, setting failure state")
 				if mp.Status.Deprecated == nil {
@@ -295,9 +286,6 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, s *
 		return ctrl.Result{}, err
 	}
 
-	if mp.Status.Initialization == nil {
-		mp.Status.Initialization = &clusterv1.MachinePoolInitializationStatus{}
-	}
 	mp.Status.Initialization.InfrastructureProvisioned = ptr.To(ready)
 
 	// Report a summary of current status of the infrastructure object defined for this machine pool.
@@ -321,7 +309,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, s *
 		return ctrl.Result{}, kerrors.NewAggregate([]error{errors.Wrapf(err, "failed to reconcile Machines for MachinePool %s", klog.KObj(mp)), errors.Wrapf(getNodeRefsErr, "failed to get nodeRefs for MachinePool %s", klog.KObj(mp))})
 	}
 
-	if mp.Status.Initialization == nil || !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
+	if !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
 		log.Info("Infrastructure provider is not yet ready", infraConfig.GetKind(), klog.KObj(infraConfig))
 		return ctrl.Result{}, nil
 	}

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -705,7 +705,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		r.reconcilePhase(machinePool)
 		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data-new"))
-		g.Expect(machinePool.Status.Initialization != nil && ptr.Deref(machinePool.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+		g.Expect(ptr.Deref(machinePool.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
 	})
 
@@ -807,7 +807,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		// The old secret should still be used, as the new bootstrap config is not marked ready
 		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
-		g.Expect(machinePool.Status.Initialization != nil && ptr.Deref(machinePool.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+		g.Expect(ptr.Deref(machinePool.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 
 		// There is no phase defined for "changing to new bootstrap config", so it should still be `Running` the
 		// old configuration
@@ -873,7 +873,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			},
 			expectError: false,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(m.Spec.Template.Spec.Bootstrap.DataSecretName).ToNot(BeNil())
 				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(ContainSubstring("secret-data"))
 			},
@@ -896,7 +896,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			},
 			expectError: true,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 				g.Expect(m.Spec.Template.Spec.Bootstrap.DataSecretName).To(BeNil())
 			},
 		},
@@ -915,7 +915,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError:  false,
 			expectResult: ctrl.Result{},
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 			},
 		},
 		{
@@ -932,7 +932,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			},
 			expectError: true,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 			},
 		},
 		{
@@ -986,14 +986,14 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachinePoolStatus{
-					Initialization: &clusterv1.MachinePoolInitializationStatus{
+					Initialization: clusterv1.MachinePoolInitializationStatus{
 						BootstrapDataSecretCreated: ptr.To(true),
 					},
 				},
 			},
 			expectError: false,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
 			},
 		},
@@ -1029,14 +1029,14 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachinePoolStatus{
-					Initialization: &clusterv1.MachinePoolInitializationStatus{
+					Initialization: clusterv1.MachinePoolInitializationStatus{
 						BootstrapDataSecretCreated: ptr.To(true),
 					},
 				},
 			},
 			expectError: false,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("data"))
 			},
 		},
@@ -1077,7 +1077,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachinePoolStatus{
-					Initialization: &clusterv1.MachinePoolInitializationStatus{
+					Initialization: clusterv1.MachinePoolInitializationStatus{
 						BootstrapDataSecretCreated: ptr.To(false),
 					},
 				},
@@ -1085,7 +1085,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 			expectError:  false,
 			expectResult: ctrl.Result{},
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 			},
 		},
 	}
@@ -1207,7 +1207,7 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 			expectError:   false,
 			expectChanged: true,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 			},
 		},
 		{
@@ -1237,7 +1237,7 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachinePoolStatus{
-					Initialization: &clusterv1.MachinePoolInitializationStatus{
+					Initialization: clusterv1.MachinePoolInitializationStatus{
 						InfrastructureProvisioned:  ptr.To(true),
 						BootstrapDataSecretCreated: ptr.To(true),
 					},
@@ -1286,7 +1286,7 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 			expectError:        false,
 			expectRequeueAfter: false,
 			expected: func(g *WithT, m *clusterv1.MachinePool) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Status.Deprecated.V1Beta1.ReadyReplicas).To(Equal(int32(0)))
 				g.Expect(m.Status.Deprecated.V1Beta1.AvailableReplicas).To(Equal(int32(0)))
 				g.Expect(m.Status.Deprecated.V1Beta1.UnavailableReplicas).To(Equal(int32(0)))

--- a/internal/api/bootstrap/kubeadm/v1alpha3/conversion.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha3/conversion.go
@@ -60,13 +60,10 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := bootstrapv1.KubeadmConfigInitializationStatus{}
-	var restoredBootstrapDataSecretCreated *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.DataSecretCreated
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.DataSecretCreated
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Ready, ok, restoredBootstrapDataSecretCreated, &initialization.DataSecretCreated)
 	if !reflect.DeepEqual(initialization, bootstrapv1.KubeadmConfigInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 	if err := RestoreBoolIntentKubeadmConfigSpec(&src.Spec, &dst.Spec, ok, &restored.Spec); err != nil {
 		return err
@@ -299,9 +296,7 @@ func (dst *KubeadmConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.Ready = ptr.Deref(src.Status.Initialization.DataSecretCreated, false)
-	}
+	dst.Status.Ready = ptr.Deref(src.Status.Initialization.DataSecretCreated, false)
 
 	// Convert timeouts moved from one struct to another.
 	dst.Spec.ConvertFrom(&src.Spec)

--- a/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -120,13 +119,6 @@ func hubKubeadmConfigStatus(in *bootstrapv1.KubeadmConfigStatus, c randfill.Cont
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &bootstrapv1.KubeadmConfigV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &bootstrapv1.KubeadmConfigInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 }
 

--- a/internal/api/bootstrap/kubeadm/v1alpha4/conversion.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha4/conversion.go
@@ -60,13 +60,10 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := bootstrapv1.KubeadmConfigInitializationStatus{}
-	var restoredBootstrapDataSecretCreated *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.DataSecretCreated
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.DataSecretCreated
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Ready, ok, restoredBootstrapDataSecretCreated, &initialization.DataSecretCreated)
 	if !reflect.DeepEqual(initialization, bootstrapv1.KubeadmConfigInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 	if err := RestoreBoolIntentKubeadmConfigSpec(&src.Spec, &dst.Spec, ok, &restored.Spec); err != nil {
 		return err
@@ -297,9 +294,7 @@ func (dst *KubeadmConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.Ready = ptr.Deref(src.Status.Initialization.DataSecretCreated, false)
-	}
+	dst.Status.Ready = ptr.Deref(src.Status.Initialization.DataSecretCreated, false)
 
 	// Convert timeouts moved from one struct to another.
 	dst.Spec.ConvertFrom(&src.Spec)

--- a/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -118,13 +117,6 @@ func hubKubeadmConfigStatus(in *bootstrapv1.KubeadmConfigStatus, c randfill.Cont
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &bootstrapv1.KubeadmConfigV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &bootstrapv1.KubeadmConfigInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 }
 

--- a/internal/api/controlplane/kubeadm/v1alpha3/conversion.go
+++ b/internal/api/controlplane/kubeadm/v1alpha3/conversion.go
@@ -82,13 +82,10 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := controlplanev1.KubeadmControlPlaneInitializationStatus{}
-	var restoredControlPlaneInitialized *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Initialized, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	if !reflect.DeepEqual(initialization, controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	if err := bootstrapv1alpha3.RestoreBoolIntentKubeadmConfigSpec(&src.Spec.KubeadmConfigSpec, &dst.Spec.KubeadmConfigSpec, ok, &restored.Spec.KubeadmConfigSpec); err != nil {
@@ -163,9 +160,7 @@ func (dst *KubeadmControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move ControlPlaneInitialized to old fields, rebuild ready
-	if src.Status.Initialization != nil {
-		dst.Status.Initialized = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
-	}
+	dst.Status.Initialized = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
 	dst.Status.Ready = dst.Status.ReadyReplicas > 0
 
 	// Convert timeouts moved from one struct to another.

--- a/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
@@ -20,7 +20,6 @@ package v1alpha3
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -118,13 +117,6 @@ func hubKubeadmControlPlaneStatus(in *controlplanev1.KubeadmControlPlaneStatus, 
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &controlplanev1.KubeadmControlPlaneV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 
 	// nil becomes &0 after hub => spoke => hub conversion

--- a/internal/api/controlplane/kubeadm/v1alpha4/conversion.go
+++ b/internal/api/controlplane/kubeadm/v1alpha4/conversion.go
@@ -82,13 +82,10 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := controlplanev1.KubeadmControlPlaneInitializationStatus{}
-	var restoredControlPlaneInitialized *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.Initialized, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	if !reflect.DeepEqual(initialization, controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	if err := bootstrapv1alpha4.RestoreBoolIntentKubeadmConfigSpec(&src.Spec.KubeadmConfigSpec, &dst.Spec.KubeadmConfigSpec, ok, &restored.Spec.KubeadmConfigSpec); err != nil {
@@ -160,9 +157,7 @@ func (dst *KubeadmControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move ControlPlaneInitialized to old fields, rebuild ready
-	if src.Status.Initialization != nil {
-		dst.Status.Initialized = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
-	}
+	dst.Status.Initialized = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
 	dst.Status.Ready = dst.Status.ReadyReplicas > 0
 
 	// Convert timeouts moved from one struct to another.

--- a/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
@@ -20,7 +20,6 @@ package v1alpha4
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -143,13 +142,6 @@ func hubKubeadmControlPlaneStatus(in *controlplanev1.KubeadmControlPlaneStatus, 
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &controlplanev1.KubeadmControlPlaneV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &controlplanev1.KubeadmControlPlaneInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 
 	// nil becomes &0 after hub => spoke => hub conversion

--- a/internal/api/core/v1alpha3/conversion.go
+++ b/internal/api/core/v1alpha3/conversion.go
@@ -102,15 +102,12 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 	clusterv1.Convert_bool_To_Pointer_bool(src.Spec.Paused, ok, restored.Spec.Paused, &dst.Spec.Paused)
 
 	initialization := clusterv1.ClusterInitializationStatus{}
-	var restoredControlPlaneInitialized, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.ControlPlaneReady, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.ClusterInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	for i, fd := range dst.Status.FailureDomains {
@@ -187,10 +184,8 @@ func (dst *Cluster) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.ControlPlaneReady = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.ControlPlaneReady = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
@@ -235,15 +230,12 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachineInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachineInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	// Recover other values
@@ -288,10 +280,8 @@ func (dst *Machine) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	dropEmptyStringsMachineSpec(&dst.Spec)
 
@@ -611,15 +601,12 @@ func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachinePoolInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachinePoolInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	// Recover other values
@@ -671,10 +658,8 @@ func (dst *MachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	dst.Spec.MinReadySeconds = src.Spec.Template.Spec.MinReadySeconds
 

--- a/internal/api/core/v1alpha3/conversion_test.go
+++ b/internal/api/core/v1alpha3/conversion_test.go
@@ -127,13 +127,6 @@ func hubMachineStatus(in *clusterv1.MachineStatus, c randfill.Continue) {
 			in.Deprecated = nil
 		}
 	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachineInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func spokeMachine(in *Machine, c randfill.Continue) {
@@ -344,13 +337,6 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c randfill.Continue) {
 		}
 	}
 
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.ClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
-
 	if len(in.FailureDomains) > 0 {
 		in.FailureDomains = nil // Remove all pre-existing potentially invalid FailureDomains
 		for i := range c.Int31n(20) {
@@ -461,13 +447,6 @@ func hubMachinePoolStatus(in *clusterv1.MachinePoolStatus, c randfill.Continue) 
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachinePoolInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 
 	// nil becomes &0 after hub => spoke => hub conversion

--- a/internal/api/core/v1alpha4/conversion.go
+++ b/internal/api/core/v1alpha4/conversion.go
@@ -95,15 +95,12 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 	clusterv1.Convert_bool_To_Pointer_bool(src.Spec.Paused, ok, restored.Spec.Paused, &dst.Spec.Paused)
 
 	initialization := clusterv1.ClusterInitializationStatus{}
-	var restoredControlPlaneInitialized, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredControlPlaneInitialized = restored.Status.Initialization.ControlPlaneInitialized
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredControlPlaneInitialized := restored.Status.Initialization.ControlPlaneInitialized
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.ControlPlaneReady, ok, restoredControlPlaneInitialized, &initialization.ControlPlaneInitialized)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.ClusterInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	for i, fd := range dst.Status.FailureDomains {
@@ -216,10 +213,8 @@ func (dst *Cluster) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.ControlPlaneReady = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.ControlPlaneReady = ptr.Deref(src.Status.Initialization.ControlPlaneInitialized, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
@@ -324,15 +319,12 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachineInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachineInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	// Recover other values
@@ -376,10 +368,8 @@ func (dst *Machine) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	dropEmptyStringsMachineSpec(&dst.Spec)
 
@@ -697,15 +687,12 @@ func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Recover intent for bool values converted to *bool.
 	initialization := clusterv1.MachinePoolInitializationStatus{}
-	var restoredBootstrapDataSecretCreated, restoredInfrastructureProvisioned *bool
-	if restored.Status.Initialization != nil {
-		restoredBootstrapDataSecretCreated = restored.Status.Initialization.BootstrapDataSecretCreated
-		restoredInfrastructureProvisioned = restored.Status.Initialization.InfrastructureProvisioned
-	}
+	restoredBootstrapDataSecretCreated := restored.Status.Initialization.BootstrapDataSecretCreated
+	restoredInfrastructureProvisioned := restored.Status.Initialization.InfrastructureProvisioned
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.BootstrapReady, ok, restoredBootstrapDataSecretCreated, &initialization.BootstrapDataSecretCreated)
 	clusterv1.Convert_bool_To_Pointer_bool(src.Status.InfrastructureReady, ok, restoredInfrastructureProvisioned, &initialization.InfrastructureProvisioned)
 	if !reflect.DeepEqual(initialization, clusterv1.MachinePoolInitializationStatus{}) {
-		dst.Status.Initialization = &initialization
+		dst.Status.Initialization = initialization
 	}
 
 	// Recover other values
@@ -757,10 +744,8 @@ func (dst *MachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Move initialization to old fields
-	if src.Status.Initialization != nil {
-		dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
-		dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
-	}
+	dst.Status.BootstrapReady = ptr.Deref(src.Status.Initialization.BootstrapDataSecretCreated, false)
+	dst.Status.InfrastructureReady = ptr.Deref(src.Status.Initialization.InfrastructureProvisioned, false)
 
 	dst.Spec.MinReadySeconds = src.Spec.Template.Spec.MinReadySeconds
 

--- a/internal/api/core/v1alpha4/conversion_test.go
+++ b/internal/api/core/v1alpha4/conversion_test.go
@@ -125,13 +125,6 @@ func hubMachineStatus(in *clusterv1.MachineStatus, c randfill.Continue) {
 			in.Deprecated = nil
 		}
 	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachineInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func spokeMachine(in *Machine, c randfill.Continue) {
@@ -219,13 +212,6 @@ func hubClusterStatus(in *clusterv1.ClusterStatus, c randfill.Continue) {
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &clusterv1.ClusterV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
-		}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.ClusterInitializationStatus{}) {
-			in.Initialization = nil
 		}
 	}
 
@@ -523,13 +509,6 @@ func hubMachinePoolStatus(in *clusterv1.MachinePoolStatus, c randfill.Continue) 
 	}
 	if in.Deprecated.V1Beta1 == nil {
 		in.Deprecated.V1Beta1 = &clusterv1.MachinePoolV1Beta1DeprecatedStatus{}
-	}
-
-	// Drop empty structs with only omit empty fields.
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &clusterv1.MachinePoolInitializationStatus{}) {
-			in.Initialization = nil
-		}
 	}
 
 	// nil becomes &0 after hub => spoke => hub conversion

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -48,7 +48,7 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 		},
 		Spec: clusterv1.ClusterSpec{
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{
@@ -68,7 +68,7 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 		},
 		Spec: clusterv1.ClusterSpec{
 			InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
@@ -92,7 +92,7 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 			cluster:   &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"}},
 			expectErr: false,
 			check: func(g *GomegaWithT, in *clusterv1.Cluster) {
-				g.Expect(in.Status.Initialization != nil && ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(v1beta1conditions.IsTrue(in, clusterv1.InfrastructureReadyV1Beta1Condition)).To(BeTrue())
 			},
 		},
@@ -205,7 +205,7 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 			check: func(g *GomegaWithT, in *clusterv1.Cluster) {
 				g.Expect(in.Spec.ControlPlaneEndpoint.Host).To(Equal("1.2.3.4"))
 				g.Expect(in.Spec.ControlPlaneEndpoint.Port).To(BeEquivalentTo(8443))
-				g.Expect(in.Status.Initialization != nil && ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 			},
 		},
 		{
@@ -238,7 +238,7 @@ func TestClusterReconcileInfrastructure(t *testing.T) {
 			check: func(g *GomegaWithT, in *clusterv1.Cluster) {
 				g.Expect(in.Spec.ControlPlaneEndpoint.Host).To(Equal(""))
 				g.Expect(in.Spec.ControlPlaneEndpoint.Port).To(BeEquivalentTo(0))
-				g.Expect(in.Status.Initialization != nil && ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
+				g.Expect(ptr.Deref(in.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
 			},
 		},
 	}
@@ -294,7 +294,7 @@ func TestClusterReconcileControlPlane(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 		},
 		Spec: clusterv1.ClusterSpec{
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{
@@ -314,7 +314,7 @@ func TestClusterReconcileControlPlane(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 		},
 		Spec: clusterv1.ClusterSpec{
 			ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
@@ -496,7 +496,7 @@ func TestClusterReconcileControlPlane(t *testing.T) {
 			check: func(g *GomegaWithT, in *clusterv1.Cluster) {
 				g.Expect(in.Spec.ControlPlaneEndpoint.Host).To(Equal("1.2.3.4"))
 				g.Expect(in.Spec.ControlPlaneEndpoint.Port).To(BeEquivalentTo(8443))
-				g.Expect(in.Status.Initialization != nil && ptr.Deref(in.Status.Initialization.ControlPlaneInitialized, false)).To(BeTrue())
+				g.Expect(ptr.Deref(in.Status.Initialization.ControlPlaneInitialized, false)).To(BeTrue())
 			},
 		},
 		{
@@ -526,7 +526,7 @@ func TestClusterReconcileControlPlane(t *testing.T) {
 			check: func(g *GomegaWithT, in *clusterv1.Cluster) {
 				g.Expect(in.Spec.ControlPlaneEndpoint.Host).To(Equal(""))
 				g.Expect(in.Spec.ControlPlaneEndpoint.Port).To(BeEquivalentTo(0))
-				g.Expect(in.Status.Initialization != nil && ptr.Deref(in.Status.Initialization.ControlPlaneInitialized, false)).To(BeFalse())
+				g.Expect(ptr.Deref(in.Status.Initialization.ControlPlaneInitialized, false)).To(BeFalse())
 			},
 		},
 	}
@@ -668,7 +668,7 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 		},
 		Spec: clusterv1.ClusterSpec{
 			ControlPlaneEndpoint: clusterv1.APIEndpoint{

--- a/internal/controllers/cluster/cluster_controller_status.go
+++ b/internal/controllers/cluster/cluster_controller_status.go
@@ -101,7 +101,7 @@ func setPhase(_ context.Context, cluster *clusterv1.Cluster) bool {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioning)
 	}
 
-	if cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) && cluster.Spec.ControlPlaneEndpoint.IsValid() {
+	if ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) && cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioned)
 	}
 
@@ -306,7 +306,7 @@ func setInfrastructureReadyCondition(_ context.Context, cluster *clusterv1.Clust
 	}
 
 	if infraCluster != nil {
-		infrastructureProvisioned := cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false)
+		infrastructureProvisioned := ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false)
 		ready, err := conditions.NewMirrorConditionFromUnstructured(
 			infraCluster,
 			contract.InfrastructureCluster().ReadyConditionType(), conditions.TargetConditionType(clusterv1.ClusterInfrastructureReadyCondition),
@@ -349,7 +349,7 @@ func setInfrastructureReadyCondition(_ context.Context, cluster *clusterv1.Clust
 
 	// Infra cluster missing when the cluster is deleting.
 	if !cluster.DeletionTimestamp.IsZero() {
-		if cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+		if ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 			conditions.Set(cluster, metav1.Condition{
 				Type:    clusterv1.ClusterInfrastructureReadyCondition,
 				Status:  metav1.ConditionFalse,
@@ -369,7 +369,7 @@ func setInfrastructureReadyCondition(_ context.Context, cluster *clusterv1.Clust
 	}
 
 	// Report an issue if infra cluster missing after the cluster has been initialized (and the cluster is still running).
-	if cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+	if ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 		conditions.Set(cluster, metav1.Condition{
 			Type:    clusterv1.ClusterInfrastructureReadyCondition,
 			Status:  metav1.ConditionFalse,
@@ -407,7 +407,7 @@ func setControlPlaneAvailableCondition(_ context.Context, cluster *clusterv1.Clu
 	}
 
 	if controlPlane != nil {
-		controlPlaneInitialized := cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false)
+		controlPlaneInitialized := ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false)
 		available, err := conditions.NewMirrorConditionFromUnstructured(
 			controlPlane,
 			contract.ControlPlane().AvailableConditionType(), conditions.TargetConditionType(clusterv1.ClusterControlPlaneAvailableCondition),
@@ -450,7 +450,7 @@ func setControlPlaneAvailableCondition(_ context.Context, cluster *clusterv1.Clu
 
 	// Infra cluster missing when the cluster is deleting.
 	if !cluster.DeletionTimestamp.IsZero() {
-		if cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false) {
+		if ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false) {
 			conditions.Set(cluster, metav1.Condition{
 				Type:    clusterv1.ClusterControlPlaneAvailableCondition,
 				Status:  metav1.ConditionFalse,
@@ -470,7 +470,7 @@ func setControlPlaneAvailableCondition(_ context.Context, cluster *clusterv1.Clu
 	}
 
 	// Report an issue if control plane missing after the cluster has been initialized (and the cluster is still running).
-	if cluster.Status.Initialization != nil && ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false) {
+	if ptr.Deref(cluster.Status.Initialization.ControlPlaneInitialized, false) {
 		conditions.Set(cluster, metav1.Condition{
 			Type:    clusterv1.ClusterControlPlaneAvailableCondition,
 			Status:  metav1.ConditionFalse,

--- a/internal/controllers/cluster/cluster_controller_status_test.go
+++ b/internal/controllers/cluster/cluster_controller_status_test.go
@@ -71,7 +71,7 @@ func TestSetPhases(t *testing.T) {
 					Name: "test-cluster",
 				},
 				Status: clusterv1.ClusterStatus{
-					Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+					Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 				},
 				Spec: clusterv1.ClusterSpec{
 					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{},
@@ -94,7 +94,7 @@ func TestSetPhases(t *testing.T) {
 					},
 				},
 				Status: clusterv1.ClusterStatus{
-					Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+					Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 				},
 			},
 
@@ -114,7 +114,7 @@ func TestSetPhases(t *testing.T) {
 					ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{},
 				},
 				Status: clusterv1.ClusterStatus{
-					Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}, // Note, this is automatically set when there is no cluster infrastructure (no-op).
+					Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}, // Note, this is automatically set when there is no cluster infrastructure (no-op).
 				},
 			},
 
@@ -129,7 +129,7 @@ func TestSetPhases(t *testing.T) {
 					Finalizers:        []string{clusterv1.ClusterFinalizer},
 				},
 				Status: clusterv1.ClusterStatus{
-					Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+					Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 				},
 				Spec: clusterv1.ClusterSpec{
 					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{},
@@ -3035,18 +3035,12 @@ func (r infrastructureRef) ApplyToCluster(c *clusterv1.Cluster) {
 type infrastructureProvisioned bool
 
 func (r infrastructureProvisioned) ApplyToCluster(c *clusterv1.Cluster) {
-	if c.Status.Initialization == nil {
-		c.Status.Initialization = &clusterv1.ClusterInitializationStatus{}
-	}
 	c.Status.Initialization.InfrastructureProvisioned = ptr.To(bool(r))
 }
 
 type controlPlaneInitialized bool
 
 func (r controlPlaneInitialized) ApplyToCluster(c *clusterv1.Cluster) {
-	if c.Status.Initialization == nil {
-		c.Status.Initialization = &clusterv1.ClusterInitializationStatus{}
-	}
 	c.Status.Initialization.ControlPlaneInitialized = ptr.To(bool(r))
 }
 

--- a/internal/controllers/cluster/cluster_controller_test.go
+++ b/internal/controllers/cluster/cluster_controller_test.go
@@ -210,9 +210,6 @@ func TestClusterReconciler(t *testing.T) {
 		g.Eventually(func() bool {
 			ph, err := patch.NewHelper(cluster, env)
 			g.Expect(err).ToNot(HaveOccurred())
-			if cluster.Status.Initialization == nil {
-				cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{}
-			}
 			cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 			g.Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).To(Succeed())
 			return true
@@ -224,7 +221,7 @@ func TestClusterReconciler(t *testing.T) {
 			if err := env.Get(ctx, key, instance); err != nil {
 				return false
 			}
-			return instance.Status.Initialization != nil && ptr.Deref(instance.Status.Initialization.InfrastructureProvisioned, false)
+			return ptr.Deref(instance.Status.Initialization.InfrastructureProvisioned, false)
 		}, timeout).Should(BeTrue())
 	})
 
@@ -320,9 +317,6 @@ func TestClusterReconciler(t *testing.T) {
 		g.Eventually(func() bool {
 			ph, err := patch.NewHelper(cluster, env)
 			g.Expect(err).ToNot(HaveOccurred())
-			if cluster.Status.Initialization == nil {
-				cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{}
-			}
 			cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 			cluster.Spec.InfrastructureRef = &clusterv1.ContractVersionedObjectReference{
 				APIGroup: builder.InfrastructureGroupVersion.Group,
@@ -339,7 +333,7 @@ func TestClusterReconciler(t *testing.T) {
 			if err := env.Get(ctx, key, instance); err != nil {
 				return false
 			}
-			return instance.Status.Initialization != nil && ptr.Deref(instance.Status.Initialization.InfrastructureProvisioned, false) &&
+			return ptr.Deref(instance.Status.Initialization.InfrastructureProvisioned, false) &&
 				instance.Spec.InfrastructureRef != nil &&
 				instance.Spec.InfrastructureRef.Name == "test"
 		}, timeout).Should(BeTrue())

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller_test.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller_test.go
@@ -127,7 +127,7 @@ metadata:
 		g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(testCluster.DeepCopy())
-		testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, testCluster, patch)).To(Succeed())
 
 		g.Eventually(func(g Gomega) {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -250,7 +250,7 @@ func TestGetNode(t *testing.T) {
 	g.Expect(env.Create(ctx, testCluster)).To(Succeed())
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 	patch := client.MergeFrom(testCluster.DeepCopy())
-	testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, testCluster, patch)).To(Succeed())
 
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
@@ -554,7 +554,7 @@ func TestNodeLabelSync(t *testing.T) {
 		g.Expect(env.CreateAndWait(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())

--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -178,9 +178,6 @@ func (r *Reconciler) reconcileBootstrap(ctx context.Context, s *scope) (ctrl.Res
 
 	// If the bootstrap data is populated, set ready and return.
 	if m.Spec.Bootstrap.DataSecretName != nil {
-		if m.Status.Initialization == nil {
-			m.Status.Initialization = &clusterv1.MachineInitializationStatus{}
-		}
 		m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 		v1beta1conditions.MarkTrue(m, clusterv1.BootstrapReadyV1Beta1Condition)
 		return ctrl.Result{}, nil
@@ -235,11 +232,8 @@ func (r *Reconciler) reconcileBootstrap(ctx context.Context, s *scope) (ctrl.Res
 		m.Spec.Bootstrap.DataSecretName = secretName
 	}
 
-	if m.Status.Initialization == nil || !ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false) {
+	if !ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false) {
 		log.Info("Bootstrap provider generated data secret", s.bootstrapConfig.GetKind(), klog.KObj(s.bootstrapConfig), "Secret", klog.KRef(m.Namespace, *secretName))
-	}
-	if m.Status.Initialization == nil {
-		m.Status.Initialization = &clusterv1.MachineInitializationStatus{}
 	}
 	m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 	return ctrl.Result{}, nil
@@ -262,7 +256,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 				return ctrl.Result{}, nil
 			}
 
-			if m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
+			if ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
 				// Infra object went missing after the machine was up and running
 				log.Error(err, "Machine infrastructure reference has been deleted after provisioning was completed, setting failure state")
 				if m.Status.Deprecated == nil {
@@ -298,7 +292,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 	} else {
 		provisioned = *provisionedPtr
 	}
-	if provisioned && (m.Status.Initialization == nil || !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)) {
+	if provisioned && !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
 		log.Info("Infrastructure provider has completed provisioning", s.infraMachine.GetKind(), klog.KObj(s.infraMachine))
 	}
 
@@ -314,7 +308,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 	}
 
 	// If the InfrastructureMachine is not provisioned (and it wasn't already provisioned before), return.
-	if !provisioned && (m.Status.Initialization == nil || !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)) {
+	if !provisioned && !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
 		log.Info(fmt.Sprintf("Waiting for infrastructure provider to create machine infrastructure and set %s",
 			contract.InfrastructureMachine().Provisioned(contractVersion).Path().String()),
 			s.infraMachine.GetKind(), klog.KObj(s.infraMachine))
@@ -358,9 +352,6 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, s *scope) (ctr
 	// - the infra machine is reporting provisioned for the first time
 	// - the infra machine already reported provisioned (and thus m.Status.InfrastructureReady is already true and it should not flip back)
 	m.Spec.ProviderID = *providerID
-	if m.Status.Initialization == nil {
-		m.Status.Initialization = &clusterv1.MachineInitializationStatus{}
-	}
 	m.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	return ctrl.Result{}, nil
 }

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -107,7 +107,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{RequeueAfter: externalReadyWait},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 			},
 		},
 		{
@@ -131,7 +131,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 				g.Expect(m.Spec.Bootstrap.DataSecretName).To(BeNil())
 			},
 		},
@@ -156,7 +156,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(m.Spec.Bootstrap.DataSecretName).NotTo(BeNil())
 				g.Expect(*m.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
 			},
@@ -185,7 +185,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(m.Spec.Bootstrap.DataSecretName).NotTo(BeNil())
 				g.Expect(*m.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
 			},
@@ -216,7 +216,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(m.Spec.Bootstrap.DataSecretName).NotTo(BeNil())
 				g.Expect(*m.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
 			},
@@ -241,7 +241,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             true,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeFalse())
 				g.Expect(m.Spec.Bootstrap.DataSecretName).To(BeNil())
 			},
 		},
@@ -264,7 +264,7 @@ func TestReconcileBootstrap(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						BootstrapDataSecretCreated: ptr.To(true),
 					},
 				},
@@ -286,7 +286,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectResult:            ctrl.Result{},
 			expectError:             false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false)).To(BeTrue())
 				g.Expect(*m.Spec.Bootstrap.DataSecretName).To(Equal("secret-data"))
 			},
 		},
@@ -311,7 +311,7 @@ func TestReconcileBootstrap(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						BootstrapDataSecretCreated: ptr.To(true),
 					},
 				},
@@ -431,7 +431,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{RequeueAfter: externalReadyWait},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
 				g.Expect(m.Status.Deprecated).To(BeNil())
 			},
 		},
@@ -467,7 +467,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeFalse())
 				g.Expect(m.Spec.ProviderID).To(BeEmpty())
 				g.Expect(m.Spec.FailureDomain).To(BeEmpty())
 				g.Expect(m.Status.Addresses).To(BeNil())
@@ -495,7 +495,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(BeEmpty())
 				g.Expect(m.Status.Addresses).To(BeNil())
@@ -525,7 +525,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(BeEmpty())
 				g.Expect(m.Status.Addresses).To(BeNil())
@@ -554,7 +554,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(BeNil())
@@ -592,7 +592,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(BeEmpty())
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
@@ -631,7 +631,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
@@ -673,7 +673,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
@@ -717,7 +717,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					FailureDomain: "something",
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 					Addresses: []clusterv1.MachineAddress{
@@ -757,7 +757,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
@@ -781,7 +781,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					FailureDomain: "something",
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 					Addresses: []clusterv1.MachineAddress{
@@ -821,7 +821,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
@@ -843,7 +843,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 				},
@@ -853,7 +853,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          true,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Status.Deprecated).To(BeNil())
 			},
 		},
@@ -873,7 +873,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 				},
@@ -883,7 +883,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectResult:         ctrl.Result{},
 			expectError:          true,
 			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Status.Deprecated).ToNot(BeNil())
 				g.Expect(m.Status.Deprecated.V1Beta1).ToNot(BeNil())
 				g.Expect(m.Status.Deprecated.V1Beta1.FailureMessage).ToNot(BeNil())
@@ -908,7 +908,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(false),
 					},
 				},
@@ -937,7 +937,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 					},
 				},
 				Status: clusterv1.MachineStatus{
-					Initialization: &clusterv1.MachineInitializationStatus{
+					Initialization: clusterv1.MachineInitializationStatus{
 						InfrastructureProvisioned: ptr.To(true),
 					},
 				},

--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -82,7 +82,7 @@ func setBootstrapReadyCondition(_ context.Context, machine *clusterv1.Machine, b
 	}
 
 	if bootstrapConfig != nil {
-		dataSecretCreated := machine.Status.Initialization != nil && ptr.Deref(machine.Status.Initialization.BootstrapDataSecretCreated, false)
+		dataSecretCreated := ptr.Deref(machine.Status.Initialization.BootstrapDataSecretCreated, false)
 		ready, err := conditions.NewMirrorConditionFromUnstructured(
 			bootstrapConfig,
 			contract.Bootstrap().ReadyConditionType(), conditions.TargetConditionType(clusterv1.MachineBootstrapConfigReadyCondition),
@@ -124,7 +124,7 @@ func setBootstrapReadyCondition(_ context.Context, machine *clusterv1.Machine, b
 	}
 
 	// Bootstrap config missing when the machine is deleting and we know that the BootstrapConfig actually existed.
-	if !machine.DeletionTimestamp.IsZero() && machine.Status.Initialization != nil && ptr.Deref(machine.Status.Initialization.BootstrapDataSecretCreated, false) {
+	if !machine.DeletionTimestamp.IsZero() && ptr.Deref(machine.Status.Initialization.BootstrapDataSecretCreated, false) {
 		conditions.Set(machine, metav1.Condition{
 			Type:    clusterv1.MachineBootstrapConfigReadyCondition,
 			Status:  metav1.ConditionFalse,
@@ -162,7 +162,7 @@ func bootstrapConfigReadyFallBackMessage(kind string, ready bool) string {
 
 func setInfrastructureReadyCondition(_ context.Context, machine *clusterv1.Machine, infraMachine *unstructured.Unstructured, infraMachineIsNotFound bool) {
 	if infraMachine != nil {
-		infrastructureProvisioned := machine.Status.Initialization != nil && ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false)
+		infrastructureProvisioned := ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false)
 		ready, err := conditions.NewMirrorConditionFromUnstructured(
 			infraMachine,
 			contract.InfrastructureMachine().ReadyConditionType(), conditions.TargetConditionType(clusterv1.MachineInfrastructureReadyCondition),
@@ -207,7 +207,7 @@ func setInfrastructureReadyCondition(_ context.Context, machine *clusterv1.Machi
 	// NOTE: in case an accidental deletion happens before volume detach is completed, the Node hosted on the Machine
 	// will be considered unreachable Machine deletion will complete.
 	if !machine.DeletionTimestamp.IsZero() {
-		if machine.Status.Initialization != nil && ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false) {
+		if ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false) {
 			conditions.Set(machine, metav1.Condition{
 				Type:    clusterv1.MachineInfrastructureReadyCondition,
 				Status:  metav1.ConditionFalse,
@@ -227,7 +227,7 @@ func setInfrastructureReadyCondition(_ context.Context, machine *clusterv1.Machi
 	}
 
 	// Report an issue if infra machine missing after the machine has been initialized (and the machine is still running).
-	if machine.Status.Initialization != nil && ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false) {
+	if ptr.Deref(machine.Status.Initialization.InfrastructureProvisioned, false) {
 		conditions.Set(machine, metav1.Condition{
 			Type:    clusterv1.MachineInfrastructureReadyCondition,
 			Status:  metav1.ConditionFalse,
@@ -256,7 +256,7 @@ func infrastructureReadyFallBackMessage(kind string, ready bool) string {
 }
 
 func setNodeHealthyAndReadyConditions(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, node *corev1.Node, nodeGetErr error, lastProbeSuccessTime time.Time, remoteConditionsGracePeriod time.Duration) {
-	if cluster.Status.Initialization == nil || !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+	if !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 		setNodeConditions(machine, metav1.ConditionUnknown,
 			clusterv1.MachineNodeInspectionFailedReason,
 			"Waiting for Cluster status.initialization.infrastructureProvisioned to be true")
@@ -789,7 +789,7 @@ func setMachinePhaseAndLastUpdated(_ context.Context, m *clusterv1.Machine) {
 	}
 
 	// Set the phase to "provisioning" if bootstrap is ready and the infrastructure isn't.
-	if m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false) && !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
+	if ptr.Deref(m.Status.Initialization.BootstrapDataSecretCreated, false) && !ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
 		m.Status.SetTypedPhase(clusterv1.MachinePhaseProvisioning)
 	}
 
@@ -799,7 +799,7 @@ func setMachinePhaseAndLastUpdated(_ context.Context, m *clusterv1.Machine) {
 	}
 
 	// Set the phase to "running" if there is a NodeRef field and infrastructure is ready.
-	if m.Status.NodeRef != nil && m.Status.Initialization != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
+	if m.Status.NodeRef != nil && ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false) {
 		m.Status.SetTypedPhase(clusterv1.MachinePhaseRunning)
 	}
 

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -168,7 +168,7 @@ func TestSetBootstrapReadyCondition(t *testing.T) {
 			name: "Use status.BoostrapReady flag as a fallback Ready condition from bootstrap config is missing (ready true)",
 			machine: func() *clusterv1.Machine {
 				m := defaultMachine.DeepCopy()
-				m.Status.Initialization = &clusterv1.MachineInitializationStatus{BootstrapDataSecretCreated: ptr.To(true)}
+				m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 				return m
 			}(),
 			bootstrapConfig: &unstructured.Unstructured{Object: map[string]interface{}{
@@ -231,7 +231,7 @@ func TestSetBootstrapReadyCondition(t *testing.T) {
 			name: "bootstrap config that was ready not found while machine is deleting",
 			machine: func() *clusterv1.Machine {
 				m := defaultMachine.DeepCopy()
-				m.Status.Initialization = &clusterv1.MachineInitializationStatus{BootstrapDataSecretCreated: ptr.To(true)}
+				m.Status.Initialization.BootstrapDataSecretCreated = ptr.To(true)
 				m.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
 				return m
 			}(),
@@ -391,7 +391,7 @@ func TestSetInfrastructureReadyCondition(t *testing.T) {
 			name: "Use status.InfrastructureReady flag as a fallback Ready condition from infra machine is missing (ready true)",
 			machine: func() *clusterv1.Machine {
 				m := defaultMachine.DeepCopy()
-				m.Status.Initialization = &clusterv1.MachineInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+				m.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 				return m
 			}(),
 			infraMachine: &unstructured.Unstructured{Object: map[string]interface{}{
@@ -459,7 +459,7 @@ func TestSetInfrastructureReadyCondition(t *testing.T) {
 			machine: func() *clusterv1.Machine {
 				m := defaultMachine.DeepCopy()
 				m.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
-				m.Status.Initialization = &clusterv1.MachineInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+				m.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 				return m
 			}(),
 			infraMachine:           nil,
@@ -491,7 +491,7 @@ func TestSetInfrastructureReadyCondition(t *testing.T) {
 			name: "infra machine not found after the machine has been initialized",
 			machine: func() *clusterv1.Machine {
 				m := defaultMachine.DeepCopy()
-				m.Status.Initialization = &clusterv1.MachineInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+				m.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 				return m
 			}(),
 			infraMachine:           nil,
@@ -654,7 +654,7 @@ func TestSetNodeHealthyAndReadyConditions(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
+			Initialization: clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)},
 			Conditions: []metav1.Condition{
 				{Type: clusterv1.ClusterControlPlaneInitializedCondition, Status: metav1.ConditionTrue, LastTransitionTime: metav1.Time{Time: now.Add(-5 * time.Second)}},
 			},
@@ -674,7 +674,7 @@ func TestSetNodeHealthyAndReadyConditions(t *testing.T) {
 			name: "Cluster status.infrastructureReady is false",
 			cluster: func() *clusterv1.Cluster {
 				c := defaultCluster.DeepCopy()
-				c.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(false)}
+				c.Status.Initialization.InfrastructureProvisioned = ptr.To(false)
 				return c
 			}(),
 			machine: defaultMachine.DeepCopy(),
@@ -1990,7 +1990,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2042,7 +2042,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2085,7 +2085,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2157,7 +2157,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2246,7 +2246,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2324,7 +2324,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2391,7 +2391,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
@@ -2463,7 +2463,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, defaultKubeconfigSecret)).To(Succeed())
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -127,7 +127,7 @@ func TestWatches(t *testing.T) {
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 	testClusterOriginal := client.MergeFrom(testCluster.DeepCopy())
-	testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, testCluster, testClusterOriginal)).To(Succeed())
 
 	g.Expect(env.Create(ctx, defaultBootstrap)).To(Succeed())
@@ -444,7 +444,7 @@ func TestMachine_Reconcile(t *testing.T) {
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 	testClusterOriginal := client.MergeFrom(testCluster.DeepCopy())
-	testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, testCluster, testClusterOriginal)).To(Succeed())
 
 	g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
@@ -1049,7 +1049,7 @@ func TestMachineV1Beta1Conditions(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Status: clusterv1.ClusterStatus{
-			Initialization: &clusterv1.ClusterInitializationStatus{
+			Initialization: clusterv1.ClusterInitializationStatus{
 				InfrastructureProvisioned: ptr.To(true),
 			},
 			Conditions: []metav1.Condition{
@@ -3120,7 +3120,7 @@ func TestNodeToMachine(t *testing.T) {
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 	testClusterOriginal := client.MergeFrom(testCluster.DeepCopy())
-	testCluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, testCluster, testClusterOriginal)).To(Succeed())
 
 	g.Expect(env.Create(ctx, defaultBootstrap)).To(Succeed())

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -75,7 +75,7 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		cluster.Status.Deprecated = &clusterv1.ClusterDeprecatedStatus{
 			V1Beta1: &clusterv1.ClusterV1Beta1DeprecatedStatus{
 				Conditions: clusterv1.Conditions{

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -2459,9 +2459,7 @@ func createCluster(g *WithT, namespaceName string) *clusterv1.Cluster {
 	patchHelper, err := patch.NewHelper(cluster, env.Client)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{
-		InfrastructureProvisioned: ptr.To(true),
-	}
+	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	conditions.Set(cluster, metav1.Condition{
 		Type:   clusterv1.ClusterInfrastructureReadyCondition,
 		Status: metav1.ConditionTrue,
@@ -2503,7 +2501,7 @@ func newRunningMachine(c *clusterv1.Cluster, labels map[string]string) *clusterv
 			},
 		},
 		Status: clusterv1.MachineStatus{
-			Initialization: &clusterv1.MachineInitializationStatus{
+			Initialization: clusterv1.MachineInitializationStatus{
 				InfrastructureProvisioned:  ptr.To(true),
 				BootstrapDataSecretCreated: ptr.To(true),
 			},

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -594,7 +594,7 @@ func newTestMachine(name, namespace, clusterName, nodeName string, labels map[st
 			},
 		},
 		Status: clusterv1.MachineStatus{
-			Initialization: &clusterv1.MachineInitializationStatus{
+			Initialization: clusterv1.MachineInitializationStatus{
 				InfrastructureProvisioned:  ptr.To(true),
 				BootstrapDataSecretCreated: ptr.To(true),
 			},

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -85,7 +85,7 @@ func TestMachineSetReconciler(t *testing.T) {
 
 		// Set InfrastructureReady to true so ClusterCache creates the clusterAccessor.
 		patch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+		cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 		cluster.Status.Deprecated = &clusterv1.ClusterDeprecatedStatus{
 			V1Beta1: &clusterv1.ClusterV1Beta1DeprecatedStatus{
 				Conditions: clusterv1.Conditions{

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -956,12 +956,12 @@ func setupTestEnvForIntegrationTests(ns *corev1.Namespace) (func() error, error)
 	}
 	// Set InfrastructureReady to true so ClusterCache creates the clusterAccessors.
 	patch := client.MergeFrom(cluster1.DeepCopy())
-	cluster1.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster1.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	if err := env.Status().Patch(ctx, cluster1, patch); err != nil {
 		return nil, err
 	}
 	patch = client.MergeFrom(cluster2.DeepCopy())
-	cluster2.Status.Initialization = &clusterv1.ClusterInitializationStatus{InfrastructureProvisioned: ptr.To(true)}
+	cluster2.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	if err := env.Status().Patch(ctx, cluster2, patch); err != nil {
 		return nil, err
 	}

--- a/test/infrastructure/docker/api/v1alpha3/conversion.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion.go
@@ -201,7 +201,7 @@ func Convert_v1beta2_DockerClusterStatus_To_v1alpha3_DockerClusterStatus(in *inf
 		clusterv1alpha3.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1alpha3_Conditions(&in.Deprecated.V1Beta1.Conditions, &out.Conditions)
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -231,7 +231,7 @@ func Convert_v1beta2_DockerMachineStatus_To_v1alpha3_DockerMachineStatus(in *inf
 		clusterv1alpha3.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1alpha3_Conditions(&in.Deprecated.V1Beta1.Conditions, &out.Conditions)
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -263,10 +263,6 @@ func Convert_v1alpha3_DockerMachineStatus_To_v1beta2_DockerMachineStatus(in *Doc
 		clusterv1alpha3.Convert_v1alpha3_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
 	}
 
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerMachineInitializationStatus{}
-	}
-
 	if in.Ready {
 		out.Initialization.Provisioned = ptr.To(in.Ready)
 	}
@@ -287,10 +283,6 @@ func Convert_v1alpha3_DockerClusterStatus_To_v1beta2_DockerClusterStatus(in *Doc
 		out.Deprecated = &infrav1.DockerClusterDeprecatedStatus{}
 		out.Deprecated.V1Beta1 = &infrav1.DockerClusterV1Beta1DeprecatedStatus{}
 		clusterv1alpha3.Convert_v1alpha3_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
-	}
-
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerClusterInitializationStatus{}
 	}
 
 	if in.Ready {

--- a/test/infrastructure/docker/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion_test.go
@@ -69,12 +69,6 @@ func hubDockerClusterStatus(in *infrav1.DockerClusterStatus, c randfill.Continue
 			in.Deprecated = nil
 		}
 	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func hubFailureDomain(in *clusterv1.FailureDomain, c randfill.Continue) {
@@ -98,12 +92,6 @@ func hubDockerMachineStatus(in *infrav1.DockerMachineStatus, c randfill.Continue
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &infrav1.DockerMachineV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
-		}
-	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerMachineInitializationStatus{}) {
-			in.Initialization = nil
 		}
 	}
 }

--- a/test/infrastructure/docker/api/v1alpha4/conversion.go
+++ b/test/infrastructure/docker/api/v1alpha4/conversion.go
@@ -215,7 +215,7 @@ func Convert_v1beta2_DockerClusterStatus_To_v1alpha4_DockerClusterStatus(in *inf
 		clusterv1alpha4.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1alpha4_Conditions(&in.Deprecated.V1Beta1.Conditions, &out.Conditions)
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -245,7 +245,7 @@ func Convert_v1beta2_DockerMachineStatus_To_v1alpha4_DockerMachineStatus(in *inf
 		clusterv1alpha4.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1alpha4_Conditions(&in.Deprecated.V1Beta1.Conditions, &out.Conditions)
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -292,10 +292,6 @@ func Convert_v1alpha4_DockerMachineStatus_To_v1beta2_DockerMachineStatus(in *Doc
 		clusterv1alpha4.Convert_v1alpha4_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
 	}
 
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerMachineInitializationStatus{}
-	}
-
 	if in.Ready {
 		out.Initialization.Provisioned = ptr.To(in.Ready)
 	}
@@ -316,10 +312,6 @@ func Convert_v1alpha4_DockerClusterStatus_To_v1beta2_DockerClusterStatus(in *Doc
 		out.Deprecated = &infrav1.DockerClusterDeprecatedStatus{}
 		out.Deprecated.V1Beta1 = &infrav1.DockerClusterV1Beta1DeprecatedStatus{}
 		clusterv1alpha4.Convert_v1alpha4_Conditions_To_v1beta2_Deprecated_V1Beta1_Conditions(&in.Conditions, &out.Deprecated.V1Beta1.Conditions)
-	}
-
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerClusterInitializationStatus{}
 	}
 
 	if in.Ready {

--- a/test/infrastructure/docker/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha4/conversion_test.go
@@ -83,12 +83,6 @@ func hubDockerClusterStatus(in *infrav1.DockerClusterStatus, c randfill.Continue
 			in.Deprecated = nil
 		}
 	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func DockerClusterTemplateFuzzFunc(_ runtimeserializer.CodecFactory) []any {
@@ -110,12 +104,6 @@ func hubDockerMachineStatus(in *infrav1.DockerMachineStatus, c randfill.Continue
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &infrav1.DockerMachineV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
-		}
-	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerMachineInitializationStatus{}) {
-			in.Initialization = nil
 		}
 	}
 }

--- a/test/infrastructure/docker/api/v1beta1/conversion.go
+++ b/test/infrastructure/docker/api/v1beta1/conversion.go
@@ -241,10 +241,6 @@ func Convert_v1beta1_DevClusterStatus_To_v1beta2_DevClusterStatus(in *DevCluster
 		return err
 	}
 
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DevClusterInitializationStatus{}
-	}
-
 	if in.Ready {
 		out.Initialization.Provisioned = ptr.To(in.Ready)
 	}
@@ -293,7 +289,7 @@ func Convert_v1beta2_DevClusterStatus_To_v1beta1_DevClusterStatus(in *infrav1.De
 		return err
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -331,10 +327,6 @@ func Convert_v1beta1_DevMachineStatus_To_v1beta2_DevMachineStatus(in *DevMachine
 		return err
 	}
 
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DevMachineInitializationStatus{}
-	}
-
 	if in.Ready {
 		out.Initialization.Provisioned = ptr.To(in.Ready)
 	}
@@ -369,7 +361,7 @@ func Convert_v1beta2_DevMachineStatus_To_v1beta1_DevMachineStatus(in *infrav1.De
 		return err
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -396,10 +388,6 @@ func Convert_v1beta2_DevMachineStatus_To_v1beta1_DevMachineStatus(in *infrav1.De
 func Convert_v1beta1_DockerClusterStatus_To_v1beta2_DockerClusterStatus(in *DockerClusterStatus, out *infrav1.DockerClusterStatus, s apiconversion.Scope) error {
 	if err := autoConvert_v1beta1_DockerClusterStatus_To_v1beta2_DockerClusterStatus(in, out, s); err != nil {
 		return err
-	}
-
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerClusterInitializationStatus{}
 	}
 
 	if in.Ready {
@@ -450,7 +438,7 @@ func Convert_v1beta2_DockerClusterStatus_To_v1beta1_DockerClusterStatus(in *infr
 		return err
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 
@@ -488,10 +476,6 @@ func Convert_v1beta1_DockerMachineStatus_To_v1beta2_DockerMachineStatus(in *Dock
 		return err
 	}
 
-	if out.Initialization == nil {
-		out.Initialization = &infrav1.DockerMachineInitializationStatus{}
-	}
-
 	if in.Ready {
 		out.Initialization.Provisioned = ptr.To(in.Ready)
 	}
@@ -526,7 +510,7 @@ func Convert_v1beta2_DockerMachineStatus_To_v1beta1_DockerMachineStatus(in *infr
 		return err
 	}
 
-	if in.Initialization != nil && in.Initialization.Provisioned != nil {
+	if in.Initialization.Provisioned != nil {
 		out.Ready = *in.Initialization.Provisioned
 	}
 

--- a/test/infrastructure/docker/api/v1beta1/conversion_test.go
+++ b/test/infrastructure/docker/api/v1beta1/conversion_test.go
@@ -100,12 +100,6 @@ func hubDockerClusterStatus(in *infrav1.DockerClusterStatus, c randfill.Continue
 			in.Deprecated = nil
 		}
 	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func hubFailureDomain(in *clusterv1.FailureDomain, c randfill.Continue) {
@@ -147,12 +141,6 @@ func hubDockerMachineStatus(in *infrav1.DockerMachineStatus, c randfill.Continue
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &infrav1.DockerMachineV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
-		}
-	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DockerMachineInitializationStatus{}) {
-			in.Initialization = nil
 		}
 	}
 }
@@ -198,12 +186,6 @@ func hubDevClusterStatus(in *infrav1.DevClusterStatus, c randfill.Continue) {
 			in.Deprecated = nil
 		}
 	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DevClusterInitializationStatus{}) {
-			in.Initialization = nil
-		}
-	}
 }
 
 func spokeDevClusterStatus(in *DevClusterStatus, c randfill.Continue) {
@@ -237,12 +219,6 @@ func hubDevMachineStatus(in *infrav1.DevMachineStatus, c randfill.Continue) {
 	if in.Deprecated != nil {
 		if in.Deprecated.V1Beta1 == nil || reflect.DeepEqual(in.Deprecated.V1Beta1, &infrav1.DevMachineV1Beta1DeprecatedStatus{}) {
 			in.Deprecated = nil
-		}
-	}
-
-	if in.Initialization != nil {
-		if reflect.DeepEqual(in.Initialization, &infrav1.DevMachineInitializationStatus{}) {
-			in.Initialization = nil
 		}
 	}
 }

--- a/test/infrastructure/docker/api/v1beta2/devcluster_types.go
+++ b/test/infrastructure/docker/api/v1beta2/devcluster_types.go
@@ -124,7 +124,7 @@ type DevClusterStatus struct {
 	// initialization provides observations of the DevCluster initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
 	// +optional
-	Initialization *DevClusterInitializationStatus `json:"initialization,omitempty"`
+	Initialization DevClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// failureDomains is a list of failure domain objects synced from the infrastructure provider.
 	// It don't mean much in CAPD since it's all local, but we can see how the rest of cluster API
@@ -142,6 +142,7 @@ type DevClusterStatus struct {
 }
 
 // DevClusterInitializationStatus provides observations of the DevCluster initialization process.
+// +kubebuilder:validation:MinProperties=1
 type DevClusterInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Cluster's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Cluster provisioning.

--- a/test/infrastructure/docker/api/v1beta2/devmachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/devmachine_types.go
@@ -362,7 +362,7 @@ type DevMachineStatus struct {
 	// initialization provides observations of the DevMachine initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
 	// +optional
-	Initialization *DevMachineInitializationStatus `json:"initialization,omitempty"`
+	Initialization DevMachineInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// addresses contains the associated addresses for the dev machine.
 	// +optional
@@ -378,6 +378,7 @@ type DevMachineStatus struct {
 }
 
 // DevMachineInitializationStatus provides observations of the DevMachine initialization process.
+// +kubebuilder:validation:MinProperties=1
 type DevMachineInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Machine's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.

--- a/test/infrastructure/docker/api/v1beta2/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1beta2/dockercluster_types.go
@@ -98,7 +98,7 @@ type DockerClusterStatus struct {
 	// initialization provides observations of the DockerCluster initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
 	// +optional
-	Initialization *DockerClusterInitializationStatus `json:"initialization,omitempty"`
+	Initialization DockerClusterInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// failureDomains is a list of failure domain objects synced from the infrastructure provider.
 	// It don't mean much in CAPD since it's all local, but we can see how the rest of cluster API
@@ -116,6 +116,7 @@ type DockerClusterStatus struct {
 }
 
 // DockerClusterInitializationStatus provides observations of the DockerCluster initialization process.
+// +kubebuilder:validation:MinProperties=1
 type DockerClusterInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Cluster's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Cluster provisioning.

--- a/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
@@ -95,7 +95,7 @@ type DockerMachineStatus struct {
 	// initialization provides observations of the DockerMachine initialization process.
 	// NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
 	// +optional
-	Initialization *DockerMachineInitializationStatus `json:"initialization,omitempty"`
+	Initialization DockerMachineInitializationStatus `json:"initialization,omitempty,omitzero"`
 
 	// LoadBalancerConfigured denotes that the machine has been
 	// added to the load balancer
@@ -112,6 +112,7 @@ type DockerMachineStatus struct {
 }
 
 // DockerMachineInitializationStatus provides observations of the DockerMachine initialization process.
+// +kubebuilder:validation:MinProperties=1
 type DockerMachineInitializationStatus struct {
 	// provisioned is true when the infrastructure provider reports that the Machine's infrastructure is fully provisioned.
 	// NOTE: this field is part of the Cluster API contract, and it is used to orchestrate initial Machine provisioning.

--- a/test/infrastructure/docker/api/v1beta2/zz_generated.deepcopy.go
+++ b/test/infrastructure/docker/api/v1beta2/zz_generated.deepcopy.go
@@ -209,11 +209,7 @@ func (in *DevClusterStatus) DeepCopyInto(out *DevClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(DevClusterInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.FailureDomains != nil {
 		in, out := &in.FailureDomains, &out.FailureDomains
 		*out = make([]corev1beta2.FailureDomain, len(*in))
@@ -521,11 +517,7 @@ func (in *DevMachineStatus) DeepCopyInto(out *DevMachineStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(DevMachineInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
 		*out = make([]corev1beta2.MachineAddress, len(*in))
@@ -822,11 +814,7 @@ func (in *DockerClusterStatus) DeepCopyInto(out *DockerClusterStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(DockerClusterInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.FailureDomains != nil {
 		in, out := &in.FailureDomains, &out.FailureDomains
 		*out = make([]corev1beta2.FailureDomain, len(*in))
@@ -1169,11 +1157,7 @@ func (in *DockerMachineStatus) DeepCopyInto(out *DockerMachineStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Initialization != nil {
-		in, out := &in.Initialization, &out.Initialization
-		*out = new(DockerMachineInitializationStatus)
-		(*in).DeepCopyInto(*out)
-	}
+	in.Initialization.DeepCopyInto(&out.Initialization)
 	if in.Addresses != nil {
 		in, out := &in.Addresses, &out.Addresses
 		*out = make([]corev1beta2.MachineAddress, len(*in))

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devclusters.yaml
@@ -608,6 +608,7 @@ spec:
                 description: |-
                   initialization provides observations of the DevCluster initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
+                minProperties: 1
                 properties:
                   provisioned:
                     description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
@@ -784,6 +784,7 @@ spec:
                 description: |-
                   initialization provides observations of the DevMachine initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                minProperties: 1
                 properties:
                   provisioned:
                     description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -891,6 +891,7 @@ spec:
                 description: |-
                   initialization provides observations of the DockerCluster initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Cluster provisioning.
+                minProperties: 1
                 properties:
                   provisioned:
                     description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -862,6 +862,7 @@ spec:
                 description: |-
                   initialization provides observations of the DockerMachine initialization process.
                   NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial Machine provisioning.
+                minProperties: 1
                 properties:
                   provisioned:
                     description: |-

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller_phases.go
@@ -201,8 +201,7 @@ func (r *DockerMachinePoolReconciler) reconcileDockerMachines(ctx context.Contex
 	for i := range orderedDockerMachines {
 		dockerMachine := orderedDockerMachines[i]
 		// TODO (v1beta2): test for v1beta2 conditions
-		initialization := dockerMachine.Status.Initialization
-		if initialization != nil && ptr.Deref(initialization.Provisioned, false) || v1beta1conditions.IsTrue(&dockerMachine, clusterv1.ReadyV1Beta1Condition) {
+		if ptr.Deref(dockerMachine.Status.Initialization.Provisioned, false) || v1beta1conditions.IsTrue(&dockerMachine, clusterv1.ReadyV1Beta1Condition) {
 			totalReadyMachines++
 		}
 	}
@@ -387,11 +386,10 @@ func (r *DockerMachinePoolReconciler) getDeletionCandidates(ctx context.Context,
 			return nil, nil, errors.Errorf("failed to find externalMachine for DockerMachine %s/%s", dockerMachine.Namespace, dockerMachine.Name)
 		}
 
-		initialization := dockerMachine.Status.Initialization
 		// TODO (v1beta2): test for v1beta2 conditions
 		if !isMachineMatchingInfrastructureSpec(ctx, externalMachine, machinePool, dockerMachinePool) {
 			outdatedMachines = append(outdatedMachines, dockerMachine)
-		} else if initialization != nil && ptr.Deref(initialization.Provisioned, false) || v1beta1conditions.IsTrue(&dockerMachine, clusterv1.ReadyV1Beta1Condition) {
+		} else if ptr.Deref(dockerMachine.Status.Initialization.Provisioned, false) || v1beta1conditions.IsTrue(&dockerMachine, clusterv1.ReadyV1Beta1Condition) {
 			readyMatchingMachines = append(readyMatchingMachines, dockerMachine)
 		}
 	}

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockercluster_backend.go
@@ -104,9 +104,7 @@ func (r *ClusterBackEndReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 
 	// Mark the dockerCluster ready
-	dockerCluster.Status.Initialization = &infrav1.DevClusterInitializationStatus{
-		Provisioned: ptr.To(true),
-	}
+	dockerCluster.Status.Initialization.Provisioned = ptr.To(true)
 	v1beta1conditions.MarkTrue(dockerCluster, infrav1.LoadBalancerAvailableV1Beta1Condition)
 	conditions.Set(dockerCluster, metav1.Condition{
 		Type:   infrav1.DevClusterDockerLoadBalancerAvailableCondition,

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -70,7 +70,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 
 	// Check if the infrastructure is ready, otherwise return and wait for the cluster object to be updated
-	if cluster.Status.Initialization == nil || !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+	if !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 		log.Info("Waiting for DockerCluster Controller to create cluster infrastructure")
 		v1beta1conditions.MarkFalse(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition, infrav1.WaitingForClusterInfrastructureV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(dockerMachine, metav1.Condition{
@@ -118,9 +118,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	if dockerMachine.Spec.ProviderID != "" {
 		// ensure ready state is set.
 		// This is required after move, because status is not moved to the target cluster.
-		dockerMachine.Status.Initialization = &infrav1.DevMachineInitializationStatus{
-			Provisioned: ptr.To(true),
-		}
+		dockerMachine.Status.Initialization.Provisioned = ptr.To(true)
 
 		if externalMachine.Exists() {
 			v1beta1conditions.MarkTrue(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition)
@@ -362,9 +360,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 	// Set ProviderID so the Cluster API Machine Controller can pull it
 	dockerMachine.Spec.ProviderID = externalMachine.ProviderID()
-	dockerMachine.Status.Initialization = &infrav1.DevMachineInitializationStatus{
-		Provisioned: ptr.To(true),
-	}
+	dockerMachine.Status.Initialization.Provisioned = ptr.To(true)
 
 	return ctrl.Result{}, nil
 }

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
@@ -127,9 +127,7 @@ func (r *ClusterBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 
 	// Mark the InMemoryCluster ready
-	inMemoryCluster.Status.Initialization = &infrav1.DevClusterInitializationStatus{
-		Provisioned: ptr.To(true),
-	}
+	inMemoryCluster.Status.Initialization.Provisioned = ptr.To(true)
 
 	return ctrl.Result{}, nil
 }

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -93,7 +93,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	}
 
 	// Check if the infrastructure is ready, otherwise return and wait for the cluster object to be updated
-	if cluster.Status.Initialization == nil || !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
+	if !ptr.Deref(cluster.Status.Initialization.InfrastructureProvisioned, false) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.VMProvisionedCondition, infrav1.WaitingForClusterInfrastructureV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryVMProvisionedCondition,
@@ -228,9 +228,7 @@ func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Conte
 	// TODO: consider if to surface VM provisioned also on the cloud machine (currently it surfaces only on the inMemoryMachine)
 
 	inMemoryMachine.Spec.ProviderID = calculateProviderID(inMemoryMachine)
-	inMemoryMachine.Status.Initialization = &infrav1.DevMachineInitializationStatus{
-		Provisioned: ptr.To(true),
-	}
+	inMemoryMachine.Status.Initialization.Provisioned = ptr.To(true)
 	v1beta1conditions.MarkTrue(inMemoryMachine, infrav1.VMProvisionedCondition)
 	conditions.Set(inMemoryMachine, metav1.Condition{
 		Type:   infrav1.DevMachineInMemoryVMProvisionedCondition,

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -205,13 +205,6 @@ func dockerClusterToDevCluster(dockerCluster *infrav1.DockerCluster) *infrav1.De
 		}
 	}
 
-	var initialization *infrav1.DevClusterInitializationStatus
-	if dockerCluster.Status.Initialization != nil && dockerCluster.Status.Initialization.Provisioned != nil {
-		initialization = &infrav1.DevClusterInitializationStatus{
-			Provisioned: dockerCluster.Status.Initialization.Provisioned,
-		}
-	}
-
 	return &infrav1.DevCluster{
 		ObjectMeta: dockerCluster.ObjectMeta,
 		Spec: infrav1.DevClusterSpec{
@@ -224,7 +217,9 @@ func dockerClusterToDevCluster(dockerCluster *infrav1.DockerCluster) *infrav1.De
 			},
 		},
 		Status: infrav1.DevClusterStatus{
-			Initialization: initialization,
+			Initialization: infrav1.DevClusterInitializationStatus{
+				Provisioned: dockerCluster.Status.Initialization.Provisioned,
+			},
 			FailureDomains: dockerCluster.Status.FailureDomains,
 			Conditions:     dockerCluster.Status.Conditions,
 			Deprecated:     v1Beta1Status,
@@ -243,18 +238,13 @@ func devClusterToDockerCluster(devCluster *infrav1.DevCluster, dockerCluster *in
 		}
 	}
 
-	var initialization *infrav1.DockerClusterInitializationStatus
-	if devCluster.Status.Initialization != nil && devCluster.Status.Initialization.Provisioned != nil {
-		initialization = &infrav1.DockerClusterInitializationStatus{
-			Provisioned: devCluster.Status.Initialization.Provisioned,
-		}
-	}
-
 	dockerCluster.ObjectMeta = devCluster.ObjectMeta
 	dockerCluster.Spec.ControlPlaneEndpoint = devCluster.Spec.ControlPlaneEndpoint
 	dockerCluster.Spec.FailureDomains = devCluster.Spec.Backend.Docker.FailureDomains
 	dockerCluster.Spec.LoadBalancer = devCluster.Spec.Backend.Docker.LoadBalancer
-	dockerCluster.Status.Initialization = initialization
+	dockerCluster.Status.Initialization = infrav1.DockerClusterInitializationStatus{
+		Provisioned: devCluster.Status.Initialization.Provisioned,
+	}
 	dockerCluster.Status.FailureDomains = devCluster.Status.FailureDomains
 	dockerCluster.Status.Conditions = devCluster.Status.Conditions
 	dockerCluster.Status.Deprecated = v1Beta1Status

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -304,13 +304,6 @@ func dockerMachineToDevMachine(dockerMachine *infrav1.DockerMachine) *infrav1.De
 		}
 	}
 
-	var initialization *infrav1.DevMachineInitializationStatus
-	if dockerMachine.Status.Initialization != nil && dockerMachine.Status.Initialization.Provisioned != nil {
-		initialization = &infrav1.DevMachineInitializationStatus{
-			Provisioned: dockerMachine.Status.Initialization.Provisioned,
-		}
-	}
-
 	return &infrav1.DevMachine{
 		ObjectMeta: dockerMachine.ObjectMeta,
 		Spec: infrav1.DevMachineSpec{
@@ -326,10 +319,12 @@ func dockerMachineToDevMachine(dockerMachine *infrav1.DockerMachine) *infrav1.De
 			},
 		},
 		Status: infrav1.DevMachineStatus{
-			Initialization: initialization,
-			Addresses:      dockerMachine.Status.Addresses,
-			Conditions:     dockerMachine.Status.Conditions,
-			Deprecated:     v1Beta1Status,
+			Initialization: infrav1.DevMachineInitializationStatus{
+				Provisioned: dockerMachine.Status.Initialization.Provisioned,
+			},
+			Addresses:  dockerMachine.Status.Addresses,
+			Conditions: dockerMachine.Status.Conditions,
+			Deprecated: v1Beta1Status,
 			Backend: &infrav1.DevMachineBackendStatus{
 				Docker: &infrav1.DockerMachineBackendStatus{
 					LoadBalancerConfigured: dockerMachine.Status.LoadBalancerConfigured,
@@ -350,13 +345,6 @@ func devMachineToDockerMachine(devMachine *infrav1.DevMachine, dockerMachine *in
 		}
 	}
 
-	var initialization *infrav1.DockerMachineInitializationStatus
-	if devMachine.Status.Initialization != nil && devMachine.Status.Initialization.Provisioned != nil {
-		initialization = &infrav1.DockerMachineInitializationStatus{
-			Provisioned: devMachine.Status.Initialization.Provisioned,
-		}
-	}
-
 	dockerMachine.ObjectMeta = devMachine.ObjectMeta
 	dockerMachine.Spec.ProviderID = devMachine.Spec.ProviderID
 	dockerMachine.Spec.CustomImage = devMachine.Spec.Backend.Docker.CustomImage
@@ -364,7 +352,9 @@ func devMachineToDockerMachine(devMachine *infrav1.DevMachine, dockerMachine *in
 	dockerMachine.Spec.ExtraMounts = devMachine.Spec.Backend.Docker.ExtraMounts
 	dockerMachine.Spec.Bootstrapped = devMachine.Spec.Backend.Docker.Bootstrapped
 	dockerMachine.Spec.BootstrapTimeout = devMachine.Spec.Backend.Docker.BootstrapTimeout
-	dockerMachine.Status.Initialization = initialization
+	dockerMachine.Status.Initialization = infrav1.DockerMachineInitializationStatus{
+		Provisioned: devMachine.Status.Initialization.Provisioned,
+	}
 	dockerMachine.Status.Addresses = devMachine.Status.Addresses
 	dockerMachine.Status.Conditions = devMachine.Status.Conditions
 	dockerMachine.Status.Deprecated = v1Beta1Status

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -684,9 +684,7 @@ func TestPatchHelper(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object status")
-			obj.Status.Initialization = &clusterv1.ClusterInitializationStatus{
-				InfrastructureProvisioned: ptr.To(true),
-			}
+			obj.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
@@ -732,9 +730,7 @@ func TestPatchHelper(t *testing.T) {
 			}
 
 			t.Log("Updating the object status")
-			obj.Status.Initialization = &clusterv1.ClusterInitializationStatus{
-				InfrastructureProvisioned: ptr.To(true),
-			}
+			obj.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 
 			t.Log("Setting Ready condition")
 			conditions.Set(obj, metav1.Condition{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood", LastTransitionTime: now})

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -53,7 +53,7 @@ func ClusterCreateInfraProvisioned(scheme *runtime.Scheme, logger logr.Logger) p
 			}
 
 			// Only need to trigger a reconcile if the Cluster infrastructure is provisioned.
-			if c.Status.Initialization != nil && ptr.Deref(c.Status.Initialization.InfrastructureProvisioned, false) {
+			if ptr.Deref(c.Status.Initialization.InfrastructureProvisioned, false) {
 				log.V(6).Info("Cluster infrastructure is ready, allowing further processing")
 				return true
 			}
@@ -116,7 +116,7 @@ func ClusterUpdateInfraProvisioned(scheme *runtime.Scheme, logger logr.Logger) p
 
 			newCluster := e.ObjectNew.(*clusterv1.Cluster)
 
-			if (oldCluster.Status.Initialization == nil || !ptr.Deref(oldCluster.Status.Initialization.InfrastructureProvisioned, false)) && (newCluster.Status.Initialization != nil && ptr.Deref(newCluster.Status.Initialization.InfrastructureProvisioned, false)) {
+			if !ptr.Deref(oldCluster.Status.Initialization.InfrastructureProvisioned, false) && ptr.Deref(newCluster.Status.Initialization.InfrastructureProvisioned, false) {
 				log.V(6).Info("Cluster infrastructure became ready, allowing further processing")
 				return true
 			}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Dropped the pointer from Initialization status structs. I think it's much much cleaner this way and the fields in initialization are much easier to use now

& follow-ups to:
* https://github.com/kubernetes-sigs/cluster-api/pull/12098
* https://github.com/kubernetes-sigs/cluster-api/pull/12102

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11947 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->