### PR TITLE
📖 Update v1.10-to-v1.11.md based on recent changes

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -430,6 +430,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The type of the `spec.paused` field has been changed from `bool` to `*bool`(compliance with K8s API guidelines)
 - The `spec.controlPlaneRef` and `spec.infrastructureRef` fields are now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference` (improve object references)
@@ -468,7 +469,7 @@ status:
   - Also the `spec.topology.workers.machineDeployments[].healthCheck.remediation.maxInFlight` field has been moved from `spec.topology.workers.machineDeployments[].strategy.remediation.maxInFlight`
 - All fields of type Duration in `spec.topology.{controlPlane.healthCheck.checks,workers.machineDeployments[].healthCheck.checks}`, previously
   `spec.topology.{controlPlane.healthCheck,workers.machineDeployments[].machineHealthCheck}` have
-  been renamed by adding the `Seconds` suffix and their type was changed to int32 (compliance with K8s API guidelines)
+  been renamed by adding the `Seconds` suffix and their type was changed to `*int32` (compliance with K8s API guidelines)
   - `nodeStartupTimeout` => `nodeStartupTimeoutSeconds`
   - `unhealthyNodeConditions[].timeout` => `unhealthyNodeConditions[].timeoutSeconds`
 - All the `remediation.templateRef` fields have been migrated from type `corev1.ObjectReference` to `MachineHealthCheckRemediationTemplateReference`:
@@ -640,6 +641,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The `spec.machineNamingStrategy` field was renamed to `spec.machineNaming` and is now using `MachineNamingSpec` type instead of `*MachineNamingStrategy` (improve consistency, drop unnecessary pointers)
 - The `spec.template.spec.bootstrap.configRef` and `spec.template.spec.infrastructureRef` fields are now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference` (improve object references)
@@ -796,6 +798,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The `spec.machineNamingStrategy` field was renamed to `spec.machineNaming` and is now using `MachineNamingSpec` type instead of `*MachineNamingStrategy` (improve consistency, drop unnecessary pointers)
 - The `spec.template.spec.bootstrap.configRef` and `spec.template.spec.infrastructureRef` fields are now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference` (improve object references)
@@ -944,6 +947,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The `spec.template.spec.bootstrap.configRef` and `spec.template.spec.infrastructureRef` fields are now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference` (improve object references)
   - The following fields have been removed: `namespace`, `uid`, `resourceVersion`, `fieldPath`
