### PR TITLE
🐛  Fix timeout handling in GetAPIServerCertificateExpiry and DialContext

### DIFF
--- a/controlplane/kubeadm/internal/proxy/dial.go
+++ b/controlplane/kubeadm/internal/proxy/dial.go
@@ -83,8 +83,14 @@ func (d *Dialer) DialContextWithAddr(ctx context.Context, addr string) (net.Conn
 }
 
 // DialContext creates proxied port-forwarded connections.
-// ctx is currently unused, but fulfils the type signature used by GRPC.
-func (d *Dialer) DialContext(_ context.Context, _ string, addr string) (net.Conn, error) {
+func (d *Dialer) DialContext(ctx context.Context, _ string, addr string) (net.Conn, error) {
+	// Check if context is already cancelled or timed out
+	select {
+	case <-ctx.Done():
+		return nil, errors.Wrap(ctx.Err(), "context cancelled before establishing connection")
+	default:
+	}
+
 	req := d.clientset.CoreV1().RESTClient().
 		Post().
 		Resource(d.proxy.Kind).
@@ -92,7 +98,15 @@ func (d *Dialer) DialContext(_ context.Context, _ string, addr string) (net.Conn
 		Name(addr).
 		SubResource("portforward")
 
-	dialer := spdy.NewDialer(d.upgrader, &http.Client{Transport: d.proxyTransport}, "POST", req.URL())
+	httpClient := &http.Client{
+		Transport: d.proxyTransport,
+	}
+
+	if deadline, ok := ctx.Deadline(); ok {
+		httpClient.Timeout = time.Until(deadline)
+	}
+
+	dialer := spdy.NewDialer(d.upgrader, httpClient, "POST", req.URL())
 
 	// Create a new connection from the dialer.
 	//

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -318,6 +318,10 @@ func (w *Workload) ClusterStatus(ctx context.Context) (ClusterStatus, error) {
 
 // GetAPIServerCertificateExpiry returns the certificate expiry of the apiserver on the given node.
 func (w *Workload) GetAPIServerCertificateExpiry(ctx context.Context, kubeadmConfig *bootstrapv1.KubeadmConfig, nodeName string) (*time.Time, error) {
+	// Create a context with 15 second timeout
+	ctx, cancel := context.WithTimeoutCause(ctx, 15*time.Second, errors.New("timeout getting API server certificate expiry"))
+	defer cancel()
+
 	// Create a proxy.
 	p := proxy.Proxy{
 		Kind:       "pods",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR adds proper timeout handling to prevent hanging connections when getting API server certificate expiry. The changes include:

- Add 15-second timeout using `context.WithTimeoutCause()` in `GetAPIServerCertificateExpiry()` 
- Handle context timeout in `DialContext()` by configuring HTTP client timeout based on context deadline
- Add early context cancellation checks to fail fast when context is already cancelled

These changes prevent indefinite blocking during certificate expiry checks and improve debugging with descriptive timeout errors.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12460

area/provider/control-plane-kubeadm