### PR TITLE
🐛 Stop adding conversion-data annotation to Cluster object

### DIFF
--- a/bootstrap/kubeadm/types/utils.go
+++ b/bootstrap/kubeadm/types/utils.go
@@ -115,7 +115,8 @@ func marshalForVersion(obj conversion.Hub, version semver.Version, kubeadmObjVer
 	}
 
 	targetKubeadmObj = targetKubeadmObj.DeepCopyObject().(conversion.Convertible)
-	if err := targetKubeadmObj.ConvertFrom(obj); err != nil {
+	// DeepCopy obj because ConvertFrom might have side effects.
+	if err := targetKubeadmObj.ConvertFrom(obj.DeepCopyObject().(conversion.Hub)); err != nil {
 		return "", errors.Wrapf(err, "failed to convert to KubeadmAPI type for version %s", kubeadmAPIGroupVersion)
 	}
 

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -555,7 +555,8 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 			// hook because we didn't go through an upgrade or we already called the hook after the upgrade.
 			if hooks.IsPending(runtimehooksv1.AfterControlPlaneUpgrade, s.Current.Cluster) {
 				v1beta1Cluster := &clusterv1beta1.Cluster{}
-				if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
+				// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+				if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster.DeepCopy()); err != nil {
 					return "", errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 				}
 
@@ -629,7 +630,8 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 		// At this point the control plane and the machine deployments are stable and we are almost ready to pick
 		// up the desiredVersion. Call the BeforeClusterUpgrade hook before picking up the desired version.
 		v1beta1Cluster := &clusterv1beta1.Cluster{}
-		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
+		// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster.DeepCopy()); err != nil {
 			return "", errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 		}
 

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -436,7 +436,8 @@ func (r *Reconciler) callBeforeClusterCreateHook(ctx context.Context, s *scope.S
 
 	if !s.Current.Cluster.Spec.InfrastructureRef.IsDefined() && !s.Current.Cluster.Spec.ControlPlaneRef.IsDefined() {
 		v1beta1Cluster := &clusterv1beta1.Cluster{}
-		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
+		// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+		if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster.DeepCopy()); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 		}
 
@@ -529,7 +530,8 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Clu
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		if !hooks.IsOkToDelete(cluster) {
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := v1beta1Cluster.ConvertFrom(cluster); err != nil {
+			// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+			if err := v1beta1Cluster.ConvertFrom(cluster.DeepCopy()); err != nil {
 				return ctrl.Result{}, errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -197,7 +197,8 @@ func (r *Reconciler) callAfterControlPlaneInitialized(ctx context.Context, s *sc
 	if hooks.IsPending(runtimehooksv1.AfterControlPlaneInitialized, s.Current.Cluster) {
 		if isControlPlaneInitialized(s.Current.Cluster) {
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
+			// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster.DeepCopy()); err != nil {
 				return errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 
@@ -250,7 +251,8 @@ func (r *Reconciler) callAfterClusterUpgrade(ctx context.Context, s *scope.Scope
 			!s.UpgradeTracker.MachinePools.IsAnyPendingUpgrade() && // No MachinePools are pending an upgrade
 			!s.UpgradeTracker.MachinePools.DeferredUpgrade() { // No MachinePools have deferred an upgrade
 			v1beta1Cluster := &clusterv1beta1.Cluster{}
-			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster); err != nil {
+			// DeepCopy cluster because ConvertFrom has side effects like adding the conversion annotation.
+			if err := v1beta1Cluster.ConvertFrom(s.Current.Cluster.DeepCopy()); err != nil {
 				return errors.Wrap(err, "error converting Cluster to v1beta1 Cluster")
 			}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Before this PR the topology controller was adding the conversion-data annotation to the Cluster object.

This happened because:
* we are calling `v1beta1Cluster.ConvertFrom(cluster)` in a few code paths
* ConvertFrom has a side effect that it adds the conversion annotation
* ideally this would only be added on the v1beta1 Cluster, but the generated conversion code is using `out.ObjectMeta = in.ObjectMeta` for conversion. So both objects are updated


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->