### PR TITLE
[release-1.9] 🌱 Add CVE-2025-22868 to Trivy ignore file

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,5 @@
 # According to govulncheck we are not using code that is affected by CVEs
+CVE-2025-22868
 CVE-2025-22869
 CVE-2025-22870
 CVE-2025-22872


### PR DESCRIPTION
**What this PR does / why we need it**:

Tells the Trivy security scanner not to flag the `golang.org/x/oauth2/jws` package because silencing it requires updating the Go compiler toolchain and CAPI doesn't specifically use that package.

**Which issue(s) this PR fixes**:
See https://github.com/kubernetes-sigs/cluster-api/actions/runs/16416457659
See https://avd.aquasec.com/nvd/cve-2025-22868

/area dependency
/area security