### PR TITLE
🌱 Remove nested provider from book

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -33,7 +33,6 @@ source of inspiration and ideas for others.
 - [Kamaji](https://github.com/clastix/cluster-api-control-plane-provider-kamaji)
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm)
 - [MicroK8s](https://github.com/canonical/cluster-api-control-plane-provider-microk8s)
-- [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
 - [RKE2](https://github.com/rancher/cluster-api-provider-rke2)
 - [Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
 
@@ -59,7 +58,6 @@ source of inspiration and ideas for others.
 - [MAAS](https://github.com/spectrocloud/cluster-api-provider-maas)
 - [Metal3](https://github.com/metal3-io/cluster-api-provider-metal3)
 - [Microvm](https://github.com/weaveworks-liquidmetal/cluster-api-provider-microvm)
-- [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
 - [Nutanix](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
 - [Oracle Cloud Infrastructure (OCI)](https://github.com/oracle/cluster-api-provider-oci)
 - [OpenNebula](https://github.com/OpenNebula/cluster-api-provider-opennebula)


### PR DESCRIPTION
The nested provider repository is archived and the current version of clusterctl is not compatible with it anymore (v1beta1 vs. v1alpha4) so it should not be in the provider list in the book.
