### PR TITLE
:sparkles: Additional validation in Cluster/ClusterClass webhook for chained upgrades

### DIFF
--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -2703,7 +2703,6 @@ func TestClusterTopologyValidationForTopologyClassChange(t *testing.T) {
 				Build(),
 			wantErr: false,
 		},
-
 		{
 			name: "Reject cluster.topology.class change with an incompatible infrastructureCluster Kind ref change",
 			firstClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
@@ -2762,7 +2761,6 @@ func TestClusterTopologyValidationForTopologyClassChange(t *testing.T) {
 				Build(),
 			wantErr: false,
 		},
-
 		{
 			name: "Reject cluster.topology.class change with an incompatible controlPlane Kind ref change",
 			firstClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
@@ -3120,6 +3118,38 @@ func TestClusterTopologyValidationForTopologyClassChange(t *testing.T) {
 						WithBootstrapTemplate(refToUnstructured(ref)).
 						Build(),
 				).
+				Build(),
+			wantErr: true,
+		},
+
+		// Kubernetes Version changes.
+		{
+			name: "Accept cluster.topology.class change with a compatible Kubernetes Version",
+			firstClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithInfrastructureClusterTemplate(refToUnstructured(ref)).
+				WithControlPlaneTemplate(refToUnstructured(ref)).
+				WithControlPlaneInfrastructureMachineTemplate(refToUnstructured(ref)).
+				Build(),
+			secondClass: builder.ClusterClass(metav1.NamespaceDefault, "class2").
+				WithInfrastructureClusterTemplate(refToUnstructured(compatibleNameChangeRef)).
+				WithControlPlaneTemplate(refToUnstructured(ref)).
+				WithControlPlaneInfrastructureMachineTemplate(refToUnstructured(ref)).
+				WithVersions("v1.22.2", "v1.23.2").
+				Build(),
+			wantErr: false,
+		},
+		{
+			name: "Reject cluster.topology.class change with an incompatible Kubernetes Version",
+			firstClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithInfrastructureClusterTemplate(refToUnstructured(ref)).
+				WithControlPlaneTemplate(refToUnstructured(ref)).
+				WithControlPlaneInfrastructureMachineTemplate(refToUnstructured(ref)).
+				Build(),
+			secondClass: builder.ClusterClass(metav1.NamespaceDefault, "class2").
+				WithInfrastructureClusterTemplate(refToUnstructured(compatibleNameChangeRef)).
+				WithControlPlaneTemplate(refToUnstructured(ref)).
+				WithControlPlaneInfrastructureMachineTemplate(refToUnstructured(ref)).
+				WithVersions("v1.33.0", "v1.34.0").
 				Build(),
 			wantErr: true,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR will contain series of commits to add additional validation for Cluster/ClusterClass webhook for chained upgrades and associated UTs.

More info: https://github.com/kubernetes-sigs/cluster-api/issues/12720#issuecomment-3291878739

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/12720

/area clusterclass
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->