### PR TITLE
🚀 Release v1.11.0-beta.2

### DIFF
--- a/CHANGELOG/v1.11.0-beta.2.md
+++ b/CHANGELOG/v1.11.0-beta.2.md
@@ -1,0 +1,419 @@
+🚨 This is a BETA RELEASE. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/kubernetes-sigs/cluster-api/issues/new).
+
+:warning: **BETA RELEASE NOTES** :warning:
+
+## Changes since v1.11.0-beta.1
+## :chart_with_upwards_trend: Overview
+- 23 new commits merged
+- 7 breaking changes :warning:
+- 5 feature additions ✨
+- 4 bugs fixed 🐛
+
+## :warning: Breaking Changes
+- API: Add additional MinProperties & MinItems validation across multiple APIs (#12538)
+- API: Change all *metav1.Time fields to metav1.Time (#12518)
+- API: Remove pointers from ClusterClass and Cluster healthCheck fields (#12525)
+- API: Rename namingStrategy => naming, machineNamingStrategy => machineNaming (#12524)
+- API: Restructure strategy fields (#12506)
+- CAPD: Align CAPD conversion to conversion of other providers (#12481)
+- KCP/CABPK: Change envVars fields from []EnvVar to *[]EnvVar (#12539)
+
+## :sparkles: New Features
+- CI: Bump KAL & add the notimestamps linter (#12520)
+- e2e: Bump Kubernetes version used for testing to v1.34.0-beta.0 (#12516)
+- KCP/CABPK: Add CertificateValidityPeriod and CACertificateValidityPeriod to KubeadmConfig (#12335)
+- KCP/CABPK: Stop requiring init or cluster configuration for first CP machine (#12540)
+- Runtime SDK: Add mTLS support to runtime extension server and client (#12517)
+
+## :bug: Bug Fixes
+- Conditions: Fix condition handling during controller start (#12536)
+- e2e: Fix e2e tests by fixing the etcd tag (#12523)
+- MachineSet: Fix v1beta1 MachinesReady condition on MachineSet (#12535)
+- Testing: Fix flakes in TestAPIAndWebhookChanges unit test (#12526)
+
+## :seedling: Others
+- API: Set print columns for v1beta2 types (#12534)
+- Devtools: Fix Tiltfile (#12541)
+- e2e: Print the entire object diff if resource versions are not stable in e2e tests (#12527)
+- Runtime SDK: Fix lifecycle hooks conversions (#12507)
+
+## Dependencies
+
+### Added
+- github.com/envoyproxy/go-control-plane/envoy: [v1.32.4](https://github.com/envoyproxy/go-control-plane/tree/envoy/v1.32.4)
+- github.com/envoyproxy/go-control-plane/ratelimit: [v0.1.0](https://github.com/envoyproxy/go-control-plane/tree/ratelimit/v0.1.0)
+
+### Changed
+- github.com/cncf/xds/go: [b4127c9 → cff3c89](https://github.com/cncf/xds/compare/b4127c9...cff3c89)
+- github.com/envoyproxy/go-control-plane: [v0.13.1 → v0.13.4](https://github.com/envoyproxy/go-control-plane/compare/v0.13.1...v0.13.4)
+- github.com/envoyproxy/protoc-gen-validate: [v1.1.0 → v1.2.1](https://github.com/envoyproxy/protoc-gen-validate/compare/v1.1.0...v1.2.1)
+- github.com/golang/glog: [v1.2.2 → v1.2.4](https://github.com/golang/glog/compare/v1.2.2...v1.2.4)
+- github.com/onsi/gomega: [v1.37.0 → v1.38.0](https://github.com/onsi/gomega/compare/v1.37.0...v1.38.0)
+- go.etcd.io/etcd/api/v3: v3.5.21 → v3.5.22
+- go.etcd.io/etcd/client/pkg/v3: v3.5.21 → v3.5.22
+- go.etcd.io/etcd/client/v3: v3.5.21 → v3.5.22
+- go.opentelemetry.io/contrib/detectors/gcp: v1.30.0 → v1.34.0
+- go.opentelemetry.io/otel/metric: v1.33.0 → v1.34.0
+- go.opentelemetry.io/otel/sdk/metric: v1.30.0 → v1.34.0
+- go.opentelemetry.io/otel/sdk: v1.33.0 → v1.34.0
+- go.opentelemetry.io/otel/trace: v1.33.0 → v1.34.0
+- go.opentelemetry.io/otel: v1.33.0 → v1.34.0
+- google.golang.org/genproto/googleapis/api: e6fa225 → 5f5ef82
+- google.golang.org/genproto/googleapis/rpc: 3abc09e → 1a7da9e
+- google.golang.org/grpc: v1.68.2 → v1.71.1
+- google.golang.org/protobuf: v1.36.5 → v1.36.6
+- sigs.k8s.io/yaml: v1.5.0 → v1.6.0
+
+### Removed
+_Nothing has changed._
+
+<details>
+<summary>More details about the release</summary>
+
+## Changes since v1.10.0
+## :chart_with_upwards_trend: Overview
+- 309 new commits merged
+- 81 breaking changes :warning:
+- 23 feature additions ✨
+- 38 bugs fixed 🐛
+
+## :memo: Proposals
+- Core: Update autoscaling from zero enhancement proposal with support for platform-aware autoscale from zero (#11962)
+
+## :warning: Breaking Changes
+- API: Add additional MinProperties & MinItems validation across multiple APIs (#12538)
+- API: Add CAPD v1beta2 types (#12226)
+- API: Add Minimum=0 marker to all MinReadySeconds fields (#12474)
+- API: Add v1beta2 types (#12037)
+- API: Align Spec fields to optionalfields API conventions (#12431)
+- API: Align Status fields to optionalfields API conventions (#12435)
+- API: Change .status.replicas fields to pointer + omitempty (#12250)
+- API: Change all *metav1.Time fields to metav1.Time (#12518)
+- API: Change bool to *bool for all API types (#12436)
+- API: Change type of *string fields with invalid zero value to string (#12429)
+- API: Change type of int32 fields with valid zero value  to *int32 (#12424)
+- API: Conditions: add V1Beta1 suffix and remove V1Beta2 suffix from condition types and reasons in v1beta2 packages (#12091)
+- API: Drop unnecessary fields from contract-versioned object references (#12356)
+- API: Improve Cluster CRD Go type (#12489)
+- API: Migrate API to use *Seconds instead of metav1.Duration fields (#12327)
+- API: Move APIs to ./api (#12262)
+- API: Partially revert: Remove DefaulterRemoveUnknownOrOmitableFields mutating webhook option (#12290)
+- API: Promote v1beta2 conditions (#12066)
+- API: Remove DefaulterRemoveUnknownOrOmitableFields mutating webhook option (#12231)
+- API: Remove IPFamily from public APIs (move to CAPD/kind util) (#12215)
+- API: Remove pointers from ClusterClass and Cluster healthCheck fields (#12525)
+- API: Rename namingStrategy => naming, machineNamingStrategy => machineNaming (#12524)
+- API: Restructure strategy fields (#12506)
+- CABPK: Align KubeadmConfig to kubeadm v1beta4 types (#12282)
+- CAPD: Align CAPD conversion to conversion of other providers (#12481)
+- CAPD: Conditions: add V1Beta1 suffix and remove V1Beta2 suffix from condition types and reasons in CAPD v1beta2 packages (#12393)
+- CAPD: Implement v1beta2 contract in CAPD (#12409)
+- CAPD: Keep using v1beta1 condition in CAPD Docker backend (#12450)
+- CAPD: Promote v1beta2 condition in CAPD (#12362)
+- CAPD: Stop using v1beta1 status in CAPD controllers (#12438)
+- Cluster: Remove deprecated index ByClusterClassName, ClusterByClusterClassClassName and ClusterClassNameField (#12269)
+- ClusterClass: Drop unnecessary fields from ClusterClass template references (#12358)
+- ClusterClass: Move infrastructure namingStrategy field in ClusterClass (#12216)
+- ClusterClass: Remove ClusterVariable.DefinitionFrom field (#12202)
+- ClusterClass: Remove DefaulterRemoveUnknownOrOmitableFields mutating webhook option (again) (#12404)
+- ClusterClass: Remove deprecated Cluster.spec.topology.rolloutAfter field (#12268)
+- ClusterClass: Remove deprecated ClusterCacheTracker and corresponding types (#12270)
+- ClusterClass: Rename deprecated ClusterClass Metadata fields to DeprecatedV1Beta1Metadata (#12273)
+- ClusterClass: Rename runtime extension fields in ClusterClass ExternalPatchDefinition (#12281)
+- ClusterClass: Restructure classRef field in Cluster.spec.topology (#12235)
+- clusterctl: Clusterctl describe defaults to v1beta2 (#12369)
+- clusterctl: Remove clusterctl alpha topology plan (#12283)
+- ClusterResourceSet: Change ClusterResourceSetBinding Bindings field from []*ResourceSetBinding to []ResourceSetBinding (#12476)
+- ClusterResourceSet: Make clusterName field in ClusterResourceSetBinding required (#12276)
+- ClusterResourceSet: Remove deprecated ClusterResourceSetBinding.DeleteBinding method (#12267)
+- Conditions: Swap condition packages (#12086)
+- Dependency: Bump to controller-runtime v0.21 / controller-tools v0.18 / k8s.io/* v0.33 / move to randfill (#12191)
+- e2e: Migrate E2E tests to v1beta2 (#12451)
+- e2e: Test/e2e: default to strict field validation & fix unknown field in ClusterClass YAML (#12501)
+- IPAM: Refactor reference types for IPAM (#12365)
+- KCP: KCP tolerates diff not leading to changes on machines (#12402)
+- KCP: Rename LastRemediationStatus.Timestamp to Time in KCP (#12452)
+- Machine: Drop unnecessary fields from Machine status.nodeRef (#12352)
+- MachineDeployment: Drop revisionHistory in MachineDeployment (#12274)
+- MachineDeployment: Remove MD spec.progressDeadlineSeconds (#12232)
+- MachineHealthCheck: Drop unnecessary fields from remediationTemplate references (#12368)
+- MachineHealthCheck: Rename MHC unhealthyConditions to unhealthyNodeConditions (#12245)
+- MachineSet: Make Template in MachineSet & Spec in MachineTemplateSpec required (#12420)
+- API/CAPD: Update ControlPlaneEndpoint InfraCluster contract, align CAPD to infra contracts (#12465)
+- API/Cluster: Add initialization to Cluster status (#12098)
+- API/Control-plane/Bootstrap/KCP/CABPK/Cluster: Implement v1beta2 contract in cluster controller, KCP, CABPK (#12094)
+- API/KCP/CABPK/CI: Enable nomaps linter, Remove unused kubeadm ClusterStatus struct, Migrate Cluster.status.failureDomains to array (#12083)
+- API/Machine: Add initialization to Machine Status (#12101)
+- API/Machine: Move Machine deletion timeout fields into deletion group, move KCP machineTemplate spec fields to machineTemplate.spec (#12499)
+- API/MachinePool: Add initialization to MachinePool Status (#12102)
+- ClusterClass/MachineHealthCheck/Cluster: Restructure MHC fields in MHC, Cluster and ClusterClass CRDs (#12504)
+- clusterctl/Documentation: Remove reference and configurations for Packet (Equinix Metal) (#12143)
+- KCP/CABPK: Change envVars fields from []EnvVar to *[]EnvVar (#12539)
+- KCP/CABPK: Inline ControlPlaneComponent struct in APIServer / ControllerManager / Scheduler in CABPK (#12446)
+- KCP/CABPK: Remove KubeadmConfig UseExperimentalRetryJoin (#12234)
+- KCP/CABPK: Remove more defaulting from KubeadmConfig/KubeadmConfigTemplate/KCP/KCPTemplate (#12495)
+- KCP/CABPK: Remove redundant fields from CABPK / KCP ClusterConfiguration (#12319)
+- KCP/CABPK: Remove TypeMeta from KubeadmConfigSpec (#12350)
+- KCP/MachineSet/CABPK/CAPD/e2e/Cluster: Cleanup version handling of unsupported Kubernetes releases (#12303)
+- Machine/Cluster: Stop using FailureReason and FailureMessage in controllers (#12148)
+- Machine/MachinePool/MachineSet/MachineDeployment: Add MinReadySeconds to Machine and remove it from MachineDeployment, MachineSet, MachinePool. (#12153)
+- Machine/MachineSet/MachineDeployment/Cluster: Stop using deprecated replica counters in controllers (#12149)
+- MachineSet/MachineDeployment: Use MachineSetDeletePolicy enum in MD & MS API (#12419)
+- Runtime SDK/MachineDeployment: Make DeletePolicy & FailurePolicy enum fields non-pointers (#12453)
+- Runtime SDK: Add v1beta2 API for ExtensionConfig (#12197)
+- Runtime SDK: Change ExtensionConfig handler timeoutSeconds from *int32 to int32 & add Minimum=1 (#12475)
+
+## :sparkles: New Features
+- API: Block imports to internal packages in our API + restructure import restrictions (#12302)
+- API: Deprecate v1alpha1 & v1beta1 API packages (#12254)
+- API: Remove pointer, add omitzero & MinProperties for initialization fields/structs (#12482)
+- CI: Bump KAL & add the notimestamps linter (#12520)
+- clusterctl: Add Scaleway infrastructure provider to clusterctl (#12357)
+- clusterctl: Adding Addon Provider for cdk8s (CAAPC) to cluster-api (#12332)
+- clusterctl: Clearer diagnostics when provider metadata is missing or repo URL is stale (#12238)
+- clusterctl: Validate provider metadata (#12242)
+- Dependency: Bump controller-tools v0.17.3, conversion-gen v0.33.0 (#12129)
+- Dependency: Complete bump to Kubernetes v1.33 (#12206)
+- Dependency: Update KUBEBUILDER_ENVTEST_KUBERNETES_VERSION (#12130)
+- e2e: Bump Kubernetes version used for testing to v1.34.0-beta.0 (#12516)
+- e2e: From 1.10 use GetStableReleaseOfMinor instead of GetLatestReleaseOfMinor (#12118)
+- Machine: Implement v1beta2 contract in Machine controller (#12038)
+- API/CI: Enable ssatags KAL linter (#12470)
+- KCP/CABPK: Add CertificateValidityPeriod and CACertificateValidityPeriod to KubeadmConfig (#12335)
+- KCP/CABPK: Reintroduce KCP/CABPK ClusterConfiguration controlPlaneEndpoint (#12423)
+- KCP/CABPK: Stop requiring init or cluster configuration for first CP machine (#12540)
+- Runtime SDK/ClusterClass: Extend Cluster builtin to include metadata (#12014)
+- Runtime SDK/ClusterClass: Optimize size of runtime hook requests (#12462)
+- Runtime SDK: Add mTLS support to runtime extension server and client (#12517)
+- Runtime SDK: Extend cluster builtin to include classNamespace (#12050)
+- Testing: Bump Kubernetes in tests to v1.33.0 and claim support for v1.33 (#12104)
+
+## :bug: Bug Fixes
+- API: Ensure all pointer status fields are dereferenced correctly (#12412)
+- Bootstrap: Make joinConfiguration.discovery.bootstrapToken.token optional (#12107)
+- Bootstrap: Relax minLength for bootstrap.dataSecretName to 0 (#12164)
+- CABPK: Fix rendering of .Append = false in CABPK (#12437)
+- CABPK: Fix rendering of ntp.enabled & users.inactive *bool values in cloud init (#12394)
+- CABPK: Increase ignition additionalConfig maxSize from 10 to 32 KB (#12222)
+- CABPK: Make KubeadmConfig FileSystem.Label optional (#12019)
+- CAPD: Fix IPv6 CAPD e2e test (#12488)
+- CAPD: Fix worker machine count in CAPD template (#12028)
+- CAPIM: Fix CAPD in-memory templates (#12013)
+- CAPIM: Mux: fix error check (#12230)
+- CI: Fix conversion-verifier and fix findings (#12349)
+- CI: Fixing failed to install kind for e2e tests (#12361)
+- ClusterClass: Fix continuous reconciles because of apiVersion differences in Cluster topology controller (#12341)
+- clusterctl: Accept upper case version (#12237)
+- clusterctl: Add missing API version to NS object (#12200)
+- clusterctl: Clusterctl upgrade hangs for a time on CRD migration when new version contains a number of new CRDs (#11984)
+- ClusterResourceSet: Fix potential panic if ClusterResourceSetStrategy is not defined or incorrect (#12096)
+- Conditions: Fix condition handling during controller start (#12536)
+- e2e: Bump cluster-autoscaler to v1.33, adjust RBAC, pin apiVersion to v1beta1 (#12502)
+- e2e: Fix e2e tests by fixing the etcd tag (#12523)
+- e2e: Stop overwriting ExtraPortMappings if WithDockerSockMount option is used (#12012)
+- IPAM: Enable conversion in CRDs (#12198)
+- IPAM: Revert condition func changes for IPAddressClaim v1beta1 (#12223)
+- KCP: Allow transition of KubeadmControlPlaneTemplate from defaulted rolloutStrategy to unset (#12467)
+- KCP: Fix nil pointer in conversion (#12292)
+- KCP: Fix rollout when init configuration in KCP is empty (#12344)
+- Machine: Machine deletion: fallback to InfraMachine providerID if Machine providerID is not set (#11985)
+- MachineDeployment: Bug fix to set machinedeployment AvailableReplicas (#12410)
+- MachineDeployment: Fix second rolling update for MD rolloutAfter (#12261)
+- MachineSet: Fix v1beta1 MachinesReady condition on MachineSet (#12535)
+- API/ClusterClass: Fix MaxLength of worker topology Name fields (#12072)
+- Dependency/CI: Upgrade golangci-lint to v2.1.0 (#12170)
+- Testing/CI: Fix the condition to check whether cluster has v1beta2 conditions (#12100)
+- Testing: Fix flakes in TestAPIAndWebhookChanges unit test (#12526)
+- Testing: Fix race condition in InMemoryMachine controller tests (#12347)
+- util: CRD migration: Fix cases where update validation fails (#11991)
+- util: Fix typo for WithOwnedV1beta1Conditions to WithOwnedV1Beta1Conditions (#12218)
+
+## :seedling: Others
+- API: Drop hardcoded v1beta1 references (#12027)
+- API: Enable optionalfields linter and fix remaining findings (#12299)
+- API: Move internal/apis to internal/api (#12296)
+- API: Remove old godoc comment, remove unnecessary cast in KCP (#12479)
+- API: Remove unused List conversion funcs (#12054)
+- API: Set minimum=1 on ObservedGeneration and KubeadmConfig APIEndpoint bindPort (#12417)
+- API: Set print columns for v1beta2 types (#12534)
+- CAPD: Ensure CAPD v1beta1 API package only imports core v1beta1 (#12405)
+- CAPIM: Mux: Ignore net.ErrClosed error during listener close & server shutdown (#12212)
+- CI: Add govulncheck to ensure vulnerability (#12108)
+- CI: Bump E2E to Kubernetes v1.33.0-rc.1 (#12099)
+- CI: Bump golangci-lint v2 (#12088)
+- CI: Bump KAL and remove enum exclude (#12500)
+- CI: Bump KAL to 20250605073038, cleanup excludes, fix IPAM prefix field, add MaxItems to Machine.status.addresses (#12326)
+- CI: Bump KAL to 20250626 + enable uniquemarkers linter (#12427)
+- CI: Enable duplicatemarkers linter (#12228)
+- CI: Enable statusoptional linter (#12229)
+- CI: Fix `make generate-go-openapi` if parent directory name does not equal `cluster-api` (#12461)
+- CI: Remove govulncheck from the verify target (#12348)
+- CI: Restructure excludes in KAL linter config (#12445)
+- CI: Switch plugin to kube-api-linter (#12089)
+- CI: Update version matrix for github workflows for release-1.10 (#11992)
+- CI: Use release artifacts for CAPI v1.10 (#12147)
+- Cluster: Add validation for Cluster spec.controlPlaneRef, spec.infrastructureRef and spec.topology (#12454)
+- Cluster: Ensure Cluster.status.failureDomains are alphabetically sorted (#12416)
+- Cluster: Improve error message if rebase fails because target ClusterClass is not reconciled (#12415)
+- ClusterClass: Add DropEmptyStruct to ssa patch helper (#12442)
+- ClusterClass: Extend topology upgrade test: add bool removal test case (#12484)
+- ClusterClass: Improve CC RefVersionsUpToDate condition message (#12472)
+- ClusterClass: Improve webhook output to include the names of the clusters blocking a deletion (#12060)
+- ClusterClass: Make infrastructure and controlPlane required in ClusterClass (#12444)
+- clusterctl: Add filename to clusterctl error about bad YAML (#12189)
+- clusterctl: Add support for compatible contracts to clusterctl (#12018)
+- clusterctl: Bump cert-manager to v1.17.1 (#12044)
+- clusterctl: Bump cert-manager to v1.17.2 (#12210)
+- clusterctl: Bump cert-manager to v1.18.0 (#12342)
+- clusterctl: Bump cert-manager to v1.18.1 (#12378)
+- clusterctl: Bump cert-manager to v1.18.2 (#12478)
+- clusterctl: Change k0smotron repo location (#12225)
+- clusterctl: Cleanup clusterctl tests assets (#12510)
+- clusterctl: Enforce skip upgrade policy in clusterctl (#12017)
+- Community meeting: Add JoelSpeed to approvers (#12204)
+- Conditions: Cleanup v1beta1 updateStatus functions (#12190)
+- Conditions: Drop usage of v1beta1 conditions (#12109)
+- Control-plane: Avoid large number of connection error traces in kubeadm controlplane controller (#12106)
+- Dependency: Bump Go 1.24 (#12128)
+- Dependency: Bump go to v1.23.8 (#12052)
+- Dependency: Bump Go to v1.24.5 (#12509)
+- Dependency: Bump kustomize to v5.7.0 (#12432)
+- Dependency: Bump several tool versions in Makefile (#12433)
+- Dependency: Bump sigs.k8s.io/kind to v0.28.0 (#12243)
+- Dependency: Bump sigs.k8s.io/kind to v0.29.0 (#12257)
+- Dependency: Bump to Go v1.24.4, github.com/cloudflare/circl v1.6.1 (#12351)
+- Dependency: Update github.com/go-viper/mapstructure/v2 to v2.3.0 (#12421)
+- Devtools: Add KubeVirt support to Tilt dev workflow (#11697)
+- Devtools: Fix Tiltfile (#12541)
+- Devtools: Metrics: use v1beta2 for condition metrics and add metrics for dockercluster devcluster dockermachine devmachine extensionconfig ipaddressclaim and crs (#12006)
+- e2e: Add an option to override custom node image name for kind cluster (#12186)
+- e2e: Add retry for SSA requests against Kubernetes < v1.29 in clusterctl upgrade tests (#12067)
+- e2e: Bump clusterctl_upgrade_test.go main and 1.10 tests to k8s v1.33.0 (#12193)
+- e2e: Bump Kubernetes version used for testing to v1.33.0-rc.0 (#12073)
+- e2e: Only run DescribeCluster if v1beta2 Cluster CRD is there (#12279)
+- e2e: Print the entire object diff if resource versions are not stable in e2e tests (#12527)
+- e2e: Remove redundant check in verifyV1Beta2ConditionsTrueV1Beta1 (#12477)
+- KCP: Add --etcd-client-log-level flag to KCP (#12271)
+- KCP: Allow unsetting etcd.local, etcd.external and dns (#12065)
+- KCP: Bump corefile-migration library to v1.0.26 (#12058)
+- KCP: Fix typo in forward etcd leadership error message (#12056)
+- Misc: Remove jackfrancis from reviewers (#12134)
+- KCP/CABPK: KCP: Set MinItems=1 on ExternalEtcd.Endpoints (#12411)
+- KCP/CABPK: Remove unused updateClusterStatus (#12295)
+- KCP/MachineSet/MachineHealthCheck: Remove explicit defaulting of MS deletePolicy, MHC maxUnhealthy, KCPTemplate rolloutStrategy (#12464)
+- MachinePool/MachineSet/MachineDeployment: Add validation to ensure ClusterName fields are equal in MD/MS/MP (#12447)
+- Testing/CI: Fix e2e test capi-e2e-release-1.8 (#12379)
+- Testing/CI: Fix flaky test in extensionconfig_controller_test.go (#12386)
+- Release: Add validation for PREVIOUS_RELEASE_TAG in release-notes-tool (#12380)
+- Release: Postpone v1.11 code freeze by one week (#12498)
+- Release: Prepare main for v1.11 development (#12000)
+- Release: Use github.base_ref in markdown-link-check (#12034)
+- Runtime SDK: Block dependencies to internal packages for the RX implementation (#12297)
+- Runtime SDK: Fix lifecycle hooks conversions (#12507)
+- Runtime SDK: Stop registering API types in the runtime extension scheme (#12042)
+- Testing: Add test/framework/* tests in CI (#12469)
+- Testing: Framework: Watch logs from init containers (#12208)
+- Testing: Release Notes Generator - Test cases for main.go and ref.go (#11882)
+- Testing: Test changes planned to comply optionalrequired linter (#12414)
+- util: Move contract version & GetCompatibleVersions to contract package (#12032)
+- util: Recover v1.10 util packages for conditions, patch and paused to util/deprecated/v1beta1 for provider migrations (#12224)
+
+:book: Additionally, there have been 41 contributions to our documentation and book. (#11029, #11998, #12004, #12057, #12074, #12093, #12117, #12120, #12122, #12125, #12126, #12131, #12139, #12140, #12145, #12150, #12163, #12165, #12188, #12201, #12205, #12236, #12246, #12266, #12284, #12287, #12306, #12309, #12328, #12333, #12377, #12382, #12403, #12418, #12428, #12439, #12443, #12455, #12503, #12521, #12532) 
+
+## Dependencies
+
+### Added
+- github.com/envoyproxy/go-control-plane/envoy: [v1.32.4](https://github.com/envoyproxy/go-control-plane/tree/envoy/v1.32.4)
+- github.com/envoyproxy/go-control-plane/ratelimit: [v0.1.0](https://github.com/envoyproxy/go-control-plane/tree/ratelimit/v0.1.0)
+- github.com/klauspost/compress: [v1.18.0](https://github.com/klauspost/compress/tree/v1.18.0)
+- github.com/kylelemons/godebug: [v1.1.0](https://github.com/kylelemons/godebug/tree/v1.1.0)
+- github.com/prashantv/gostub: [v1.1.0](https://github.com/prashantv/gostub/tree/v1.1.0)
+- go.opentelemetry.io/auto/sdk: v1.1.0
+- go.uber.org/automaxprocs: v1.6.0
+- go.yaml.in/yaml/v2: v2.4.2
+- go.yaml.in/yaml/v3: v3.0.3
+- gopkg.in/go-jose/go-jose.v2: v2.6.3
+- sigs.k8s.io/randfill: v1.0.0
+
+### Changed
+- cel.dev/expr: v0.18.0 → v0.19.1
+- github.com/cloudflare/circl: [v1.3.7 → v1.6.1](https://github.com/cloudflare/circl/compare/v1.3.7...v1.6.1)
+- github.com/cncf/xds/go: [b4127c9 → cff3c89](https://github.com/cncf/xds/compare/b4127c9...cff3c89)
+- github.com/coreos/go-oidc: [v2.2.1+incompatible → v2.3.0+incompatible](https://github.com/coreos/go-oidc/compare/v2.2.1...v2.3.0)
+- github.com/envoyproxy/go-control-plane: [v0.13.1 → v0.13.4](https://github.com/envoyproxy/go-control-plane/compare/v0.13.1...v0.13.4)
+- github.com/envoyproxy/protoc-gen-validate: [v1.1.0 → v1.2.1](https://github.com/envoyproxy/protoc-gen-validate/compare/v1.1.0...v1.2.1)
+- github.com/go-logr/logr: [v1.4.2 → v1.4.3](https://github.com/go-logr/logr/compare/v1.4.2...v1.4.3)
+- github.com/go-viper/mapstructure/v2: [v2.2.1 → v2.3.0](https://github.com/go-viper/mapstructure/compare/v2.2.1...v2.3.0)
+- github.com/golang-jwt/jwt/v4: [v4.5.0 → v4.5.2](https://github.com/golang-jwt/jwt/compare/v4.5.0...v4.5.2)
+- github.com/golang/glog: [v1.2.2 → v1.2.4](https://github.com/golang/glog/compare/v1.2.2...v1.2.4)
+- github.com/google/cel-go: [v0.22.0 → v0.23.2](https://github.com/google/cel-go/compare/v0.22.0...v0.23.2)
+- github.com/google/gnostic-models: [v0.6.8 → v0.6.9](https://github.com/google/gnostic-models/compare/v0.6.8...v0.6.9)
+- github.com/google/pprof: [40e02aa → 27863c8](https://github.com/google/pprof/compare/40e02aa...27863c8)
+- github.com/gorilla/websocket: [v1.5.3 → e064f32](https://github.com/gorilla/websocket/compare/v1.5.3...e064f32)
+- github.com/grpc-ecosystem/grpc-gateway/v2: [v2.20.0 → v2.24.0](https://github.com/grpc-ecosystem/grpc-gateway/compare/v2.20.0...v2.24.0)
+- github.com/onsi/ginkgo/v2: [v2.23.3 → v2.23.4](https://github.com/onsi/ginkgo/compare/v2.23.3...v2.23.4)
+- github.com/onsi/gomega: [v1.36.3 → v1.38.0](https://github.com/onsi/gomega/compare/v1.36.3...v1.38.0)
+- github.com/pmezard/go-difflib: [5d4384e → v1.0.0](https://github.com/pmezard/go-difflib/compare/5d4384e...v1.0.0)
+- github.com/prometheus/client_golang: [v1.19.1 → v1.22.0](https://github.com/prometheus/client_golang/compare/v1.19.1...v1.22.0)
+- github.com/prometheus/common: [v0.55.0 → v0.62.0](https://github.com/prometheus/common/compare/v0.55.0...v0.62.0)
+- github.com/rogpeppe/go-internal: [v1.12.0 → v1.13.1](https://github.com/rogpeppe/go-internal/compare/v1.12.0...v1.13.1)
+- github.com/spf13/pflag: [v1.0.6 → v1.0.7](https://github.com/spf13/pflag/compare/v1.0.6...v1.0.7)
+- github.com/spf13/viper: [v1.20.0 → v1.20.1](https://github.com/spf13/viper/compare/v1.20.0...v1.20.1)
+- github.com/stretchr/objx: [v0.5.0 → v0.5.2](https://github.com/stretchr/objx/compare/v0.5.0...v0.5.2)
+- go.etcd.io/etcd/api/v3: v3.5.20 → v3.5.22
+- go.etcd.io/etcd/client/pkg/v3: v3.5.20 → v3.5.22
+- go.etcd.io/etcd/client/v2: v2.305.16 → v2.305.21
+- go.etcd.io/etcd/client/v3: v3.5.20 → v3.5.22
+- go.etcd.io/etcd/pkg/v3: v3.5.16 → v3.5.21
+- go.etcd.io/etcd/raft/v3: v3.5.16 → v3.5.21
+- go.etcd.io/etcd/server/v3: v3.5.16 → v3.5.21
+- go.opentelemetry.io/contrib/detectors/gcp: v1.29.0 → v1.34.0
+- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc: v0.54.0 → v0.58.0
+- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: v0.54.0 → v0.58.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc: v1.27.0 → v1.33.0
+- go.opentelemetry.io/otel/exporters/otlp/otlptrace: v1.28.0 → v1.33.0
+- go.opentelemetry.io/otel/metric: v1.29.0 → v1.34.0
+- go.opentelemetry.io/otel/sdk/metric: v1.29.0 → v1.34.0
+- go.opentelemetry.io/otel/sdk: v1.29.0 → v1.34.0
+- go.opentelemetry.io/otel/trace: v1.29.0 → v1.34.0
+- go.opentelemetry.io/otel: v1.29.0 → v1.34.0
+- go.opentelemetry.io/proto/otlp: v1.3.1 → v1.4.0
+- golang.org/x/crypto: v0.36.0 → v0.40.0
+- golang.org/x/mod: v0.23.0 → v0.25.0
+- golang.org/x/net: v0.37.0 → v0.42.0
+- golang.org/x/oauth2: v0.28.0 → v0.30.0
+- golang.org/x/sync: v0.12.0 → v0.16.0
+- golang.org/x/sys: v0.31.0 → v0.34.0
+- golang.org/x/term: v0.30.0 → v0.33.0
+- golang.org/x/text: v0.23.0 → v0.27.0
+- golang.org/x/time: v0.8.0 → v0.9.0
+- golang.org/x/tools: v0.30.0 → v0.34.0
+- google.golang.org/genproto/googleapis/api: e6fa225 → 5f5ef82
+- google.golang.org/genproto/googleapis/rpc: 3abc09e → 1a7da9e
+- google.golang.org/grpc: v1.67.3 → v1.71.1
+- google.golang.org/protobuf: v1.36.5 → v1.36.6
+- k8s.io/api: v0.32.3 → v0.33.3
+- k8s.io/apiextensions-apiserver: v0.32.3 → v0.33.3
+- k8s.io/apimachinery: v0.32.3 → v0.33.3
+- k8s.io/apiserver: v0.32.3 → v0.33.3
+- k8s.io/client-go: v0.32.3 → v0.33.3
+- k8s.io/cluster-bootstrap: v0.32.3 → v0.33.3
+- k8s.io/code-generator: v0.32.3 → v0.33.3
+- k8s.io/component-base: v0.32.3 → v0.33.3
+- k8s.io/gengo/v2: 2b36238 → 1244d31
+- k8s.io/kms: v0.32.3 → v0.33.3
+- k8s.io/kube-openapi: 32ad38e → c8a335a
+- sigs.k8s.io/apiserver-network-proxy/konnectivity-client: v0.31.0 → v0.31.2
+- sigs.k8s.io/controller-runtime: v0.20.4 → v0.21.0
+- sigs.k8s.io/structured-merge-diff/v4: v4.4.2 → v4.6.0
+- sigs.k8s.io/yaml: v1.4.0 → v1.6.0
+
+### Removed
+- github.com/asaskevich/govalidator: [f61b66f](https://github.com/asaskevich/govalidator/tree/f61b66f)
+- github.com/go-kit/log: [v0.2.1](https://github.com/go-kit/log/tree/v0.2.1)
+- github.com/go-logfmt/logfmt: [v0.5.1](https://github.com/go-logfmt/logfmt/tree/v0.5.1)
+- gopkg.in/square/go-jose.v2: v2.6.0
+
+</details>
+<br/>
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
What this PR does / why we need it:

Release notes for v1.11.0-beta.2

Which issue(s) this PR fixes
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/12123
Closes #12542

/area release