### PR TITLE
🌱 update metrics configuration to v1beta2

### DIFF
--- a/config/metrics/crd-clusterrole.yaml
+++ b/config/metrics/crd-clusterrole.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics-custom-resource-capi
   labels:
     kube-state-metrics/aggregate-to-manager: "true"
+  name: manager-metrics-role
 rules:
 - apiGroups:
   - addons.cluster.x-k8s.io

--- a/config/metrics/crd-metrics-config.yaml
+++ b/config/metrics/crd-metrics-config.yaml
@@ -8,7 +8,7 @@ spec:
     groupVersionKind:
       group: addons.cluster.x-k8s.io
       kind: ClusterResourceSet
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       name:
       - metadata
@@ -33,7 +33,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -50,7 +49,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -62,7 +60,7 @@ spec:
     groupVersionKind:
       group: bootstrap.cluster.x-k8s.io
       kind: KubeadmConfig
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -140,7 +138,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -157,7 +154,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -169,7 +165,7 @@ spec:
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: Cluster
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       name:
       - metadata
@@ -231,10 +227,16 @@ spec:
             - spec
             - infrastructureRef
             - name
-            topology_class:
+            topology_classref_name:
             - spec
             - topology
-            - class
+            - classRef
+            - name
+            topology_classref_namespace:
+            - spec
+            - topology
+            - classRef
+            - namespace
             topology_version:
             - spec
             - topology
@@ -266,7 +268,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -283,7 +284,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -312,7 +312,7 @@ spec:
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: ClusterClass
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       name:
       - metadata
@@ -386,7 +386,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -403,7 +402,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -415,7 +413,7 @@ spec:
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: Machine
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - spec
@@ -563,7 +561,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -580,7 +577,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -592,8 +588,6 @@ spec:
           labelsFromPath:
             node_name:
             - name
-            node_uid:
-            - uid
           path:
           - status
           - nodeRef
@@ -624,7 +618,7 @@ spec:
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: MachineDeployment
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - spec
@@ -743,6 +737,7 @@ spec:
           nilIsZero: false
           path:
           - spec
+          - rollout
           - strategy
           - rollingUpdate
           - maxSurge
@@ -756,6 +751,7 @@ spec:
           nilIsZero: false
           path:
           - spec
+          - rollout
           - strategy
           - rollingUpdate
           - maxUnavailable
@@ -775,7 +771,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -792,7 +787,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -850,27 +844,17 @@ spec:
           nilIsZero: true
           path:
           - status
-          - unavailableReplicas
+          - upToDateReplicas
           valueFrom: null
         type: Gauge
-      help: The number of unavailable replicas per machinedeployment.
-      name: status_replicas_unavailable
-    - each:
-        gauge:
-          nilIsZero: true
-          path:
-          - status
-          - updatedReplicas
-          valueFrom: null
-        type: Gauge
-      help: The number of updated replicas per machinedeployment.
-      name: status_replicas_updated
+      help: The number of up-to-date replicas per machinedeployment.
+      name: status_replicas_uptodate
     resourcePlural: ""
   - errorLogV: 0
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: MachineHealthCheck
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - spec
@@ -911,9 +895,16 @@ spec:
     - each:
         info:
           labelsFromPath:
-            maxUnhealthy:
+            remediation_triggerif_unhealthylessthanorequalto:
             - spec
-            - maxUnhealthy
+            - remediation
+            - triggerIf
+            - unhealthyLessThanOrEqualTo
+            remediation_triggerif_unhealthyrange:
+            - spec
+            - remediation
+            - triggerIf
+            - unhealthyRange
           path: null
         type: Info
       help: Information about a machinehealthcheck.
@@ -947,7 +938,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -964,7 +954,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1006,7 +995,7 @@ spec:
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: MachinePool
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - spec
@@ -1126,7 +1115,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1143,7 +1131,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1201,17 +1188,17 @@ spec:
           nilIsZero: true
           path:
           - status
