### PR TITLE
🌱 Add quickstart e2e test with v1beta1 with ClusterClass and RuntimeSDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ hack/tools/bin
 test/e2e/data/infrastructure-docker/**/cluster-template*.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-quick-start.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-quick-start-runtimesdk.yaml
+!test/e2e/data/infrastructure-docker/**/clusterclass-quick-start-runtimesdk-v1beta1.yaml
 !test/e2e/data/infrastructure-docker/**/cluster-template-in-memory.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-in-memory.yaml
 test/e2e/data/infrastructure-docker/**/clusterclass-*.yaml

--- a/Makefile
+++ b/Makefile
@@ -627,6 +627,7 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-autoscaler --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-autoscaler.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology.yaml

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -343,6 +343,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-no-workers.yaml"
+    - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-kcp-only.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-autoscaler.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology.yaml"
@@ -351,6 +352,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start-kcp-only.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk.yaml"
+    - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk-v1beta1.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-in-memory.yaml"
     - sourcePath: "../data/shared/main/metadata.yaml"
 

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/cluster-runtimesdk.yaml
@@ -1,0 +1,44 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: default
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ['${DOCKER_SERVICE_CIDRS}']
+    pods:
+      cidrBlocks: ['${DOCKER_POD_CIDRS}']
+    serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
+  topology:
+    class: "quick-start-runtimesdk-v1beta1"
+    classNamespace: '${CLUSTER_CLASS_NAMESPACE:-${NAMESPACE}}'
+    version: "${KUBERNETES_VERSION}"
+    controlPlane:
+      nodeDeletionTimeout: 30s
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+        - class: "default-worker"
+          name: "md-0"
+          nodeDeletionTimeout: 30s
+          nodeVolumeDetachTimeout: 300s
+          minReadySeconds: 5
+          replicas: ${WORKER_MACHINE_COUNT}
+          failureDomain: fd4
+      machinePools:
+        - class: "default-worker"
+          name: "mp-0"
+          nodeDeletionTimeout: 30s
+          nodeVolumeDetachTimeout: 300s
+          minReadySeconds: 5
+          replicas: ${WORKER_MACHINE_COUNT}
+          failureDomains:
+            - fd4
+    variables:
+      - name: kubeadmControlPlaneMaxSurge
+        value: "1"
+      - name: imageRepository
+        value: "kindest"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/cluster-runtimesdk.yaml
@@ -1,3 +1,4 @@
+# Note: This file is intentionally using v1beta1 for v1beta1 test coverage.
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../bases/crs.yaml
+  - cluster-runtimesdk.yaml

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk-v1beta1.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk-v1beta1.yaml
@@ -1,64 +1,66 @@
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: quick-start-runtimesdk
+  name: quick-start-runtimesdk-v1beta1
 spec:
   controlPlane:
-    templateRef:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
       name: quick-start-control-plane
     machineInfrastructure:
-      templateRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: quick-start-control-plane
-    naming:
+    namingStrategy:
       template: "{{ .cluster.name }}-cp-{{ .random }}"
   infrastructure:
-    templateRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerClusterTemplate
       name: quick-start-cluster
-    naming:
+  infrastructureNamingStrategy:
       template: "{{ .cluster.name }}-infra-{{ .random }}"
   workers:
     machineDeployments:
     - class: default-worker
-      naming:
+      namingStrategy:
         template: "{{ .cluster.name }}-md-{{ .machineDeployment.topologyName }}-{{ .random }}"
-      bootstrap:
-        templateRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-          kind: KubeadmConfigTemplate
-          name: quick-start-default-worker-bootstraptemplate
-      infrastructure:
-        templateRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: DockerMachineTemplate
-          name: quick-start-default-worker-machinetemplate
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: quick-start-default-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: quick-start-default-worker-machinetemplate
     machinePools:
     - class: default-worker
-      naming:
+      namingStrategy:
         template: "{{ .cluster.name }}-mp-{{ .machinePool.topologyName }}-{{ .random }}"
-      bootstrap:
-        templateRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
-          kind: KubeadmConfigTemplate
-          name: quick-start-default-worker-bootstraptemplate
-      infrastructure:
-        templateRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: DockerMachinePoolTemplate
-          name: quick-start-default-worker-machinepooltemplate
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: quick-start-default-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachinePoolTemplate
+            name: quick-start-default-worker-machinepooltemplate
   patches:
   - name: test-patch
     external:
-      generatePatchesExtension: generate-patches.${EXTENSION_CONFIG_NAME:-k8s-upgrade-with-runtimesdk}
-      validateTopologyExtension: validate-topology.${EXTENSION_CONFIG_NAME:-k8s-upgrade-with-runtimesdk}
-      discoverVariablesExtension: discover-variables.${EXTENSION_CONFIG_NAME:-k8s-upgrade-with-runtimesdk}
+      generateExtension: generate-patches.${EXTENSION_CONFIG_NAME:-test-extension}
+      validateExtension: validate-topology.${EXTENSION_CONFIG_NAME:-test-extension}
+      discoverVariablesExtension: discover-variables.${EXTENSION_CONFIG_NAME:-test-extension}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   name: quick-start-cluster
@@ -66,41 +68,43 @@ spec:
   template:
     spec:
       failureDomains:
-        - name: fd1
+        fd1:
           controlPlane: true
-        - name: fd2
+        fd2:
           controlPlane: true
-        - name: fd3
+        fd3:
           controlPlane: true
-        - name: fd4
+        fd4:
           controlPlane: false
-        - name: fd5
+        fd5:
           controlPlane: false
-        - name: fd6
+        fd6:
           controlPlane: false
-        - name: fd7
+        fd7:
           controlPlane: false
-        - name: fd8
+        fd8:
           controlPlane: false
 ---
 kind: KubeadmControlPlaneTemplate
-apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: quick-start-control-plane
 spec:
   template:
     spec:
       machineTemplate:
-        spec:
-          deletion:
-            nodeDrainTimeoutSeconds: 1
+        nodeDrainTimeout: 1s
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
+        initConfiguration:
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
+        joinConfiguration:
+          nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-control-plane
@@ -112,7 +116,7 @@ spec:
         hostPath: "/var/run/docker.sock"
       preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-default-worker-machinetemplate
@@ -124,7 +128,7 @@ spec:
         hostPath: "/var/run/docker.sock"
       preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePoolTemplate
 metadata:
   name: quick-start-default-worker-machinepooltemplate
@@ -137,7 +141,12 @@ spec:
           hostPath: "/var/run/docker.sock"
         preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: quick-start-default-worker-bootstraptemplate
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration: {} # node registration parameters are automatically injected by CAPD according to the kindest/node image in use.

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk-v1beta1.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start-runtimesdk-v1beta1.yaml
@@ -1,3 +1,4 @@
+# Note: This file is intentionally using v1beta1 for v1beta1 test coverage.
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -122,6 +122,31 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 	})
 })
 
+var _ = Describe("When following the Cluster API quick-start with v1beta1 ClusterClass [ClusterClass]", Label("ClusterClass"), func() {
+	QuickStartSpec(ctx, func() QuickStartSpecInput {
+		return QuickStartSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                ptr.To("topology-runtimesdk-v1beta1"),
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
+			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
+				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
+				// continuous reconciles when everything should be stable.
+				By("Checking that resourceVersions are stable")
+				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+			},
+		}
+	})
+})
+
 // NOTE: This test requires an IPv6 management cluster (can be configured via IP_FAMILY=IPv6).
 var _ = Describe("When following the Cluster API quick-start with IPv6 [IPv6]", Label("IPv6"), func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -263,7 +263,7 @@ func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, _ map[str
 		}
 		obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["v"] = "2"
 	case *bootstrapv1.KubeadmConfigTemplate:
-		obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = append(obj.Spec.Template.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs, bootstrapv1.Arg{Name: "v", Value: ptr.To("2")})
+		obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = append(obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs, bootstrapv1.Arg{Name: "v", Value: ptr.To("2")})
 	}
 }
 

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -174,7 +174,6 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
 			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1beta1.ClusterConfiguration{}
 		}
-
 		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs == nil {
 			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs = map[string]string{}
 		}
@@ -190,11 +189,17 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 		}
 		obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler.ExtraArgs["v"] = "2"
 
+		if obj.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+			obj.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1beta1.InitConfiguration{}
+		}
 		if obj.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs == nil {
 			obj.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
 		}
 		obj.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs["v"] = "2"
 
+		if obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
+			obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1beta1.JoinConfiguration{}
+		}
 		if obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs == nil {
 			obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
 		}
@@ -250,6 +255,9 @@ func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, _ map[str
 	// 1) Set extraArgs
 	switch obj := obj.(type) {
 	case *bootstrapv1beta1.KubeadmConfigTemplate:
+		if obj.Spec.Template.Spec.JoinConfiguration == nil {
+			obj.Spec.Template.Spec.JoinConfiguration = &bootstrapv1beta1.JoinConfiguration{}
+		}
 		if obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs == nil {
 			obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
 		}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11947

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->