@@ -1072,6 +1076,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The `spec.bootstrap.configRef` and `spec.infrastructureRef` fields are now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference` (improve object references)
   - The following fields have been removed: `namespace`, `uid`, `resourceVersion`, `fieldPath`
@@ -1177,6 +1182,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The `spec` has been restructured and made consistent across all resources. Notably fields for checks and remediation
   are now well identified under corresponding fields.
   The Go structs have been modified accordingly. For more details see YAML above (improve consistency).
@@ -1184,7 +1190,7 @@ status:
   was changed to int32 (compliance with K8s API guidelines)
 - The `spec.unhealthyConditions` field has been renamed to `spec.checks.unhealthyNodeConditions` (improve consistency)
 - The type of the `spec.checks.unhealthyNodeConditions[].timeoutSeconds` field, previously `spec.unhealthyConditions[].timeout`,
-  was changed to int32 (compliance with K8s API guidelines)
+  was changed to `*int32` (compliance with K8s API guidelines)
 - The type of the `spec.remediation.templateRef` field, previously `spec.remediationTemplate`, was changed from
   `corev1.ObjectReference` to `MachineHealthCheckRemediationTemplateReference` (improve object references):
   - The following fields have been removed from `templateRef`: `namespace`, `uid`, `resourceVersion`, `fieldPath`
@@ -1492,6 +1498,7 @@ status:
 </table>
 
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - All fields of type Duration in `spec.{controlPlane,workers.machineDeployments[],workers.machinePools[]}` have
   been renamed by adding the `Seconds` suffix, moved into the `deletion` section and their type was changed to int32 (compliance with K8s API guidelines)
   - `nodeDrainTimeout` => `deletion.nodeDrainTimeoutSeconds`
@@ -1499,7 +1506,7 @@ status:
   - `nodeDeletionTimeout` => `deletion.nodeDeletionTimeoutSeconds`
 - All fields of type Duration in `spec.controlPlane.healthCheck` and `spec.workers.machineDeployments[].healthCheck`, previously
   `spec.controlPlane.machineHealthCheck` and `spec.workers.machineDeployments[].machineHealthCheck`, have
-  been renamed by adding the `Seconds` suffix and their type was changed to int32 (compliance with K8s API guidelines)
+  been renamed by adding the `Seconds` suffix and their type was changed to `*int32` (compliance with K8s API guidelines)
   - `nodeStartupTimeout` => `nodeStartupTimeoutSeconds`
   - `unhealthyNodeConditions[].timeout` => `unhealthyNodeConditions[].timeoutSeconds`
 - All fields implementing or embedding a reference to a template are now using the `ClusterClassTemplateReference` type instead
@@ -1519,7 +1526,7 @@ status:
   - Also the `spec.workers.machineDeployments[].healthCheck.remediation.maxInFlight` field has been moved from `spec.workers.machineDeployments[].strategy.remediation.maxInFlight`
 - All fields of type Duration in `spec.{controlPlane.healthCheck.checks,workers.machineDeployments[].healthCheck.checks}`, previously
   `spec.{controlPlane.healthCheck,workers.machineDeployments[].machineHealthCheck}` have
-  been renamed by adding the `Seconds` suffix and their type was changed to int32 (compliance with K8s API guidelines)
+  been renamed by adding the `Seconds` suffix and their type was changed to `*int32` (compliance with K8s API guidelines)
   - `nodeStartupTimeout` => `nodeStartupTimeoutSeconds`
   - `unhealthyNodeConditions[].timeout` => `unhealthyNodeConditions[].timeoutSeconds`
 - All the `remediation.templateRef` fields have been migrated from type `corev1.ObjectReference` to `MachineHealthCheckRemediationTemplateReference`:
@@ -1554,8 +1561,8 @@ status:
   to `spec.variables[].deprecatedV1Beta1Metadata` and `.status.variables[].definitions[].deprecatedV1Beta1Metadata`
   - These fields are deprecated and will be removed when support for v1beta1 will be dropped
   - Please use `XMetadata` in `JSONSchemaProps` instead
-- The type of the `spec.variables[].schema.openAPIV3Schema.uniqueItems`, `spec.variables[].schema.openAPIV3Schema.exclusiveMaximum`, `spec.variables[].schema.openAPIV3Schema.exclusiveMinimum`,
-  `spec.variables[].schema.openAPIV3Schema.x-kubernetes-preserve-unknown-fields`, `spec.variables[].schema.openAPIV3Schema.x-kubernetes-int-or-string` fields
+- The type of the `spec.variables[].required`, `spec.variables[].schema.openAPIV3Schema.uniqueItems`, `spec.variables[].schema.openAPIV3Schema.exclusiveMaximum`, `spec.variables[].schema.openAPIV3Schema.exclusiveMinimum`,
+  `spec.variables[].schema.openAPIV3Schema.x-kubernetes-preserve-unknown-fields`, `spec.variables[].schema.openAPIV3Schema.x-kubernetes-int-or-string`, `.status.variables[].definitions[].required` fields
   has been changed from `bool` to `*bool`(compliance with K8s API guidelines)
   - Same applies to the corresponding fields under:
     - `spec.variables.schema.openAPIV3Schema.properties[]`
@@ -1825,6 +1832,8 @@ status:
 
 - KubeadmConfig (and the entire CABPK provider) now implements the v1beta2 Cluster API contract
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) and 
+  [#12560](https://github.com/kubernetes-sigs/cluster-api/pull/12560) for details (drop unnecessary pointers)
 - `extraArg` field types have been changed from `map[string]sting` to `[]Arg`, thus aligning with kubeadm v1beta4 API;
   however, using multiple args with the same name will be enabled only when v1beta1 is removed, tentatively in August 2026
   - `spec.clusterConfiguration.apiServer.extraArgs` type has been changed to `[]Arg`
@@ -1859,6 +1868,7 @@ status:
   `spec.clusterConfiguration.scheduler` and `spec.clusterConfiguration.etcd.local` has been changed from `[]EnvVar` to `*[]EnvVar` (compliance with K8s API guidelines)
 - The type of the `spec.clusterConfiguration.apiServer.extraVolumes.readOnly`, `spec.clusterConfiguration.controllerManager.extraVolumes.readOnly`
   , `spec.clusterConfiguration.scheduler.extraVolumes.readOnly` fields have been changed from `bool` to `*bool` (compliance with K8s API guidelines)
+- The type of the `spec.initConfiguration.bootstrapTokens[].token` field has been changed from `*BootstrapTokenString` to `BootstrapTokenString` (drop unnecessary pointers)
 - The type of the `spec.initConfiguration.nodeRegistration`, `spec.joinConfiguration.nodeRegistration` fields have been changed from `[]corev1.Taint` to `*[]corev1.Taint` (avoid custom serialization)
 - The type of the `spec.joinConfiguration.discovery.bootstrapToken.unsafeSkipCAVerification` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - The type of the `spec.joinConfiguration.discovery.file.kubeConfig.cluster.insecureSkipTLSVerify` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
@@ -1868,6 +1878,7 @@ status:
   `spec.users[].pr`, `spec.users[].sudo` fields have been changed from `*string` to `string` (drop unnecessary pointers)
 - The type of the `spec.diskSetup.filesystems[].partition`, `spec.diskSetup.filesystems[].replaceFS` fields have been changed from `*string` to `string` (drop unnecessary pointers)
 - The type of the `spec.diskSetup.partitions[].tableType` field has been changed from `*string` to `string` (drop unnecessary pointers)
+- The type of the `spec.diskSetup.partitions[].layout` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - The type of the `spec.ignition.containerLinuxConfig.strict` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - The `spec.useExperimentalRetryJoin` field (deprecated in CAPI v1.2!) has been removed
 - The following `spec` fields have been removed because they are not necessary because Cluster API automatically applies the right gvk when generating kubeadm config files:
@@ -2236,6 +2247,8 @@ status:
 
 - KubeadmControlPlane (and the entire KCP provider) now implements the v1beta2 Cluster API contract
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) and
+  [#12560](https://github.com/kubernetes-sigs/cluster-api/pull/12560) for details (drop unnecessary pointers)
 - The `spec.machineNamingStrategy` field was renamed to `spec.machineNaming` and is now using `MachineNamingSpec` type instead of `*MachineNamingStrategy` (improve consistency, drop unnecessary pointers)
 - The `spec.machineTemplate.infrastructureRef` field was moved to `spec.machineTemplate.spec.infrastructureRef` and is now using `ContractVersionedObjectReference` type instead
   of `corev1.ObjectReference`
@@ -2276,6 +2289,7 @@ status:
   `spec.kubeadmConfigSpec.clusterConfiguration.scheduler` and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local` has been changed from `[]EnvVar` to `*[]EnvVar` (compliance with K8s API guidelines)
 - The type of the `spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraVolumes.readOnly`, `spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraVolumes.readOnly`
   , `spec.kubeadmConfigSpec.clusterConfiguration.scheduler.extraVolumes.readOnly` fields have been changed from `bool` to `*bool` (avoid custom serialization)
