### PR TITLE
 📖  add links to CAPI e2e deep dive sessions

### DIFF
--- a/docs/book/src/developer/getting-started.md
+++ b/docs/book/src/developer/getting-started.md
@@ -189,3 +189,10 @@ see [Let's chat about ...](https://github.com/kubernetes-sigs/cluster-api/discus
 * [Local CAPI development and debugging with Tilt (APAC/EMEA) - February 2022](https://www.youtube.com/watch?v=CM-dotO2nSU)
 * [Code structure & Makefile targets (EMEA/Americas) - February 2022](https://www.youtube.com/watch?v=_prbOnziCJw)
 * [Code structure & Makefile targets (APAC/EMEA) - February 2022](https://www.youtube.com/watch?v=Y6Gws65H1tE)
+
+**CAPI e2e Deep Dive***
+
+These are Deep-dive sessions with the CI team to investigate failing and flaking tests.
+
+* [CAPI e2e Deep Dive - 2023-05-11](https://www.youtube.com/watch?v=H6s2SWpTGtU)
+* [CAPI e2e Deep Dive - 2023-05-04](https://www.youtube.com/watch?v=YApWftmiDTg)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adds video links for the CAPI e2e deep dive sessions to the book, so they are easier to find.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation