### PR TITLE
⚠️ Add omitempty to required string without zero value

### DIFF
--- a/api/addons/v1beta2/clusterresourceset_types.go
+++ b/api/addons/v1beta2/clusterresourceset_types.go
@@ -88,12 +88,12 @@ type ResourceRef struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// kind of the resource. Supported kinds are: Secrets and ConfigMaps.
 	// +kubebuilder:validation:Enum=Secret;ConfigMap
 	// +required
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 }
 
 // ClusterResourceSetStrategy is a string representation of a ClusterResourceSet Strategy.

--- a/api/addons/v1beta2/clusterresourcesetbinding_types.go
+++ b/api/addons/v1beta2/clusterresourcesetbinding_types.go
@@ -49,7 +49,7 @@ type ResourceSetBinding struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	ClusterResourceSetName string `json:"clusterResourceSetName"`
+	ClusterResourceSetName string `json:"clusterResourceSetName,omitempty"`
 
 	// resources is a list of resources that the ClusterResourceSet has.
 	// +optional
@@ -140,7 +140,7 @@ type ClusterResourceSetBindingSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -545,21 +545,21 @@ type ExternalEtcd struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	CAFile string `json:"caFile"`
+	CAFile string `json:"caFile,omitempty"`
 
 	// certFile is an SSL certification file used to secure etcd communication.
 	// Required if using a TLS connection.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	CertFile string `json:"certFile"`
+	CertFile string `json:"certFile,omitempty"`
 
 	// keyFile is an SSL key file used to secure etcd communication.
 	// Required if using a TLS connection.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	KeyFile string `json:"keyFile"`
+	KeyFile string `json:"keyFile,omitempty"`
 }
 
 // JoinConfiguration contains elements describing a particular node.
@@ -685,7 +685,7 @@ type FileDiscovery struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	KubeConfigPath string `json:"kubeConfigPath"`
+	KubeConfigPath string `json:"kubeConfigPath,omitempty"`
 
 	// kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
 	// The file is generated at the path specified in KubeConfigPath.
@@ -785,7 +785,7 @@ type KubeConfigAuthProvider struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// config holds the parameters for the authentication plugin.
 	// +optional
@@ -802,7 +802,7 @@ type KubeConfigAuthExec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=1024
-	Command string `json:"command"`
+	Command string `json:"command,omitempty"`
 
 	// args is the arguments to pass to the command when executing it.
 	// +optional
@@ -846,12 +846,13 @@ type KubeConfigAuthExecEnv struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
+
 	// value of the environment variable
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Value string `json:"value"`
+	Value string `json:"value,omitempty"`
 }
 
 // HostPathMount contains elements describing volumes that are mounted from the
@@ -861,21 +862,25 @@ type HostPathMount struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
+
 	// hostPath is the path in the host that will be mounted inside
 	// the pod.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	HostPath string `json:"hostPath"`
+	HostPath string `json:"hostPath,omitempty"`
+
 	// mountPath is the path inside the pod where hostPath will be mounted.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	MountPath string `json:"mountPath"`
+	MountPath string `json:"mountPath,omitempty"`
+
 	// readOnly controls write access to the volume
 	// +optional
 	ReadOnly *bool `json:"readOnly,omitempty"`
+	
 	// pathType is the type of the HostPath.
 	// +optional
 	PathType corev1.HostPathType `json:"pathType,omitempty"`
@@ -963,7 +968,7 @@ type Arg struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// value is the Value of the extraArg.
 	// +required

--- a/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadmconfig_types.go
@@ -611,7 +611,7 @@ type File struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// owner specifies the ownership of the file, e.g. "root:root".
 	// +optional
@@ -662,13 +662,13 @@ type SecretFileSource struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// key is the key in the secret's data map for this value.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 }
 
 // PasswdSource is a union of all possible external source types for passwd data.
@@ -689,13 +689,13 @@ type SecretPasswdSource struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// key is the key in the secret's data map for this value.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 }
 
 // User defines the input for a generated user in cloud-init.
