### PR TITLE
:seedling: Fix TestReconcileMachinePhases flake

### DIFF
--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2071,7 +2071,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		// Wait until BootstrapConfig has the ownerReference.
 		g.Eventually(func(g Gomega) bool {
@@ -2123,7 +2124,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		g.Expect(env.Create(ctx, bootstrapConfig)).To(Succeed())
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
@@ -2168,7 +2170,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		// Set the LastUpdated to be able to verify it is updated when the phase changes
 		modifiedMachine := machine.DeepCopy()
@@ -2240,7 +2242,9 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
@@ -2329,7 +2333,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
@@ -2407,7 +2412,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
@@ -2474,7 +2480,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		// Set bootstrap ready.
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
@@ -2546,7 +2553,8 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
 		// We have to subtract 2 seconds, because .status.lastUpdated does not contain milliseconds.
 		preUpdate := time.Now().Add(-2 * time.Second)
-		g.Expect(env.Create(ctx, machine)).To(Succeed())
+		// Create and wait on machine to make sure caches sync and reconciliation triggers.
+		g.Expect(env.CreateAndWait(ctx, machine)).To(Succeed())
 
 		// Set bootstrap ready.
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
@@ -2578,7 +2586,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		g.Expect(env.Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		// Delete Machine
-		g.Expect(env.Delete(ctx, machine)).To(Succeed())
+		g.Expect(env.DeleteAndWait(ctx, machine)).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Mitigates flaking test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

This adds CreateAndWait on machine creation in the TestReconcileMachinePhases envtests. Also adds a DeleteAndWait function for the test that runs the delete to check machine phase.