### PR TITLE
🐛 Fix runtime-sdk E2E test

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -331,6 +331,20 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 			input.PostUpgrade(input.BootstrapClusterProxy, namespace.Name, clusterResources.Cluster.Name)
 		}
 
+		Byf("Verify Cluster Available condition is true")
+		framework.VerifyClusterAvailable(ctx, framework.VerifyClusterAvailableInput{
+			Getter:    input.BootstrapClusterProxy.GetClient(),
+			Name:      clusterResources.Cluster.Name,
+			Namespace: clusterResources.Cluster.Namespace,
+		})
+
+		Byf("Verify Machines Ready condition is true")
+		framework.VerifyMachinesReady(ctx, framework.VerifyMachinesReadyInput{
+			Lister:    input.BootstrapClusterProxy.GetClient(),
+			Name:      clusterResources.Cluster.Name,
+			Namespace: clusterResources.Cluster.Namespace,
+		})
+
 		By("Dumping resources and deleting the workload cluster; deletion waits for BeforeClusterDeleteHook to gate the operation")
 		dumpAndDeleteCluster(ctx, input.BootstrapClusterProxy, input.ClusterctlConfigPath, namespace.Name, clusterName, input.ArtifactFolder)
 
@@ -346,20 +360,6 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 			"AfterControlPlaneInitialized": "Success",
 			"AfterClusterUpgrade":          "Success",
 		})).To(Succeed(), "Lifecycle hook calls were not as expected")
-
-		Byf("Verify Cluster Available condition is true")
-		framework.VerifyClusterAvailable(ctx, framework.VerifyClusterAvailableInput{
-			Getter:    input.BootstrapClusterProxy.GetClient(),
-			Name:      clusterResources.Cluster.Name,
-			Namespace: clusterResources.Cluster.Namespace,
-		})
-
-		Byf("Verify Machines Ready condition is true")
-		framework.VerifyMachinesReady(ctx, framework.VerifyMachinesReadyInput{
-			Lister:    input.BootstrapClusterProxy.GetClient(),
-			Name:      clusterResources.Cluster.Name,
-			Namespace: clusterResources.Cluster.Namespace,
-		})
 
 		By("PASSED!")
 	})

--- a/test/framework/cluster_helpers.go
+++ b/test/framework/cluster_helpers.go
@@ -452,7 +452,7 @@ func VerifyClusterAvailable(ctx context.Context, input VerifyClusterAvailableInp
 		g.Expect(input.Getter.Get(ctx, key, cluster)).To(Succeed())
 		for _, condition := range cluster.Status.Conditions {
 			if condition.Type == clusterv1.AvailableCondition {
-				g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Available condition on the Cluster should be set to true")
+				g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Available condition on the Cluster should be set to true; message: %s", condition.Message)
 				g.Expect(condition.Message).To(BeEmpty(), "The Available condition on the Cluster should have an empty message")
 				return
 			}
@@ -484,7 +484,7 @@ func VerifyMachinesReady(ctx context.Context, input VerifyMachinesReadyInput) {
 			for _, condition := range machine.Status.Conditions {
 				if condition.Type == clusterv1.ReadyCondition {
 					readyConditionFound = true
-					g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Ready condition on Machine %q should be set to true", machine.Name)
+					g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Ready condition on Machine %q should be set to true; message: %s", machine.Name, condition.Message)
 					g.Expect(condition.Message).To(BeEmpty(), "The Ready condition on Machine %q should have an empty message", machine.Name)
 					break
 				}


### PR DESCRIPTION
fix a regression introduced by https://github.com/kubernetes-sigs/cluster-api/pull/12546 (sorry I missed in the last round of review)

/area e2e-testing