### PR TITLE
📖 Show MHC unhealthyNodeConditions example

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -1125,7 +1125,10 @@ spec:
   clusterName: ""
   selector: { ... }
   nodeStartupTimeout: 300s
-  unhealthyConditions: { ... }
+  unhealthyConditions:
+    - type: ""
+      status: ""
+      timeout: 300s
   unhealthyRange: "[1-4]"
   maxUnhealthy: "80%"
   remediationTemplate:
@@ -1156,7 +1159,10 @@ spec:
   selector: { ... }
   checks:
     nodeStartupTimeoutSeconds: 300
-    unhealthyNodeConditions: [ ... ]
+    unhealthyNodeConditions:
+      - type: ""
+        status: ""
+        timeoutSeconds: 300
   remediation:
     triggerIf:
       unhealthyInRange: "[1-4]"


### PR DESCRIPTION
**What this PR does / why we need it**:

The migration docs for v1.10 - v1.11 mentions the change to the timeout field but the example doesn't show it. This commit adds it to the example.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation