### PR TITLE
🌱 Simplify rollout planner

### DIFF
--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 12 replicas, maxsurge 3, maxunavailable 1, scale down to 6, random(0).test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 12 replicas, maxsurge 3, maxunavailable 1, scale down to 6, random(0).test.log.golden
@@ -18,20 +18,19 @@
   - ms2, 3/3 replicas (m1,m2,m3 <= ms1)
 [Toleration] tolerate maxSurge breach
 [MS controller] Iteration 2, Reconcile ms1, 9/2 replicas (m4,m5,m6,m7,m8,m9,m10,m11,m12 => ms2)
-[MS controller] - Move capped to 3 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 6/2 replicas (m4,m5,m6 moved to ms2)
-[MS controller] - ms1 scale down to 2/2 replicas (m7,m8,m9,m10 deleted)
+[MS controller] - ms1 scale down to 2/2 replicas (m4,m5,m6,m7,m8,m9,m10 moved to ms2)
 [MS controller] Iteration 2, Reconcile ms1, 2/2 replicas (m11,m12 => ms2)
 [MD controller] Iteration 3, Reconcile md
 [MD controller] - Input to rollout planner
   md, 12/6 replicas
   - ms1, 2/2 replicas (m11,m12 => ms2)
-  - ms2, 3/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡 <= ms1)
+  - ms2, 3/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡,m7🟠🟡,m8🟠🟡,m9🟠🟡,m10🟠🟡 <= ms1)
 [MD controller] - Result of rollout planner
   md, 5/6 replicas
   - ms1, 2/2 replicas (m11,m12 => ms2)
-  - ms2, 3/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡 <= ms1)
-[MS controller] Iteration 3, Reconcile ms2, 3/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡 <= ms1)
+  - ms2, 3/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡,m7🟡,m8🟡,m9🟡,m10🟡 <= ms1)
+[MS controller] Iteration 3, Reconcile ms2, 3/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡,m7🟡,m8🟡,m9🟡,m10🟡 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m10,m9,m8,m7 deleted)
 [MD controller] Iteration 4, Reconcile md
 [MD controller] - Input to rollout planner
   md, 5/6 replicas
@@ -75,12 +74,24 @@
   - ms1, 2/0 replicas (m11,m12 => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
 [MS controller] Iteration 8, Reconcile ms1, 2/0 replicas (m11,m12 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 2/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m11,m12 deleted)
-[MS controller] Iteration 9, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
+[MS controller] - ms1 scale down to 0/0 replicas (m11,m12 moved to ms2)
+[MS controller] Iteration 9, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6,m11🟠🟡,m12🟠🟡 <= ms1)
+[MS controller] - Replicas m11,m12 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MS controller] Iteration 9, Reconcile ms1, 0/0 replicas ( => ms2)
 [MD controller] Iteration 9, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 8/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟠🟡,m12🟠🟡 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 8/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟡,m12🟡 <= ms1)
+[MS controller] Iteration 10, Reconcile ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟡,m12🟡 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m12,m11 deleted)
+[MS controller] Iteration 10, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 11, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
+[MD controller] Iteration 11, Reconcile md
 [MD controller] - Input to rollout planner
   md, 8/6 replicas
   - ms1, 0/0 replicas ( => ms2)

--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 12 replicas, maxsurge 3, maxunavailable 1, scale down to 6.test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 12 replicas, maxsurge 3, maxunavailable 1, scale down to 6.test.log.golden
@@ -16,25 +16,25 @@
   - ms2, 3/3 replicas (m1,m2,m3 <= ms1)
 [Toleration] tolerate maxSurge breach
 [MS controller] Iteration 1, Reconcile ms1, 9/2 replicas (m4,m5,m6,m7,m8,m9,m10,m11,m12 => ms2)
-[MS controller] - Move capped to 3 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 6/2 replicas (m4,m5,m6 moved to ms2)
-[MS controller] - ms1 scale down to 2/2 replicas (m7,m8,m9,m10 deleted)
-[MS controller] Iteration 1, Reconcile ms2, 3/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡 <= ms1)
-[MS controller] - Replicas m4,m5,m6 moved from an old MachineSet still pending acknowledge from machine deployment md
+[MS controller] - ms1 scale down to 2/2 replicas (m4,m5,m6,m7,m8,m9,m10 moved to ms2)
+[MS controller] Iteration 1, Reconcile ms2, 3/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡,m7🟠🟡,m8🟠🟡,m9🟠🟡,m10🟠🟡 <= ms1)
+[MS controller] - Replicas m10,m4,m5,m6,m7,m8,m9 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MD controller] Iteration 2, Reconcile md
 [MD controller] - Input to rollout planner
   md, 12/6 replicas
   - ms1, 2/2 replicas (m11,m12 => ms2)
-  - ms2, 6/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡 <= ms1)
+  - ms2, 10/3 replicas (m1,m2,m3,m4🟠🟡,m5🟠🟡,m6🟠🟡,m7🟠🟡,m8🟠🟡,m9🟠🟡,m10🟠🟡 <= ms1)
 [MD controller] - Result of rollout planner
