### PR TITLE
🐛 CAPD: Remove finalizers during deletion if ownerRef was never set

### DIFF
--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -96,6 +96,18 @@ func (r *DockerMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	if machinePool == nil {
+		// Note: If ownerRef was not set, there is nothing to delete. Remove finalizer so deletion can succeed.
+		if !dockerMachinePool.DeletionTimestamp.IsZero() {
+			if controllerutil.ContainsFinalizer(dockerMachinePool, infraexpv1.MachinePoolFinalizer) {
+				dockerMachinePoolWithoutFinalizer := dockerMachinePool.DeepCopy()
+				controllerutil.RemoveFinalizer(dockerMachinePoolWithoutFinalizer, infraexpv1.MachinePoolFinalizer)
+				if err := r.Client.Patch(ctx, dockerMachinePoolWithoutFinalizer, client.MergeFrom(dockerMachinePool)); err != nil {
+					return ctrl.Result{}, errors.Wrapf(err, "failed to patch DockerMachinePool %s", klog.KObj(dockerMachinePool))
+				}
+			}
+			return ctrl.Result{}, nil
+		}
+
 		log.Info("Waiting for MachinePool Controller to set OwnerRef on DockerMachinePool")
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->