### PR TITLE
⚠️ feat(clusterctl): block move when Cluster or ClusterClass is paused

### DIFF
--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -99,6 +99,40 @@ var moveTests = []struct {
 		wantErr: false,
 	},
 	{
+		name: "Paused Cluster",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "foo").WithPaused().Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ // group 1
+				clusterv1.GroupVersion.String() + ", Kind=Cluster, ns1/foo",
+			},
+			{ // group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/foo-ca",
+				"/v1, Kind=Secret, ns1/foo-kubeconfig",
+				clusterv1.GroupVersionInfrastructure.String() + ", Kind=GenericInfrastructureCluster, ns1/foo",
+			},
+		},
+		wantErr: true,
+	},
+	{
+		name: "Paused ClusterClass",
+		fields: moveTestsFields{
+			objs: test.NewFakeClusterClass("ns1", "class1").WithPaused().Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ // group 1
+				clusterv1.GroupVersion.String() + ", Kind=ClusterClass, ns1/class1",
+			},
+			{ // group 2
+				clusterv1.GroupVersionInfrastructure.String() + ", Kind=GenericInfrastructureClusterTemplate, ns1/class1",
+				clusterv1.GroupVersionControlPlane.String() + ", Kind=GenericControlPlaneTemplate, ns1/class1",
+			},
+		},
+		wantErr: true,
+	},
+	{
 		name: "Cluster with cloud config secret with the force move label",
 		fields: moveTestsFields{
 			objs: test.NewFakeCluster("ns1", "foo").WithCloudConfigSecret().Objs(),
@@ -923,8 +957,29 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 }
 
 func Test_objectMover_toDirectory(t *testing.T) {
-	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
-	for _, tt := range backupRestoreTests {
+	tests := []struct {
+		name    string
+		fields  moveTestsFields
+		files   map[string]string
+		wantErr bool
+	}{
+		{
+			name: "Cluster is paused",
+			fields: moveTestsFields{
+				objs: test.NewFakeCluster("ns1", "foo").WithPaused().Objs(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "ClusterClass is paused",
+			fields: moveTestsFields{
+				objs: test.NewFakeClusterClass("ns1", "foo").WithPaused().Objs(),
+			},
+			wantErr: true,
+		},
+	}
+	tests = append(tests, backupRestoreTests...)
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 

--- a/util/test/builder/builders.go
+++ b/util/test/builder/builders.go
@@ -342,6 +342,7 @@ func (m *MachinePoolTopologyBuilder) Build() clusterv1.MachinePoolTopology {
 type ClusterClassBuilder struct {
 	namespace                                 string
 	name                                      string
+	annotations                               map[string]string
 	infrastructureClusterTemplate             *unstructured.Unstructured
 	controlPlaneMetadata                      *clusterv1.ObjectMeta
 	controlPlaneReadinessGates                []clusterv1.MachineReadinessGate
@@ -368,6 +369,12 @@ func ClusterClass(namespace, name string) *ClusterClassBuilder {
 		namespace: namespace,
 		name:      name,
 	}
+}
+
+// WithAnnotations adds the passed annotations to the ClusterClassBuilder.
+func (c *ClusterClassBuilder) WithAnnotations(annotations map[string]string) *ClusterClassBuilder {
+	c.annotations = annotations
+	return c
 }
 
 // WithInfrastructureClusterTemplate adds the passed InfrastructureClusterTemplate to the ClusterClassBuilder.
@@ -501,6 +508,9 @@ func (c *ClusterClassBuilder) Build() *clusterv1.ClusterClass {
 		Status: clusterv1.ClusterClassStatus{
 			Variables: c.statusVariables,
 		},
+	}
+	if c.annotations != nil {
+		obj.Annotations = c.annotations
 	}
 	if c.conditions != nil {
 		obj.Status.Conditions = c.conditions


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Add checks that ensure clusters and cluster classes are not paused before starting move operations. This ensures that the paused state is not inadvertently altered during the directory move operation.

Marked this PR as a breaking change as it may break some users worflows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12742

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl