### PR TITLE
🐛 Fix the format error of healthCheck in test templates

### DIFF
--- a/test/infrastructure/docker/templates/clusterclass-in-memory.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-in-memory.yaml
@@ -117,15 +117,15 @@ spec:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: in-memory-control-plane
-      healthCheck:
-        checks:
-          unhealthyNodeConditions:
-            - type: Ready
-              status: Unknown
-              timeoutSeconds: 300
-            - type: Ready
-              status: "False"
-              timeoutSeconds: 300
+    healthCheck:
+      checks:
+        unhealthyNodeConditions:
+          - type: Ready
+            status: Unknown
+            timeoutSeconds: 300
+          - type: Ready
+            status: "False"
+            timeoutSeconds: 300
   infrastructure:
     templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I was following this doc https://cluster-api.sigs.k8s.io/developer/core/tilt#deploying-a-workload-cluster to try to deploy a workload cluster with CAPD. But got an error like this:

> Error from server (BadRequest): error when creating "/go/src/sigs.k8s.io/cluster-api/target": ClusterClass in version "v1beta2" cannot be handled as a ClusterClass: strict decoding error: unknown field "spec.controlPlane.templateRef.healthCheck

Then I found the indent for `healthCheck` in  [test/infrastructure/docker/templates/clusterclass-in-memory.yaml](https://github.com/kubernetes-sigs/cluster-api/blob/f3a97263ebecf2c25297f68c43b210c8156af2ac/test/infrastructure/docker/templates/clusterclass-in-memory.yaml#L120-L128) seems not correct

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->