### PR TITLE
:book: Update control-plane contract to mention the label cluster.x-k8s.io/control-plane

### DIFF
--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -420,7 +420,9 @@ policies when a Cluster derived from a ClusterClass is managed by the Topology c
 ### ControlPlane: machines
 
 In case you are developing a control plane provider which uses a Cluster API Machine object to represent each
-control plane instance, following fields MUST be implemented in
+control plane instance, the providers MUST set the `cluster.x-k8s.io/control-plane` label with an empty value on the created Machines.
+
+Additionally following the fields MUST be implemented in
 the ControlPlane `spec`.
 
 ```go


### PR DESCRIPTION
**What this PR does / why we need it**:

During the discussions [here](https://github.com/kubernetes-sigs/cluster-api/pull/12329#discussion_r2459328549) we found out this was missed to get added to the contract.

Some code relies on it though.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation