### PR TITLE
:seedling: Add input validations for desired state generator function

### DIFF
--- a/controllers/clustercache/cluster_cache_fake.go
+++ b/controllers/clustercache/cluster_cache_fake.go
@@ -44,3 +44,8 @@ func NewFakeClusterCache(workloadClient client.Client, clusterKey client.ObjectK
 	}
 	return testCacheTracker
 }
+
+// NewFakeEmptyClusterCache creates a new empty ClusterCache that can be used by unit tests.
+func NewFakeEmptyClusterCache() ClusterCache {
+	return &clusterCache{}
+}

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -63,13 +63,21 @@ type Generator interface {
 }
 
 // NewGenerator creates a new generator to generate desired state.
-func NewGenerator(client client.Client, clusterCache clustercache.ClusterCache, runtimeClient runtimeclient.Client) Generator {
+func NewGenerator(client client.Client, clusterCache clustercache.ClusterCache, runtimeClient runtimeclient.Client) (Generator, error) {
+	if client == nil || clusterCache == nil {
+		return nil, errors.New("Client and ClusterCache must not be nil")
+	}
+
+	if feature.Gates.Enabled(feature.RuntimeSDK) && runtimeClient == nil {
+		return nil, errors.New("RuntimeClient must not be nil")
+	}
+
 	return &generator{
 		Client:        client,
 		ClusterCache:  clusterCache,
 		RuntimeClient: runtimeClient,
 		patchEngine:   patches.NewEngine(runtimeClient),
-	}
+	}, nil
 }
 
 // generator is a generator to generate desired state.

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -156,7 +156,11 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Scheme:          mgr.GetScheme(),
 		PredicateLogger: &predicateLog,
 	}
-	r.desiredStateGenerator = desiredstate.NewGenerator(r.Client, r.ClusterCache, r.RuntimeClient)
+	r.desiredStateGenerator, err = desiredstate.NewGenerator(r.Client, r.ClusterCache, r.RuntimeClient)
+	if err != nil {
+		return errors.Wrap(err, "failed creating desired state generator")
+	}
+
 	r.recorder = mgr.GetEventRecorderFor("topology/cluster-controller")
 	r.ssaCache = ssa.NewCache("topology/cluster")
 	return nil

--- a/test/extension/handlers/topologymutation/handler_integration_test.go
+++ b/test/extension/handlers/topologymutation/handler_integration_test.go
@@ -50,6 +50,7 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/exp/runtime/client"
 	"sigs.k8s.io/cluster-api/exp/topology/desiredstate"
@@ -114,7 +115,12 @@ func TestHandler(t *testing.T) {
 	clientWithV1Beta2ContractCRD := fake.NewClientBuilder().WithScheme(scheme).WithObjects(crd).Build()
 
 	// Create a desired state generator.
-	desiredStateGenerator := desiredstate.NewGenerator(clientWithV1Beta2ContractCRD, nil, runtimeClient)
+	desiredStateGenerator, err := desiredstate.NewGenerator(
+		clientWithV1Beta2ContractCRD,
+		clustercache.NewFakeEmptyClusterCache(),
+		runtimeClient,
+	)
+	g.Expect(err).ToNot(HaveOccurred())
 
 	// Note: as of today we don't have to set any fields and also don't have to call
 	// SetupWebhookWithManager because DefaultAndValidateVariables doesn't need any of that.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds input validation for nil checking for Generator function in desired_state.go file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Ref https://github.com/kubernetes-sigs/cluster-api/issues/12614#issuecomment-3201444805

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->