### PR TITLE
🐛 refactored cleanup for clusterctl upgrade e2e

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -60,15 +60,17 @@ import (
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
+// Allow alphanumeric characters, hyphens, and underscores
+// This matches typical Kubernetes resource naming conventions
+var validNameRegex = regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
+	
 // isValidClusterName validates that a cluster name is safe to use in shell commands.
 // It only allows alphanumeric characters, hyphens, and underscores.
 func isValidClusterName(name string) bool {
 	if name == "" {
 		return false
 	}
-	// Allow alphanumeric characters, hyphens, and underscores
-	// This matches typical Kubernetes resource naming conventions
-	validNameRegex := regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
+	
 	return validNameRegex.MatchString(name)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR used DeferCleanup instead of AfterEach to ensure a better cleanup process
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12578 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing