### PR TITLE
Fix KubeadmConfig fuzz test flake

### DIFF
--- a/api/bootstrap/kubeadm/v1beta1/conversion_test.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion_test.go
@@ -218,6 +218,16 @@ func spokeKubeadmConfigSpec(in *KubeadmConfigSpec, c randfill.Continue) {
 		}
 		in.Users[i] = user
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeClusterConfiguration(in *ClusterConfiguration, c randfill.Continue) {

--- a/api/controlplane/kubeadm/v1beta1/conversion_test.go
+++ b/api/controlplane/kubeadm/v1beta1/conversion_test.go
@@ -345,6 +345,16 @@ func spokeKubeadmConfigSpec(in *bootstrapv1beta1.KubeadmConfigSpec, c randfill.C
 		}
 		in.Users[i] = user
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &bootstrapv1beta1.ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &bootstrapv1beta1.InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &bootstrapv1beta1.JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeClusterConfiguration(in *bootstrapv1beta1.ClusterConfiguration, c randfill.Continue) {

--- a/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha3/conversion_test.go
@@ -190,6 +190,16 @@ func spokeKubeadmConfigSpec(in *KubeadmConfigSpec, c randfill.Continue) {
 		}
 		in.Files[i] = file
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeKubeadmConfigStatus(obj *KubeadmConfigStatus, c randfill.Continue) {

--- a/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/bootstrap/kubeadm/v1alpha4/conversion_test.go
@@ -188,6 +188,16 @@ func spokeKubeadmConfigSpec(in *KubeadmConfigSpec, c randfill.Continue) {
 		}
 		in.Files[i] = file
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeKubeadmConfigStatus(obj *KubeadmConfigStatus, c randfill.Continue) {

--- a/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha3/conversion_test.go
@@ -277,6 +277,16 @@ func spokeKubeadmConfigSpec(in *bootstrapv1alpha3.KubeadmConfigSpec, c randfill.
 		}
 		in.Files[i] = file
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &bootstrapv1alpha3.ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &bootstrapv1alpha3.InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &bootstrapv1alpha3.JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeAPIServer(in *bootstrapv1alpha3.APIServer, c randfill.Continue) {

--- a/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
+++ b/internal/api/controlplane/kubeadm/v1alpha4/conversion_test.go
@@ -302,6 +302,16 @@ func spokeKubeadmConfigSpec(in *bootstrapv1alpha4.KubeadmConfigSpec, c randfill.
 		}
 		in.Files[i] = file
 	}
+
+	if reflect.DeepEqual(in.ClusterConfiguration, &bootstrapv1alpha4.ClusterConfiguration{}) {
+		in.ClusterConfiguration = nil
+	}
+	if reflect.DeepEqual(in.InitConfiguration, &bootstrapv1alpha4.InitConfiguration{}) {
+		in.InitConfiguration = nil
+	}
+	if reflect.DeepEqual(in.JoinConfiguration, &bootstrapv1alpha4.JoinConfiguration{}) {
+		in.JoinConfiguration = nil
+	}
 }
 
 func spokeClusterConfiguration(in *bootstrapv1alpha4.ClusterConfiguration, c randfill.Continue) {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api/12676/pull-cluster-api-test-main/1959996188031717376

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->