### PR TITLE
🐛 Fix flaky TestReconcileMachinePhases unit test

### DIFF
--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2166,7 +2166,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
@@ -2238,7 +2238,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
@@ -2327,7 +2327,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
@@ -2405,7 +2405,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
@@ -2472,7 +2472,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 
@@ -2529,7 +2529,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			},
 			Spec: corev1.NodeSpec{ProviderID: nodeProviderID},
 		}
-		g.Expect(env.Create(ctx, node)).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, node)).To(Succeed())
 		defer func() {
 			g.Expect(env.Cleanup(ctx, node)).To(Succeed())
 		}()
@@ -2544,7 +2544,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		// We have to subtract 2 seconds, because .status.lastUpdated does not contain miliseconds.
+		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
 		g.Expect(env.Create(ctx, machine)).To(Succeed())
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I think this might fix: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-main/1954702482470866944

There are some logs like this right before the test failure:
> E0811 00:41:39.620195   35588 controller.go:353] "Reconciler error" err="no matching Node for Machine \"machine-test\" in namespace \"test-reconcile-machine-phases-lr76c\": cannot find node with matching ProviderID" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="test-reconcile-machine-phases-lr76c/machine-test" namespace="test-reconcile-machine-phases-lr76c" name="machine-test" reconcileID="ebe26c28-de85-422b-9f1b-94476f34bb5a"

So I'm wondering if the client cache is not up-to-date. In any case ensuring the Node is actually created at this time should be fine

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->