### PR TITLE
🐛 Fix field paths in ClusterClass compatibility validation errors

### DIFF
--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -94,15 +94,15 @@ func ClusterClassTemplateAreCompatible(current, desired clusterv1.ClusterClassTe
 
 	if currentGK.Group != desiredGK.Group {
 		allErrs = append(allErrs, field.Forbidden(
-			pathPrefix.Child("ref", "apiVersion"),
-			fmt.Sprintf("apiVersion.group cannot be changed from %q to %q to prevent incompatible changes in the Clusters",
+			pathPrefix.Child("apiVersion"),
+			fmt.Sprintf("group of apiVersion cannot be changed from %q to %q to prevent incompatible changes in the Clusters",
 				currentGK.Group, desiredGK.Group),
 		))
 	}
 	if currentGK.Kind != desiredGK.Kind {
 		allErrs = append(allErrs, field.Forbidden(
-			pathPrefix.Child("ref", "kind"),
-			fmt.Sprintf("apiVersion.kind cannot be changed from %q to %q to prevent incompatible changes in the Clusters",
+			pathPrefix.Child("kind"),
+			fmt.Sprintf("kind cannot be changed from %q to %q to prevent incompatible changes in the Clusters",
 				currentGK.Kind, desiredGK.Kind),
 		))
 	}
@@ -174,14 +174,14 @@ func ClusterClassesAreCompatible(current, desired *clusterv1.ClusterClass) field
 
 	// Validate InfrastructureClusterTemplate changes desired a compatible way.
 	allErrs = append(allErrs, ClusterClassTemplateAreCompatible(current.Spec.Infrastructure.TemplateRef, desired.Spec.Infrastructure.TemplateRef,
-		field.NewPath("spec", "infrastructure"))...)
+		field.NewPath("spec", "infrastructure", "templateRef"))...)
 
 	// Validate control plane changes desired a compatible way.
 	allErrs = append(allErrs, ClusterClassTemplateAreCompatible(current.Spec.ControlPlane.TemplateRef, desired.Spec.ControlPlane.TemplateRef,
-		field.NewPath("spec", "controlPlane"))...)
+		field.NewPath("spec", "controlPlane", "templateRef"))...)
 	if desired.Spec.ControlPlane.MachineInfrastructure.TemplateRef.IsDefined() && current.Spec.ControlPlane.MachineInfrastructure.TemplateRef.IsDefined() {
 		allErrs = append(allErrs, ClusterClassTemplateAreCompatible(current.Spec.ControlPlane.MachineInfrastructure.TemplateRef, desired.Spec.ControlPlane.MachineInfrastructure.TemplateRef,
-			field.NewPath("spec", "controlPlane", "machineInfrastructure"))...)
+			field.NewPath("spec", "controlPlane", "machineInfrastructure", "templateRef"))...)
 	}
 
 	// Validate changes to MachineDeployments.
@@ -199,8 +199,8 @@ func MachineDeploymentClassesAreCompatible(current, desired *clusterv1.ClusterCl
 	var allErrs field.ErrorList
 
 	// Ensure previous MachineDeployment class was modified in a compatible way.
-	for _, class := range desired.Spec.Workers.MachineDeployments {
-		for i, oldClass := range current.Spec.Workers.MachineDeployments {
+	for i, class := range desired.Spec.Workers.MachineDeployments {
+		for _, oldClass := range current.Spec.Workers.MachineDeployments {
 			if class.Class == oldClass.Class {
 				// NOTE: class.Template.Metadata and class.Template.Bootstrap are allowed to change;
 
@@ -208,7 +208,7 @@ func MachineDeploymentClassesAreCompatible(current, desired *clusterv1.ClusterCl
 
 				// Validates class.Template.Infrastructure template changes in a compatible way
 				allErrs = append(allErrs, ClusterClassTemplateAreCompatible(oldClass.Infrastructure.TemplateRef, class.Infrastructure.TemplateRef,
-					field.NewPath("spec", "workers", "machineDeployments").Index(i))...)
+					field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("infrastructure", "templateRef"))...)
 			}
 		}
 	}
@@ -240,8 +240,8 @@ func MachinePoolClassesAreCompatible(current, desired *clusterv1.ClusterClass) f
 	var allErrs field.ErrorList
 
 	// Ensure previous MachinePool class was modified in a compatible way.
-	for _, class := range desired.Spec.Workers.MachinePools {
-		for i, oldClass := range current.Spec.Workers.MachinePools {
+	for i, class := range desired.Spec.Workers.MachinePools {
+		for _, oldClass := range current.Spec.Workers.MachinePools {
 			if class.Class == oldClass.Class {
 				// NOTE: class.Template.Metadata and class.Template.Bootstrap are allowed to change;
 
@@ -249,7 +249,7 @@ func MachinePoolClassesAreCompatible(current, desired *clusterv1.ClusterClass) f
 
 				// Validates class.Template.Infrastructure template changes in a compatible way
 				allErrs = append(allErrs, ClusterClassTemplateAreCompatible(oldClass.Infrastructure.TemplateRef, class.Infrastructure.TemplateRef,
-					field.NewPath("spec", "workers", "machinePools").Index(i))...)
+					field.NewPath("spec", "workers", "machinePools").Index(i).Child("infrastructure", "templateRef"))...)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->