### PR TITLE
📖 Fix extraArgs examples in v1beta2 migration docs

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -1608,7 +1608,7 @@ spec:
     apiServer:
       certSANs: [ ... ]
       extraArgs:
-      - "v": "5"
+        "v": "5"
       extraEnvs: [ ... ]
       extraVolumes: [ ... ]
       timeoutForControlPlane: "25s"
@@ -1616,7 +1616,7 @@ spec:
     controlPlaneEndpoint: ""
     controllerManager:
       extraArgs:
-      - "v": "5"
+        "v": "5"
       extraEnvs: [ ... ]
       extraVolumes: [ ... ]
     dns: { ... }
@@ -1625,7 +1625,7 @@ spec:
       local:
         dataDir: ""
         extraArgs:
-        - "v": "5"
+          "v": "5"
         extraEnvs: [ ... ]
         imageRepository: ""
         imageTag: ""
@@ -1635,7 +1635,7 @@ spec:
     imageRepository: ""
     scheduler:
       extraArgs:
-      - "v": "5"
+        "v": "5"
       extraEnvs: [ ... ]
       extraVolumes: [ ... ]
   diskSetup: { ... }
@@ -1659,7 +1659,7 @@ spec:
       imagePullPolicy: ""
       imagePullSerial: true
       kubeletExtraArgs:
-      - "v": "5"
+        "v": "5"
       name: ""
       taints: [ ... ]
     patches: { ... }
@@ -1680,7 +1680,7 @@ spec:
       imagePullPolicy: ""
       imagePullSerial: true
       kubeletExtraArgs:
-      - "v": "5"
+        "v": "5"
       name: ""
       taints: [ ... ]
     patches: { ...}
@@ -1832,7 +1832,7 @@ status:
 
 - KubeadmConfig (and the entire CABPK provider) now implements the v1beta2 Cluster API contract
 - See changes that apply to [all CRDs](#all-crds)
-- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) and 
+- Pointers have been removed from various struct fields. See [#12545](https://github.com/kubernetes-sigs/cluster-api/pull/12545) and
   [#12560](https://github.com/kubernetes-sigs/cluster-api/pull/12560) for details (drop unnecessary pointers)
 - `extraArg` field types have been changed from `map[string]sting` to `[]Arg`, thus aligning with kubeadm v1beta4 API;
   however, using multiple args with the same name will be enabled only when v1beta1 is removed, tentatively in August 2026
@@ -1864,7 +1864,7 @@ status:
   - `extraArgs`, `extraVolumes`, `extraEnvs` fields have been added to the `spec.clusterConfiguration.apiServer` struct
 - The type of the `spec.clusterConfiguration.controllerManager` field has been changed from `ControlPlaneComponent` to `ControllerManager` (avoid embedding structs)
 - The type of the `spec.clusterConfiguration.scheduler` field has been changed from `ControlPlaneComponent` to `Scheduler` (avoid embedding structs)
-- The type of the `extraEnvs` fields in `spec.clusterConfiguration.apiServer`, `spec.clusterConfiguration.controllerManager`, 
+- The type of the `extraEnvs` fields in `spec.clusterConfiguration.apiServer`, `spec.clusterConfiguration.controllerManager`,
   `spec.clusterConfiguration.scheduler` and `spec.clusterConfiguration.etcd.local` has been changed from `[]EnvVar` to `*[]EnvVar` (compliance with K8s API guidelines)
 - The type of the `spec.clusterConfiguration.apiServer.extraVolumes.readOnly`, `spec.clusterConfiguration.controllerManager.extraVolumes.readOnly`
   , `spec.clusterConfiguration.scheduler.extraVolumes.readOnly` fields have been changed from `bool` to `*bool` (compliance with K8s API guidelines)
@@ -1939,7 +1939,7 @@ spec:
       apiServer:
         certSANs: [ ... ]
         extraArgs:
-          - "v": "5"
+          "v": "5"
         extraEnvs: [ ... ]
         extraVolumes: [ ... ]
         timeoutForControlPlane: "25s"
@@ -1947,7 +1947,7 @@ spec:
       controlPlaneEndpoint: ""
       controllerManager:
         extraArgs:
-          - "v": "5"
+          "v": "5"
         extraEnvs: [ ... ]
         extraVolumes: [ ... ]
       dns: { ...}
@@ -1956,7 +1956,7 @@ spec:
         local:
           dataDir: ""
           extraArgs:
-            - "v": "5"
+            "v": "5"
           extraEnvs: [ ... ]
           imageRepository: ""
           imageTag: ""
@@ -1966,7 +1966,7 @@ spec:
       imageRepository: ""
       scheduler:
         extraArgs:
-          - "v": "5"
+          "v": "5"
         extraEnvs: [ ... ]
         extraVolumes: [ ... ]
     diskSetup: { ...}
@@ -1990,7 +1990,7 @@ spec:
         imagePullPolicy: ""
         imagePullSerial: true
         kubeletExtraArgs:
-          - "v": "5"
+          "v": "5"
         name: ""
         taints: [ ... ]
       patches: { ...}
@@ -2011,7 +2011,7 @@ spec:
         imagePullPolicy: ""
         imagePullSerial: true
         kubeletExtraArgs:
-          - "v": "5"
+          "v": "5"
         name: ""
         taints: [ ... ]
       patches: { ...}
@@ -3047,4 +3047,4 @@ Following table should help to pick the right utils.
 | `status.conditions` of type `[]metav1.Conditions`                     | `"sigs.k8s.io/cluster-api/util/conditions"`                                                | `"sigs.k8s.io/cluster-api/util/patch"`                                 |
 Important!
 - Please pay special attention to use the correct patch helper import everywhere, because using a wrong
-  one could in some cases lead to dropping conditions at runtime while not having compile errors.  
+  one could in some cases lead to dropping conditions at runtime while not having compile errors.


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed that the ExtraArgs in the v1.10 - v1.11 migration docs didn't match with what I had in my old v1beta1 manifests.
The ExtraArgs are map[string]string in v1beta1 but the examples show them as arrays.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation