### PR TITLE
🌱 Improve check for Cluster Available condition in e2e tests

### DIFF
--- a/test/framework/cluster_helpers.go
+++ b/test/framework/cluster_helpers.go
@@ -450,13 +450,16 @@ func VerifyClusterAvailable(ctx context.Context, input VerifyClusterAvailableInp
 	// Wait for the cluster Available condition to stabilize.
 	Eventually(func(g Gomega) {
 		g.Expect(input.Getter.Get(ctx, key, cluster)).To(Succeed())
+		availableConditionFound := false
 		for _, condition := range cluster.Status.Conditions {
 			if condition.Type == clusterv1.AvailableCondition {
+				availableConditionFound = true
 				g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Available condition on the Cluster should be set to true; message: %s", condition.Message)
 				g.Expect(condition.Message).To(BeEmpty(), "The Available condition on the Cluster should have an empty message")
-				return
+				break
 			}
 		}
+		g.Expect(availableConditionFound).To(BeTrue(), "Cluster %q should have an Available condition", input.Name)
 	}, 5*time.Minute, 10*time.Second).Should(Succeed(), "Failed to verify Cluster Available condition for %s", klog.KRef(input.Namespace, input.Name))
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/12111

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->