### PR TITLE
feat: Update release notes tool to handle multiples_areas and colons

### DIFF
--- a/hack/tools/release/notes/process.go
+++ b/hack/tools/release/notes/process.go
@@ -200,9 +200,29 @@ func (g prEntriesProcessor) generateNoteEntry(p *pr) *notesEntry {
 	}
 
 	entry.prNumber = fmt.Sprintf("%d", p.number)
+	entry.title = updateTitle(entry.title)
 	entry.title = formatPREntry(entry.title, entry.prNumber)
 
 	return entry
+}
+
+// UpdateTitle updates a title by removing the "MULTIPLE_AREAS[]" substrings and multiple colons(:).
+func updateTitle(input string) string {
+	// Remove "MULTIPLE_AREAS[" from the input
+	input = strings.Replace(input, "MULTIPLE_AREAS[", "", 1)
+	input = strings.Replace(input, "]", "", 1)
+
+	// Remove the extra colons from the title
+	colonCount := strings.Count(input, ":")
+	if colonCount == 2 {
+		// Find the position of the first colon
+		firstColonIndex := strings.Index(input, ":")
+		// Extract the part after the first colon and remove any leading spaces
+		partAfterColon := strings.TrimSpace(input[firstColonIndex+1:])
+		// Replace the first colon with "/"
+		input = input[:firstColonIndex] + "/" + partAfterColon
+	}
+	return input
 }
 
 // extractArea processes the PR labels to extract the area.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
- Handle `MULTIPLE_AREAS` in the generated notes
   - From `MULTIPLE_AREAS[KCP/CABPK]: Change envVars fields from []EnvVar to *[]EnvVar (#12539)` to `KCP/CABPK: Change envVars fields from []EnvVar to *[]EnvVar (#12539)`
- Handle multiple colons
   - From `Testing:Framework: Watch logs from init containers (#12208)` to `Testing/Framework: Watch logs from init containers (#12208)`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/12280

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release