### PR TITLE
🐛 Ensure holder field path in GeneratePatchRequest is set based on contract

### DIFF
--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -76,7 +76,7 @@ func NewGenerator(client client.Client, clusterCache clustercache.ClusterCache, 
 		Client:        client,
 		ClusterCache:  clusterCache,
 		RuntimeClient: runtimeClient,
-		patchEngine:   patches.NewEngine(runtimeClient),
+		patchEngine:   patches.NewEngine(client, runtimeClient),
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Since CAPI v1.11.0 the patch engine always sets the holder field path in a GeneratePatchesRequest for the CP InfraMachineTemplate to `spec.machineTemplate.spec.infrastructureRef`.
This broke existing Runtime Extension implementations that were checking for `spec.machineTemplate.infrastructureRef` (the v1beta1 path).

With this PR we are now setting the holder field path depending on which contract the corresponding control plane object implements.

Examples:
* KCP v1beta1 implements the v1beta1 contract so fieldPath will be set to `spec.machineTemplate.infrastructureRef`
* KCP v1beta2 implements the v1beta2 contract so fieldPath will be set to `spec.machineTemplate.spec.infrastructureRef`

This way existing implementations for v1beta1 that matched on the old path still work and new implementations can either match for both paths or for the absolutely correct one based on contract. Both would be fine.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->