### PR TITLE
📖 Update v1.12 release timeline for k/k release

### DIFF
--- a/docs/release/releases/release-1.12.md
+++ b/docs/release/releases/release-1.12.md
@@ -24,7 +24,7 @@ The following table shows the preliminary dates for the `v1.12` release cycle.
 | **v1.12.0 released**                                 | Release Lead | Tuesday 9th December 2025   | week 16  |
 | *v1.10.x & v1.11.x released*                         | Release Lead | Tuesday 9th December 2025   | week 16  |
 | Organize release retrospective                       | Release Lead | TBC                         | week 16  |
-| *v1.12.1 released (tentative)*                       | Release Lead | Tuesday 16th December 2025  |          |
+| *v1.12.1 released (tentative)*                       | Release Lead | Thursday 18th December 2025 |          |
 
 After CAPI v1.12.0, the .1 release will follow up to add support for Kubernetes 1.35.0 when it becomes available. After .1, we expect to do monthly patch releases (more details will be provided in the 1.13 release schedule).
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Looks like k/k v1.35.0 will be released on Wednesday 17th December:
* https://lwkd.info/2025/20250911
* https://github.com/kubernetes/sig-release/pull/2860

Accordingly I would like to propose to move the CAPI v1.12.1 release to Thursday 18th December (otherwise we would have to move it to 23rd December, which doesn't work because of Christmas)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->