### PR TITLE
🐛 Fix objects with Changed Resource Versions flake

### DIFF
--- a/test/framework/resourceversion_helpers.go
+++ b/test/framework/resourceversion_helpers.go
@@ -49,7 +49,7 @@ func ValidateResourceVersionStable(ctx context.Context, proxy ClusterProxy, name
 		}()
 		// This is intentionally failing on the first run.
 		g.Expect(objectsWithResourceVersion).To(BeComparableTo(previousResourceVersions))
-	}, 1*time.Minute, 15*time.Second).Should(Succeed(), "resourceVersions never became stable")
+	}, 2*time.Minute, 15*time.Second).MustPassRepeatedly(4).Should(Succeed(), "resourceVersions never became stable")
 
 	// Verify resourceVersions are stable for a while.
 	byf("Check resourceVersions remain stable")
@@ -57,7 +57,7 @@ func ValidateResourceVersionStable(ctx context.Context, proxy ClusterProxy, name
 		objectsWithResourceVersion, objects, err := getObjectsWithResourceVersion(ctx, proxy, namespace, ownerGraphFilterFunction)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(previousResourceVersions).To(BeComparableTo(objectsWithResourceVersion), printObjectDiff(previousObjects, objects))
-	}, 2*time.Minute, 15*time.Second).Should(Succeed(), "resourceVersions didn't stay stable")
+	}, 2*time.Minute, 5*time.Second).Should(Succeed(), "resourceVersions didn't stay stable")
 }
 
 func printObjectDiff(previousObjects, newObjects map[string]client.Object) func() string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fix objects with Changed Resource Versions e2e flake
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/12334

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->