@@ -704,7 +704,7 @@ type User struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// gecos specifies the gecos to use for the user
 	// +optional
@@ -807,16 +807,19 @@ type Partition struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Device string `json:"device"`
+	Device string `json:"device,omitempty"`
+
 	// layout specifies the device layout.
 	// If it is true, a single partition will be created for the entire device.
 	// When layout is false, it means don't partition or ignore existing partitioning.
 	// +required
-	Layout bool `json:"layout"`
+	Layout bool `json:"layout,omitempty"`
+
 	// overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
 	// Use with caution. Default is 'false'.
 	// +optional
 	Overwrite *bool `json:"overwrite,omitempty"`
+	
 	// tableType specifies the tupe of partition table. The following are supported:
 	// 'mbr': default and setups a MS-DOS partition table
 	// 'gpt': setups a GPT partition table
@@ -831,13 +834,13 @@ type Filesystem struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Device string `json:"device"`
+	Device string `json:"device,omitempty"`
 
 	// filesystem specifies the file system type.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	Filesystem string `json:"filesystem"`
+	Filesystem string `json:"filesystem,omitempty"`
 
 	// label specifies the file system label to be used. If set to None, no label is used.
 	// +optional

--- a/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
+++ b/api/controlplane/kubeadm/v1beta2/kubeadm_control_plane_types.go
@@ -432,7 +432,7 @@ type KubeadmControlPlaneSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 
 	// machineTemplate contains information about how machines
 	// should be shaped when creating or updating a control plane.
@@ -805,7 +805,7 @@ type LastRemediationStatus struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Machine string `json:"machine"`
+	Machine string `json:"machine,omitempty"`
 
 	// time is when last remediation happened. It is represented in RFC3339 form and is in UTC.
 	// +required

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -525,7 +525,7 @@ type ClusterAvailabilityGate struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=316
-	ConditionType string `json:"conditionType"`
+	ConditionType string `json:"conditionType,omitempty"`
 
 	// polarity of the conditionType specified in this availabilityGate.
 	// Valid values are Positive, Negative and omitted.
@@ -546,7 +546,7 @@ type Topology struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 
 	// controlPlane describes the cluster control plane.
 	// +optional
@@ -578,7 +578,7 @@ type ClusterClassRef struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// namespace is the namespace of the ClusterClass that should be used for the topology.
 	// If namespace is empty or not set, it is defaulted to the namespace of the Cluster object.
@@ -822,7 +822,7 @@ type MachineDeploymentTopology struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Class string `json:"class"`
+	Class string `json:"class,omitempty"`
 
 	// name is the unique identifier for this MachineDeploymentTopology.
 	// The value is used with other unique identifiers to create a MachineDeployment's Name
@@ -831,7 +831,7 @@ type MachineDeploymentTopology struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// failureDomain is the failure domain the machines will be created in.
 	// Must match a key in the FailureDomains map stored on the cluster object.
@@ -1132,7 +1132,7 @@ type MachinePoolTopology struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Class string `json:"class"`
+	Class string `json:"class,omitempty"`
 
 	// name is the unique identifier for this MachinePoolTopology.
 	// The value is used with other unique identifiers to create a MachinePool's Name
@@ -1141,7 +1141,7 @@ type MachinePoolTopology struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// failureDomains is the list of failure domains the machine pool will be created in.
 	// Must match a key in the FailureDomains map stored on the cluster object.
@@ -1208,7 +1208,7 @@ type ClusterVariable struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// value of the variable.
 	// Note: the value will be validated against the schema of the corresponding ClusterClassVariable
@@ -1608,7 +1608,7 @@ type FailureDomain struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// controlPlane determines if this failure domain is suitable for use by control plane machines.
 	// +optional

--- a/api/core/v1beta2/clusterclass_types.go
+++ b/api/core/v1beta2/clusterclass_types.go
@@ -404,7 +404,7 @@ type MachineDeploymentClass struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Class string `json:"class"`
+	Class string `json:"class,omitempty"`
 
 	// bootstrap contains the bootstrap template reference to be used
 	// for the creation of worker Machines.
@@ -709,7 +709,7 @@ type MachinePoolClass struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Class string `json:"class"`
+	Class string `json:"class,omitempty"`
 
 	// bootstrap contains the bootstrap template reference to be used
 	// for the creation of the Machines in the MachinePool.
@@ -800,7 +800,7 @@ type ClusterClassVariable struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// required specifies if the variable is required.
 	// Note: this applies to the variable as a whole and thus the
@@ -1137,7 +1137,7 @@ type ValidationRule struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=4096
-	Rule string `json:"rule"`
+	Rule string `json:"rule,omitempty"`
 	// message represents the message displayed when validation fails. The message is required if the Rule contains
 	// line breaks. The message must not contain line breaks.
 	// If unset, the message is "failed rule: {Rule}".
@@ -1208,7 +1208,7 @@ type ClusterClassPatch struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// description is a human-readable description of this patch.
 	// +optional
@@ -1267,7 +1267,7 @@ type PatchSelector struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=317
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion"`
+	APIVersion string `json:"apiVersion,omitempty"`
 
 	// kind filters templates by kind.
 	// kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
@@ -1275,7 +1275,7 @@ type PatchSelector struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// matchResources selects templates based on where they are referenced.
 	// +required
@@ -1337,7 +1337,7 @@ type JSONPatch struct {
 	// Note: Only `add`, `replace` and `remove` are supported.
 	// +required
 	// +kubebuilder:validation:Enum=add;replace;remove
-	Op string `json:"op"`
+	Op string `json:"op,omitempty"`
 
 	// path defines the path of the patch.
 	// Note: Only the spec of a template can be patched, thus the path has to start with /spec/.
@@ -1347,7 +1347,7 @@ type JSONPatch struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// value defines the value of the patch.
 	// Note: Either Value or ValueFrom is required for add and replace
@@ -1456,7 +1456,7 @@ type ClusterClassTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// name of the template.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -1464,7 +1464,7 @@ type ClusterClassTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// apiVersion of the template.
 	// apiVersion must be fully qualified domain name followed by / and a version.
@@ -1472,7 +1472,7 @@ type ClusterClassTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=317
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion"`
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // ToObjectReference returns an object reference for the ClusterClassTemplateReference in a given namespace.
@@ -1545,7 +1545,7 @@ type ClusterClassStatusVariable struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// definitionsConflict specifies whether or not there are conflicting definitions for a single variable name.
 	// +optional
@@ -1566,7 +1566,7 @@ type ClusterClassStatusVariableDefinition struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	From string `json:"from"`
+	From string `json:"from,omitempty"`
 
 	// required specifies if the variable is required.
 	// Note: this applies to the variable as a whole and thus the

--- a/api/core/v1beta2/common_types.go
+++ b/api/core/v1beta2/common_types.go
@@ -298,7 +298,7 @@ type MachineAddress struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Address string `json:"address"`
+	Address string `json:"address,omitempty"`
 }
 
 // MachineAddresses is a slice of MachineAddress items to be used by infrastructure providers.
@@ -365,7 +365,7 @@ type ContractVersionedObjectReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// name of the resource being referenced.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -373,7 +373,7 @@ type ContractVersionedObjectReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// apiGroup is the group of the resource being referenced.
 	// apiGroup must be fully qualified domain name.
@@ -383,7 +383,7 @@ type ContractVersionedObjectReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	APIGroup string `json:"apiGroup"`
+	APIGroup string `json:"apiGroup,omitempty"`
 }
 
 // GroupKind returns the GroupKind of the reference.

--- a/api/core/v1beta2/machine_types.go
+++ b/api/core/v1beta2/machine_types.go
@@ -381,7 +381,7 @@ type MachineSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// bootstrap is a reference to a local struct which encapsulates
 	// fields to configure the Machine’s bootstrapping mechanism.
@@ -486,7 +486,7 @@ type MachineReadinessGate struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=316
-	ConditionType string `json:"conditionType"`
+	ConditionType string `json:"conditionType,omitempty"`
 
 	// polarity of the conditionType specified in this readinessGate.
 	// Valid values are Positive, Negative and omitted.
