### PR TITLE
🌱 Bump go to v1.24.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.24.6
+GO_VERSION ?= 1.24.7
 GO_DIRECTIVE_VERSION ?= 1.24.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -172,7 +172,7 @@ def load_provider_tilt_files():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.24.6 as tilt-helper
+FROM golang:1.24.7 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24
 # Support live reloading with Tilt
@@ -183,7 +183,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.24.6 as tilt
+FROM golang:1.24.7 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/docs/release/role-handbooks/release-lead/README.md
+++ b/docs/release/role-handbooks/release-lead/README.md
@@ -174,7 +174,7 @@ The goal of this task is to ensure we are always using the latest Go version for
 
 1. Keep track of new Go versions
 2. Bump the Go version in supported branches if necessary
-   <br>Prior art: [Bump go to v1.24.7](https://github.com/kubernetes-sigs/cluster-api/pull/11981)
+   <br>Prior art: [Bump go to v1.23.7](https://github.com/kubernetes-sigs/cluster-api/pull/11981)
 
 Note: If the Go minor version of one of our supported branches goes out of support, we should consider bumping
 to a newer Go minor version according to our [backport policy](./../../../../CONTRIBUTING.md#backporting-a-patch).

--- a/docs/release/role-handbooks/release-lead/README.md
+++ b/docs/release/role-handbooks/release-lead/README.md
@@ -174,7 +174,7 @@ The goal of this task is to ensure we are always using the latest Go version for
 
 1. Keep track of new Go versions
 2. Bump the Go version in supported branches if necessary
-   <br>Prior art: [Bump go to v1.23.7](https://github.com/kubernetes-sigs/cluster-api/pull/11981)
+   <br>Prior art: [Bump go to v1.24.7](https://github.com/kubernetes-sigs/cluster-api/pull/11981)
 
 Note: If the Go minor version of one of our supported branches goes out of support, we should consider bumping
 to a newer Go minor version according to our [backport policy](./../../../../CONTRIBUTING.md#backporting-a-patch).

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.24.6"
+    GO_VERSION = "1.24.7"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What this PR does / why we need it:**
Updates the Go toolchain to the latest patch release.

> go1.24.7 (released 2025-09-xx) includes security fixes and bug fixes across standard library packages and the runtime. See the [[Go 1.24.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.7)](https://github.com/golang/go/issues?q=milestone%3AGo1.24.7) on our issue tracker for details.

**Which issue(s) this PR fixes:**
N/A, but see #12509 for prior art.

/area dependency