-  md, 8/6 replicas
+  md, 12/6 replicas
   - ms1, 2/2 replicas (m11,m12 => ms2)
-  - ms2, 6/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡 <= ms1)
+  - ms2, 10/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡,m7🟡,m8🟡,m9🟡,m10🟡 <= ms1)
+[Toleration] tolerate maxSurge breach
 [MS controller] Iteration 2, Reconcile ms1, 2/2 replicas (m11,m12 => ms2)
-[MS controller] Iteration 2, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡 <= ms1)
+[MS controller] Iteration 2, Reconcile ms2, 10/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡,m7🟡,m8🟡,m9🟡,m10🟡 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m10,m9,m8,m7 deleted)
 [MD controller] Iteration 3, Reconcile md
 [MD controller] - Input to rollout planner
-  md, 8/6 replicas
+  md, 12/6 replicas
   - ms1, 2/2 replicas (m11,m12 => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4🟡,m5🟡,m6🟡 <= ms1)
 [MD controller] - Result of rollout planner
@@ -54,11 +54,22 @@
   - ms1, 2/0 replicas (m11,m12 => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
 [MS controller] Iteration 4, Reconcile ms1, 2/0 replicas (m11,m12 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 2/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m11,m12 deleted)
-[MS controller] Iteration 4, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
+[MS controller] - ms1 scale down to 0/0 replicas (m11,m12 moved to ms2)
+[MS controller] Iteration 4, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6,m11🟠🟡,m12🟠🟡 <= ms1)
+[MS controller] - Replicas m11,m12 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MD controller] Iteration 5, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 8/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟠🟡,m12🟠🟡 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 8/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟡,m12🟡 <= ms1)
+[MS controller] Iteration 5, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 5, Reconcile ms2, 8/6 replicas (m1,m2,m3,m4,m5,m6,m11🟡,m12🟡 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m12,m11 deleted)
+[MD controller] Iteration 6, Reconcile md
 [MD controller] - Input to rollout planner
   md, 8/6 replicas
   - ms1, 0/0 replicas ( => ms2)
@@ -67,8 +78,8 @@
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
-[MS controller] Iteration 5, Reconcile ms1, 0/0 replicas ( => ms2)
-[MS controller] Iteration 5, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
+[MS controller] Iteration 6, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 6, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6 <= ms1)
 [Test] Final state
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)

--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 3 replicas, maxsurge 1, maxunavailable 0, random(0).test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 3 replicas, maxsurge 1, maxunavailable 0, random(0).test.log.golden
@@ -128,18 +128,28 @@
 [MS controller] Iteration 16, Reconcile ms2, 3/3 replicas (m1,m2,m4 <= ms1)
 [MS controller] Iteration 16, Reconcile ms2, 3/3 replicas (m1,m2,m4 <= ms1)
 [MS controller] Iteration 16, Reconcile ms1, 1/0 replicas (m3 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 1/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m3 deleted)
+[MS controller] - ms1 scale down to 0/0 replicas (m3 moved to ms2)
 [MD controller] Iteration 16, Reconcile md
 [MD controller] - Input to rollout planner
   md, 4/3 replicas
   - ms1, 0/0 replicas ( => ms2)
-  - ms2, 3/3 replicas (m1,m2,m4 <= ms1)
+  - ms2, 3/3 replicas (m1,m2,m3🟠🟡,m4 <= ms1)
 [MD controller] - Result of rollout planner
   md, 3/3 replicas
   - ms1, 0/0 replicas ( => ms2)
-  - ms2, 3/3 replicas (m1,m2,m4 <= ms1)
+  - ms2, 3/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MD controller] Iteration 17, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 3/3 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 3/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 3/3 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 3/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MS controller] Iteration 17, Reconcile ms2, 3/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MS controller] - ms2 scale down to 3/3 replicas (m3 deleted)
+[MS controller] Iteration 17, Reconcile ms1, 0/0 replicas ( => ms2)
 [Test] Final state
   md, 3/3 replicas
   - ms1, 0/0 replicas ( => ms2)

--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 3 replicas, maxsurge 1, maxunavailable 0.test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 3 replicas, maxsurge 1, maxunavailable 0.test.log.golden
@@ -97,11 +97,22 @@
   - ms1, 1/0 replicas (m3 => ms2)
   - ms2, 3/3 replicas (m1,m2,m4 <= ms1)
 [MS controller] Iteration 8, Reconcile ms1, 1/0 replicas (m3 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 1/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m3 deleted)
