### PR TITLE
🌱 Enable audit logs for envtest-based unit tests if ARTIFACTS env var is set

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -298,7 +298,7 @@ func newEnvironment(scheme *runtime.Scheme, additionalCRDDirectoryPaths []string
 
 	// if ARTIFACTS is setup, configure apiserver audit logs to log to ARTIFACTS dir
 	if os.Getenv("ARTIFACTS") != "" {
-		_, packageFileName, _, _ := goruntime.Caller(2) //nolint:dogsled
+		_, packageFileName, _, _ := goruntime.Caller(2)
 		relativePathPackageCallerFile, err := filepath.Rel(root, packageFileName)
 		if err != nil {
 			klog.Fatalf("unable to get relative path of calling package %+v", err)
@@ -448,7 +448,7 @@ rules:
       - resources: ["*"]
 `)
 
-	if err := os.WriteFile(policyFile, policyYAML, 0644); err != nil {
+	if err := os.WriteFile(policyFile, policyYAML, 0600); err != nil {
 		return "", err
 	}
 	return policyFile, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: 
Adds a flag to envtest input to enable apiserver audit logs to log to a file. This can be enabled per package to help debug test flake. Enabling it with this PR for machine package. Audit logs will log to ARTIFACTS dir.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->