### PR TITLE
🐛 Fix flaky TestFuzzyConversion (Cluster) test

### DIFF
--- a/api/core/v1beta1/conversion_test.go
+++ b/api/core/v1beta1/conversion_test.go
@@ -229,6 +229,10 @@ func spokeCluster(in *Cluster, c randfill.Continue) {
 			in.Spec.ClusterNetwork = nil
 		}
 	}
+
+	if in.Spec.Topology != nil && reflect.DeepEqual(in.Spec.Topology, &Topology{}) {
+		in.Spec.Topology = nil
+	}
 }
 
 func spokeClusterTopology(in *Topology, c randfill.Continue) {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Should fix: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-main/1953750272333320192

Apparently happens very rarely which is why we didn't notice it earlier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->