### PR TITLE
🌱 Bump autoscaler in e2e tests to v1.33.1

### DIFF
--- a/test/e2e/autoscaler_test.go
+++ b/test/e2e/autoscaler_test.go
@@ -36,7 +36,7 @@ var _ = Describe("When using the autoscaler with Cluster API using ClusterClass 
 			InfrastructureMachinePoolTemplateKind: "dockermachinepooltemplates",
 			InfrastructureMachinePoolKind:         "dockermachinepools",
 			Flavor:                                ptr.To("topology-autoscaler"),
-			AutoscalerVersion:                     "v1.32.1",
+			AutoscalerVersion:                     "v1.33.1",
 			ScaleToAndFromZero:                    true,
 		}
 	})

--- a/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
@@ -176,7 +176,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-        - image: gcr.io/k8s-staging-autoscaling/cluster-autoscaler:v20250814-cluster-autoscaler-chart-9.50.1-4-ga9cb59fdd
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
           name: cluster-autoscaler
           command:
             - /cluster-autoscaler


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Let's bump to a regular autoscaler version again, now that there is one with the bug fixes

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12704

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->