### PR TITLE
✨ Ensure ExtensionConfig controller can be used outside of the core provider

### DIFF
--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -303,19 +303,23 @@ func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 
 // ExtensionConfigReconciler reconciles an ExtensionConfig object.
 type ExtensionConfigReconciler struct {
-	Client        client.Client
-	APIReader     client.Reader
-	RuntimeClient runtimeclient.Client
+	Client             client.Client
+	APIReader          client.Reader
+	RuntimeClient      runtimeclient.Client
+	PartialSecretCache cache.Cache
+	ReadOnly           bool
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 }
 
-func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options, partialSecretCache cache.Cache) error {
+func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&extensionconfigcontroller.Reconciler{
-		Client:           r.Client,
-		APIReader:        r.APIReader,
-		RuntimeClient:    r.RuntimeClient,
-		WatchFilterValue: r.WatchFilterValue,
-	}).SetupWithManager(ctx, mgr, options, partialSecretCache)
+		Client:             r.Client,
+		APIReader:          r.APIReader,
+		RuntimeClient:      r.RuntimeClient,
+		PartialSecretCache: r.PartialSecretCache,
+		ReadOnly:           r.ReadOnly,
+		WatchFilterValue:   r.WatchFilterValue,
+	}).SetupWithManager(ctx, mgr, options)
 }

--- a/controlplane/kubeadm/config/rbac/role.yaml
+++ b/controlplane/kubeadm/config/rbac/role.yaml
@@ -14,6 +14,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
@@ -89,4 +97,12 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - runtime.cluster.x-k8s.io
+  resources:
+  - extensionconfigs
+  verbs:
+  - get
+  - list
   - watch

--- a/internal/controllers/extensionconfig/extensionconfig_controller_test.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller_test.go
@@ -64,6 +64,11 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		Catalog:  cat,
 		Registry: registry,
 	})
+	registryReadOnly := runtimeregistry.New()
+	runtimeClientReadOnly := internalruntimeclient.New(internalruntimeclient.Options{
+		Catalog:  cat,
+		Registry: registryReadOnly,
+	})
 
 	g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
@@ -71,6 +76,12 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		Client:        env.GetAPIReader().(client.Client),
 		APIReader:     env.GetAPIReader(),
 		RuntimeClient: runtimeClient,
+	}
+	rReadOnly := &Reconciler{
+		Client:        env.GetAPIReader().(client.Client),
+		APIReader:     env.GetAPIReader(),
+		RuntimeClient: runtimeClientReadOnly,
+		ReadOnly:      true,
 	}
 
 	caCertSecret := fakeCASecret(ns.Name, "ext1-webhook", testcerts.CACert)
@@ -85,11 +96,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	defer func() {
 		g.Expect(env.CleanupAndWait(ctx, caCertSecret)).To(Succeed())
 	}()
