### PR TITLE
✨ Stop requiring init or cluster configuration for first CP machine

### DIFF
--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -73,6 +73,7 @@ const (
 
 // InitConfiguration contains a list of elements that is specific "kubeadm init"-only runtime
 // information.
+// +kubebuilder:validation:MinProperties=1
 type InitConfiguration struct {
 	// bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
 	// This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
@@ -117,6 +118,7 @@ type InitConfiguration struct {
 }
 
 // ClusterConfiguration contains cluster-wide configuration for a kubeadm cluster.
+// +kubebuilder:validation:MinProperties=1
 type ClusterConfiguration struct {
 	// etcd holds configuration for etcd.
 	// NB: This value defaults to a Local (stacked) etcd
@@ -529,6 +531,7 @@ type ExternalEtcd struct {
 }
 
 // JoinConfiguration contains elements describing a particular node.
+// +kubebuilder:validation:MinProperties=1
 type JoinConfiguration struct {
 	// nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
 	// When used in the context of control plane nodes, NodeRegistration should remain consistent

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -4143,6 +4143,7 @@ spec:
               clusterConfiguration:
                 description: clusterConfiguration along with InitConfiguration are
                   the configurations necessary for the init command
+                minProperties: 1
                 properties:
                   apiServer:
                     description: apiServer contains extra settings for the API server
@@ -5294,6 +5295,7 @@ spec:
               initConfiguration:
                 description: initConfiguration along with ClusterConfiguration are
                   the configurations necessary for the init command
+                minProperties: 1
                 properties:
                   bootstrapTokens:
                     description: |-
@@ -5591,6 +5593,7 @@ spec:
               joinConfiguration:
                 description: joinConfiguration is the kubeadm configuration for the
                   join command
+                minProperties: 1
                 properties:
                   caCertPath:
                     description: |-

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -4012,6 +4012,7 @@ spec:
                       clusterConfiguration:
                         description: clusterConfiguration along with InitConfiguration
                           are the configurations necessary for the init command
+                        minProperties: 1
                         properties:
                           apiServer:
                             description: apiServer contains extra settings for the
@@ -5196,6 +5197,7 @@ spec:
                       initConfiguration:
                         description: initConfiguration along with ClusterConfiguration
                           are the configurations necessary for the init command
+                        minProperties: 1
                         properties:
                           bootstrapTokens:
                             description: |-
@@ -5493,6 +5495,7 @@ spec:
                       joinConfiguration:
                         description: joinConfiguration is the kubeadm configuration
                           for the join command
+                        minProperties: 1
                         properties:
                           caCertPath:
                             description: |-

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -494,12 +494,6 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// if the machine has not ClusterConfiguration and InitConfiguration, requeue
-	if scope.Config.Spec.InitConfiguration == nil && scope.Config.Spec.ClusterConfiguration == nil {
-		scope.Info("Control plane is not ready, requeuing joining control planes until ready.")
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
 	machine := &clusterv1.Machine{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(scope.ConfigOwner.Object, machine); err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "cannot convert %s to Machine", scope.ConfigOwner.GetKind())

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -5057,6 +5057,7 @@ spec:
                   clusterConfiguration:
                     description: clusterConfiguration along with InitConfiguration
                       are the configurations necessary for the init command
+                    minProperties: 1
                     properties:
                       apiServer:
                         description: apiServer contains extra settings for the API
@@ -6221,6 +6222,7 @@ spec:
                   initConfiguration:
                     description: initConfiguration along with ClusterConfiguration
                       are the configurations necessary for the init command
+                    minProperties: 1
                     properties:
                       bootstrapTokens:
                         description: |-
@@ -6518,6 +6520,7 @@ spec:
                   joinConfiguration:
                     description: joinConfiguration is the kubeadm configuration for
                       the join command
+                    minProperties: 1
                     properties:
                       caCertPath:
                         description: |-

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -3422,6 +3422,7 @@ spec:
                           clusterConfiguration:
                             description: clusterConfiguration along with InitConfiguration
                               are the configurations necessary for the init command
+                            minProperties: 1
                             properties:
                               apiServer:
                                 description: apiServer contains extra settings for
@@ -4628,6 +4629,7 @@ spec:
                           initConfiguration:
                             description: initConfiguration along with ClusterConfiguration
                               are the configurations necessary for the init command
+                            minProperties: 1
                             properties:
                               bootstrapTokens:
                                 description: |-
@@ -4926,6 +4928,7 @@ spec:
                           joinConfiguration:
                             description: joinConfiguration is the kubeadm configuration
                               for the join command
+                            minProperties: 1
                             properties:
                               caCertPath:
                                 description: |-

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -223,9 +223,6 @@ func getGetFailureDomainIDs(failureDomains []clusterv1.FailureDomain) []string {
 // InitialControlPlaneConfig returns a new KubeadmConfigSpec that is to be used for an initializing control plane.
 func (c *ControlPlane) InitialControlPlaneConfig() *bootstrapv1.KubeadmConfigSpec {
 	bootstrapSpec := c.KCP.Spec.KubeadmConfigSpec.DeepCopy()
-	if bootstrapSpec.InitConfiguration == nil {
-		bootstrapSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
-	}
 	bootstrapSpec.JoinConfiguration = nil
 	return bootstrapSpec
 }

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1740,8 +1740,7 @@ func TestKubeadmControlPlaneReconciler_syncMachines(t *testing.T) {
 
 	// Existing KubeadmConfig
 	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
-		Users:             []bootstrapv1.User{{Name: "test-user"}},
-		JoinConfiguration: &bootstrapv1.JoinConfiguration{},
+		Users: []bootstrapv1.User{{Name: "test-user"}},
 	}
 	existingKubeadmConfig := &bootstrapv1.KubeadmConfig{
 		TypeMeta: metav1.TypeMeta{

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -372,9 +372,7 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 		recorder:            record.NewFakeRecorder(32),
 	}
 
-	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
-		JoinConfiguration: &bootstrapv1.JoinConfiguration{},
-	}
+	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{}
 	_, err := r.cloneConfigsAndGenerateMachine(ctx, cluster, kcp, bootstrapSpec, "")
 	g.Expect(err).To(Succeed())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There are assumptions across KCP & kubeadm config about init or cluster configuration to be set on the first CP machines.
This PR removes those assumption and align those field + kcp to the rest of API objects do not allowing {}

/area provider/bootstrap-kubeadm
/area provider/controlplane-kubeadm
