### PR TITLE
:seedling: add clusterapi crd groups to audit logs for envtest

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -445,7 +445,13 @@ kind: Policy
 rules:
   - level: RequestResponse
     resources:
-      - resources: ["*"]
+      - group: ""
+      - group: "cluster.x-k8s.io"
+      - group: "infrastructure.cluster.x-k8s.io"
+      - group: "controlplane.cluster.x-k8s.io"
+      - group: "addons.cluster.x-k8s.io"
+      - group: "bootstrap.cluster.x-k8s.io"
+      - group: "runtime.cluster.x-k8s.io"
 `)
 
 	if err := os.WriteFile(policyFile, policyYAML, 0600); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:  adds clusterapi crd groups to audit logs for envtest so we can troubleshoot envteset flake easier. Follows up on https://github.com/kubernetes-sigs/cluster-api/pull/12847 by enabling the required groups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->