### PR TITLE
📖  Added documentation about the gitlab-access-token

### DIFF
--- a/docs/book/src/developer/providers/contracts/clusterctl.md
+++ b/docs/book/src/developer/providers/contracts/clusterctl.md
@@ -131,7 +131,9 @@ A provider url should be in the form
 * The components YAML, the metadata YAML and eventually the workload cluster templates are included into the same package version
 
 See the [GitLab docs](https://docs.gitlab.com/ee/user/packages/generic_packages/) for more information
-about how to create a generic package.
+about how to create a generic package. 
+
+If you are hosting a private Gitlab repository, you can use a [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) or [project access token](https://docs.gitlab.com/user/project/settings/project_access_tokens.html) to access the provider artifacts by adding the `gitlab-access-token` variable to the `clusterctl` configuration in order to authenticate against the GitLab API.
 
 This can be used in conjunction with [GitLabracadabra](https://gitlab.com/gitlabracadabra/gitlabracadabra/)
 to avoid direct internet access from `clusterctl`, and use GitLab as artifacts repository. For example,
@@ -167,6 +169,8 @@ for the core provider:
 
 Limitation: Provider artifacts hosted on GitLab don't support getting all versions.
 As a consequence, you need to set version explicitly for upgrades.
+
+
 
 #### Creating a local provider repository
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: 

I had an issue with my air gap setup on how to deal with some private gitlab projects and I found `gitlab-access-token` configuration variable [here](https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/config/variables_client.go#L23) and no documentation related. So here is a small contribution. 



/area clusterctl
/area documentation

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->