### PR TITLE
:seedling: Add OpenAPI defaulting detection for KubeadmConfig by using forbiddenmarkers

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -82,12 +82,6 @@ linters:
       linters:
         - kubeapilinter
 
-    ## Apply forbiddenmarkers only to api/bootstrap/kubeadm
-    - path-except: "api/bootstrap/kubeadm/.*"
-      text: "forbiddenmarkers"
-      linters:
-        - kubeapilinter
-
     ## Excludes for old apiVersions that can be removed once the apiVersions are dropped (we don't want to make any changes to these APIs).
     - path: "api/addons/v1beta1|api/bootstrap/kubeadm/v1beta1|api/controlplane/kubeadm/v1beta1|api/core/v1beta1|api/ipam/v1beta1|api/ipam/v1alpha1|api/runtime/v1alpha1"
       linters:
@@ -165,6 +159,17 @@ linters:
     ## Today we have MinItems=1, but we might have to support MinItems=0 in the future if kubeadm starts supporting it.
     - path: "api/bootstrap/kubeadm/v1beta2/kubeadm_types.go"
       text: "optionalfields: field ExtraEnvs does not allow the zero value. The field does not need to be a pointer."
+      linters:
+        - kubeapilinter
+
+    # Excludes for existing default markers 
+    # We don't want to use OpenAPI defaulting anymore.
+    - path: "api/core/v1beta2/clusterclass_types.go"
+      text: 'forbiddenmarkers: field Reason has forbidden marker "kubebuilder:default=FieldValueInvalid"'
+      linters:
+        - kubeapilinter
+    - path: "api/core/v1beta2/clusterclass_types.go"
+      text: 'forbiddenmarkers: field Reason has forbidden marker "default=ref\(sigs.k8s.io/cluster-api/api/core/v1beta2.FieldValueInvalid\)"'
       linters:
         - kubeapilinter
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR introduces a new forbiddenmarkers linter check targeting the KubeadmConfigSpec struct and its nested fields. We've repeatedly encountered issues where adding new default values via OpenAPI markers (e.g., // +kubebuilder:default) leads to unintended KubeadmControlPlane (KCP) rollouts following a CAPI upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8147 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci