### PR TITLE
🐛Verify providers need upgrade before applying

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -175,6 +175,15 @@ func (u *providerUpgrader) ApplyPlan(ctx context.Context, opts UpgradeOptions, c
 		return err
 	}
 
+	// Make sure there is something to upgrade, clear providers that do not
+	// need it
+	for i := len(upgradePlan.Providers) - 1; i >= 0; i-- {
+		if upgradePlan.Providers[i].NextVersion == "" {
+			// Remove this from our plan
+			upgradePlan.Providers = append(upgradePlan.Providers[:i], upgradePlan.Providers[i+1:]...)
+		}
+	}
+
 	// Do the upgrade
 	return u.doUpgrade(ctx, upgradePlan, opts)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If a user runs `upgrade plan` and the results show there are no available upgrades, the expectation is they then do not attempt to apply the plan. But nothing prevents them from doing so.

If a non-upgrade plan is applied, the current apply logic does not handle the case where the "next version" is empty. To make this more robust, and to protect against users trying to apply plans with no available upgrades, this performs a quick validation on the plan providers to make sure they have a version to upgrade to. If not, the `upgrade apply` call ends up being a no-op and avoids potentially confusing error output.

**Which issue(s) this PR fixes**:

Fixes #12751 

/area clusterctl