+- The type of the `spec.kubeadmConfigSpec.initConfiguration.bootstrapTokens[].token` field has been changed from `*BootstrapTokenString` to `BootstrapTokenString` (drop unnecessary pointers)
 - The type of the `spec.kubeadmConfigSpec.initConfiguration.nodeRegistration`, `spec.kubeadmConfigSpec.joinConfiguration.nodeRegistration` fields have been changed from `[]corev1.Taint` to `*[]corev1.Taint` (avoid custom serialization)
 - The type of the `spec.kubeadmConfigSpec.joinConfiguration.discovery.bootstrapToken.unsafeSkipCAVerification` field has been changed from `bool` to `*bool`(compliance with K8s API guidelines)
 - The type of the `spec.kubeadmConfigSpec.joinConfiguration.discovery.file.kubeConfig.cluster.insecureSkipTLSVerify` field has been changed from `bool` to `*bool`(compliance with K8s API guidelines)
@@ -2285,6 +2299,7 @@ status:
   `spec.kubeadmConfigSpec.users[].primaryGroup`, `spec.kubeadmConfigSpec.users[].sudo` fields have been changed from `*string` to `string` (drop unnecessary pointers)
 - The type of the `spec.kubeadmConfigSpec.diskSetup.filesystems[].partition`, `spec.kubeadmConfigSpec.diskSetup.filesystems[].replaceFS` fields have been changed from `*string` to `string` (drop unnecessary pointers)
 - The type of the `spec.kubeadmConfigSpec.diskSetup.partitions[].tableType` field has been changed from `*string` to `string` (drop unnecessary pointers)
