### PR TITLE
📖 Fix small typo in contract docs

### DIFF
--- a/docs/book/src/developer/providers/contracts/bootstrap-config.md
+++ b/docs/book/src/developer/providers/contracts/bootstrap-config.md
@@ -286,7 +286,7 @@ In case conditions are implemented on a BootstrapConfig resource, Cluster API wi
 - `reason` (optional, if omitted a default one will be used)
 - `message` (optional, if omitted an empty message will be used)
 - `lastTransitionTime` (optional, if omitted time.Now will be used)
-- `observedGeeneration` (optional, if omitted the generation of the BootstrapConfig resource will be used)
+- `observedGeneration` (optional, if omitted the generation of the BootstrapConfig resource will be used)
 
 Other fields will be ignored.
 

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -627,7 +627,7 @@ In case conditions are implemented on a ControlPlane resource, Cluster API will 
 - `reason` (optional, if omitted a default one will be used)
 - `message` (optional, if omitted an empty message will be used)
 - `lastTransitionTime` (optional, if omitted time.Now will be used)
-- `observedGeeneration` (optional, if omitted the generation of the ControlPlane resource will be used)
+- `observedGeneration` (optional, if omitted the generation of the ControlPlane resource will be used)
 
 Other fields will be ignored.
 

--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -380,7 +380,7 @@ In case conditions are implemented on a InfraCluster resource, Cluster API will 
 - `reason` (optional, if omitted a default one will be used)
 - `message` (optional, if omitted an empty message will be used)
 - `lastTransitionTime` (optional, if omitted time.Now will be used)
-- `observedGeeneration` (optional, if omitted the generation of the InfraCluster resource will be used)
+- `observedGeneration` (optional, if omitted the generation of the InfraCluster resource will be used)
 
 Other fields will be ignored.
 

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -345,7 +345,7 @@ In case conditions are implemented on a InfraMachine resource, Cluster API will 
 - `reason` (optional, if omitted a default one will be used)
 - `message` (optional, if omitted an empty message will be used)
 - `lastTransitionTime` (optional, if omitted time.Now will be used)
-- `observedGeeneration` (optional, if omitted the generation of the InfraMachine resource will be used)
+- `observedGeneration` (optional, if omitted the generation of the InfraMachine resource will be used)
 
 Other fields will be ignored.
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes a typo in our contract docs I noticed while reviewing https://github.com/kubernetes-sigs/cluster-api/pull/12093

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->