-[MS controller] Iteration 8, Reconcile ms2, 3/3 replicas (m1,m2,m4 <= ms1)
+[MS controller] - ms1 scale down to 0/0 replicas (m3 moved to ms2)
+[MS controller] Iteration 8, Reconcile ms2, 3/3 replicas (m1,m2,m3🟠🟡,m4 <= ms1)
+[MS controller] - Replicas m3 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MD controller] Iteration 9, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 4/3 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 4/3 replicas (m1,m2,m3🟠🟡,m4 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 4/3 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 4/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MS controller] Iteration 9, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 9, Reconcile ms2, 4/3 replicas (m1,m2,m3🟡,m4 <= ms1)
+[MS controller] - ms2 scale down to 3/3 replicas (m3 deleted)
+[MD controller] Iteration 10, Reconcile md
 [MD controller] - Input to rollout planner
   md, 4/3 replicas
   - ms1, 0/0 replicas ( => ms2)
@@ -110,8 +121,8 @@
   md, 3/3 replicas
   - ms1, 0/0 replicas ( => ms2)
   - ms2, 3/3 replicas (m1,m2,m4 <= ms1)
-[MS controller] Iteration 9, Reconcile ms1, 0/0 replicas ( => ms2)
-[MS controller] Iteration 9, Reconcile ms2, 3/3 replicas (m1,m2,m4 <= ms1)
+[MS controller] Iteration 10, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 10, Reconcile ms2, 3/3 replicas (m1,m2,m4 <= ms1)
 [Test] Final state
   md, 3/3 replicas
   - ms1, 0/0 replicas ( => ms2)

--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 6 replicas, maxsurge 10, maxunavailable 0, random(0).test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 6 replicas, maxsurge 10, maxunavailable 0, random(0).test.log.golden
@@ -246,11 +246,42 @@
   - ms1, 1/0 replicas (m6 => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
 [MS controller] Iteration 27, Reconcile ms1, 1/0 replicas (m6 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 1/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m6 deleted)
-[MS controller] Iteration 27, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
+[MS controller] - ms1 scale down to 0/0 replicas (m6 moved to ms2)
+[MS controller] Iteration 27, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6🟠🟡,m7 <= ms1)
+[MS controller] - Replicas m6 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MD controller] Iteration 27, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟠🟡,m7 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MD controller] Iteration 28, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MS controller] Iteration 28, Reconcile ms1, 0/0 replicas ( => ms2)
+[MD controller] Iteration 29, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MS controller] Iteration 29, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 30, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 30, Reconcile ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m6 deleted)
+[MD controller] Iteration 31, Reconcile md
 [MD controller] - Input to rollout planner
   md, 7/6 replicas
   - ms1, 0/0 replicas ( => ms2)
@@ -259,6 +290,8 @@
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
+[MS controller] Iteration 31, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
+[MS controller] Iteration 31, Reconcile ms1, 0/0 replicas ( => ms2)
 [Test] Final state
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)

--- a/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 6 replicas, maxsurge 10, maxunavailable 0.test.log.golden
+++ b/internal/controllers/machinedeployment/testdata/rollingupdate/in-place rollout, 6 replicas, maxsurge 10, maxunavailable 0.test.log.golden
@@ -205,11 +205,22 @@
   - ms1, 1/0 replicas (m6 => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
 [MS controller] Iteration 17, Reconcile ms1, 1/0 replicas (m6 => ms2)
-[MS controller] - Move capped to 0 replicas to avoid unnecessary in-place upgrades
-[MS controller] - ms1 scale down to 1/0 replicas ( moved to ms2)
-[MS controller] - ms1 scale down to 0/0 replicas (m6 deleted)
-[MS controller] Iteration 17, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
+[MS controller] - ms1 scale down to 0/0 replicas (m6 moved to ms2)
+[MS controller] Iteration 17, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m6🟠🟡,m7 <= ms1)
+[MS controller] - Replicas m6 moved from an old MachineSet still pending acknowledge from machine deployment md
 [MD controller] Iteration 18, Reconcile md
+[MD controller] - Input to rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟠🟡,m7 <= ms1)
+[MD controller] - Result of rollout planner
+  md, 7/6 replicas
+  - ms1, 0/0 replicas ( => ms2)
+  - ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MS controller] Iteration 18, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 18, Reconcile ms2, 7/6 replicas (m1,m2,m3,m4,m5,m6🟡,m7 <= ms1)
+[MS controller] - ms2 scale down to 6/6 replicas (m6 deleted)
+[MD controller] Iteration 19, Reconcile md
 [MD controller] - Input to rollout planner
   md, 7/6 replicas
   - ms1, 0/0 replicas ( => ms2)
@@ -218,8 +229,8 @@
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)
   - ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
-[MS controller] Iteration 18, Reconcile ms1, 0/0 replicas ( => ms2)
-[MS controller] Iteration 18, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
+[MS controller] Iteration 19, Reconcile ms1, 0/0 replicas ( => ms2)
+[MS controller] Iteration 19, Reconcile ms2, 6/6 replicas (m1,m2,m3,m4,m5,m7 <= ms1)
 [Test] Final state
   md, 6/6 replicas
   - ms1, 0/0 replicas ( => ms2)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simplifies fake ms controller in the rollout planner, to get rid of unnecessary code and to change an assumption that would have been racy when implementing the same in the prod code for the ms controller.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/12291

/area machinedeployment