### PR TITLE
📖 Add Cluster API release-1.12 timeline document

### DIFF
--- a/docs/release/releases/release-1.12.md
+++ b/docs/release/releases/release-1.12.md
@@ -12,7 +12,7 @@ The following table shows the preliminary dates for the `v1.12` release cycle.
 | *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 2nd September 2025  | week 2   |
 | *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 7th October 2025    | week 7   |
 | *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 4th November 2025   | week 11  |
-| v1.11.0-beta.0 released                              | Release Lead | Tuesday 4th November 2025   | week 11  |
+| v1.12.0-beta.0 released                              | Release Lead | Tuesday 4th November 2025   | week 11  |
 | Communicate beta to providers                        | Comms Lead   | Tuesday 4th November 2025   | week 11  |
 | Communicate upcoming code freeze to the community    | Comms Lead   | Tuesday 4th November 2025   | week 11  |
 | KubeCon idle week                                    | ---          | ---                         | week 12  |

--- a/docs/release/releases/release-1.12.md
+++ b/docs/release/releases/release-1.12.md
@@ -1,0 +1,37 @@
+# Cluster API v1.12
+
+## Timeline
+
+The following table shows the preliminary dates for the `v1.12` release cycle.
+
+| **What**                                             | **Who**      | **When**                    | **Week** |
+|------------------------------------------------------|--------------|-----------------------------|----------|
+| Start of Release Cycle                               | Release Lead | Monday 25th August 2025     | week 1   |
+| Schedule finalized                                   | Release Lead | Friday 29nd August 2025     | week 1   |
+| Team finalized                                       | Release Lead | Friday 29nd August 2025     | week 1   |
+| *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 2nd September 2025  | week 2   |
+| *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 7th October 2025    | week 7   |
+| *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 4th November 2025   | week 11  |
+| v1.11.0-beta.0 released                              | Release Lead | Tuesday 4th November 2025   | week 11  |
+| Communicate beta to providers                        | Comms Lead   | Tuesday 4th November 2025   | week 11  |
+| Communicate upcoming code freeze to the community    | Comms Lead   | Tuesday 4th November 2025   | week 11  |
+| KubeCon idle week                                    | ---          | ---                         | week 12  |
+| v1.12.0-beta.x released                              | Release Lead | Tuesday 18th November 2025  | week 13  |
+| release-1.12 branch created (**Begin Code Freeze**)  | Release Lead | Tuesday 25th November 2025  | week 14  |
+| v1.12.0-rc.0 released                                | Release Lead | Tuesday 25th November 2025  | week 14  |
+| release-1.12 jobs created                            | Release Lead | Tuesday 25th November 2025  | week 14  |
+| v1.12.0-rc.x released                                | Release Lead | Tuesday 2nd December 2025   | week 15  |
+| **v1.12.0 released**                                 | Release Lead | Tuesday 9th December 2025   | week 16  |
+| *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 9th December 2025   | week 16  |
+| Organize release retrospective                       | Release Lead | TBC                         | week 16  |
+| *v1.12.1 released (tentative)*                       | Release Lead | Tuesday 16th December 2025  |          |
+
+After CAPI v1.12.0, the .1 release will follow up to add support for Kubernetes 1.35.0 when it becomes available. After .1, we expect to do monthly patch releases (more details will be provided in the 1.13 release schedule).
+
+## Release team
+
+| **Role**                                  | **Lead** (**GitHub / Slack ID**)                                                      | **Team member(s) (GitHub / Slack ID)** |
+|-------------------------------------------|-------------------------------------------------------------------------------------------|----------------------------------------|
+| Release Lead                              | TBD | TBD |
+| Communications/Docs/Release Notes Manager | TBD | TBD |
+| CI Signal/Bug Triage/Automation Manager   | TBD | TBD |


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds the release-1.12 cycle schedule document with preliminary dates.

/area release
/kind documentation