### PR TITLE
🌱 Set startup taint for autoscaler in e2e tests

### DIFF
--- a/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
@@ -198,6 +198,8 @@ spec:
             # Note: The E2E test should only go up to 4 (assuming it starts with a min node group size of 2).
             # Using 6 for additional some buffer and to allow different starting min node group sizes.
             - --max-nodes-total=6
+            # CABPK sets this taint on startup, so we should configure it here accordingly
+            - --startup-taint=node.cluster.x-k8s.io/uninitialized
             # Set the log verbosity
             - --v=4
           volumeMounts:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Noticed that we forgot to configure this

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->