### PR TITLE
📖 Document e2e test timeout changes in v1.11-to-v1.12 migration doc

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.11-to-v1.12.md
+++ b/docs/book/src/developer/providers/migrations/v1.11-to-v1.12.md
@@ -28,6 +28,13 @@ maintainers of providers and consumers of our Go API.
 
 * `util.IsOwnedByObject`, `util.IsControlledBy` and `collections.OwnedMachines` now also require `schema.GroupKind` as input parameter.
   `schema.GroupKind` is needed for cases where typed objects are passed in because controller-runtime does not guarantee that GVK is set on typed objects.
+* Various Cluster API e2e tests with Kubernetes upgrades now use the `wait-control-plane-upgrade` and `wait-machine-deployment-upgrade` timeouts.
+  If you are running Cluster API e2e tests with upgrades you have to configure the timeouts in your e2e test configuration file, otherwise 
+  the e2e tests will use `1s` timeout which will lead to test failures. Example: 
+  ```yaml
+  default/wait-control-plane-upgrade: ["15m", "10s"]
+  default/wait-machine-deployment-upgrade: ["10m", "10s"]
+  ```
 
 ### Suggested changes for providers
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Noticed when bumping CAPI in CAPV: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3656

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->