-          - unavailableReplicas
+          - upToDateReplicas
           valueFrom: null
         type: Gauge
-      help: The number of unavailable replicas per machinepool.
-      name: status_replicas_unavailable
+      help: The number of up-to-date replicas per machinepool.
+      name: status_replicas_uptodate
     resourcePlural: ""
   - errorLogV: 0
     groupVersionKind:
       group: cluster.x-k8s.io
       kind: MachineSet
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - spec
@@ -1326,7 +1313,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1343,7 +1329,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1375,27 +1360,27 @@ spec:
           nilIsZero: true
           path:
           - status
-          - fullyLabeledReplicas
-          valueFrom: null
-        type: Gauge
-      help: The number of fully labeled replicas per machineset.
-      name: status_replicas_fully_labeled
-    - each:
-        gauge:
-          nilIsZero: true
-          path:
-          - status
           - readyReplicas
           valueFrom: null
         type: Gauge
       help: The number of ready replicas per machineset.
       name: status_replicas_ready
+    - each:
+        gauge:
+          nilIsZero: true
+          path:
+          - status
+          - upToDateReplicas
+          valueFrom: null
+        type: Gauge
+      help: The number of up-to-date replicas per machineset.
+      name: status_replicas_uptodate
     resourcePlural: ""
   - errorLogV: 0
     groupVersionKind:
       group: controlplane.cluster.x-k8s.io
       kind: KubeadmControlPlane
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1477,7 +1462,8 @@ spec:
           nilIsZero: false
           path:
           - spec
-          - rolloutStrategy
+          - rollout
+          - strategy
           - rollingUpdate
           - maxSurge
           valueFrom: null
@@ -1497,7 +1483,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1514,7 +1499,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1536,6 +1520,16 @@ spec:
           nilIsZero: true
           path:
           - status
+          - availableReplicas
+          valueFrom: null
+        type: Gauge
+      help: The number of available replicas per kubeadmcontrolplane.
+      name: status_replicas_available
+    - each:
+        gauge:
+          nilIsZero: true
+          path:
+          - status
           - readyReplicas
           valueFrom: null
         type: Gauge
@@ -1546,27 +1540,17 @@ spec:
           nilIsZero: true
           path:
           - status
-          - unavailableReplicas
+          - upToDateReplicas
           valueFrom: null
         type: Gauge
-      help: The number of unavailable replicas per kubeadmcontrolplane.
-      name: status_replicas_unavailable
-    - each:
-        gauge:
-          nilIsZero: true
-          path:
-          - status
-          - updatedReplicas
-          valueFrom: null
-        type: Gauge
-      help: The number of updated replicas per kubeadmcontrolplane.
-      name: status_replicas_updated
+      help: The number of up-to-date replicas per kubeadmcontrolplane.
+      name: status_replicas_uptodate
     resourcePlural: ""
   - errorLogV: 0
     groupVersionKind:
       group: infrastructure.cluster.x-k8s.io
       kind: DevCluster
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1595,7 +1579,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1612,7 +1595,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1624,7 +1606,7 @@ spec:
     groupVersionKind:
       group: infrastructure.cluster.x-k8s.io
       kind: DevMachine
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1653,7 +1635,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1670,7 +1651,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1682,7 +1662,7 @@ spec:
     groupVersionKind:
       group: infrastructure.cluster.x-k8s.io
       kind: DockerCluster
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1711,7 +1691,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1728,7 +1707,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1740,7 +1718,7 @@ spec:
     groupVersionKind:
       group: infrastructure.cluster.x-k8s.io
       kind: DockerMachine
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1769,7 +1747,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1786,7 +1763,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1798,7 +1774,7 @@ spec:
     groupVersionKind:
       group: ipam.cluster.x-k8s.io
       kind: IPAddressClaim
-      version: v1beta1
+      version: v1beta2
     labelsFromPath:
       cluster_name:
       - metadata
@@ -1827,7 +1803,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1844,7 +1819,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime
@@ -1856,7 +1830,7 @@ spec:
     groupVersionKind:
       group: runtime.cluster.x-k8s.io
       kind: ExtensionConfig
-      version: v1alpha1
+      version: v1beta2
     labelsFromPath:
       name:
       - metadata
@@ -1881,7 +1855,6 @@ spec:
           - Unknown
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - status
@@ -1898,7 +1871,6 @@ spec:
           nilIsZero: false
           path:
           - status
-          - v1beta2
           - conditions
           valueFrom:
           - lastTransitionTime

--- a/config/metrics/crd-metrics-config.yaml
+++ b/config/metrics/crd-metrics-config.yaml
@@ -895,7 +895,7 @@ spec:
     - each:
         info:
           labelsFromPath:
-            remediation_triggerif_unhealthyInRange:
+            remediation_triggerif_unhealthyinrange:
             - spec
             - remediation
             - triggerIf

--- a/config/metrics/crd-metrics-config.yaml
+++ b/config/metrics/crd-metrics-config.yaml
@@ -895,16 +895,16 @@ spec:
     - each:
         info:
           labelsFromPath:
+            remediation_triggerif_unhealthyInRange:
+            - spec
+            - remediation
+            - triggerIf
+            - unhealthyInRange
             remediation_triggerif_unhealthylessthanorequalto:
             - spec
             - remediation
             - triggerIf
             - unhealthyLessThanOrEqualTo
-            remediation_triggerif_unhealthyrange:
-            - spec
-            - remediation
-            - triggerIf
-            - unhealthyRange
           path: null
         type: Info
       help: Information about a machinehealthcheck.

--- a/config/metrics/kustomization.yaml
+++ b/config/metrics/kustomization.yaml
@@ -2,9 +2,10 @@ resources:
   - ./crd-clusterrole.yaml
 
 namespace: observability
+namePrefix: kube-state-metrics-
 
 configMapGenerator:
-- name: kube-state-metrics-crd-config-capi
+- name: crd-config-capi
   files:
   - capi.yaml=crd-metrics-config.yaml
   options:

--- a/hack/observability/grafana/dashboards/cluster-api-state.json
+++ b/hack/observability/grafana/dashboards/cluster-api-state.json
@@ -1213,9 +1213,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum (capi_kubeadmcontrolplane_status_replicas_updated)",
+              "expr": "sum (capi_kubeadmcontrolplane_status_replicas_uptodate)",
               "hide": false,
-              "legendFormat": "status updated replicas",
+              "legendFormat": "status up-to-date replicas",
               "range": true,
               "refId": "E"
             }
@@ -1572,9 +1572,9 @@
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "sum (capi_machinedeployment_status_replicas_updated)",
+              "expr": "sum (capi_machinedeployment_status_replicas_uptodate)",
               "hide": false,
-              "legendFormat": "status updated replicas",
+              "legendFormat": "status up-to-date replicas",
               "range": true,
               "refId": "E"
             },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Updates the metrics configuration to use the v1beta2 api version instead of v1beta1.

Small adjustments to metrics:

- Added ClusterClass classref namespace metric (`capi_clusterclass_spec_topology_classref_namespace`)
- renamed `capi_clusterclass_spec_topology_class` to `capi_clusterclass_spec_topology_classref_name`
- dropped metrics related to .Status.UnavailableReplicas (deprecated)
- dropped metrics related to .Status.UpdatedReplicas
- Added metrics for .Status.UpToDateReplicas
- MHC: removed label `maxUnhealthy`, added `remediation_triggerif_unhealthylessthanorequalto` and `remediation_triggerif_unhealthyrange`

Adjustments to dashboards:

* For KCP and MD: use uptodate metric instead of updated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of:
- #11947

/area ci