### PR TITLE
:seedling: TestReconcileMachinePhases: use apireader to directly talk to apiserver

### DIFF
--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2085,7 +2085,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until InfraMachine has the ownerReference.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
 				return false
 			}
 			g.Expect(infraMachine.GetOwnerReferences()).To(HaveLen(1))
@@ -2127,7 +2127,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhasePending))
@@ -2182,7 +2182,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
@@ -2270,7 +2270,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.Addresses).To(HaveLen(2))
@@ -2349,7 +2349,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2427,7 +2427,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2489,7 +2489,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
@@ -2582,7 +2582,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseDeleting))

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2085,7 +2085,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until InfraMachine has the ownerReference.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
 				return false
 			}
 			g.Expect(infraMachine.GetOwnerReferences()).To(HaveLen(1))
@@ -2127,7 +2127,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhasePending))
@@ -2182,7 +2182,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
@@ -2270,7 +2270,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.Addresses).To(HaveLen(2))
@@ -2349,7 +2349,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2427,7 +2427,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2489,7 +2489,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
@@ -2582,7 +2582,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectApiServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseDeleting))

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -565,10 +565,10 @@ func (e *Environment) PatchAndWait(ctx context.Context, obj client.Object, opts 
 	return nil
 }
 
-// DirectApiServerGet gets an object directly from apiserver bypassing informer caches..
+// DirectAPIServerGet gets an object directly from apiserver bypassing informer caches..
 //
 // NOTE: Bypassing cache helps in preventing test flakes due to the cache sync delays but should only be used in validation steps of testing.
-func (e *Environment) DirectApiServerGet(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (e *Environment) DirectAPIServerGet(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	return e.Manager.GetAPIReader().Get(ctx, key, obj, opts...)
 }
 

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -565,6 +565,13 @@ func (e *Environment) PatchAndWait(ctx context.Context, obj client.Object, opts 
 	return nil
 }
 
+// DirectApiServerGet gets an object directly from apiserver bypassing informer caches..
+//
+// NOTE: Bypassing cache helps in preventing test flakes due to the cache sync delays but should only be used in validation steps of testing.
+func (e *Environment) DirectApiServerGet(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return e.Manager.GetAPIReader().Get(ctx, key, obj, opts...)
+}
+
 // CreateNamespace creates a new namespace with a generated name.
 func (e *Environment) CreateNamespace(ctx context.Context, generateName string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: reduce flake in envtest test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

use APIReader with helper Get function. My comment in the issue explains what I'm thinking is going. For some of the flake you can see the logs reconcile so the status must be set to i.e. `Pending`. Instead the phase is empty and reads as `Unknown`. Completed reconciliations would set the status and the logs show those completing so the cache must be stale on the check where we `Get` the object and validate the status. This adds helper function and uses it for validation where it queries directly against apiserver.

Note: comments on APIReader say to use it sparingly. I would not suggest disabling cache in controller clients during testing however for validation of state after a test run is complete it should be safe to use and reduce flake.