### PR TITLE
🐛 Always use latest apiVersion when getting owner of KubeadmConfig in CABPK

### DIFF
--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -162,7 +162,9 @@ func getConfigOwner(ctx context.Context, c client.Client, obj metav1.Object, get
 		for _, gk := range allowedGKs {
 			if refGVK.Group == gk.Group && refGVK.Kind == gk.Kind {
 				return getFn(ctx, c, &corev1.ObjectReference{
-					APIVersion: ref.APIVersion,
+					// Intentionally always using the latest apiVersion to get Machine or MachinePool,
+					// even if the apiVersion in the ownerRef has not been bumped yet.
+					APIVersion: clusterv1.GroupVersion.String(),
 					Kind:       ref.Kind,
 					Name:       ref.Name,
 					Namespace:  obj.GetNamespace(),


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->