### PR TITLE
🐛 Fix autoscaler e2e test flake

### DIFF
--- a/test/e2e/autoscaler.go
+++ b/test/e2e/autoscaler.go
@@ -203,7 +203,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 		By("Checking the MachineDeployment is scaled up")
 		mdScaledUpReplicas := mdOriginalReplicas + 1
 		framework.AssertMachineDeploymentReplicas(ctx, framework.AssertMachineDeploymentReplicasInput{
-			Getter:                   input.BootstrapClusterProxy.GetClient(),
+			GetLister:                input.BootstrapClusterProxy.GetClient(),
 			MachineDeployment:        clusterResources.MachineDeployments[0],
 			Replicas:                 mdScaledUpReplicas,
 			WaitForMachineDeployment: input.E2EConfig.GetIntervals(specName, "wait-autoscaler"),
@@ -240,7 +240,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 		// Since we scaled up the MachineDeployment manually and the workload has not changed auto scaler
 		// should detect that there are unneeded nodes and scale down the MachineDeployment.
 		framework.AssertMachineDeploymentReplicas(ctx, framework.AssertMachineDeploymentReplicasInput{
-			Getter:                   input.BootstrapClusterProxy.GetClient(),
+			GetLister:                input.BootstrapClusterProxy.GetClient(),
 			MachineDeployment:        clusterResources.MachineDeployments[0],
 			Replicas:                 mdScaledUpReplicas,
 			WaitForMachineDeployment: input.E2EConfig.GetIntervals(specName, "wait-controllers"),
@@ -257,7 +257,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 				WaitForAnnotationsToBeAdded: input.E2EConfig.GetIntervals(specName, "wait-autoscaler"),
 			})
 
-			By("Scaling the MachineDeployment scale up deployment to zero")
+			By("Scaling the MachineDeployment scale up deployment to 0")
 			framework.ScaleScaleUpDeploymentAndWait(ctx, framework.ScaleScaleUpDeploymentAndWaitInput{
 				ClusterProxy: workloadClusterProxy,
 				Replicas:     0,
@@ -265,13 +265,13 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 
 			By("Checking the MachineDeployment finished scaling down to zero")
 			framework.AssertMachineDeploymentReplicas(ctx, framework.AssertMachineDeploymentReplicasInput{
-				Getter:                   input.BootstrapClusterProxy.GetClient(),
+				GetLister:                input.BootstrapClusterProxy.GetClient(),
 				MachineDeployment:        clusterResources.MachineDeployments[0],
 				Replicas:                 0,
 				WaitForMachineDeployment: input.E2EConfig.GetIntervals(specName, "wait-controllers"),
 			})
 
-			By("Scaling the MachineDeployment scale up deployment to 1")
+			Byf("Scaling the MachineDeployment scale up deployment to %d", mpOriginalReplicas+1)
 			framework.ScaleScaleUpDeploymentAndWait(ctx, framework.ScaleScaleUpDeploymentAndWaitInput{
 				ClusterProxy: workloadClusterProxy,
 				// We need to sum up the expected number of MachineDeployment replicas and the current
@@ -281,7 +281,7 @@ func AutoscalerSpec(ctx context.Context, inputGetter func() AutoscalerSpecInput)
 
 			By("Checking the MachineDeployment finished scaling up")
 			framework.AssertMachineDeploymentReplicas(ctx, framework.AssertMachineDeploymentReplicasInput{
-				Getter:                   input.BootstrapClusterProxy.GetClient(),
+				GetLister:                input.BootstrapClusterProxy.GetClient(),
 				MachineDeployment:        clusterResources.MachineDeployments[0],
 				Replicas:                 1,
 				WaitForMachineDeployment: input.E2EConfig.GetIntervals(specName, "wait-controllers"),

--- a/test/framework/autoscaler_helpers.go
+++ b/test/framework/autoscaler_helpers.go
@@ -221,7 +221,7 @@ func AddScaleUpDeploymentAndWait(ctx context.Context, input AddScaleUpDeployment
 		},
 	}
 
-	By("Create scale up deployment")
+	byf("Create scale up deployment (%d replicas)", replicas)
 	Expect(input.ClusterProxy.GetClient().Create(ctx, scaleUpDeployment)).To(Succeed(), "failed to create the scale up pod")
 
 	By("Wait for the scale up deployment to become ready (this implies machines to be created)")


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We recently started running the autoscaler test with `ScaleToAndFromZero: true`. Since then there were a few flakes like this: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-mink8s-main/1954475054460833792

I think the problem is:
* In l.282: "Checking the MachineDeployment finished scaling up" the MD has 1 replica, but the corresponding Node is not up yet
* Because of that the Deployment in l.315: "Creating workload that forces the system to scale up" is created with 2 replicas instead of 3 replicas (AddScaleUpDeploymentAndWait uses `count(Nodes) + 1` as replicas)
* The test then fails later because we don't have enough Pods

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->