### PR TITLE
✨ feat: set new replica fields for machine pools

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -276,6 +276,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, s *
 		return ctrl.Result{}, err
 	}
 	infraConfig := infraReconcileResult.Result
+	s.infraMachinePool = infraConfig
 
 	if !infraConfig.GetDeletionTimestamp().IsZero() {
 		return ctrl.Result{}, nil

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -145,7 +145,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -188,7 +188,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -228,7 +228,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -284,7 +284,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -356,7 +356,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -406,7 +406,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -459,7 +459,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -529,7 +529,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -605,7 +605,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -679,7 +679,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinePool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -699,7 +699,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinePool.Spec.Template.Spec.Bootstrap.ConfigRef.Name = newBootstrapConfig.GetName()
 
 		// Reconcile again. The new bootstrap config should be used.
-		res, err = r.reconcile(ctx, scope)
+		res, err = doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -775,7 +775,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 			machinePool: machinePool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -797,7 +797,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinePool.Spec.Template.Spec.Bootstrap.ConfigRef.Name = newBootstrapConfig.GetName()
 
 		// Reconcile again. The new bootstrap config should be used
-		res, err = r.reconcile(ctx, scope)
+		res, err = doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Controller should wait until bootstrap provider reports ready bootstrap config
@@ -1856,7 +1856,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -1924,7 +1924,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -1932,9 +1932,9 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
 
 		delNode := &corev1.Node{}
-		err = env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(node), delNode)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		err2 := env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(node), delNode)
+		g.Expect(err2).To(HaveOccurred())
+		g.Expect(apierrors.IsNotFound(err2)).To(BeTrue())
 	})
 
 	t.Run("Should set `Running` when scaled to zero", func(t *testing.T) {
@@ -1975,7 +1975,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -2022,7 +2022,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -2091,7 +2091,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 			machinePool: machinepool,
 		}
 
-		res, err := r.reconcile(ctx, scope)
+		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.Requeue).To(BeFalse())
 
@@ -2323,5 +2323,16 @@ func TestMachinePoolReconciler_getNodeRefMap(t *testing.T) {
 				g.Expect(node.GetObjectMeta().GetName()).Should(Equal(tt.expected[providerID].GetObjectMeta().GetName()))
 			}
 		})
+	}
+}
+
+func reconcileNormalFuncsForTest(mpr *MachinePoolReconciler) []machinePoolReconcileFunc {
+	return []machinePoolReconcileFunc{
+		mpr.reconcileSetOwnerAndLabels,
+		mpr.reconcileBootstrap,
+		mpr.reconcileInfrastructure,
+		mpr.getMachinesForMachinePool,
+		mpr.reconcileNodeRefs,
+		mpr.setMachinesUptoDate,
 	}
 }

--- a/exp/internal/controllers/machinepool_controller_scope.go
+++ b/exp/internal/controllers/machinepool_controller_scope.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+)
+
+// scope holds the different objects that are read and used during the reconcile.
+type scope struct {
+	// cluster is the Cluster object the Machine belongs to.
+	// It is set at the beginning of the reconcile function.
+	cluster *clusterv1.Cluster
+
+	// machinePool is the MachinePool object. It is set at the beginning
+	// of the reconcile function.
+	machinePool *clusterv1.MachinePool
+
+	// infraMachinePool is the infrastructure machinepool object. It is set during
+	// the reconcile infrastructure phase.
+	infraMachinePool *unstructured.Unstructured
+
+	// nodeRefMapResult is a map of providerIDs to Nodes that are associated with the Cluster.
+	// It is set after reconcileInfrastructure is called.
+	nodeRefMap map[string]*corev1.Node
+
+	// machines holds a list of the machines associated with this machine pool.
+	machines []*clusterv1.Machine
+}
+
+func (s *scope) hasMachinePoolMachines() (bool, error) {
+	if s.infraMachinePool == nil {
+		return false, errors.New("infra machine pool not set on scope")
+	}
+
+	machineKind, found, err := unstructured.NestedString(s.infraMachinePool.Object, "status", "infrastructureMachineKind")
+	if err != nil {
+		return false, fmt.Errorf("failed to lookup infrastructureMachineKind: %w", err)
+	}
+
+	return found && (machineKind != ""), nil
+}

--- a/exp/internal/controllers/machinepool_controller_status.go
+++ b/exp/internal/controllers/machinepool_controller_status.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
+)
+
+func (r *MachinePoolReconciler) updateStatus(ctx context.Context, s *scope) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if s.infraMachinePool == nil {
+		log.V(4).Info("infra machine pool isn't set, skipping setting status")
+		return nil
+	}
+	hasMachinePoolMachines, err := s.hasMachinePoolMachines()
+	if err != nil {
+		return fmt.Errorf("determining if there are machine pool machines: %w", err)
+	}
+
+	setReplicas(s.machinePool, hasMachinePoolMachines, s.machines)
+
+	// TODO: in future add setting conditions here
+
+	return nil
+}
+
+func setReplicas(mp *clusterv1.MachinePool, hasMachinePoolMachines bool, machines []*clusterv1.Machine) {
+	if !hasMachinePoolMachines {
+		// If we don't have machinepool machine then calculate the values differently
+		mp.Status.ReadyReplicas = mp.Status.Replicas
+		mp.Status.AvailableReplicas = mp.Status.Replicas
+		mp.Status.UpToDateReplicas = mp.Spec.Replicas
+
+		return
+	}
+
+	var readyReplicas, availableReplicas, upToDateReplicas int32
+	for _, machine := range machines {
+		if conditions.IsTrue(machine, clusterv1.MachineReadyCondition) {
+			readyReplicas++
+		}
+		if conditions.IsTrue(machine, clusterv1.MachineAvailableCondition) {
+			availableReplicas++
+		}
+		if conditions.IsTrue(machine, clusterv1.MachineUpToDateCondition) {
+			upToDateReplicas++
+		}
+	}
+
+	mp.Status.ReadyReplicas = ptr.To(readyReplicas)
+	mp.Status.AvailableReplicas = ptr.To(availableReplicas)
+	mp.Status.UpToDateReplicas = ptr.To(upToDateReplicas)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the MachinePool reconciliation to set the values for the v1beta2 replica fields in the status section to be consistent with things like the MachineSets.

If a infra machine pool doesn't have "machine pool machines" then we can't realistically set the values for all the fields, so in this case we set the values the same as the replicas.

This change also introduces setting the "UptoDate" condition on the Machines for the first time. It currently only takes the deletion timestamp into account when determining if a machine is outdated. We can iterate on this going forward.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12413 


/area machinepool
