### PR TITLE
🌱 add DisableCertPrivateKey function for clustercache for test flake

### DIFF
--- a/controllers/clustercache/cluster_accessor.go
+++ b/controllers/clustercache/cluster_accessor.go
@@ -82,6 +82,10 @@ type clusterAccessorConfig struct {
 	// connection after creating a connection failed.
 	ConnectionCreationRetryInterval time.Duration
 
+	// DisableClientCertificatePrivateKey is the flag to disable the creation of the client
+	// certificate private key.
+	DisableClientCertificatePrivateKey bool
+
 	// Cache is the config used for the cache that the clusterAccessor creates.
 	Cache *clusterAccessorCacheConfig
 
@@ -284,7 +288,7 @@ func (ca *clusterAccessor) Connect(ctx context.Context) (retErr error) {
 	// Only generate the clientCertificatePrivateKey once as there is no need to regenerate it after disconnect/connect.
 	// Note: This has to be done before setting connection, because otherwise this code wouldn't be re-entrant if the
 	// private key generation fails because we check Connected above.
-	if ca.lockedState.clientCertificatePrivateKey == nil {
+	if ca.lockedState.clientCertificatePrivateKey == nil && !ca.config.DisableClientCertificatePrivateKey {
 		log.V(6).Info("Generating client certificate private key")
 		clientCertificatePrivateKey, err := certs.NewPrivateKey()
 		if err != nil {

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -698,6 +698,12 @@ func (cc *clusterCache) SetConnectionCreationRetryInterval(interval time.Duratio
 	cc.clusterAccessorConfig.ConnectionCreationRetryInterval = interval
 }
 
+// DisablePrivateKeyGeneration can be used to disable the creation of cluster cert private key on clusteraccessor.
+// This method should only be used for tests and is not part of the public ClusterCache interface.
+func (cc *clusterCache) DisablePrivateKeyGeneration() {
+	cc.clusterAccessorConfig.DisableClientCertificatePrivateKey = true
+}
+
 // Shutdown can be used to shut down the ClusterCache in unit tests.
 // This method should only be used for tests because it hasn't been designed for production usage
 // in a manager (race conditions with manager shutdown etc.).

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -96,6 +96,8 @@ func TestMain(m *testing.M) {
 		clusterCache.(interface{ SetConnectionCreationRetryInterval(time.Duration) }).
 			SetConnectionCreationRetryInterval(2 * time.Second)
 
+		clusterCache.(interface{ DisablePrivateKeyGeneration() }).DisablePrivateKeyGeneration()
+
 		if err := (&Reconciler{
 			Client:                           mgr.GetClient(),
 			APIReader:                        mgr.GetAPIReader(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Disables private key generation until the function is removed to fix flake when mutex locks and privatekey generation takes a long time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/12785 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->