### PR TITLE
:seedling: Avoid using deprecated client.Patch method

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -269,10 +269,6 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: .*(res|result|i|j)\.Requeue is deprecated: Use `RequeueAfter` instead'
-      # CR v0.22 deprecated client.Apply, will be fixed via: https://github.com/kubernetes-sigs/cluster-api/issues/12695
-      - linters:
-          - staticcheck
-        text: 'SA1019: client.Apply is deprecated: Use client.Client.Apply'
       # TODO: var-naming: avoid meaningless package names by revive
       #   * test/infrastructure/docker/internal/docker/types/
       #   * bootstrap/kubeadm/types/

--- a/controllers/crdmigrator/crd_migrator.go
+++ b/controllers/crdmigrator/crd_migrator.go
@@ -412,7 +412,7 @@ func (r *CRDMigrator) reconcileStorageVersionMigration(ctx context.Context, crd 
 		if migrationConfig.UseStatusForStorageVersionMigration {
 			err = r.Client.Status().Patch(ctx, u, client.Apply, client.FieldOwner("crdmigrator"))
 		} else {
-			err = r.Client.Patch(ctx, u, client.Apply, client.FieldOwner("crdmigrator"))
+			err = r.Client.Apply(ctx, client.ApplyConfigurationFromUnstructured(u), client.FieldOwner("crdmigrator"))
 		}
 		// If we got a NotFound error, the object no longer exists so no need to update it.
 		// If we got a Conflict error, another client wrote the object already so no need to update it.

--- a/controllers/crdmigrator/crd_migrator_test.go
+++ b/controllers/crdmigrator/crd_migrator_test.go
@@ -195,10 +195,10 @@ func TestReconcile(t *testing.T) {
 			// Deploy test-cluster-1 and test-cluster-2.
 			testClusterT1 := unstructuredTestCluster("test-cluster-1", t1v1beta1.GroupVersion.WithKind("TestCluster"))
 			g.Expect(unstructured.SetNestedField(testClusterT1.Object, "foo-value", "spec", "foo")).To(Succeed())
-			g.Expect(managerT1.GetClient().Patch(ctx, testClusterT1, client.Apply, fieldOwner)).To(Succeed())
+			g.Expect(managerT1.GetClient().Apply(ctx, client.ApplyConfigurationFromUnstructured(testClusterT1), fieldOwner)).To(Succeed())
 			testClusterT1 = unstructuredTestCluster("test-cluster-2", t1v1beta1.GroupVersion.WithKind("TestCluster"))
 			g.Expect(unstructured.SetNestedField(testClusterT1.Object, "foo-value", "spec", "foo")).To(Succeed())
-			g.Expect(managerT1.GetClient().Patch(ctx, testClusterT1, client.Apply, fieldOwner)).To(Succeed())
+			g.Expect(managerT1.GetClient().Apply(ctx, client.ApplyConfigurationFromUnstructured(testClusterT1), fieldOwner)).To(Succeed())
 			validateManagedFields(t, g, "v1beta1", map[string][]string{
 				"test-cluster-1": {"test.cluster.x-k8s.io/v1beta1"},
 				"test-cluster-2": {"test.cluster.x-k8s.io/v1beta1"},
@@ -226,11 +226,11 @@ func TestReconcile(t *testing.T) {
 			// Set an additional field with a different field manager and v1beta2 apiVersion in test-cluster-2
 			testClusterT2 := unstructuredTestCluster("test-cluster-2", t2v1beta2.GroupVersion.WithKind("TestCluster"))
 			g.Expect(unstructured.SetNestedField(testClusterT2.Object, "bar-value", "spec", "bar")).To(Succeed())
-			g.Expect(managerT2.GetClient().Patch(ctx, testClusterT2, client.Apply, client.FieldOwner("different-unit-test-client"))).To(Succeed())
+			g.Expect(managerT2.GetClient().Apply(ctx, client.ApplyConfigurationFromUnstructured(testClusterT2), client.FieldOwner("different-unit-test-client"))).To(Succeed())
 			// Deploy test-cluster-3.
 			testClusterT2 = unstructuredTestCluster("test-cluster-3", t2v1beta2.GroupVersion.WithKind("TestCluster"))
 			g.Expect(unstructured.SetNestedField(testClusterT2.Object, "foo-value", "spec", "foo")).To(Succeed())
-			g.Expect(managerT2.GetClient().Patch(ctx, testClusterT2, client.Apply, fieldOwner)).To(Succeed())
+			g.Expect(managerT2.GetClient().Apply(ctx, client.ApplyConfigurationFromUnstructured(testClusterT2), fieldOwner)).To(Succeed())
 			// At this point we have clusters with all combinations of managedField apiVersions.
 			validateManagedFields(t, g, "v1beta2", map[string][]string{
 				"test-cluster-1": {"test.cluster.x-k8s.io/v1beta1"},
@@ -323,7 +323,7 @@ func TestReconcile(t *testing.T) {
 				// Try to patch the test-clusters CRs with SSA.
 				testClusterT4 := unstructuredTestCluster(clusterName, t4v1beta2.GroupVersion.WithKind("TestCluster"))
 				g.Expect(unstructured.SetNestedField(testClusterT4.Object, "new-foo-value", "spec", "foo")).To(Succeed())
-				err = managerT4.GetClient().Patch(ctx, testClusterT4, client.Apply, fieldOwner)
+				err = managerT4.GetClient().Apply(ctx, client.ApplyConfigurationFromUnstructured(testClusterT4), fieldOwner)
 
 				// If managedField cleanup was skipped before, the SSA patch will fail for the clusters which still have v1beta1 managedFields.
 				if skipCRDMigrationPhases.Has(CleanupManagedFieldsPhase) && (clusterName == "test-cluster-1" || clusterName == "test-cluster-2") {

--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -81,7 +81,7 @@ func dryRunSSAPatch(ctx context.Context, dryRunCtx *dryRunSSAPatchInput) (bool, 
 	}
 
 	// Do a server-side apply dry-run with modifiedUnstructured to get the updated object.
-	err = dryRunCtx.client.Patch(ctx, dryRunCtx.modifiedUnstructured, client.Apply, client.DryRunAll, client.FieldOwner(TopologyManagerName), client.ForceOwnership)
+	err = dryRunCtx.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(dryRunCtx.modifiedUnstructured), client.DryRunAll, client.FieldOwner(TopologyManagerName), client.ForceOwnership)
 	if err != nil {
 		// This catches errors like metadata.uid changes.
 		return false, false, nil, errors.Wrap(err, "server side apply dry-run failed for modified object")
@@ -107,7 +107,7 @@ func dryRunSSAPatch(ctx context.Context, dryRunCtx *dryRunSSAPatchInput) (bool, 
 	// Note: Otherwise we would get the following error:
 	// "failed to request dry-run server side apply: metadata.managedFields must be nil"
 	dryRunCtx.originalUnstructured.SetManagedFields(nil)
-	err = dryRunCtx.client.Patch(ctx, dryRunCtx.originalUnstructured, client.Apply, client.DryRunAll, client.FieldOwner(TopologyManagerName), client.ForceOwnership)
+	err = dryRunCtx.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(dryRunCtx.originalUnstructured), client.DryRunAll, client.FieldOwner(TopologyManagerName), client.ForceOwnership)
 	if err != nil {
 		return false, false, nil, errors.Wrap(err, "server side apply dry-run failed for original object")
 	}

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -141,11 +141,11 @@ func (h *serverSidePatchHelper) Patch(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Patching object", "intent", h.modified)
 
-	options := []client.PatchOption{
+	options := []client.ApplyOption{
 		client.FieldOwner(TopologyManagerName),
 		// NOTE: we are using force ownership so in case of conflicts the topology controller
 		// overwrite values and become sole manager.
 		client.ForceOwnership,
 	}
-	return h.client.Patch(ctx, h.modified, client.Apply, options...)
+	return h.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(h.modified), options...)
 }

--- a/internal/util/ssa/patch.go
+++ b/internal/util/ssa/patch.go
@@ -99,11 +99,11 @@ func Patch(ctx context.Context, c client.Client, fieldManager string, modified c
 		}
 	}
 
-	patchOptions := []client.PatchOption{
+	applyOptions := []client.ApplyOption{
 		client.ForceOwnership,
 		client.FieldOwner(fieldManager),
 	}
-	if err := c.Patch(ctx, modifiedUnstructured, client.Apply, patchOptions...); err != nil {
+	if err := c.Apply(ctx, client.ApplyConfigurationFromUnstructured(modifiedUnstructured), applyOptions...); err != nil {
 		return errors.Wrapf(err, "failed to apply %s %s", gvk.Kind, klog.KObj(modifiedUnstructured))
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR contains the changes remove usage of deprecated client.Patch method

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Part of [12695](https://github.com/kubernetes-sigs/cluster-api/issues/12695)

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->