### PR TITLE
:book: Introduction to "Generating a Kubeconfig with your own CA"

### DIFF
--- a/docs/book/src/tasks/certs/generate-kubeconfig.md
+++ b/docs/book/src/tasks/certs/generate-kubeconfig.md
@@ -1,5 +1,8 @@
 ## Generating a Kubeconfig with your own CA
 
+This guide applies when you are [using custom certificates](using-custom-certificates.md) for a
+Cluster API workload cluster, rather than relying on automatically generated certificates.
+
 1. Create a new Certificate Signing Request (CSR) for the `admin` user with the `system:masters` Kubernetes role, or specify any other role under O.
 
    ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a short introduction to https://cluster-api.sigs.k8s.io/tasks/certs/generate-kubeconfig

