### PR TITLE
🌱 CAPD: recreate container if we re-enter reconciliation and it exists but is not running

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -192,6 +192,14 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		role = constants.ControlPlaneNodeRoleValue
 	}
 
+	// If re-entering the reconcile loop and reaching this point, the container is expected to be running. If it is not, delete it so we can try to create it again.
+	if externalMachine.Exists() && !externalMachine.IsRunning() {
+		// This deletes the machine and results in re-creating it below.
+		if err := externalMachine.Delete(ctx); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "Failed to delete not running DockerMachine")
+		}
+	}
+
 	// Create the machine if not existing yet
 	if !externalMachine.Exists() {
 		// NOTE: FailureDomains don't mean much in CAPD since it's all local, but we are setting a label on

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -158,6 +158,15 @@ func (m *Machine) Exists() bool {
 	return m.container != nil
 }
 
+// IsRunning returns true if the container for this machine is running.
+func (m *Machine) IsRunning() bool {
+	if !m.Exists() {
+		return false
+	}
+
+	return m.container.IsRunning()
+}
+
 // Name returns the name of the machine.
 func (m *Machine) Name() string {
 	return m.machine
@@ -540,6 +549,8 @@ func (m *Machine) Delete(ctx context.Context) error {
 		if err := m.container.Delete(ctx); err != nil {
 			return err
 		}
+
+		m.container = nil
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixes a race condition in CAPD, when CAPD gets interrupted (e.g. via loosing leader election) right after a container was created but container was not started yet.

Related to:
- #12886

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Area example:
/area provider/infrastructure-docker