### PR TITLE
🌱 e2e: fix self-hosted to actually read DOCKER_PRELOAD_IMAGES from the e2e config

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -161,7 +161,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// controller images into the nodes.
 		if hasDockerInfrastructureProvider {
 			images := []string{}
-			if preloadList := strings.TrimSuffix(strings.TrimPrefix(clusterctlVariables["DOCKER_PRELOAD_IMAGES"], "["), "]"); preloadList != "" {
+			if preloadList := strings.TrimSuffix(strings.TrimPrefix(input.E2EConfig.GetVariableOrEmpty("DOCKER_PRELOAD_IMAGES"), "["), "]"); preloadList != "" {
 				images = strings.Split(preloadList, ",")
 			}
 			for _, image := range input.E2EConfig.Images {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This should stabilize self-hosted e2e tests regarding pulling kindnet.

Finding was in https://github.com/kubernetes-sigs/cluster-api/issues/12886#issuecomment-3460807822

Kindnet took >10m to pull.

Turns out we did fail to properly use DOCKER_PRELOAD_IMAGES in the self-hosted tests, which did result in not preloading kindnet and thus slowly pulling it from docker hub.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing