### PR TITLE
🐛 Fix Test_ValidateCluster unit tests for mink8s

### DIFF
--- a/internal/webhooks/test/cluster_test.go
+++ b/internal/webhooks/test/cluster_test.go
@@ -57,8 +57,8 @@ func Test_ValidateCluster(t *testing.T) {
 			mdTopologyName: "machine-deployment-topology-name-that-has-longerthan63characterlooooooooooooooooooooooongname",
 			mpTopologyName: "machine-pool-topology-name-that-has-longerthan63characterlooooooooooooooooooooooongname",
 			wantErrs: []string{
-				"spec.topology.workers.machineDeployments[0].name: Too long: may not be more than 63 bytes",
-				"spec.topology.workers.machinePools[0].name: Too long: may not be more than 63 bytes",
+				"spec.topology.workers.machineDeployments[0].name: Too long",
+				"spec.topology.workers.machinePools[0].name: Too long",
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Error message returned by the apiserver looks slightly different on older Kubernetes versions

xref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/1951167127310307328

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->