### PR TITLE
:bug: Allow metadata.yaml's Kind to be empty

### DIFF
--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -113,7 +113,9 @@ func validateMetadata(metadata *clusterctlv1.Metadata, providerLabel string) err
 			metadata.APIVersion, providerLabel, clusterctlv1.GroupVersion.String())
 	}
 
-	if metadata.Kind != "Metadata" {
+	// v1.11 started enforcing the Metadata Kind, but several providers did not actually have the field serialized.
+	// Ratchet validation so that an empty Kind is accepted.
+	if metadata.Kind != "Metadata" && metadata.Kind != "" {
 		return errors.Errorf("invalid provider metadata: unexpected kind %q for provider %s (expected \"Metadata\")",
 			metadata.Kind, providerLabel)
 	}

--- a/cmd/clusterctl/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/client/repository/metadata_client_test.go
@@ -189,6 +189,20 @@ func Test_validateMetadata(t *testing.T) {
 			errMessage:    "invalid provider metadata: unexpected kind \"WrongKind\" for provider infra-test (expected \"Metadata\")",
 		},
 		{
+			name: "empty kind passes validation",
+			metadata: &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1beta1"},
+				},
+			},
+			providerLabel: "infra-test",
+			wantErr:       false,
+		},
+		{
 			name: "empty releaseSeries",
 			metadata: &clusterctlv1.Metadata{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
clusterctl v1.11 started validating that the metadata.yaml file had a `kind: Metadata` value. However, many providers hadn't populated this field at all, resulting in errors evaluating them.

This change allows the field to be empty or missing, in addition to the primary value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12712


/area clusterctl