### PR TITLE
✨ ClusterCache: Add GetUncachedClient()

### DIFF
--- a/controllers/clustercache/cluster_accessor.go
+++ b/controllers/clustercache/cluster_accessor.go
@@ -191,6 +191,10 @@ type clusterAccessorLockedConnectionState struct {
 	// all typed objects except the ones for which caching has been disabled via DisableFor.
 	cachedClient client.Client
 
+	// uncachedClient to communicate with the workload cluster.
+	// It performs live GET/LIST calls directly against the API server with no caching.
+	uncachedClient client.Client
+
 	// cache is the cache used by the client.
 	// It manages informers that have been created e.g. by adding indexes to the cache,
 	// Get & List calls from the client or via the Watch method of the clusterAccessor.
@@ -297,11 +301,12 @@ func (ca *clusterAccessor) Connect(ctx context.Context) (retErr error) {
 		consecutiveFailures:  0,
 	}
 	ca.lockedState.connection = &clusterAccessorLockedConnectionState{
-		restConfig:   connection.RESTConfig,
-		restClient:   connection.RESTClient,
-		cachedClient: connection.CachedClient,
-		cache:        connection.Cache,
-		watches:      sets.Set[string]{},
+		restConfig:     connection.RESTConfig,
+		restClient:     connection.RESTClient,
+		cachedClient:   connection.CachedClient,
+		uncachedClient: connection.UncachedClient,
+		cache:          connection.Cache,
+		watches:        sets.Set[string]{},
 	}
 
 	return nil
@@ -405,6 +410,18 @@ func (ca *clusterAccessor) GetReader(ctx context.Context) (client.Reader, error)
 	}
 
 	return ca.lockedState.connection.cachedClient, nil
+}
+
+// GetUncachedClient returns a live (uncached) client for the given cluster.
+func (ca *clusterAccessor) GetUncachedClient(ctx context.Context) (client.Client, error) {
+	ca.rLock(ctx)
+	defer ca.rUnlock(ctx)
+
+	if ca.lockedState.connection == nil {
+		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting uncached client")
+	}
+
+	return ca.lockedState.connection.uncachedClient, nil
 }
 
 func (ca *clusterAccessor) GetRESTConfig(ctx context.Context) (*rest.Config, error) {

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -134,6 +134,10 @@ type ClusterCache interface {
 	// If there is no connection to the workload cluster ErrClusterNotConnected will be returned.
 	GetReader(ctx context.Context, cluster client.ObjectKey) (client.Reader, error)
 
+	// GetUncachedClient returns a live (uncached) client for the given cluster.
+	// If there is no connection to the workload cluster ErrClusterNotConnected will be returned.
+	GetUncachedClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error)
+
 	// GetRESTConfig returns a REST config for the given cluster.
 	// If there is no connection to the workload cluster ErrClusterNotConnected will be returned.
 	GetRESTConfig(ctx context.Context, cluster client.ObjectKey) (*rest.Config, error)
@@ -390,6 +394,16 @@ func (cc *clusterCache) GetReader(ctx context.Context, cluster client.ObjectKey)
 		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting client reader")
 	}
 	return accessor.GetReader(ctx)
+}
+
+// GetUncachedClient returns a live (uncached) client for the given cluster.
+// If there is no connection to the workload cluster ErrClusterNotConnected will be returned.
+func (cc *clusterCache) GetUncachedClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
+	accessor := cc.getClusterAccessor(cluster)
+	if accessor == nil {
+		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting uncached client")
+	}
+	return accessor.GetUncachedClient(ctx)
 }
 
 func (cc *clusterCache) GetRESTConfig(ctx context.Context, cluster client.ObjectKey) (*rest.Config, error) {

--- a/controllers/clustercache/cluster_cache_fake.go
+++ b/controllers/clustercache/cluster_cache_fake.go
@@ -32,8 +32,9 @@ func NewFakeClusterCache(workloadClient client.Client, clusterKey client.ObjectK
 	testCacheTracker.clusterAccessors[clusterKey] = &clusterAccessor{
 		lockedState: clusterAccessorLockedState{
 			connection: &clusterAccessorLockedConnectionState{
-				cachedClient: workloadClient,
-				watches:      sets.Set[string]{}.Insert(watchObjects...),
+				cachedClient:   workloadClient,
+				uncachedClient: workloadClient,
+				watches:        sets.Set[string]{}.Insert(watchObjects...),
 			},
 			healthChecking: clusterAccessorLockedHealthCheckingState{
 				lastProbeTime:        time.Now(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds GetUncachedClient method to the ClusterCache interface to support live (uncached) API calls to workload clusters. This helps reduce memory usage when you want to cache only a few types instead of having to exclude most types via DisableFor. 
The uncached client is created alongside the cached one during connection setup and follows the same lifecycle (connect/disconnect).
Note: This introduces a breaking change to any existing implementations that are directly using ClusterCache.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12784 

/area controllers
/area clustercache