### PR TITLE
⚠️ Improve KAL config docs for forbidding OpenAPI defaulting

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -55,6 +55,8 @@ linters:
                 description: "A field with a default value cannot be required"
             forbiddenmarkers:
               markers:
+                # We don't want to do any defaulting (including OpenAPI) anymore on API fields because we prefer
+                # to have a clear signal on user intent. This also allows us to easily change the default behavior if necessary.
                 - identifier: "kubebuilder:default"
                 - identifier: "default"
             conditions:
@@ -163,7 +165,6 @@ linters:
         - kubeapilinter
 
     # Excludes for existing default markers 
-    # We don't want to use OpenAPI defaulting anymore.
     - path: "api/core/v1beta2/clusterclass_types.go"
       text: 'forbiddenmarkers: field Reason has forbidden marker "kubebuilder:default=FieldValueInvalid"'
       linters:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/12851

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->