-	// Create the ExtensionConfig.
-	g.Expect(env.CreateAndWait(ctx, extensionConfig)).To(Succeed())
-	defer func() {
-		g.Expect(env.CleanupAndWait(ctx, extensionConfig)).To(Succeed())
-	}()
+
 	t.Run("fail reconcile if registry has not been warmed up", func(*testing.T) {
 		// Attempt to reconcile. This will be an error as the registry has not been warmed up at this point.
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
@@ -99,13 +106,30 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	})
 
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(*testing.T) {
-		// Warm up the registry before trying reconciliation again.
+		// Warm up the registry before trying reconciliation again (these are no-ops as ExtensionConfig doesn't exist yet).
 		warmup := &warmupRunnable{
 			Client:        env.GetAPIReader().(client.Client),
 			APIReader:     env.GetAPIReader(),
 			RuntimeClient: runtimeClient,
 		}
 		g.Expect(warmup.Start(ctx)).To(Succeed())
+		warmupReadOnly := &warmupRunnable{
+			ReadOnly:      true,
+			warmupTimeout: 3 * time.Second, // Use a short timeout so the test doesn't take too long
+			Client:        env.GetAPIReader().(client.Client),
+			APIReader:     env.GetAPIReader(),
+			RuntimeClient: internalruntimeclient.New(internalruntimeclient.Options{
+				Catalog:  cat,
+				Registry: registryReadOnly,
+			}),
+		}
+		g.Expect(warmupReadOnly.Start(ctx)).To(Succeed())
+
+		// Create the ExtensionConfig.
+		g.Expect(env.CreateAndWait(ctx, extensionConfig)).To(Succeed())
+		t.Cleanup(func() {
+			g.Expect(env.CleanupAndWait(ctx, extensionConfig)).To(Succeed())
+		})
 
 		// Reconcile the extension and assert discovery has succeeded (the first reconcile adds the Paused condition).
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
@@ -120,7 +144,38 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			g.Expect(pausedCondition.ObservedGeneration).To(Equal(conf.Generation))
 		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
+		// Initially Reconcile on the read-only Reconciler should fail if ExtensionConfig has not been reconciled yet.
+		_, err = rReadOnly.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(Equal("failed to validate ExtensionConfig: caBundle is not set on ExtensionConfig ext1"))
+
+		// Reconcile should succeed on the regular Reconciler.
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Regular registry should have the handlers.
+		_, err = registry.Get("first.ext1")
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = registry.Get("second.ext1")
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = registry.Get("third.ext1")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Read-only registry should not have the handlers yet
+		_, err = registryReadOnly.Get("first.ext1")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(Equal("failed to get extension handler \"first.ext1\" from registry: handler with name \"first.ext1\" has not been registered"))
+
+		// Reconcile should succeed on the read-only Reconciler now as well.
+		_, err = rReadOnly.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		// Read-only registry should have the handlers now as well.
+		_, err = registryReadOnly.Get("first.ext1")
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = registryReadOnly.Get("second.ext1")
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = registryReadOnly.Get("third.ext1")
 		g.Expect(err).ToNot(HaveOccurred())
 
 		config := &runtimev1.ExtensionConfig{}
@@ -143,13 +198,6 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		g.Expect(v1beta2Conditions[0].Type).To(Equal(runtimev1.ExtensionConfigDiscoveredCondition))
 		g.Expect(v1beta2Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(v1beta2Conditions[0].Reason).To(Equal(runtimev1.ExtensionConfigDiscoveredReason))
-
-		_, err = registry.Get("first.ext1")
-		g.Expect(err).ToNot(HaveOccurred())
-		_, err = registry.Get("second.ext1")
-		g.Expect(err).ToNot(HaveOccurred())
-		_, err = registry.Get("third.ext1")
-		g.Expect(err).ToNot(HaveOccurred())
 	})
 
 	t.Run("Successful reconcile and discovery on Extension update", func(*testing.T) {
@@ -183,6 +231,20 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
 
+		_, err = rReadOnly.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		for _, registry := range []runtimeregistry.ExtensionRegistry{registry, registryReadOnly} {
+			_, err := registry.Get("first.ext1")
+			g.Expect(err).ToNot(HaveOccurred())
+			_, err = registry.Get("third.ext1")
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Second should not be found in the registry, as it has been removed from the ExtensionServer.
+			_, err = registry.Get("second.ext1")
+			g.Expect(err).To(HaveOccurred())
+		}
+
 		var config runtimev1.ExtensionConfig
 		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), &config)).To(Succeed())
 
@@ -201,24 +263,21 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		g.Expect(v1beta2Conditions[0].Type).To(Equal(runtimev1.ExtensionConfigDiscoveredCondition))
 		g.Expect(v1beta2Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(v1beta2Conditions[0].Reason).To(Equal(runtimev1.ExtensionConfigDiscoveredReason))
-
-		_, err = registry.Get("first.ext1")
-		g.Expect(err).ToNot(HaveOccurred())
-		_, err = registry.Get("third.ext1")
-		g.Expect(err).ToNot(HaveOccurred())
-
-		// Second should not be found in the registry:
-		_, err = registry.Get("second.ext1")
-		g.Expect(err).To(HaveOccurred())
 	})
 	t.Run("Successful reconcile and deregister on ExtensionConfig delete", func(*testing.T) {
 		g.Expect(env.CleanupAndWait(ctx, extensionConfig)).To(Succeed())
 		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
-		g.Expect(env.Get(ctx, util.ObjectKey(extensionConfig), extensionConfig)).To(Not(Succeed()))
-		_, err = registry.Get("first.ext1")
-		g.Expect(err).To(HaveOccurred())
-		_, err = registry.Get("third.ext1")
-		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
+		_, err = rReadOnly.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		for _, registry := range []runtimeregistry.ExtensionRegistry{registry, registryReadOnly} {
+			g.Expect(env.Get(ctx, util.ObjectKey(extensionConfig), extensionConfig)).To(Not(Succeed()))
+			_, err = registry.Get("first.ext1")
+			g.Expect(err).To(HaveOccurred())
+			_, err = registry.Get("third.ext1")
+			g.Expect(err).To(HaveOccurred())
+		}
 	})
 }
 
@@ -374,6 +433,73 @@ func Test_reconcileCABundle(t *testing.T) {
 	}
 }
 
+func Test_validateExtensionConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *runtimev1.ExtensionConfig
+		wantErr        bool
+		wantErrMessage string
+	}{
+		{
+			name:           "caBundle not set",
+			config:         extensionConfig(nil),
+			wantErr:        true,
+			wantErrMessage: "caBundle is not set on ExtensionConfig default/extensionconfig",
+		},
+		{
+			name:           "condition missing",
+			config:         extensionConfig([]byte("caBundle")),
+			wantErr:        true,
+			wantErrMessage: "Discovered condition not yet set on ExtensionConfig default/extensionconfig",
+		},
+		{
+			name: "condition false",
+			config: extensionConfig([]byte("caBundle"), metav1.Condition{
+				Type:               runtimev1.ExtensionConfigDiscoveredCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             runtimev1.ExtensionConfigNotDiscoveredReason,
+				ObservedGeneration: 1, // ExtensionConfig has generation 1.
+			}),
+			wantErr:        true,
+			wantErrMessage: "Discovered condition on ExtensionConfig default/extensionconfig must have status: True (instead it has: False)",
+		},
+		{
+			name: "condition observedGeneration outdated",
+			config: extensionConfig([]byte("caBundle"), metav1.Condition{
+				Type:               runtimev1.ExtensionConfigDiscoveredCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             runtimev1.ExtensionConfigDiscoveredReason,
+				ObservedGeneration: 0, // ExtensionConfig has generation 1.
+			}),
+			wantErr:        true,
+			wantErrMessage: "Discovered condition on ExtensionConfig default/extensionconfig must have observedGeneration: 1 (instead it has: 0)",
+		},
+		{
+			name: "All good",
+			config: extensionConfig([]byte("caBundle"), metav1.Condition{
+				Type:               runtimev1.ExtensionConfigDiscoveredCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             runtimev1.ExtensionConfigDiscoveredReason,
+				ObservedGeneration: 1, // ExtensionConfig has generation 1.
+			}),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := validateExtensionConfig(tt.config)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal(tt.wantErrMessage))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
 func discoveryHandler(handlerList ...string) func(http.ResponseWriter, *http.Request) {
 	handlers := []runtimehooksv1.ExtensionHandler{}
 	for _, name := range handlerList {
@@ -470,4 +596,22 @@ func fakeCAInjectionRuntimeExtensionConfig(namespace, name, annotationString, ca
 		ext.Spec.ClientConfig.CABundle = []byte(caBundleData)
 	}
 	return ext
+}
+
+func extensionConfig(caBundle []byte, conditions ...metav1.Condition) *runtimev1.ExtensionConfig {
+	return &runtimev1.ExtensionConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "extensionconfig",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: runtimev1.ExtensionConfigSpec{
+			ClientConfig: runtimev1.ClientConfig{
+				CABundle: caBundle,
+			},
+		},
+		Status: runtimev1.ExtensionConfigStatus{
+			Conditions: conditions,
+		},
+	}
 }

--- a/main.go
+++ b/main.go
@@ -620,11 +620,12 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		if err = (&controllers.ExtensionConfigReconciler{
-			Client:           mgr.GetClient(),
-			APIReader:        mgr.GetAPIReader(),
-			RuntimeClient:    runtimeClient,
-			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, concurrency(extensionConfigConcurrency), partialSecretCache); err != nil {
+			Client:             mgr.GetClient(),
+			APIReader:          mgr.GetAPIReader(),
+			RuntimeClient:      runtimeClient,
+			PartialSecretCache: partialSecretCache,
+			WatchFilterValue:   watchFilterValue,
+		}).SetupWithManager(ctx, mgr, concurrency(extensionConfigConcurrency)); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "ExtensionConfig")
 			os.Exit(1)
 		}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/12291

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->