### PR TITLE
⚠️ Remove more defaulting from KubeadmConfig/KubeadmConfigTemplate/KCP/KCPTemplate

### DIFF
--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -375,7 +375,7 @@ type NodeRegistrationOptions struct {
 	// imagePullPolicy specifies the policy for image pulling
 	// during kubeadm "init" and "join" operations. The value of
 	// this field must be one of "Always", "IfNotPresent" or
-	// "Never". Defaults to "IfNotPresent".
+	// "Never". Defaults to "IfNotPresent" if not set.
 	// +kubebuilder:validation:Enum=Always;IfNotPresent;Never
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
@@ -120,7 +120,8 @@ type KubeadmConfigSpec struct {
 	// +optional
 	NTP *NTP `json:"ntp,omitempty"`
 
-	// format specifies the output format of the bootstrap data
+	// format specifies the output format of the bootstrap data.
+	// Defaults to cloud-config if not set.
 	// +optional
 	Format Format `json:"format,omitempty"`
 
@@ -132,28 +133,6 @@ type KubeadmConfigSpec struct {
 	// ignition contains Ignition specific configuration.
 	// +optional
 	Ignition *IgnitionSpec `json:"ignition,omitempty"`
-}
-
-// Default defaults a KubeadmConfigSpec.
-func (c *KubeadmConfigSpec) Default() {
-	if c.Format == "" {
-		c.Format = CloudConfig
-	}
-	if c.InitConfiguration != nil && c.InitConfiguration.NodeRegistration.ImagePullPolicy == "" {
-		c.InitConfiguration.NodeRegistration.ImagePullPolicy = "IfNotPresent"
-	}
-	if c.JoinConfiguration != nil && c.JoinConfiguration.NodeRegistration.ImagePullPolicy == "" {
-		c.JoinConfiguration.NodeRegistration.ImagePullPolicy = "IfNotPresent"
-	}
-	if c.JoinConfiguration != nil && c.JoinConfiguration.Discovery.File != nil {
-		if kfg := c.JoinConfiguration.Discovery.File.KubeConfig; kfg != nil {
-			if kfg.User.Exec != nil {
-				if kfg.User.Exec.APIVersion == "" {
-					kfg.User.Exec.APIVersion = "client.authentication.k8s.io/v1"
-				}
-			}
-		}
-	}
 }
 
 // Validate ensures the KubeadmConfigSpec is valid.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -5254,7 +5254,9 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               format:
-                description: format specifies the output format of the bootstrap data
+                description: |-
+                  format specifies the output format of the bootstrap data.
+                  Defaults to cloud-config if not set.
                 enum:
                 - cloud-config
                 - ignition
@@ -5399,7 +5401,7 @@ spec:
                           imagePullPolicy specifies the policy for image pulling
                           during kubeadm "init" and "join" operations. The value of
                           this field must be one of "Always", "IfNotPresent" or
-                          "Never". Defaults to "IfNotPresent".
+                          "Never". Defaults to "IfNotPresent" if not set.
                         enum:
                         - Always
                         - IfNotPresent
@@ -5870,7 +5872,7 @@ spec:
                           imagePullPolicy specifies the policy for image pulling
                           during kubeadm "init" and "join" operations. The value of
                           this field must be one of "Always", "IfNotPresent" or
-                          "Never". Defaults to "IfNotPresent".
+                          "Never". Defaults to "IfNotPresent" if not set.
                         enum:
                         - Always
                         - IfNotPresent

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -5155,8 +5155,9 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       format:
-                        description: format specifies the output format of the bootstrap
-                          data
+                        description: |-
+                          format specifies the output format of the bootstrap data.
+                          Defaults to cloud-config if not set.
                         enum:
                         - cloud-config
                         - ignition
@@ -5303,7 +5304,7 @@ spec:
                                   imagePullPolicy specifies the policy for image pulling
                                   during kubeadm "init" and "join" operations. The value of
                                   this field must be one of "Always", "IfNotPresent" or
-                                  "Never". Defaults to "IfNotPresent".
+                                  "Never". Defaults to "IfNotPresent" if not set.
                                 enum:
                                 - Always
                                 - IfNotPresent
@@ -5781,7 +5782,7 @@ spec:
                                   imagePullPolicy specifies the policy for image pulling
                                   during kubeadm "init" and "join" operations. The value of
                                   this field must be one of "Always", "IfNotPresent" or
-                                  "Never". Defaults to "IfNotPresent".
+                                  "Never". Defaults to "IfNotPresent" if not set.
                                 enum:
                                 - Always
                                 - IfNotPresent

--- a/bootstrap/kubeadm/config/webhook/manifests.yaml
+++ b/bootstrap/kubeadm/config/webhook/manifests.yaml
@@ -11,27 +11,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-kubeadmconfig
-  failurePolicy: Fail
-  name: default.kubeadmconfig.bootstrap.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - bootstrap.cluster.x-k8s.io
-    apiVersions:
-    - v1beta2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kubeadmconfigs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-bootstrap-cluster-x-k8s-io-v1beta2-kubeadmconfigtemplate
   failurePolicy: Fail
   name: default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io

--- a/bootstrap/kubeadm/defaulting/defaulting.go
+++ b/bootstrap/kubeadm/defaulting/defaulting.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package defaulting contains defaulting code that is used in CABPK and KCP.
+package defaulting
+
+import bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+
+// ApplyPreviousKubeadmConfigDefaults defaults a KubeadmConfig with default values we used in the past.
+// This is done in multiple places (webhooks and KCP controller) to ensure no rollouts are triggered now that
+// we removed this defaulting from webhooks.
+func ApplyPreviousKubeadmConfigDefaults(c *bootstrapv1.KubeadmConfigSpec) {
+	if c.Format == "" {
+		c.Format = bootstrapv1.CloudConfig
+	}
+	if c.InitConfiguration != nil && c.InitConfiguration.NodeRegistration.ImagePullPolicy == "" {
+		c.InitConfiguration.NodeRegistration.ImagePullPolicy = "IfNotPresent"
+	}
+	if c.JoinConfiguration != nil && c.JoinConfiguration.NodeRegistration.ImagePullPolicy == "" {
+		c.JoinConfiguration.NodeRegistration.ImagePullPolicy = "IfNotPresent"
+	}
+	if c.JoinConfiguration != nil && c.JoinConfiguration.Discovery.File != nil {
+		if kfg := c.JoinConfiguration.Discovery.File.KubeConfig; kfg != nil {
+			if kfg.User.Exec != nil {
+				if kfg.User.Exec.APIVersion == "" {
+					kfg.User.Exec.APIVersion = "client.authentication.k8s.io/v1"
+				}
+			}
+		}
+	}
+}

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -827,7 +827,8 @@ func TestBootstrapDataFormat(t *testing.T) {
 			clusterInitialized: true,
 		},
 		{
-			name: "Empty format field",
+			name:   "Empty format field",
+			format: bootstrapv1.CloudConfig,
 		},
 	}
 
@@ -2315,8 +2316,7 @@ func TestKubeadmConfigReconciler_ResolveDiscoveryFileKubeConfig(t *testing.T) {
 								KubeConfig: &bootstrapv1.FileDiscoveryKubeConfig{
 									User: bootstrapv1.KubeConfigUser{
 										Exec: &bootstrapv1.KubeConfigAuthExec{
-											APIVersion: "client.authentication.k8s.io/v1",
-											Command:    "/usr/bin/bootstrap",
+											Command: "/usr/bin/bootstrap",
 											Env: []bootstrapv1.KubeConfigAuthExecEnv{
 												{Name: "ENV_TEST", Value: "value"},
 											},

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfig.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfig.go
@@ -33,31 +33,16 @@ import (
 func (webhook *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&bootstrapv1.KubeadmConfig{}).
-		WithDefaulter(webhook).
 		WithValidator(webhook).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta2-kubeadmconfig,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigs,versions=v1beta2,name=default.kubeadmconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 // +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta2-kubeadmconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigs,versions=v1beta2,name=validation.kubeadmconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 // KubeadmConfig implements a validation and defaulting webhook for KubeadmConfig.
 type KubeadmConfig struct{}
 
 var _ webhook.CustomValidator = &KubeadmConfig{}
-var _ webhook.CustomDefaulter = &KubeadmConfig{}
-
-// Default implements webhook.Defaulter so a webhook will be registered for the type.
-func (webhook *KubeadmConfig) Default(_ context.Context, obj runtime.Object) error {
-	c, ok := obj.(*bootstrapv1.KubeadmConfig)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfig but got a %T", obj))
-	}
-
-	c.Spec.Default()
-
-	return nil
-}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (webhook *KubeadmConfig) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfig_test.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfig_test.go
@@ -27,42 +27,9 @@ import (
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	"sigs.k8s.io/cluster-api/feature"
-	"sigs.k8s.io/cluster-api/internal/webhooks/util"
 )
 
 var ctx = ctrl.SetupSignalHandler()
-
-func TestKubeadmConfigDefault(t *testing.T) {
-	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
-
-	g := NewWithT(t)
-
-	kubeadmConfig := &bootstrapv1.KubeadmConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-		},
-		Spec: bootstrapv1.KubeadmConfigSpec{},
-	}
-	updateDefaultingKubeadmConfig := kubeadmConfig.DeepCopy()
-	updateDefaultingKubeadmConfig.Spec.Verbosity = ptr.To[int32](4)
-	webhook := &KubeadmConfig{}
-	t.Run("for KubeadmConfig", util.CustomDefaultValidateTest(ctx, updateDefaultingKubeadmConfig, webhook))
-
-	g.Expect(webhook.Default(ctx, kubeadmConfig)).To(Succeed())
-
-	g.Expect(kubeadmConfig.Spec.Format).To(Equal(bootstrapv1.CloudConfig))
-
-	ignitionKubeadmConfig := &bootstrapv1.KubeadmConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-		},
-		Spec: bootstrapv1.KubeadmConfigSpec{
-			Format: bootstrapv1.Ignition,
-		},
-	}
-	g.Expect(webhook.Default(ctx, ignitionKubeadmConfig)).To(Succeed())
-	g.Expect(ignitionKubeadmConfig.Spec.Format).To(Equal(bootstrapv1.Ignition))
-}
 
 func TestKubeadmConfigValidate(t *testing.T) {
 	cases := map[string]struct {

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -193,7 +193,9 @@ type GenerateTemplateInput struct {
 func GenerateTemplate(in *GenerateTemplateInput) (*unstructured.Unstructured, error) {
 	template, found, err := unstructured.NestedMap(in.Template.Object, "spec", "template")
 	if !found {
-		return nil, errors.Errorf("missing Spec.Template on %v %q", in.Template.GroupVersionKind(), in.Template.GetName())
+		// Tolerate template objects without `spec.template`.
+		// Intentionally using an empty template as replacement.
+		template = nil
 	} else if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve Spec.Template map on %v %q", in.Template.GroupVersionKind(), in.Template.GetName())
 	}

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -6189,8 +6189,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   format:
-                    description: format specifies the output format of the bootstrap
-                      data
+                    description: |-
+                      format specifies the output format of the bootstrap data.
+                      Defaults to cloud-config if not set.
                     enum:
                     - cloud-config
                     - ignition
@@ -6335,7 +6336,7 @@ spec:
                               imagePullPolicy specifies the policy for image pulling
                               during kubeadm "init" and "join" operations. The value of
                               this field must be one of "Always", "IfNotPresent" or
-                              "Never". Defaults to "IfNotPresent".
+                              "Never". Defaults to "IfNotPresent" if not set.
                             enum:
                             - Always
                             - IfNotPresent
@@ -6809,7 +6810,7 @@ spec:
                               imagePullPolicy specifies the policy for image pulling
                               during kubeadm "init" and "join" operations. The value of
                               this field must be one of "Always", "IfNotPresent" or
-                              "Never". Defaults to "IfNotPresent".
+                              "Never". Defaults to "IfNotPresent" if not set.
                             enum:
                             - Always
                             - IfNotPresent

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -4591,8 +4591,9 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           format:
-                            description: format specifies the output format of the
-                              bootstrap data
+                            description: |-
+                              format specifies the output format of the bootstrap data.
+                              Defaults to cloud-config if not set.
                             enum:
                             - cloud-config
                             - ignition
@@ -4739,7 +4740,7 @@ spec:
                                       imagePullPolicy specifies the policy for image pulling
                                       during kubeadm "init" and "join" operations. The value of
                                       this field must be one of "Always", "IfNotPresent" or
-                                      "Never". Defaults to "IfNotPresent".
+                                      "Never". Defaults to "IfNotPresent" if not set.
                                     enum:
                                     - Always
                                     - IfNotPresent
@@ -5219,7 +5220,7 @@ spec:
                                       imagePullPolicy specifies the policy for image pulling
                                       during kubeadm "init" and "join" operations. The value of
                                       this field must be one of "Always", "IfNotPresent" or
-                                      "Never". Defaults to "IfNotPresent".
+                                      "Never". Defaults to "IfNotPresent" if not set.
                                     enum:
                                     - Always
                                     - IfNotPresent

--- a/controlplane/kubeadm/config/webhook/manifests.yaml
+++ b/controlplane/kubeadm/config/webhook/manifests.yaml
@@ -26,27 +26,6 @@ webhooks:
     resources:
     - kubeadmcontrolplanes
   sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-kubeadmcontrolplanetemplate
-  failurePolicy: Fail
-  name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - controlplane.cluster.x-k8s.io
-    apiVersions:
-    - v1beta2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kubeadmcontrolplanetemplates
-  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -31,6 +31,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/defaulting"
 	"sigs.k8s.io/cluster-api/internal/util/compare"
 	"sigs.k8s.io/cluster-api/util/collections"
 )
@@ -321,8 +322,8 @@ func matchInitOrJoinConfiguration(machineConfig *bootstrapv1.KubeadmConfig, kcp 
 	// *Note* This assumes that newly added default values never
 	// introduce a semantic difference to the unset value.
 	// But that is something that is ensured by our API guarantees.
-	kcpConfig.Default()
-	machineConfig.Spec.Default()
+	defaulting.ApplyPreviousKubeadmConfigDefaults(kcpConfig)
+	defaulting.ApplyPreviousKubeadmConfigDefaults(&machineConfig.Spec)
 
 	// cleanups all the fields that are not relevant for the comparison.
 	cleanupConfigFields(kcpConfig, machineConfig)

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane.go
@@ -82,8 +82,6 @@ func defaultKubeadmControlPlaneSpec(s *controlplanev1.KubeadmControlPlaneSpec) {
 		s.Version = "v" + s.Version
 	}
 
-	s.KubeadmConfigSpec.Default()
-
 	s.RolloutStrategy = defaultRolloutStrategy(s.RolloutStrategy)
 }
 

--- a/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadm_control_plane_test.go
@@ -69,7 +69,6 @@ func TestKubeadmControlPlaneDefault(t *testing.T) {
 	t.Run("for KubeadmControlPlane", util.CustomDefaultValidateTest(ctx, updateDefaultingValidationKCP, webhook))
 	g.Expect(webhook.Default(ctx, kcp)).To(Succeed())
 
-	g.Expect(kcp.Spec.KubeadmConfigSpec.Format).To(Equal(bootstrapv1.CloudConfig))
 	g.Expect(kcp.Spec.Version).To(Equal("v1.18.3"))
 	g.Expect(kcp.Spec.RolloutStrategy.Type).To(Equal(controlplanev1.RollingUpdateStrategyType))
 	g.Expect(kcp.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntVal).To(Equal(int32(1)))

--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplanetemplate_test.go
@@ -30,36 +30,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/feature"
-	"sigs.k8s.io/cluster-api/internal/webhooks/util"
 )
-
-func TestKubeadmControlPlaneTemplateDefault(t *testing.T) {
-	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
-
-	g := NewWithT(t)
-
-	kcpTemplate := &controlplanev1.KubeadmControlPlaneTemplate{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-		},
-		Spec: controlplanev1.KubeadmControlPlaneTemplateSpec{
-			Template: controlplanev1.KubeadmControlPlaneTemplateResource{
-				Spec: controlplanev1.KubeadmControlPlaneTemplateResourceSpec{
-					MachineTemplate: &controlplanev1.KubeadmControlPlaneTemplateMachineTemplate{
-						NodeDrainTimeoutSeconds: ptr.To(int32(10)),
-					},
-				},
-			},
-		},
-	}
-	updateDefaultingValidationKCPTemplate := kcpTemplate.DeepCopy()
-	updateDefaultingValidationKCPTemplate.Spec.Template.Spec.MachineTemplate.NodeDrainTimeoutSeconds = ptr.To(int32(20))
-	webhook := &KubeadmControlPlaneTemplate{}
-	t.Run("for KubeadmControlPlaneTemplate", util.CustomDefaultValidateTest(ctx, updateDefaultingValidationKCPTemplate, webhook))
-	g.Expect(webhook.Default(ctx, kcpTemplate)).To(Succeed())
-
-	g.Expect(kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.Format).To(Equal(bootstrapv1.CloudConfig))
-}
 
 func TestKubeadmControlPlaneTemplateValidationFeatureGateEnabled(t *testing.T) {
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)

--- a/internal/controllers/topology/cluster/patches/patch.go
+++ b/internal/controllers/topology/cluster/patches/patch.go
@@ -195,7 +195,8 @@ func copySpec(in copySpecInput) error {
 	// Get spec from src.
 	srcSpec, found, err := unstructured.NestedFieldNoCopy(in.src.Object, strings.Split(in.srcSpecPath, ".")...)
 	if !found {
-		return errors.Errorf("missing field %q in %s %s", in.srcSpecPath, in.src.GetKind(), klog.KObj(in.src))
+		// Return if srcSpecPath does not exist in src, nothing to do.
+		return nil
 	} else if err != nil {
 		return errors.Wrapf(err, "failed to get field %q from %s %s", in.srcSpecPath, in.src.GetKind(), klog.KObj(in.src))
 	}

--- a/internal/controllers/topology/cluster/patches/patch_test.go
+++ b/internal/controllers/topology/cluster/patches/patch_test.go
@@ -351,6 +351,34 @@ func TestCopySpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Field not in src, no-op",
+			input: copySpecInput{
+				src: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"differentSpec": map[string]interface{}{
+							"B": "B",
+						},
+					},
+				},
+				dest: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"spec": map[string]interface{}{
+							"A": "A",
+						},
+					},
+				},
+				srcSpecPath:  "spec",
+				destSpecPath: "spec",
+			},
+			want: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"A": "A",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/data/infrastructure-docker/main/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/md.yaml
@@ -19,10 +19,6 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-md-0"
-spec:
-  template:
-    spec:
-      joinConfiguration:
 ---
 # MachineDeployment object
 apiVersion: cluster.x-k8s.io/v1beta2

