### PR TITLE
🐛 Removing Ready/Available prefix from STATUS Column

### DIFF
--- a/internal/util/tree/tree.go
+++ b/internal/util/tree/tree.go
@@ -551,7 +551,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 
 		if available := tree.GetAvailableCondition(obj); available != nil {
 			availableColor, availableStatus, availableAge, availableReason, availableMessage := conditionInfo(*available, true)
-			v.status = availableColor.Sprintf("Available: %s", availableStatus)
+			v.status = availableColor.Sprintf("%s", availableStatus)
 			v.reason = availableReason
 			v.age = availableAge
 			v.message = availableMessage
@@ -574,7 +574,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 
 		if available := tree.GetAvailableCondition(obj); available != nil {
 			availableColor, availableStatus, availableAge, availableReason, availableMessage := conditionInfo(*available, true)
-			v.status = availableColor.Sprintf("Available: %s", availableStatus)
+			v.status = availableColor.Sprintf("%s", availableStatus)
 			v.reason = availableReason
 			v.age = availableAge
 			v.message = availableMessage
@@ -611,7 +611,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 		v.readyCounters = "0"
 		if ready := tree.GetReadyCondition(obj); ready != nil {
 			readyColor, readyStatus, readyAge, readyReason, readyMessage := conditionInfo(*ready, true)
-			v.status = readyColor.Sprintf("Ready: %s", readyStatus)
+			v.status = readyColor.Sprintf("%s", readyStatus)
 			v.reason = readyReason
 			v.age = readyAge
 			v.message = readyMessage
@@ -634,7 +634,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 		// corresponding replica counters.
 		if ready := tree.GetReadyCondition(obj); ready != nil {
 			readyColor, readyStatus, readyAge, readyReason, readyMessage := conditionInfo(*ready, true)
-			v.status = readyColor.Sprintf("Ready: %s", readyStatus)
+			v.status = readyColor.Sprintf("%s", readyStatus)
 			v.reason = readyReason
 			v.age = readyAge
 			v.message = readyMessage
@@ -671,7 +671,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 
 		if ready := tree.GetReadyCondition(obj); ready != nil {
 			readyColor, readyStatus, readyAge, readyReason, readyMessage := conditionInfo(*ready, true)
-			v.status = readyColor.Sprintf("Ready: %s", readyStatus)
+			v.status = readyColor.Sprintf("%s", readyStatus)
 			v.reason = readyReason
 			v.age = readyAge
 			v.message = readyMessage


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR gets rid of the duplicate test in STATUS and REASON when running `clusterctl describe cluster <cluster-name>` without adding any flags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12666 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->