### PR TITLE
🌱 Stop using unsafe for EnvVar conversion

### DIFF
--- a/api/bootstrap/kubeadm/v1beta1/conversion.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"fmt"
 	"reflect"
-	"unsafe"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
@@ -359,7 +358,12 @@ func Convert_v1beta2_APIServer_To_v1beta1_APIServer(in *bootstrapv1.APIServer, o
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_v1beta1_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	if err := convert_v1beta2_ExtraVolumes_To_v1beta1_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s); err != nil {
 		return err
@@ -373,7 +377,12 @@ func Convert_v1beta2_ControllerManager_To_v1beta1_ControlPlaneComponent(in *boot
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_v1beta1_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta2_ExtraVolumes_To_v1beta1_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -384,7 +393,12 @@ func Convert_v1beta2_Scheduler_To_v1beta1_ControlPlaneComponent(in *bootstrapv1.
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_v1beta1_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta2_ExtraVolumes_To_v1beta1_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -409,7 +423,12 @@ func Convert_v1beta2_LocalEtcd_To_v1beta1_LocalEtcd(in *bootstrapv1.LocalEtcd, o
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_v1beta1_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
@@ -450,7 +469,12 @@ func Convert_v1beta1_APIServer_To_v1beta2_APIServer(in *APIServer, out *bootstra
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_v1beta1_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	if err := convert_v1beta1_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s); err != nil {
 		return err
@@ -463,7 +487,12 @@ func Convert_v1beta1_ControlPlaneComponent_To_v1beta2_ControllerManager(in *Cont
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_v1beta1_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta1_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -473,7 +502,12 @@ func Convert_v1beta1_ControlPlaneComponent_To_v1beta2_Scheduler(in *ControlPlane
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_v1beta1_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta1_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -519,7 +553,12 @@ func Convert_v1beta1_LocalEtcd_To_v1beta2_LocalEtcd(in *LocalEtcd, out *bootstra
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_v1beta1_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag

--- a/bootstrap/kubeadm/types/upstreamv1beta4/conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta4/conversion.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"reflect"
 	"time"
-	"unsafe"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
@@ -193,7 +192,12 @@ func Convert_upstreamv1beta4_APIServer_To_v1beta2_APIServer(in *APIServer, out *
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_upstreamv1beta4_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	if err := convert_upstreamv1beta4_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s); err != nil {
 		return err
@@ -213,7 +217,12 @@ func Convert_upstreamv1beta4_ControlPlaneComponent_To_v1beta2_ControllerManager(
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_upstreamv1beta4_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_upstreamv1beta4_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -230,7 +239,12 @@ func Convert_upstreamv1beta4_ControlPlaneComponent_To_v1beta2_Scheduler(in *Cont
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_upstreamv1beta4_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_upstreamv1beta4_ExtraVolumes_To_v1beta2_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -239,7 +253,12 @@ func Convert_upstreamv1beta4_LocalEtcd_To_v1beta2_LocalEtcd(in *LocalEtcd, out *
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = (*[]bootstrapv1.EnvVar)(unsafe.Pointer(&in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = ptr.To(make([]bootstrapv1.EnvVar, len(in.ExtraEnvs)))
+		for i := range in.ExtraEnvs {
+			if err := Convert_upstreamv1beta4_EnvVar_To_v1beta2_EnvVar(&(in.ExtraEnvs)[i], &(*out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag
@@ -345,7 +364,12 @@ func Convert_v1beta2_APIServer_To_upstreamv1beta4_APIServer(in *bootstrapv1.APIS
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_upstreamv1beta4_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	if err := convert_v1beta2_ExtraVolumes_To_upstreamv1beta4_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s); err != nil {
 		return err
@@ -366,7 +390,12 @@ func Convert_v1beta2_ControllerManager_To_upstreamv1beta4_ControlPlaneComponent(
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_upstreamv1beta4_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta2_ExtraVolumes_To_upstreamv1beta4_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -384,7 +413,12 @@ func Convert_v1beta2_Scheduler_To_upstreamv1beta4_ControlPlaneComponent(in *boot
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_upstreamv1beta4_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	return convert_v1beta2_ExtraVolumes_To_upstreamv1beta4_ExtraVolumes(&in.ExtraVolumes, &out.ExtraVolumes, s)
 }
@@ -393,7 +427,12 @@ func Convert_v1beta2_LocalEtcd_To_upstreamv1beta4_LocalEtcd(in *bootstrapv1.Loca
 	if in.ExtraEnvs == nil {
 		out.ExtraEnvs = nil
 	} else {
-		out.ExtraEnvs = *(*[]EnvVar)(unsafe.Pointer(in.ExtraEnvs)) //nolint:gosec // copied over from generated code, fuzzer should detect if we run into issues
+		out.ExtraEnvs = make([]EnvVar, len(*in.ExtraEnvs))
+		for i := range *in.ExtraEnvs {
+			if err := Convert_v1beta2_EnvVar_To_upstreamv1beta4_EnvVar(&(*in.ExtraEnvs)[i], &(out.ExtraEnvs)[i], s); err != nil {
+				return err
+			}
+		}
 	}
 	out.ImageRepository = in.ImageRepository
 	out.ImageTag = in.ImageTag


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Turns out the fuzz tests do not detect if the structs are not identical. They would only detect it if after the conversion we would try to read the fields.

So let's stop using unsafe for conversion

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->