### PR TITLE
:seedling: flake TestReconcileMachinePhases: add PatchStatusAndWait

### DIFF
--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2255,7 +2255,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, true, "status", "initialization", "dataSecretCreated")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, "secret-data", "status", "dataSecretName")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
 
 		// Set infra ready.
 		modifiedInfraMachine := infraMachine.DeepCopy()
@@ -2270,7 +2270,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				"address": "10.0.0.2",
 			},
 		}, "status", "addresses")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
@@ -2339,18 +2339,18 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedMachine := machine.DeepCopy()
 		// Set NodeRef.
 		machine.Status.NodeRef = clusterv1.MachineNodeReference{Name: node.Name}
-		g.Expect(env.Status().Patch(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedMachine, client.MergeFrom(machine))).To(Succeed())
 
 		// Set bootstrap ready.
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, true, "status", "initialization", "dataSecretCreated")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, "secret-data", "status", "dataSecretName")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
 
 		// Set infra ready.
 		modifiedInfraMachine := infraMachine.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedInfraMachine.Object, true, "status", "initialization", "provisioned")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
@@ -2424,12 +2424,12 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, true, "status", "initialization", "dataSecretCreated")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, "secret-data", "status", "dataSecretName")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
 
 		// Set infra ready.
 		modifiedInfraMachine := infraMachine.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedInfraMachine.Object, true, "status", "initialization", "provisioned")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
@@ -2487,12 +2487,12 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, true, "status", "initialization", "dataSecretCreated")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, "secret-data", "status", "dataSecretName")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
 
 		// Set infra ready.
 		modifiedInfraMachine := infraMachine.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedInfraMachine.Object, true, "status", "initialization", "provisioned")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
@@ -2560,12 +2560,12 @@ func TestReconcileMachinePhases(t *testing.T) {
 		modifiedBootstrapConfig := bootstrapConfig.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, true, "status", "initialization", "dataSecretCreated")).To(Succeed())
 		g.Expect(unstructured.SetNestedField(modifiedBootstrapConfig.Object, "secret-data", "status", "dataSecretName")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedBootstrapConfig, client.MergeFrom(bootstrapConfig))).To(Succeed())
 
 		// Set infra ready.
 		modifiedInfraMachine := infraMachine.DeepCopy()
 		g.Expect(unstructured.SetNestedField(modifiedInfraMachine.Object, true, "status", "initialization", "provisioned")).To(Succeed())
-		g.Expect(env.Status().Patch(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
+		g.Expect(env.PatchStatusAndWait(ctx, modifiedInfraMachine, client.MergeFrom(infraMachine))).To(Succeed())
 
 		// Wait until the Machine has the Machine finalizer
 		g.Eventually(func() []string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: helps reduce flake in TestReconcileMachinePhases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

You can see the test log Infrastructure provider has completed provisioning so we know it sees [this inframachine status patch](https://github.com/kubernetes-sigs/cluster-api/blob/cc29d495ff3a7f2f5598afda89746a2ab8e81507/internal/controllers/machine/machine_controller_status_test.go#L2262) but not [this next status patch](https://github.com/kubernetes-sigs/cluster-api/blob/cc29d495ff3a7f2f5598afda89746a2ab8e81507/internal/controllers/machine/machine_controller_status_test.go#L2263).

I'll add a PatchStatusAndWait function to go with the PatchAndWait function we already have and update these steps to use that to make sure the caches have the latest status of the infra machine.