### PR TITLE
🐛 Fix flaky TestReconcileState unit test

### DIFF
--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -3662,7 +3662,8 @@ func TestReconcileState(t *testing.T) {
 		g.Expect(got.Spec.InfrastructureRef.IsDefined()).To(BeTrue())
 		g.Expect(got.Spec.ControlPlaneRef.IsDefined()).To(BeFalse())
 
-		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, currentCluster, clusterClass, ict, cpt)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, currentCluster)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, clusterClass, ict, cpt)).To(Succeed())
 	})
 	t.Run("Cluster get reconciled with both infrastructure Ref and control plane ref when both reconcileInfrastructureCluster and reconcileControlPlane pass", func(t *testing.T) {
 		g := NewWithT(t)
@@ -3722,7 +3723,8 @@ func TestReconcileState(t *testing.T) {
 		g.Expect(got.Spec.InfrastructureRef.IsDefined()).To(BeTrue())
 		g.Expect(got.Spec.ControlPlaneRef.IsDefined()).To(BeTrue())
 
-		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, controlPlane, currentCluster, clusterClass, ict, cpt)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, currentCluster)).To(Succeed())
+		g.Expect(env.CleanupAndWait(ctx, infrastructureCluster, controlPlane, clusterClass, ict, cpt)).To(Succeed())
 	})
 	t.Run("Cluster does not get reconciled when reconcileControlPlane fails and infrastructure Ref is set", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This should fix: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/1953071454073393152

ClusterClasses cannot be deleted when they are still used. So we should first delete the Cluster, wait until the client observes the Cluster deletion and then delete the ClusterClass in our tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->