### PR TITLE
🌱 Fix lifecycle hooks conversions

### DIFF
--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -532,7 +532,7 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 			// hook because we didn't go through an upgrade or we already called the hook after the upgrade.
 			if hooks.IsPending(runtimehooksv1.AfterControlPlaneUpgrade, s.Current.Cluster) {
 				v1beta1Cluster := &clusterv1beta1.Cluster{}
-				if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(s.Current.Cluster, v1beta1Cluster, nil); err != nil {
+				if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
 					return "", errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 				}
 
@@ -606,7 +606,7 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 		// At this point the control plane and the machine deployments are stable and we are almost ready to pick
 		// up the desiredVersion. Call the BeforeClusterUpgrade hook before picking up the desired version.
 		v1beta1Cluster := &clusterv1beta1.Cluster{}
-		if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(s.Current.Cluster, v1beta1Cluster, nil); err != nil {
+		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
 			return "", errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 		}
 

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -432,7 +432,7 @@ func (r *Reconciler) callBeforeClusterCreateHook(ctx context.Context, s *scope.S
 
 	if s.Current.Cluster.Spec.InfrastructureRef == nil && s.Current.Cluster.Spec.ControlPlaneRef == nil {
 		v1beta1Cluster := &clusterv1beta1.Cluster{}
-		if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(s.Current.Cluster, v1beta1Cluster, nil); err != nil {
+		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 		}
 
@@ -525,7 +525,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Clu
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		if !hooks.IsOkToDelete(cluster) {
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(cluster, v1beta1Cluster, nil); err != nil {
+			if err := v1beta1Cluster.ConvertFrom(cluster); err != nil {
 				return ctrl.Result{}, errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -197,7 +197,7 @@ func (r *Reconciler) callAfterControlPlaneInitialized(ctx context.Context, s *sc
 	if hooks.IsPending(runtimehooksv1.AfterControlPlaneInitialized, s.Current.Cluster) {
 		if isControlPlaneInitialized(s.Current.Cluster) {
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(s.Current.Cluster, v1beta1Cluster, nil); err != nil {
+			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
 				return errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 
@@ -250,7 +250,7 @@ func (r *Reconciler) callAfterClusterUpgrade(ctx context.Context, s *scope.Scope
 			!s.UpgradeTracker.MachinePools.IsAnyPendingUpgrade() && // No MachinePools are pending an upgrade
 			!s.UpgradeTracker.MachinePools.DeferredUpgrade() { // No MachinePools have deferred an upgrade
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := clusterv1beta1.Convert_v1beta2_Cluster_To_v1beta1_Cluster(s.Current.Cluster, v1beta1Cluster, nil); err != nil {
+			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
 				return errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -42,6 +43,7 @@ import (
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
@@ -290,6 +292,27 @@ func TestReconcileShim(t *testing.T) {
 }
 
 func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
+	var testGVKs = []schema.GroupVersionKind{
+		{
+			Group:   "refAPIGroup1",
+			Kind:    "refKind1",
+			Version: "v1beta4",
+		},
+	}
+
+	apiVersionGetter := func(gk schema.GroupKind) (string, error) {
+		for _, gvk := range testGVKs {
+			if gvk.GroupKind() == gk {
+				return schema.GroupVersion{
+					Group:   gk.Group,
+					Version: gvk.Version,
+				}.String(), nil
+			}
+		}
+		return "", fmt.Errorf("unknown GroupVersionKind: %v", gk)
+	}
+	clusterv1beta1.SetAPIVersionGetter(apiVersionGetter)
+
 	catalog := runtimecatalog.New()
 	_ = runtimehooksv1.AddToCatalog(catalog)
 
@@ -342,8 +365,16 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
-					ControlPlaneRef:   &clusterv1.ContractVersionedObjectReference{},
-					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{},
+					ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
+					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
 				},
 				Status: clusterv1.ClusterStatus{
 					Conditions: []metav1.Condition{
@@ -367,8 +398,16 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
-					ControlPlaneRef:   &clusterv1.ContractVersionedObjectReference{},
-					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{},
+					ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
+					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
 				},
 				Status: clusterv1.ClusterStatus{
 					Conditions: []metav1.Condition{
@@ -392,8 +431,16 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
-					ControlPlaneRef:   &clusterv1.ContractVersionedObjectReference{},
-					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{},
+					ControlPlaneRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
+					InfrastructureRef: &clusterv1.ContractVersionedObjectReference{
+						APIGroup: "refAPIGroup1",
+						Kind:     "refKind1",
+						Name:     "refName1",
+					},
 				},
 				Status: clusterv1.ClusterStatus{
 					Conditions: []metav1.Condition{


### PR DESCRIPTION
**What this PR does / why we need it**:
Lifecycle hooks are still using v1beta1 objects, but initially we implemented conversion by calling autogenerated conversions func.

Now, after all the work for v1beta2 this is not correct anymore and we have to call the ConverFrom func instead, which also has code to handle "special" conversions like e.g. references 

/area runtime-sdk