+- The type of the `spec.kubeadmConfigSpec.diskSetup.partitions[].layout` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - The type of the `spec.kubeadmConfigSpec.ignition.containerLinuxConfig.strict` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - The `spec.kubeadmConfigSpec.useExperimentalRetryJoin` field (deprecated in CAPI v1.2!) has been removed
 - The following `spec.kubeadmConfigSpec` fields have been removed because they are not necessary (Cluster API automatically applies the right gvk when generating kubeadm config files):
@@ -2335,6 +2350,7 @@ status:
   - `status.failureReason` and `status.failureMessage` will continue to exist temporarily under `status.deprecated.v1beta1`
 - The type of the `status.version` field has been changed from `*string` to `string` (drop unnecessary pointers)
 - The `status.lastRemediation.timestamp` field has been renamed to `status.lastRemediation.time` (compliance with K8s API guidelines)
+- The type of the `status.lastRemediation.retryCount` field has been changed from `int32` to `*int32` (compliance with K8s API guidelines)
 
 ### KubeadmControlPlaneTemplate
 
@@ -2430,6 +2446,7 @@ spec:
 - See changes that apply to [all CRDs](#all-crds)
 - The type of the `spec.bindings` field has been changed from `[]*ResourceSetBinding` to `[]ResourceSetBinding` (drop unnecessary pointers)
 - The type of the `spec.bindings[].resources[].lastAppliedTime` field has been changed from `*metav1.Time` to `metav1.Time` (drop unnecessary pointers)
+- The type of the `spec.bindings[].resources[].applied` field has been changed from `bool` to `*bool` (compliance with K8s API guidelines)
 - Remove deprecated `ClusterResourceSetBinding.DeleteBinding` func
 
 ### ExtensionConfig
@@ -2482,6 +2499,7 @@ status:
 - `ExtensionConfig` v1beta2 has been created, thus aligning with other Cluster API resources
 - `ExtensionConfig` v1alpha1 has been deprecated, and it will be removed in a following release
 - See changes that apply to [all CRDs](#all-crds)
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) for details (drop unnecessary pointers)
 - The type of the `spec.clientConfig.url` field has been changed from `*string` to `string` (drop unnecessary pointers)
 - The type of the `spec.clientConfig.service.path` field has been changed from `*string` to `string` (drop unnecessary pointers)
 - `status.conditions` has been replaced with `status.v1beta2.conditions` based on metav1 condition types (improve status)
@@ -2525,6 +2543,7 @@ spec: { ... }
 - The type of the `spec.claimRef` field has been changed from `corev1.LocalObjectReference` to `IPAddressClaimReference` (improve object references)
 - The type of the `spec.poolRef` field has been changed from `corev1.TypedLocalObjectReference` to `IPPoolReference` (improve object references)
 - The type of the `spec.poolRef.apiGroup` field has been changed from `*string` to `string` (drop unnecessary pointers)
+- The type of the `spec.prefix` field has been changed from `int32` to `*int32` (compliance with K8s API guidelines)
 
 ### IPAddressClaim
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Updates the migration doc according to the changes in:
  * https://github.com/kubernetes-sigs/cluster-api/pull/12545
  * https://github.com/kubernetes-sigs/cluster-api/pull/12558
  * https://github.com/kubernetes-sigs/cluster-api/pull/12560
  * https://github.com/kubernetes-sigs/cluster-api/pull/12565

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->