@@ -568,7 +568,7 @@ type MachineNodeReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // MachineInitializationStatus provides observations of the Machine initialization process.

--- a/api/core/v1beta2/machinedeployment_types.go
+++ b/api/core/v1beta2/machinedeployment_types.go
@@ -238,7 +238,7 @@ type MachineDeploymentSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// replicas is the number of desired machines.
 	// This is a pointer to distinguish between explicit zero and not specified.

--- a/api/core/v1beta2/machinehealthcheck_types.go
+++ b/api/core/v1beta2/machinehealthcheck_types.go
@@ -52,7 +52,7 @@ type MachineHealthCheckSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// selector is a label selector to match machines whose health will be exercised
 	// +required
@@ -163,7 +163,7 @@ type MachineHealthCheckRemediationTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// name of the remediation template.
 	// name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
@@ -171,7 +171,7 @@ type MachineHealthCheckRemediationTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// apiVersion of the remediation template.
 	// apiVersion must be fully qualified domain name followed by / and a version.
@@ -180,7 +180,7 @@ type MachineHealthCheckRemediationTemplateReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=317
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[a-z]([-a-z0-9]*[a-z0-9])?$`
-	APIVersion string `json:"apiVersion"`
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // ToObjectReference returns an object reference for the MachineHealthCheckRemediationTemplateReference in a given namespace.

--- a/api/core/v1beta2/machinepool_types.go
+++ b/api/core/v1beta2/machinepool_types.go
@@ -70,7 +70,7 @@ type MachinePoolSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// replicas is the number of desired machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.

--- a/api/core/v1beta2/machineset_types.go
+++ b/api/core/v1beta2/machineset_types.go
@@ -41,7 +41,7 @@ type MachineSetSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	ClusterName string `json:"clusterName"`
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// replicas is the number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -297,7 +297,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterAvailabilityGate(ref common.Refe
 					"conditionType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "conditionType refers to a condition with matching type in the Cluster's condition list. If the conditions doesn't exist, it will be treated as unknown. Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -449,7 +448,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassPatch(ref common.ReferenceC
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the patch.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -512,7 +510,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassRef(ref common.ReferenceCal
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the ClusterClass that should be used for the topology. name must be a valid ClusterClass name and because of that be at most 253 characters in length and it must consist only of lower case alphanumeric characters, hyphens (-) and periods (.), and must start and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -707,7 +704,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassStatusVariable(ref common.R
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the variable.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -757,7 +753,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassStatusVariableDefinition(re
 					"from": {
 						SchemaProps: spec.SchemaProps{
 							Description: "from specifies the origin of the variable definition. This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass for variables discovered from a DiscoverVariables runtime extensions.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -803,7 +798,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassTemplateReference(ref commo
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kind of the template. kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -811,7 +805,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassTemplateReference(ref commo
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the template. name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -819,7 +812,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassTemplateReference(ref commo
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "apiVersion of the template. apiVersion must be fully qualified domain name followed by / and a version.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -870,7 +862,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterClassVariable(ref common.Referen
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the variable.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1368,7 +1359,6 @@ func schema_cluster_api_api_core_v1beta2_ClusterVariable(ref common.ReferenceCal
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the variable.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1457,7 +1447,6 @@ func schema_cluster_api_api_core_v1beta2_ContractVersionedObjectReference(ref co
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kind of the resource being referenced. kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1465,7 +1454,6 @@ func schema_cluster_api_api_core_v1beta2_ContractVersionedObjectReference(ref co
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the resource being referenced. name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1473,7 +1461,6 @@ func schema_cluster_api_api_core_v1beta2_ContractVersionedObjectReference(ref co
 					"apiGroup": {
 						SchemaProps: spec.SchemaProps{
 							Description: "apiGroup is the group of the resource being referenced. apiGroup must be fully qualified domain name. The corresponding version for this reference will be looked up from the contract labels of the corresponding CRD of the resource being referenced.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2103,7 +2090,6 @@ func schema_cluster_api_api_core_v1beta2_FailureDomain(ref common.ReferenceCallb
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the failure domain.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2198,7 +2184,6 @@ func schema_cluster_api_api_core_v1beta2_JSONPatch(ref common.ReferenceCallback)
 					"op": {
 						SchemaProps: spec.SchemaProps{
 							Description: "op defines the operation of the patch. Note: Only `add`, `replace` and `remove` are supported.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2206,7 +2191,6 @@ func schema_cluster_api_api_core_v1beta2_JSONPatch(ref common.ReferenceCallback)
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "path defines the path of the patch. Note: Only the spec of a template can be patched, thus the path has to start with /spec/. Note: For now the only allowed array modifications are `append` and `prepend`, i.e.: * for op: `add`: only index 0 (prepend) and - (append) are allowed * for op: `replace` or `remove`: no indexes are allowed",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2615,7 +2599,6 @@ func schema_cluster_api_api_core_v1beta2_MachineAddress(ref common.ReferenceCall
 					"address": {
 						SchemaProps: spec.SchemaProps{
 							Description: "address is the machine address.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2756,7 +2739,6 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentClass(ref common.Refer
 					"class": {
 						SchemaProps: spec.SchemaProps{
 							Description: "class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3376,7 +3358,6 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentSpec(ref common.Refere
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the name of the Cluster this object belongs to.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3555,7 +3536,6 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentTopology(ref common.Re
 					"class": {
 						SchemaProps: spec.SchemaProps{
 							Description: "class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3563,7 +3543,6 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentTopology(ref common.Re
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4468,7 +4447,6 @@ func schema_cluster_api_api_core_v1beta2_MachineHealthCheckRemediationTemplateRe
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kind of the remediation template. kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4476,7 +4454,6 @@ func schema_cluster_api_api_core_v1beta2_MachineHealthCheckRemediationTemplateRe
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the remediation template. name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4484,7 +4461,6 @@ func schema_cluster_api_api_core_v1beta2_MachineHealthCheckRemediationTemplateRe
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "apiVersion of the remediation template. apiVersion must be fully qualified domain name followed by / and a version. NOTE: This field must be kept in sync with the APIVersion of the remediation template.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4534,7 +4510,6 @@ func schema_cluster_api_api_core_v1beta2_MachineHealthCheckSpec(ref common.Refer
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the name of the Cluster this object belongs to.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4797,7 +4772,6 @@ func schema_cluster_api_api_core_v1beta2_MachineNodeReference(ref common.Referen
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name of the node. name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4877,7 +4851,6 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolClass(ref common.ReferenceCa
 					"class": {
 						SchemaProps: spec.SchemaProps{
 							Description: "class denotes a type of machine pool present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachinePool.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5155,7 +5128,6 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolSpec(ref common.ReferenceCal
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the name of the Cluster this object belongs to.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5351,7 +5323,6 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolTopology(ref common.Referenc
 					"class": {
 						SchemaProps: spec.SchemaProps{
 							Description: "class is the name of the MachinePoolClass used to create the pool of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5359,7 +5330,6 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolTopology(ref common.Referenc
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the unique identifier for this MachinePoolTopology. The value is used with other unique identifiers to create a MachinePool's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5566,7 +5536,6 @@ func schema_cluster_api_api_core_v1beta2_MachineReadinessGate(ref common.Referen
 					"conditionType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "conditionType refers to a condition with matching type in the Machine's condition list. If the conditions doesn't exist, it will be treated as unknown. Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5738,7 +5707,6 @@ func schema_cluster_api_api_core_v1beta2_MachineSetSpec(ref common.ReferenceCall
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the name of the Cluster this object belongs to.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5949,7 +5917,6 @@ func schema_cluster_api_api_core_v1beta2_MachineSpec(ref common.ReferenceCallbac
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "clusterName is the name of the Cluster this object belongs to.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6346,7 +6313,6 @@ func schema_cluster_api_api_core_v1beta2_PatchSelector(ref common.ReferenceCallb
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "apiVersion filters templates by apiVersion. apiVersion must be fully qualified domain name followed by / and a version.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6354,7 +6320,6 @@ func schema_cluster_api_api_core_v1beta2_PatchSelector(ref common.ReferenceCallb
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kind filters templates by kind. kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6499,7 +6464,6 @@ func schema_cluster_api_api_core_v1beta2_Topology(ref common.ReferenceCallback) 
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "version is the Kubernetes version of the cluster.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6597,7 +6561,6 @@ func schema_cluster_api_api_core_v1beta2_ValidationRule(ref common.ReferenceCall
 					"rule": {
 						SchemaProps: spec.SchemaProps{
 							Description: "rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. If the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {\"rule\": \"self.components['Widget'].priority < 10\"} - Rule scoped to a list of integers: {\"rule\": \"self.values.all(value, value >= 0 && value < 100)\"} - Rule scoped to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an \"unknown type\". An \"unknown type\" is recursively defined as:\n  - A schema with no type and x-kubernetes-preserve-unknown-fields set to true\n  - An array where the items schema is of an \"unknown type\"\n  - An object where the additionalProperties schema is of an \"unknown type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Rule accessing a property named \"namespace\": {\"rule\": \"self.__namespace__ > 0\"}\n  - Rule accessing a property named \"x-prop\": {\"rule\": \"self.x__dash__prop > 0\"}\n  - Rule accessing a property named \"redact__d\": {\"rule\": \"self.redact__underscores__d > 0\"}\n\nIf `rule` makes use of the `oldSelf` variable it is implicitly a `transition rule`.\n\nBy default, the `oldSelf` variable is the same type as `self`.\n\nTransition rules by default are applied only on UPDATE requests and are skipped if an old value could not be found.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/ipam/v1beta2/ipaddress_types.go
+++ b/api/ipam/v1beta2/ipaddress_types.go
@@ -34,7 +34,7 @@ type IPAddressSpec struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=39
-	Address string `json:"address"`
+	Address string `json:"address,omitempty"`
 
 	// prefix is the prefix of the address.
 	// +required
@@ -55,7 +55,7 @@ type IPAddressClaimReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // IPPoolReference is a reference to an IPPool.
@@ -66,7 +66,7 @@ type IPPoolReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// kind of the IPPool.
 	// kind must consist of alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character.
@@ -74,7 +74,7 @@ type IPPoolReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// apiGroup of the IPPool.
 	// apiGroup must be fully qualified domain name.
@@ -82,7 +82,7 @@ type IPPoolReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	APIGroup string `json:"apiGroup"`
+	APIGroup string `json:"apiGroup,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/ipam/v1beta2/ipaddressclaim_types.go
+++ b/api/ipam/v1beta2/ipaddressclaim_types.go
@@ -81,7 +81,7 @@ type IPAddressReference struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // IPAddressClaimDeprecatedStatus groups all the status fields that are deprecated and will be removed in a future version.

--- a/api/runtime/v1beta2/extensionconfig_types.go
+++ b/api/runtime/v1beta2/extensionconfig_types.go
@@ -87,13 +87,13 @@ type ServiceReference struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 
 	// name is the name of the service.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// path is an optional URL path and if present may be any string permissible in
 	// a URL. If a path is set it will be used as prefix to the hook-specific path.
@@ -159,7 +159,7 @@ type ExtensionHandler struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// requestHook defines the versioned runtime hook which this ExtensionHandler serves.
 	// +required
@@ -183,13 +183,13 @@ type GroupVersionHook struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=512
-	APIVersion string `json:"apiVersion"`
+	APIVersion string `json:"apiVersion,omitempty"`
 
 	// hook is the name of the hook.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	Hook string `json:"hook"`
+	Hook string `json:"hook,omitempty"`
 }
 
 // FailurePolicy specifies how unrecognized errors when calling the ExtensionHandler are handled.


### PR DESCRIPTION
**What this PR does / why we need it**:
... this prevents go types to marshal to invalid yaml

part of https://github.com/kubernetes-sigs/cluster-api/issues/10852

/area api