--- a/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/mp.yaml
@@ -42,5 +42,3 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfig
 metadata:
   name: "${CLUSTER_NAME}-mp-0-config"
-spec:
-  joinConfiguration:

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-in-memory.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-in-memory.yaml
@@ -12,29 +12,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: in-memory-control-plane
-spec:
-  template:
-    spec:
-      kubeadmConfigSpec:
-        clusterConfiguration:
-          apiServer:
-            certSANs:
-              - localhost
-              - 127.0.0.1
-              - 0.0.0.0
-              - host.docker.internal
-        initConfiguration:
-          nodeRegistration:
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              - name: eviction-hard
-                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        joinConfiguration:
-          nodeRegistration:
-            criSocket: unix:///var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              - name: eviction-hard
-                value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+# Note: Intentionally using an empty object here to verify the Cluster topology controller can handle it.
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DevMachineTemplate
@@ -92,15 +70,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: in-memory-default-worker-bootstraptemplate
-spec:
-  template:
-    spec:
-      joinConfiguration:
-        nodeRegistration:
-          criSocket: unix:///var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            - name: eviction-hard
-              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+# Note: Intentionally using an empty object here to verify the Cluster topology controller can handle it.
 ---
 apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml
@@ -139,7 +139,3 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: quick-start-default-worker-bootstraptemplate
-spec:
-  template:
-    spec:
-      joinConfiguration:

