### PR TITLE
⚠️ test/e2e: default to strict field validation & fix unknown field in ClusterClass YAML

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -74,7 +74,7 @@ spec:
   - name: etcdImageTag
     required: true
     # This metadata has just been added to verify that we can set metadata.
-    metadata:
+    deprecatedV1Beta1Metadata:
       labels:
         testLabelKey: testLabelValue
       annotations:

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -307,6 +307,7 @@ func (p *clusterProxy) GetCache(ctx context.Context) cache.Cache {
 }
 
 // CreateOrUpdate creates or updates objects using the clusterProxy client.
+// Defaults to use FieldValidation: strict, which can be overwritten with CreateOrUpdateOptions.
 func (p *clusterProxy) CreateOrUpdate(ctx context.Context, resources []byte, opts ...CreateOrUpdateOption) error {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for CreateOrUpdate")
 	Expect(resources).NotTo(BeNil(), "resources is required for CreateOrUpdate")
@@ -318,6 +319,9 @@ func (p *clusterProxy) CreateOrUpdate(ctx context.Context, resources []byte, opt
 	if config.labelSelector != nil {
 		labelSelector = config.labelSelector
 	}
+	// Prepending field validation strict so that it is used per default, but can still be overwritten.
+	config.createOpts = append([]client.CreateOption{client.FieldValidation("Strict")}, config.createOpts...)
+	config.updateOpts = append([]client.UpdateOption{client.FieldValidation("Strict")}, config.updateOpts...)
 	objs, err := yaml.ToUnstructured(resources)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Before this PR we got warnings in logs if we used unknown fields in our e2e test YAMLs, after this PR the tests will actually fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->