### PR TITLE
🐛 Bump cluster-autoscaler to v1.33, adjust RBAC, pin apiVersion to v1beta1

### DIFF
--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -36,7 +36,7 @@ var _ = Describe("When using the autoscaler with Cluster API using ClusterClass 
 			InfrastructureMachinePoolTemplateKind: "dockermachinepooltemplates",
 			InfrastructureMachinePoolKind:         "dockermachinepools",
 			Flavor:                                ptr.To("topology-autoscaler"),
-			AutoscalerVersion:                     "v1.31.1",
+			AutoscalerVersion:                     "v1.33.0",
 		}
 	})
 })

--- a/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
@@ -77,6 +77,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - nodes
@@ -190,6 +198,12 @@ spec:
             # Note: The E2E test should only go up to 4 (assuming it starts with a min node group size of 2).
             # Using 6 for additional some buffer and to allow different starting min node group sizes.
             - --max-nodes-total=6
+          env:
+            # Per default autoscaler uses the preferred apiVersion to retrieve MachineDeployments.
+            # If that apiVersion is v1beta2 the current autoscaler implementation is not able
+            # to resolve infrastructureRefs as the ref format changed. This would break scale from zero.
+            - name: CAPI_VERSION
+              value: v1beta1
           volumeMounts:
             - name: kubeconfig-management-cluster
               mountPath: /management-cluster

--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -542,6 +542,16 @@ func getAuthenticationTokenForAutoscaler(ctx context.Context, managementClusterP
 	}
 	Expect(managementClusterProxy.GetClient().Create(ctx, sa)).To(Succeed(), fmt.Sprintf("failed to create %s service account", name))
 
+	var resources []string
+	if infraMachineTemplateKind != "" {
+		resources = append(resources, infraMachineTemplateKind)
+	}
+	if infraMachinePoolTemplateKind != "" {
+		resources = append(resources, infraMachinePoolTemplateKind)
+	}
+	if infraMachinePoolKind != "" {
+		resources = append(resources, infraMachinePoolKind)
+	}
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -549,14 +559,14 @@ func getAuthenticationTokenForAutoscaler(ctx context.Context, managementClusterP
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				Verbs:     []string{"get", "list", "update", "watch"},
+				Verbs:     []string{"get", "list", "watch", "patch", "update"},
 				APIGroups: []string{"cluster.x-k8s.io"},
 				Resources: []string{"machinedeployments", "machinedeployments/scale", "machinepools", "machinepools/scale", "machines", "machinesets"},
 			},
 			{
-				Verbs:     []string{"get", "list"},
+				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{infraAPIGroup},
-				Resources: []string{infraMachineTemplateKind, infraMachinePoolTemplateKind, infraMachinePoolKind},
+				Resources: resources,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Additional context https://kubernetes.slack.com/archives/C8TSNPY4T/p1752765473253889

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->