--- a/test/infrastructure/docker/internal/webhooks/devmachinetemplate_webhook.go
+++ b/test/infrastructure/docker/internal/webhooks/devmachinetemplate_webhook.go
@@ -93,7 +93,7 @@ func (webhook *DevMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw ru
 	}
 
 	var allErrs field.ErrorList
-	if !topology.ShouldSkipImmutabilityChecks(req, newObj) {
+	if !topology.IsDryRunRequest(req, newObj) {
 		equal, diff, err := compare.Diff(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
 		if err != nil {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new DevMachineTemplate: %v", err))

--- a/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook.go
+++ b/test/infrastructure/docker/internal/webhooks/dockermachinetemplate_webhook.go
@@ -78,7 +78,7 @@ func (webhook *DockerMachineTemplate) ValidateUpdate(ctx context.Context, oldRaw
 	}
 
 	var allErrs field.ErrorList
-	if !topology.ShouldSkipImmutabilityChecks(req, newObj) {
+	if !topology.IsDryRunRequest(req, newObj) {
 		equal, diff, err := compare.Diff(oldObj.Spec.Template.Spec, newObj.Spec.Template.Spec)
 		if err != nil {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to compare old and new DockerMachineTemplate: %v", err))

--- a/util/topology/topology.go
+++ b/util/topology/topology.go
@@ -28,7 +28,15 @@ import (
 // TopologyDryRunAnnotation annotation set, false otherwise.
 // This ensures that the immutability check is skipped only when dry-running and when the operations has been invoked by the topology controller.
 // Instead, kubectl dry-run behavior remains consistent with the one user gets when doing kubectl apply (immutability is enforced).
+//
+// Deprecated: Please use IsDryRunRequest instead.
 func ShouldSkipImmutabilityChecks(req admission.Request, obj metav1.Object) bool {
+	return IsDryRunRequest(req, obj)
+}
+
+// IsDryRunRequest returns true if it is a dry-run request and the object has the
+// TopologyDryRunAnnotation annotation set, false otherwise.
+func IsDryRunRequest(req admission.Request, obj metav1.Object) bool {
 	// Check if the request is a dry-run
 	if req.DryRun == nil || !*req.DryRun {
 		return false

--- a/util/topology/topology_test.go
+++ b/util/topology/topology_test.go
@@ -85,7 +85,7 @@ func TestShouldSkipImmutabilityChecks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ShouldSkipImmutabilityChecks(tt.req, tt.obj); got != tt.want {
+			if got := IsDryRunRequest(tt.req, tt.obj); got != tt.want {
 				t.Errorf("ShouldSkipImmutabilityChecks() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR removes some more redundant defaulting to reduce noise in objects. I also added some handling to avoid triggering rollouts after CAPI upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #10852 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->