### PR TITLE
📖 book: fix v1.10 to v1.11 warning at the end

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
+++ b/docs/book/src/developer/providers/migrations/v1.10-to-v1.11.md
@@ -3051,6 +3051,8 @@ Following table should help to pick the right utils.
 | `status.v1beta2.conditions` of type `[]metav1.Conditions`             | `v1beta2conditions "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions/v1beta2"`   | `v1beta1patch "sigs.k8s.io/cluster-api/util/deprecated/v1beta1/patch"` |
 | `status.deprecated.v1beta1.conditions` of type `clusterv1.Conditions` | `deprecatedv1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"` | `"sigs.k8s.io/cluster-api/util/patch"`                                 |
 | `status.conditions` of type `[]metav1.Conditions`                     | `"sigs.k8s.io/cluster-api/util/conditions"`                                                | `"sigs.k8s.io/cluster-api/util/patch"`                                 |
-Important!
+
+**Important!**
+
 - Please pay special attention to use the correct patch helper import everywhere, because using a wrong
   one could in some cases lead to dropping conditions at runtime while not having compile errors.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Before: hidden in the table and not present

<img width="1793" height="472" alt="image" src="https://github.com/user-attachments/assets/19b1c95a-cd91-4882-b895-0383719d9e3a" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area book