### PR TITLE
🌱 Fix flaky test in extensionconfig_controller_test.go (#12386)

### DIFF
--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -69,7 +69,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
 	r := &Reconciler{
-		Client:        env.GetClient(),
+		Client:        env.GetAPIReader().(client.Client),
 		APIReader:     env.GetAPIReader(),
 		RuntimeClient: runtimeClient,
 	}
@@ -102,7 +102,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(*testing.T) {
 		// Warm up the registry before trying reconciliation again.
 		warmup := &warmupRunnable{
-			Client:        env.GetClient(),
+			Client:        env.GetAPIReader().(client.Client),
 			APIReader:     env.GetAPIReader(),
 			RuntimeClient: runtimeClient,
 		}


### PR DESCRIPTION
* fix: flaky test

* Revert "fix: flaky test"

This reverts commit 4c2629963630b76a8989695edc7f33fd66d20a77.

* fix: flaky test

* ci

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

related: https://github.com/kubernetes-sigs/cluster-api/pull/12386#issuecomment-3307526423