### PR TITLE
🌱 Add defensive response status checking in runtime client

### DIFF
--- a/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
@@ -227,6 +227,7 @@ func Test_canExtensionsUpdateMachine(t *testing.T) {
 	_ = unstructured.SetNestedField(desiredInfraMachine.Object, "in-place updated world", "spec", "hello")
 
 	responseWithEmptyPatches := &runtimehooksv1.CanUpdateMachineResponse{
+		CommonResponse: runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 		MachinePatch: runtimehooksv1.Patch{
 			PatchType: runtimehooksv1.JSONPatchType,
 			Patch:     []byte("[]"),
@@ -343,6 +344,7 @@ func Test_canExtensionsUpdateMachine(t *testing.T) {
 			extensionHandlers: []string{"test-update-extension"},
 			callExtensionResponses: map[string]runtimehooksv1.ResponseObject{
 				"test-update-extension": &runtimehooksv1.CanUpdateMachineResponse{
+					CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 					MachinePatch:               patchToUpdateMachine,
 					InfrastructureMachinePatch: patchToUpdateInfraMachine,
 					BootstrapConfigPatch:       patchToUpdateKubeadmConfig,
@@ -362,12 +364,15 @@ func Test_canExtensionsUpdateMachine(t *testing.T) {
 			extensionHandlers: []string{"test-update-extension-1", "test-update-extension-2", "test-update-extension-3"},
 			callExtensionResponses: map[string]runtimehooksv1.ResponseObject{
 				"test-update-extension-1": &runtimehooksv1.CanUpdateMachineResponse{
-					MachinePatch: patchToUpdateMachine,
+					CommonResponse: runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
+					MachinePatch:   patchToUpdateMachine,
 				},
 				"test-update-extension-2": &runtimehooksv1.CanUpdateMachineResponse{
+					CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 					InfrastructureMachinePatch: patchToUpdateInfraMachine,
 				},
 				"test-update-extension-3": &runtimehooksv1.CanUpdateMachineResponse{
+					CommonResponse:       runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 					BootstrapConfigPatch: patchToUpdateKubeadmConfig,
 				},
 			},
@@ -403,6 +408,7 @@ func Test_canExtensionsUpdateMachine(t *testing.T) {
 			extensionHandlers: []string{"test-update-extension"},
 			callExtensionResponses: map[string]runtimehooksv1.ResponseObject{
 				"test-update-extension": &runtimehooksv1.CanUpdateMachineResponse{
+					CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 					MachinePatch:               patchToUpdateMachine,
 					InfrastructureMachinePatch: emptyPatch,
 					BootstrapConfigPatch:       emptyPatch,
@@ -954,6 +960,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 	_ = unstructured.SetNestedField(patchedInfraMachine.Object, "in-place updated world", "spec", "hello")
 
 	responseWithEmptyPatches := &runtimehooksv1.CanUpdateMachineResponse{
+		CommonResponse: runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 		MachinePatch: runtimehooksv1.Patch{
 			PatchType: runtimehooksv1.JSONPatchType,
 			Patch:     []byte("[]"),
@@ -1040,6 +1047,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 				},
 			},
 			resp: &runtimehooksv1.CanUpdateMachineResponse{
+				CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 				MachinePatch:               patchToUpdateMachine,
 				InfrastructureMachinePatch: patchToUpdateInfraMachine,
 				BootstrapConfigPatch:       patchToUpdateKubeadmConfig,
@@ -1062,6 +1070,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 				},
 			},
 			resp: &runtimehooksv1.CanUpdateMachineResponse{
+				CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 				MachinePatch:               jsonMergePatchToUpdateMachine,
 				InfrastructureMachinePatch: jsonMergePatchToUpdateInfraMachine,
 				BootstrapConfigPatch:       jsonMergePatchToUpdateKubeadmConfig,
@@ -1084,6 +1093,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 				},
 			},
 			resp: &runtimehooksv1.CanUpdateMachineResponse{
+				CommonResponse:             runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 				MachinePatch:               patchToUpdateMachineStatus,
 				InfrastructureMachinePatch: patchToUpdateInfraMachineStatus,
 				BootstrapConfigPatch:       patchToUpdateKubeadmConfigStatus,
@@ -1106,6 +1116,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 				},
 			},
 			resp: &runtimehooksv1.CanUpdateMachineResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 				MachinePatch: runtimehooksv1.Patch{
 					// PatchType is missing
 					Patch: []byte(`[{"op":"add","path":"/status","value":{"observedGeneration": 10}}]`),
@@ -1124,6 +1135,7 @@ func Test_applyPatchesToRequest(t *testing.T) {
 				},
 			},
 			resp: &runtimehooksv1.CanUpdateMachineResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{Status: runtimehooksv1.ResponseStatusSuccess},
 				MachinePatch: runtimehooksv1.Patch{
 					PatchType: "UnknownType",
 					Patch:     []byte(`[{"op":"add","path":"/status","value":{"observedGeneration": 10}}]`),

--- a/internal/controllers/extensionconfig/extensionconfig_controller_test.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller_test.go
@@ -516,6 +516,9 @@ func discoveryHandler(handlerList ...string) func(http.ResponseWriter, *http.Req
 			Kind:       "DiscoveryResponse",
 			APIVersion: runtimehooksv1.GroupVersion.String(),
 		},
+		CommonResponse: runtimehooksv1.CommonResponse{
+			Status: runtimehooksv1.ResponseStatusSuccess,
+		},
 		Handlers: handlers,
 	}
 	respBody, err := json.Marshal(response)

--- a/internal/controllers/topology/cluster/patches/engine_test.go
+++ b/internal/controllers/topology/cluster/patches/engine_test.go
@@ -416,6 +416,9 @@ func TestApply(t *testing.T) {
 			},
 			externalPatchResponses: map[string]runtimehooksv1.ResponseObject{
 				"patch-infrastructureCluster": &runtimehooksv1.GeneratePatchesResponse{
+					CommonResponse: runtimehooksv1.CommonResponse{
+						Status: runtimehooksv1.ResponseStatusSuccess,
+					},
 					Items: []runtimehooksv1.GeneratePatchesResponseItem{
 						{
 							UID:       "1",
@@ -453,6 +456,9 @@ func TestApply(t *testing.T) {
 			},
 			externalPatchResponses: map[string]runtimehooksv1.ResponseObject{
 				"patch-infrastructureCluster": &runtimehooksv1.GeneratePatchesResponse{
+					CommonResponse: runtimehooksv1.CommonResponse{
+						Status: runtimehooksv1.ResponseStatusSuccess,
+					},
 					Items: []runtimehooksv1.GeneratePatchesResponseItem{
 						{
 							UID:       "1",
@@ -493,6 +499,9 @@ func TestApply(t *testing.T) {
 
 			externalPatchResponses: map[string]runtimehooksv1.ResponseObject{
 				"patch-infrastructureCluster": &runtimehooksv1.GeneratePatchesResponse{
+					CommonResponse: runtimehooksv1.CommonResponse{
+						Status: runtimehooksv1.ResponseStatusSuccess,
+					},
 					Items: []runtimehooksv1.GeneratePatchesResponseItem{
 						{
 							UID:       "1",
@@ -515,6 +524,9 @@ func TestApply(t *testing.T) {
 					},
 				},
 				"patch-controlPlane": &runtimehooksv1.GeneratePatchesResponse{
+					CommonResponse: runtimehooksv1.CommonResponse{
+						Status: runtimehooksv1.ResponseStatusSuccess,
+					},
 					Items: []runtimehooksv1.GeneratePatchesResponseItem{
 						{
 							UID:       "2",

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -761,6 +761,42 @@ func TestClient_CallExtension(t *testing.T) {
 			wantErr:            true,
 			wantResponseCached: false,
 		},
+		{
+			name:                       "should fail when calling ExtensionHandler with unknown response status and FailurePolicyFail",
+			registeredExtensionConfigs: []runtimev1.ExtensionConfig{validExtensionHandlerWithFailPolicy},
+			testServer: testServerConfig{
+				start: true,
+				responses: map[string]testServerResponse{
+					"/*": response(runtimehooksv1.ResponseStatus("Unknown")),
+				},
+			},
+			args: args{
+				hook:     fakev1alpha1.FakeHook,
+				name:     "valid-extension",
+				request:  &fakev1alpha1.FakeRequest{},
+				response: &fakev1alpha1.FakeResponse{},
+			},
+			wantErr:            true,
+			wantResponseCached: false,
+		},
+		{
+			name:                       "should fail when calling ExtensionHandler with unknown response status and FailurePolicyIgnore",
+			registeredExtensionConfigs: []runtimev1.ExtensionConfig{validExtensionHandlerWithIgnorePolicy},
+			testServer: testServerConfig{
+				start: true,
+				responses: map[string]testServerResponse{
+					"/*": response(runtimehooksv1.ResponseStatus("Unknown")),
+				},
+			},
+			args: args{
+				hook:     fakev1alpha1.FakeHook,
+				name:     "valid-extension",
+				request:  &fakev1alpha1.FakeRequest{},
+				response: &fakev1alpha1.FakeResponse{},
+			},
+			wantErr:            true,
+			wantResponseCached: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/runtime/client/fake/fake_client.go
+++ b/internal/runtime/client/fake/fake_client.go
@@ -154,8 +154,11 @@ func (fc *RuntimeClient) CallAllExtensions(ctx context.Context, hook runtimecata
 		panic("cannot update response")
 	}
 
-	if response.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-		return errors.Errorf("runtime hook %q failed", gvh)
+	if response.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
+		if response.GetStatus() == runtimehooksv1.ResponseStatusFailure {
+			return errors.Errorf("runtime hook %q failed", gvh)
+		}
+		return errors.Errorf("runtime hook %q got unknown response status %q", gvh, response.GetStatus())
 	}
 	return nil
 }
@@ -179,9 +182,12 @@ func (fc *RuntimeClient) CallExtension(ctx context.Context, _ runtimecatalog.Hoo
 		panic("cannot update response")
 	}
 
-	// If the received response is a failure then return an error.
-	if response.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-		return errors.Errorf("ExtensionHandler %s failed with message %s", name, response.GetMessage())
+	// If the received response is not a success then return an error.
+	if response.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
+		if response.GetStatus() == runtimehooksv1.ResponseStatusFailure {
+			return errors.Errorf("ExtensionHandler %s failed with message %s", name, response.GetMessage())
+		}
+		return errors.Errorf("ExtensionHandler %s got unknown response status %q", name, response.GetStatus())
 	}
 	return nil
 }

--- a/test/extension/handlers/topologymutation/handler_integration_test.go
+++ b/test/extension/handlers/topologymutation/handler_integration_test.go
@@ -437,8 +437,11 @@ func (i injectRuntimeClient) CallExtension(ctx context.Context, hook runtimecata
 			return err
 		}
 		i.runtimeExtension.DiscoverVariables(ctx, reqCopy, resp.(*runtimehooksv1.DiscoverVariablesResponse))
-		if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-			return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+		if resp.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
+			if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
+				return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+			}
+			return errors.Errorf("failed to call extension handler: got unknown response status %q", resp.GetStatus())
 		}
 		return nil
 	case runtimecatalog.HookName(runtimehooksv1.GeneratePatches):
@@ -447,8 +450,11 @@ func (i injectRuntimeClient) CallExtension(ctx context.Context, hook runtimecata
 			return err
 		}
 		i.runtimeExtension.GeneratePatches(ctx, reqCopy, resp.(*runtimehooksv1.GeneratePatchesResponse))
-		if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-			return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+		if resp.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
+			if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
+				return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+			}
+			return errors.Errorf("failed to call extension handler: got unknown response status %q", resp.GetStatus())
 		}
 		return nil
 	case runtimecatalog.HookName(runtimehooksv1.ValidateTopology):
@@ -457,8 +463,11 @@ func (i injectRuntimeClient) CallExtension(ctx context.Context, hook runtimecata
 			return err
 		}
 		i.runtimeExtension.ValidateTopology(ctx, reqCopy, resp.(*runtimehooksv1.ValidateTopologyResponse))
-		if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-			return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+		if resp.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
+			if resp.GetStatus() == runtimehooksv1.ResponseStatusFailure {
+				return errors.Errorf("failed to call extension handler: got failure response: %v", resp.GetMessage())
+			}
+			return errors.Errorf("failed to call extension handler: got unknown response status %q", resp.GetStatus())
 		}
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds defensive response status checking to the runtime client to validate that extension handler responses properly have a `Success` status, rather than just checking they don't have a `Failure` status.

Currently, the runtime client checks if `response.GetStatus() == ResponseStatusFailure`, which means any other value (including empty string, nil, or invalid values) would be treated as success.


### Example Error Messages

**Before**: Unknown status would be silently accepted as success

**After**:
- Known failure: `"failed to call extension: ExtensionHandler X got failure response ..."`
- Unknown status: `"failed to call extension: ExtensionHandler X got unknown response status \"foo\""`

/area runtime-sdk

Part of https://github.com/kubernetes-sigs/cluster-api/issues/12291