### PR TITLE
✨ Bump Kubernetes in tests to v1.34.0 and claim support for v1.34

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -282,6 +282,7 @@ See [Cluster API release support](#cluster-api-release-support) and [Kubernetes 
 | Kubernetes v1.31 | ✓                        | ✓                 | ✓                 |
 | Kubernetes v1.32 | ✓ >= v1.9.1              | ✓                 | ✓                 |
 | Kubernetes v1.33 |                          | ✓ >= v1.10.1      | ✓                 |
+| Kubernetes v1.34 |                          |                   | ✓ >= v1.11.1      |
 
 See also [Kubernetes version specific notes](#kubernetes-version-specific-notes).
 
@@ -312,6 +313,7 @@ using the [kubeadm API](https://kubernetes.io/docs/setup/production-environment/
 | Kubernetes v1.31 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
 | Kubernetes v1.32 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
 | Kubernetes v1.33 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
+| Kubernetes v1.34 | [v1beta4](https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/) |
 
 ### Kubeadm Control Plane provider (`kubeadm-control-plane-controller`)
 

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -369,10 +369,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.34.0-rc.2"
-  KUBERNETES_VERSION: "v1.34.0-rc.2"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.34.0"
+  KUBERNETES_VERSION: "v1.34.0"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.33.1"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.34.0-rc.2"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.34.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.34"
   ETCD_VERSION_UPGRADE_TO: "3.6.4-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.12.1"

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.34.0-rc.2
+  version: v1.34.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.34.0-rc.2
+      version: v1.34.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.34.0-rc.2
+  version: v1.34.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -92,7 +92,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.34.0-rc.2
+      version: v1.34.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -31,7 +31,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.34.0-rc.2
+  version: v1.34.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -74,7 +74,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.34.0-rc.2
+      version: v1.34.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.34.0-rc.2
+  version: v1.34.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.34.0-rc.2
+      version: v1.34.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12325

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->