### PR TITLE
✨ Implement e2e test for in-place updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -615,6 +615,7 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-ipv6 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-ipv6.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-in-place --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-in-place.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only.yaml

--- a/exp/topology/desiredstate/lifecycle_hooks.go
+++ b/exp/topology/desiredstate/lifecycle_hooks.go
@@ -174,7 +174,7 @@ func (g *generator) callAfterControlPlaneUpgradeHook(ctx context.Context, s *sco
 		s.HookResponseTracker.Add(runtimehooksv1.AfterControlPlaneUpgrade, hookResponse)
 
 		if hookResponse.RetryAfterSeconds != 0 {
-			log.Info(fmt.Sprintf("Cluster Upgrade is blocked after control plane upgrade to version %s by %s hook", *currentVersion, runtimecatalog.HookName(runtimehooksv1.AfterControlPlaneUpgrade)),
+			log.Info(fmt.Sprintf("Cluster upgrade is blocked after control plane upgrade to version %s by %s hook", *currentVersion, runtimecatalog.HookName(runtimehooksv1.AfterControlPlaneUpgrade)),
 				"ControlPlaneUpgrades", hookRequest.ControlPlaneUpgrades,
 				"WorkersUpgrades", hookRequest.WorkersUpgrades,
 			)

--- a/test/e2e/cluster_in_place_update.go
+++ b/test/e2e/cluster_in_place_update.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// ClusterInPlaceUpdateSpecInput is the input for ClusterInPlaceUpdateSpec.
+type ClusterInPlaceUpdateSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+
+	// InfrastructureProvider allows to specify the infrastructure provider to be used when looking for
+	// cluster templates.
+	// If not set, clusterctl will look at the infrastructure provider installed in the management cluster;
+	// if only one infrastructure provider exists, it will be used, otherwise the operation will fail if more than one exists.
+	InfrastructureProvider *string
+
+	// Flavor, if specified is the template flavor used to create the cluster for testing.
+	// If not specified, the default flavor for the selected infrastructure provider is used.
+	Flavor *string
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	WorkerMachineCount *int64
+
+	// ExtensionConfigName is the name of the ExtensionConfig. Defaults to "in-place-update".
+	// This value is provided to clusterctl as "EXTENSION_CONFIG_NAME" variable and can be used to template the
+	// name of the ExtensionConfig into the ClusterClass.
+	ExtensionConfigName string
+
+	// ExtensionServiceNamespace is the namespace where the service for the Runtime Extension is located.
+	// Note: This should only be set if a Runtime Extension is used.
+	ExtensionServiceNamespace string
+
+	// ExtensionServiceNamespace is the name where the service for the Runtime Extension is located.
+	// Note: This should only be set if a Runtime Extension is used.
+	ExtensionServiceName string
+
+	// Allows to inject a function to be run after test namespace is created.
+	// If not specified, this is a no-op.
+	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+
+	// ClusterctlVariables allows injecting variables to the cluster template.
+	// If not specified, this is a no-op.
+	ClusterctlVariables map[string]string
+}
+
+// ClusterInPlaceUpdateSpec implements a test for in-place updates.
+// Note: This test works with KCP as it tests the KCP in-place update feature.
+func ClusterInPlaceUpdateSpec(ctx context.Context, inputGetter func() ClusterInPlaceUpdateSpecInput) {
+	var (
+		specName         = "in-place-update"
+		input            ClusterInPlaceUpdateSpecInput
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			if input.ExtensionConfigName == "" {
+				input.ExtensionConfigName = specName
+			}
+		}
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)
+
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should create a workload cluster", func() {
+		By("Creating a workload cluster")
+
+		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
+		if input.InfrastructureProvider != nil {
+			infrastructureProvider = *input.InfrastructureProvider
+		}
+
+		flavor := clusterctl.DefaultFlavor
+		if input.Flavor != nil {
+			flavor = *input.Flavor
+		}
+
+		workerMachineCount := ptr.To[int64](1)
+		if input.WorkerMachineCount != nil {
+			workerMachineCount = input.WorkerMachineCount
+		}
+
+		clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			// NOTE: test extension is already deployed in the management cluster. If for any reason in future we want
+			// to make this test more self-contained this test should be modified in order to create an additional
+			// management cluster; also the E2E test configuration should be modified introducing something like
+			// optional:true allowing to define which providers should not be installed by default in
+			// a management cluster.
+			By("Deploy Test Extension ExtensionConfig")
+
+			// In this test we are defaulting all handlers to non-blocking because we don't expect the handlers to block the
+			// cluster lifecycle by default. Setting defaultAllHandlersToBlocking to false enforces that the test-extension
+			// automatically creates the ConfigMap with non-blocking preloaded responses.
+			defaultAllHandlersToBlocking := false
+			// select on the current namespace
+			// This is necessary so in CI this test doesn't influence other tests by enabling lifecycle hooks
+			// in other test namespaces.
+			namespaces := []string{namespace.Name}
+			extensionConfig := extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, defaultAllHandlersToBlocking, namespaces...)
+			Expect(input.BootstrapClusterProxy.GetClient().Create(ctx,
+				extensionConfig)).
+				To(Succeed(), "Failed to create the ExtensionConfig")
+		}
+
+		variables := map[string]string{
+			// This is used to template the name of the ExtensionConfig into the ClusterClass.
+			"EXTENSION_CONFIG_NAME": input.ExtensionConfigName,
+		}
+		maps.Copy(variables, input.ClusterctlVariables)
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:              filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:   input.ClusterctlConfigPath,
+				ClusterctlVariables:    variables,
+				KubeconfigPath:         input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider: infrastructureProvider,
+				Flavor:                 flavor,
+				Namespace:              namespace.Name,
+				ClusterName:            clusterName,
+				KubernetesVersion:      input.E2EConfig.MustGetVariable(KubernetesVersion),
+				// ControlPlaneMachineCount is not configurable because it has to be 3 because we want
+				// to use scale-in to test in-place updates without any Machine re-creations.
+				ControlPlaneMachineCount: ptr.To[int64](3),
+				WorkerMachineCount:       workerMachineCount,
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		cluster := clusterResources.Cluster
+		mgmtClient := input.BootstrapClusterProxy.GetClient()
+
+		Byf("Verify Cluster is Available and Machines are Ready before starting in-place updates")
+		framework.VerifyClusterAvailable(ctx, framework.VerifyClusterAvailableInput{
+			Getter:    mgmtClient,
+			Name:      clusterResources.Cluster.Name,
+			Namespace: clusterResources.Cluster.Namespace,
+		})
+		framework.VerifyMachinesReady(ctx, framework.VerifyMachinesReadyInput{
+			Lister:    mgmtClient,
+			Name:      clusterResources.Cluster.Name,
+			Namespace: clusterResources.Cluster.Namespace,
+		})
+
+		var machineObjectsBeforeInPlaceUpdate machineObjects
+		Eventually(func(g Gomega) {
+			machineObjectsBeforeInPlaceUpdate = getMachineObjects(ctx, g, mgmtClient, cluster)
+		}, 30*time.Second, 1*time.Second).Should(Succeed())
+
+		// Doing multiple in-place updates for additional coverage.
+		filePath := "/tmp/test"
+		for i, fileContent := range []string{"first in-place update", "second in-place update"} {
+			Byf("[%d] Trigger in-place update by modifying the files variable", i)
+
+			originalCluster := cluster.DeepCopy()
+			// Ensure the files variable is set to the expected value (first remove, then add the variable).
+			cluster.Spec.Topology.Variables = slices.DeleteFunc(cluster.Spec.Topology.Variables, func(v clusterv1.ClusterVariable) bool {
+				return v.Name == "files"
+			})
+			cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, clusterv1.ClusterVariable{
+				Name:  "files",
+				Value: apiextensionsv1.JSON{Raw: []byte(fmt.Sprintf(`[{"path":%q,"content":%q}]`, filePath, fileContent))},
+			})
+			Expect(mgmtClient.Patch(ctx, cluster, client.MergeFrom(originalCluster))).To(Succeed())
+
+			var machineObjectsAfterInPlaceUpdate machineObjects
+			Eventually(func(g Gomega) {
+				// Ensure the in-place update was done.
+				framework.VerifyClusterCondition(ctx, framework.VerifyClusterConditionInput{
+					Getter:        mgmtClient,
+					Name:          clusterResources.Cluster.Name,
+					Namespace:     clusterResources.Cluster.Namespace,
+					ConditionType: clusterv1.ClusterControlPlaneMachinesUpToDateCondition,
+				})
+				framework.VerifyClusterCondition(ctx, framework.VerifyClusterConditionInput{
+					Getter:        mgmtClient,
+					Name:          clusterResources.Cluster.Name,
+					Namespace:     clusterResources.Cluster.Namespace,
+					ConditionType: clusterv1.ClusterWorkerMachinesUpToDateCondition,
+				})
+				for _, kubeadmConfig := range machineObjectsAfterInPlaceUpdate.KubeadmConfigByMachine {
+					g.Expect(kubeadmConfig.Spec.Files).To(ContainElement(HaveField("Path", filePath)))
+					g.Expect(kubeadmConfig.Spec.Files).To(ContainElement(HaveField("Content", fileContent)))
+				}
+
+				// Ensure only in-place updates were executed and no Machine was re-created.
+				machineObjectsAfterInPlaceUpdate = getMachineObjects(ctx, g, mgmtClient, cluster)
+				g.Expect(machineNames(machineObjectsAfterInPlaceUpdate.ControlPlaneMachines)).To(Equal(machineNames(machineObjectsBeforeInPlaceUpdate.ControlPlaneMachines)))
+				// TODO(in-place): enable once MD/MS/Machine controller PRs are merged
+				// g.Expect(machineNames(machineObjectsAfterInPlaceUpdate.WorkerMachines)).To(Equal(machineNames(machineObjectsBeforeInPlaceUpdate.WorkerMachines)))
+			}, input.E2EConfig.GetIntervals(specName, "wait-control-plane")...).Should(Succeed())
+
+			// Update machineObjectsBeforeInPlaceUpdate for the next round of in-place update.
+			machineObjectsBeforeInPlaceUpdate = machineObjectsAfterInPlaceUpdate
+		}
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		framework.DumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ClusterctlConfigPath, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+		if !input.SkipCleanup {
+			if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+				Eventually(func() error {
+					return input.BootstrapClusterProxy.GetClient().Delete(ctx, extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, true))
+				}, 10*time.Second, 1*time.Second).Should(Succeed(), "Deleting ExtensionConfig failed")
+			}
+		}
+	})
+}
+
+type machineObjects struct {
+	ControlPlaneMachines []*clusterv1.Machine
+	WorkerMachines       []*clusterv1.Machine
+
+	KubeadmConfigByMachine map[string]*bootstrapv1.KubeadmConfig
+}
+
+// getMachineObjects retrieves Machines and corresponding KubeadmConfigs.
+func getMachineObjects(ctx context.Context, g Gomega, c client.Client, cluster *clusterv1.Cluster) machineObjects {
+	res := machineObjects{
+		KubeadmConfigByMachine: map[string]*bootstrapv1.KubeadmConfig{},
+	}
+
+	// ControlPlane Machines.
+	controlPlaneMachineList := &clusterv1.MachineList{}
+	g.Expect(c.List(ctx, controlPlaneMachineList, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+		clusterv1.MachineControlPlaneLabel: "",
+		clusterv1.ClusterNameLabel:         cluster.Name,
+	})).To(Succeed())
+	for _, machine := range controlPlaneMachineList.Items {
+		res.ControlPlaneMachines = append(res.ControlPlaneMachines, &machine)
+		kubeadmConfig := &bootstrapv1.KubeadmConfig{}
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: machine.Namespace, Name: machine.Spec.Bootstrap.ConfigRef.Name}, kubeadmConfig)).To(Succeed())
+		res.KubeadmConfigByMachine[machine.Name] = kubeadmConfig
+	}
+
+	// MachineDeployments Machines.
+	machines := framework.GetMachinesByCluster(ctx, framework.GetMachinesByClusterInput{
+		Lister:      c,
+		ClusterName: cluster.Name,
+		Namespace:   cluster.Namespace,
+	})
+	for _, machine := range machines {
+		res.WorkerMachines = append(res.WorkerMachines, &machine)
+		kubeadmConfig := &bootstrapv1.KubeadmConfig{}
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: machine.Namespace, Name: machine.Spec.Bootstrap.ConfigRef.Name}, kubeadmConfig)).To(Succeed())
+		res.KubeadmConfigByMachine[machine.Name] = kubeadmConfig
+	}
+
+	return res
+}
+
+func machineNames(machines []*clusterv1.Machine) sets.Set[string] {
+	ret := sets.Set[string]{}
+	for _, m := range machines {
+		ret.Insert(m.Name)
+	}
+	return ret
+}

--- a/test/e2e/cluster_in_place_update_test.go
+++ b/test/e2e/cluster_in_place_update_test.go
@@ -1,0 +1,44 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("When in-place updating a workload cluster using ClusterClass", Label("ClusterClass"), func() {
+	ClusterInPlaceUpdateSpec(ctx, func() ClusterInPlaceUpdateSpecInput {
+		return ClusterInPlaceUpdateSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                ptr.To("topology-in-place"),
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
+		}
+	})
+})

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -342,6 +342,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-ipv6.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary.yaml"
+    - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-in-place.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-no-workers.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-kcp-only.yaml"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-in-place/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-in-place/cluster-runtimesdk.yaml
@@ -1,0 +1,37 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+  namespace: default
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ['${DOCKER_SERVICE_CIDRS}']
+    pods:
+      cidrBlocks: ['${DOCKER_POD_CIDRS}']
+    serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
+  topology:
+    classRef:
+      name: "quick-start-runtimesdk"
+      namespace: '${CLUSTER_CLASS_NAMESPACE:-${NAMESPACE}}'
+    version: "${KUBERNETES_VERSION}"
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+        - class: "default-worker"
+          name: "md-0"
+          replicas: ${WORKER_MACHINE_COUNT}
+          rollout:
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxSurge: 1
+                maxUnavailable: 1
+    variables:
+      - name: kubeadmControlPlaneMaxSurge
+        value: "0"
+      - name: imageRepository
+        value: "kindest"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-in-place/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-in-place/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../bases/crs.yaml
+  - cluster-runtimesdk.yaml

--- a/test/extension/handlers/inplaceupdate/handlers.go
+++ b/test/extension/handlers/inplaceupdate/handlers.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package inplaceupdate contains the handlers for the in-place update hooks.
+//
+// The implementation of the handlers is specifically designed for Cluster API E2E test use cases.
+// When implementing custom RuntimeExtension, it is only required to expose HandlerFunc with the
+// signature defined in sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1.
+package inplaceupdate
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
+	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
+)
+
+// ExtensionHandlers provides a common struct shared across the in-place update hook handlers.
+type ExtensionHandlers struct {
+	decoder runtime.Decoder
+	client  client.Client
+	state   sync.Map
+}
+
+// NewExtensionHandlers returns a new ExtensionHandlers for the in-place update hook handlers.
+func NewExtensionHandlers(client client.Client) *ExtensionHandlers {
+	scheme := runtime.NewScheme()
+	_ = infrav1.AddToScheme(scheme)
+	_ = bootstrapv1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
+	return &ExtensionHandlers{
+		client: client,
+		decoder: serializer.NewCodecFactory(scheme).UniversalDecoder(
+			infrav1.GroupVersion,
+			bootstrapv1.GroupVersion,
+		),
+	}
+}
+
+// canUpdateMachineSpec declares that this extension can update:
+// * MachineSpec.FailureDomain
+// * MachineSpec.Version.
+func canUpdateMachineSpec(current, desired *clusterv1.MachineSpec) {
+	if current.FailureDomain != desired.FailureDomain {
+		current.FailureDomain = desired.FailureDomain
+	}
+	// TBD if we should keep this, but for now using it to test KCP machinery as this
+	// is the only field on Machine that KCP will try to roll out in-place.
+	if current.Version != desired.Version {
+		current.Version = desired.Version
+	}
+}
+
+// canUpdateKubeadmConfigSpec declares that this extension can update:
+// * KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageTag
+// * KubeadmConfigSpec.Files.
+func canUpdateKubeadmConfigSpec(current, desired *bootstrapv1.KubeadmConfigSpec) {
+	if current.ClusterConfiguration.Etcd.Local.ImageTag != desired.ClusterConfiguration.Etcd.Local.ImageTag {
+		current.ClusterConfiguration.Etcd.Local.ImageTag = desired.ClusterConfiguration.Etcd.Local.ImageTag
+	}
+	if !reflect.DeepEqual(current.Files, desired.Files) {
+		current.Files = desired.Files
+	}
+}
+
+// canUpdateDockerMachineSpec declares that this extension can update:
+// * DockerMachineSpec.BootstrapTimeout.
+func canUpdateDockerMachineSpec(current, desired *infrav1.DockerMachineSpec) {
+	if current.BootstrapTimeout != desired.BootstrapTimeout {
+		current.BootstrapTimeout = desired.BootstrapTimeout
+	}
+}
+
+// DoCanUpdateMachine implements the CanUpdateMachine hook.
+func (h *ExtensionHandlers) DoCanUpdateMachine(ctx context.Context, req *runtimehooksv1.CanUpdateMachineRequest, resp *runtimehooksv1.CanUpdateMachineResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(&req.Desired.Machine))
+	log.Info("CanUpdateMachine is called")
+
+	currentMachine, desiredMachine,
+		currentBootstrapConfig, desiredBootstrapConfig,
+		currentInfraMachine, desiredInfraMachine, err := h.getObjectsFromCanUpdateMachineRequest(req)
+	if err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	// Declare changes that this Runtime Extension can update in-place.
+
+	// Machine
+	canUpdateMachineSpec(&currentMachine.Spec, &desiredMachine.Spec)
+
+	// BootstrapConfig (we can only update KubeadmConfigs)
+	currentKubeadmConfig, isCurrentKubeadmConfig := currentBootstrapConfig.(*bootstrapv1.KubeadmConfig)
+	desiredKubeadmConfig, isDesiredKubeadmConfig := desiredBootstrapConfig.(*bootstrapv1.KubeadmConfig)
+	if isCurrentKubeadmConfig && isDesiredKubeadmConfig {
+		canUpdateKubeadmConfigSpec(&currentKubeadmConfig.Spec, &desiredKubeadmConfig.Spec)
+	}
+
+	// InfraMachine (we can only update DockerMachines)
+	currentDockerMachine, isCurrentDockerMachine := currentInfraMachine.(*infrav1.DockerMachine)
+	desiredDockerMachine, isDesiredDockerMachine := desiredInfraMachine.(*infrav1.DockerMachine)
+	if isCurrentDockerMachine && isDesiredDockerMachine {
+		canUpdateDockerMachineSpec(&currentDockerMachine.Spec, &desiredDockerMachine.Spec)
+	}
+
+	if err := h.computeCanUpdateMachineResponse(req, resp, currentMachine, currentBootstrapConfig, currentInfraMachine); err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+}
+
+// DoCanUpdateMachineSet implements the CanUpdateMachineSet hook.
+func (h *ExtensionHandlers) DoCanUpdateMachineSet(ctx context.Context, req *runtimehooksv1.CanUpdateMachineSetRequest, resp *runtimehooksv1.CanUpdateMachineSetResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("MachineSet", klog.KObj(&req.Desired.MachineSet))
+	log.Info("CanUpdateMachineSet is called")
+
+	currentMachineSet, desiredMachineSet,
+		currentBootstrapConfigTemplate, desiredBootstrapConfigTemplate,
+		currentInfraMachineTemplate, desiredInfraMachineTemplate, err := h.getObjectsFromCanUpdateMachineSetRequest(req)
+	if err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	// Declare changes that this Runtime Extension can update in-place.
+
+	// Machine
+	canUpdateMachineSpec(&currentMachineSet.Spec.Template.Spec, &desiredMachineSet.Spec.Template.Spec)
+
+	// BootstrapConfig (we can only update KubeadmConfigs)
+	currentKubeadmConfigTemplate, isCurrentKubeadmConfigTemplate := currentBootstrapConfigTemplate.(*bootstrapv1.KubeadmConfigTemplate)
+	desiredKubeadmConfigTemplate, isDesiredKubeadmConfigTemplate := desiredBootstrapConfigTemplate.(*bootstrapv1.KubeadmConfigTemplate)
+	if isCurrentKubeadmConfigTemplate && isDesiredKubeadmConfigTemplate {
+		canUpdateKubeadmConfigSpec(&currentKubeadmConfigTemplate.Spec.Template.Spec, &desiredKubeadmConfigTemplate.Spec.Template.Spec)
+	}
+
+	// InfraMachine (we can only update DockerMachines)
+	currentDockerMachineTemplate, isCurrentDockerMachineTemplate := currentInfraMachineTemplate.(*infrav1.DockerMachineTemplate)
+	desiredDockerMachineTemplate, isDesiredDockerMachineTemplate := desiredInfraMachineTemplate.(*infrav1.DockerMachineTemplate)
+	if isCurrentDockerMachineTemplate && isDesiredDockerMachineTemplate {
+		canUpdateDockerMachineSpec(&currentDockerMachineTemplate.Spec.Template.Spec, &desiredDockerMachineTemplate.Spec.Template.Spec)
+	}
+
+	if err := h.computeCanUpdateMachineSetResponse(req, resp, currentMachineSet, currentBootstrapConfigTemplate, currentInfraMachineTemplate); err != nil {
+		resp.Status = runtimehooksv1.ResponseStatusFailure
+		resp.Message = err.Error()
+		return
+	}
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+}
+
+// DoUpdateMachine implements the UpdateMachine hook.
+// Note: We are intentionally not actually applying any in-place changes we are just faking them,
+// which is good enough for test purposes.
+func (h *ExtensionHandlers) DoUpdateMachine(ctx context.Context, req *runtimehooksv1.UpdateMachineRequest, resp *runtimehooksv1.UpdateMachineResponse) {
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(&req.Desired.Machine))
+	log.Info("UpdateMachine is called")
+	defer func() {
+		log.Info("UpdateMachine response", "Machine", klog.KObj(&req.Desired.Machine), "status", resp.Status, "message", resp.Message, "retryAfterSeconds", resp.RetryAfterSeconds)
+	}()
+
+	key := klog.KObj(&req.Desired.Machine).String()
+
+	// Note: We are intentionally not actually applying any in-place changes we are just faking them,
+	// which is good enough for test purposes.
+	if firstTimeCalled, ok := h.state.Load(key); ok {
+		if time.Since(firstTimeCalled.(time.Time)) > 20*time.Second {
+			h.state.Delete(key)
+			resp.Status = runtimehooksv1.ResponseStatusSuccess
+			resp.Message = "In-place update is done"
+			resp.RetryAfterSeconds = 0
+			return
+		}
+	} else {
+		h.state.Store(key, time.Now())
+	}
+
+	resp.Status = runtimehooksv1.ResponseStatusSuccess
+	resp.Message = "In-place update still in progress"
+	resp.RetryAfterSeconds = 5
+}
+
+func (h *ExtensionHandlers) getObjectsFromCanUpdateMachineRequest(req *runtimehooksv1.CanUpdateMachineRequest) (*clusterv1.Machine, *clusterv1.Machine, runtime.Object, runtime.Object, runtime.Object, runtime.Object, error) { //nolint:gocritic // accepting high number of return parameters for now
+	currentMachine := req.Current.Machine.DeepCopy()
+	desiredMachine := req.Desired.Machine.DeepCopy()
+	currentBootstrapConfig, _, err := h.decoder.Decode(req.Current.BootstrapConfig.Raw, nil, req.Current.BootstrapConfig.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredBootstrapConfig, _, err := h.decoder.Decode(req.Desired.BootstrapConfig.Raw, nil, req.Desired.BootstrapConfig.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	currentInfraMachine, _, err := h.decoder.Decode(req.Current.InfrastructureMachine.Raw, nil, req.Current.InfrastructureMachine.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredInfraMachine, _, err := h.decoder.Decode(req.Desired.InfrastructureMachine.Raw, nil, req.Desired.InfrastructureMachine.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
+	return currentMachine, desiredMachine, currentBootstrapConfig, desiredBootstrapConfig, currentInfraMachine, desiredInfraMachine, nil
+}
+
+func (h *ExtensionHandlers) computeCanUpdateMachineResponse(req *runtimehooksv1.CanUpdateMachineRequest, resp *runtimehooksv1.CanUpdateMachineResponse, currentMachine *clusterv1.Machine, currentBootstrapConfig, currentInfraMachine runtime.Object) error {
+	marshalledCurrentMachine, err := json.Marshal(req.Current.Machine)
+	if err != nil {
+		return err
+	}
+	machinePatch, err := createJSONPatch(marshalledCurrentMachine, currentMachine)
+	if err != nil {
+		return err
+	}
+	bootstrapConfigPatch, err := createJSONPatch(req.Current.BootstrapConfig.Raw, currentBootstrapConfig)
+	if err != nil {
+		return err
+	}
+	infraMachinePatch, err := createJSONPatch(req.Current.InfrastructureMachine.Raw, currentInfraMachine)
+	if err != nil {
+		return err
+	}
+
+	resp.MachinePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     machinePatch,
+	}
+	resp.BootstrapConfigPatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     bootstrapConfigPatch,
+	}
+	resp.InfrastructureMachinePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     infraMachinePatch,
+	}
+	return nil
+}
+
+func (h *ExtensionHandlers) getObjectsFromCanUpdateMachineSetRequest(req *runtimehooksv1.CanUpdateMachineSetRequest) (*clusterv1.MachineSet, *clusterv1.MachineSet, runtime.Object, runtime.Object, runtime.Object, runtime.Object, error) { //nolint:gocritic // accepting high number of return parameters for now
+	currentMachineSet := req.Current.MachineSet.DeepCopy()
+	desiredMachineSet := req.Desired.MachineSet.DeepCopy()
+	currentBootstrapConfigTemplate, _, err := h.decoder.Decode(req.Current.BootstrapConfigTemplate.Raw, nil, req.Current.BootstrapConfigTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredBootstrapConfigTemplate, _, err := h.decoder.Decode(req.Desired.BootstrapConfigTemplate.Raw, nil, req.Desired.BootstrapConfigTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	currentInfraMachineTemplate, _, err := h.decoder.Decode(req.Current.InfrastructureMachineTemplate.Raw, nil, req.Current.InfrastructureMachineTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+	desiredInfraMachineTemplate, _, err := h.decoder.Decode(req.Desired.InfrastructureMachineTemplate.Raw, nil, req.Desired.InfrastructureMachineTemplate.Object)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, err
+	}
+
+	return currentMachineSet, desiredMachineSet, currentBootstrapConfigTemplate, desiredBootstrapConfigTemplate, currentInfraMachineTemplate, desiredInfraMachineTemplate, nil
+}
+
+func (h *ExtensionHandlers) computeCanUpdateMachineSetResponse(req *runtimehooksv1.CanUpdateMachineSetRequest, resp *runtimehooksv1.CanUpdateMachineSetResponse, currentMachineSet *clusterv1.MachineSet, currentBootstrapConfigTemplate, currentInfraMachineTemplate runtime.Object) error {
+	marshalledCurrentMachineSet, err := json.Marshal(req.Current.MachineSet)
+	if err != nil {
+		return err
+	}
+	machineSetPatch, err := createJSONPatch(marshalledCurrentMachineSet, currentMachineSet)
+	if err != nil {
+		return err
+	}
+	bootstrapConfigTemplatePatch, err := createJSONPatch(req.Current.BootstrapConfigTemplate.Raw, currentBootstrapConfigTemplate)
+	if err != nil {
+		return err
+	}
+	infraMachineTemplatePatch, err := createJSONPatch(req.Current.InfrastructureMachineTemplate.Raw, currentInfraMachineTemplate)
+	if err != nil {
+		return err
+	}
+
+	resp.MachineSetPatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     machineSetPatch,
+	}
+	resp.BootstrapConfigTemplatePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     bootstrapConfigTemplatePatch,
+	}
+	resp.InfrastructureMachineTemplatePatch = runtimehooksv1.Patch{
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     infraMachineTemplatePatch,
+	}
+	return nil
+}
+
+// createJSONPatch creates a RFC 6902 JSON patch from the original and the modified object.
+func createJSONPatch(marshalledOriginal []byte, modified runtime.Object) ([]byte, error) {
+	// TODO: avoid producing patches for status (although they will be ignored by the KCP / MD controllers anyway)
+	marshalledModified, err := json.Marshal(modified)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal modified object: %v", err)
+	}
+
+	patch, err := jsonpatch.CreatePatch(marshalledOriginal, marshalledModified)
+	if err != nil {
+		return nil, errors.Errorf("failed to create patch: %v", err)
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal patch: %v", err)
+	}
+
+	return patchBytes, nil
+}

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -111,7 +111,11 @@ func (h *ExtensionHandlers) GeneratePatches(ctx context.Context, req *runtimehoo
 			// the patchKubeadmConfigTemplate func shows how to implement patches only for KubeadmConfigTemplates
 			// linked to a specific MachineDeployment class; another option is to check the holderRef value and call
 			// this func or more specialized func conditionally.
-			patchKubeadmConfigTemplate(ctx, obj, variables)
+			err := patchKubeadmConfigTemplate(ctx, obj, variables)
+			if err != nil {
+				log.Error(err, "Error patching KubeadmConfigTemplate")
+				return errors.Wrapf(err, "error patching KubeadmConfigTemplate")
+			}
 		case *infrav1beta1.DockerMachineTemplate, *infrav1.DockerMachineTemplate:
 			// NOTE: DockerMachineTemplate could be linked to the ControlPlane or one or more of the existing MachineDeployment class;
 			// the patchDockerMachineTemplate func shows how to implement different patches for DockerMachineTemplate
@@ -214,40 +218,56 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 	// 2) Patch RolloutStrategy RollingUpdate MaxSurge with the value from the Cluster Topology variable.
 	//    If this is unset continue as this variable is not required.
 	kcpControlPlaneMaxSurge, err := topologymutation.GetStringVariable(templateVariables, "kubeadmControlPlaneMaxSurge")
-	if err != nil {
-		if topologymutation.IsNotFoundError(err) {
-			return nil
-		}
+	if err != nil && !topologymutation.IsNotFoundError(err) {
 		return errors.Wrap(err, "could not set KubeadmControlPlaneTemplate MaxSurge")
 	}
+	if kcpControlPlaneMaxSurge != "" {
+		// This has to be converted to IntOrString type.
+		kubeadmControlPlaneMaxSurgeIntOrString := intstrutil.Parse(kcpControlPlaneMaxSurge)
+		log.Info(fmt.Sprintf("Setting KubeadmControlPlaneMaxSurge to %q", kubeadmControlPlaneMaxSurgeIntOrString.String()))
 
-	// This has to be converted to IntOrString type.
-	kubeadmControlPlaneMaxSurgeIntOrString := intstrutil.Parse(kcpControlPlaneMaxSurge)
-	log.Info(fmt.Sprintf("Setting KubeadmControlPlaneMaxSurge to %q", kubeadmControlPlaneMaxSurgeIntOrString.String()))
+		kcpTemplateV1Beta1, ok := obj.(*controlplanev1beta1.KubeadmControlPlaneTemplate)
+		if ok {
+			if kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy == nil {
+				kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy = &controlplanev1beta1.RolloutStrategy{}
+			}
+			if kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate == nil {
+				kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate = &controlplanev1beta1.RollingUpdate{}
+			}
+			kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate.MaxSurge = &kubeadmControlPlaneMaxSurgeIntOrString
+		}
 
-	kcpTemplateV1Beta1, ok := obj.(*controlplanev1beta1.KubeadmControlPlaneTemplate)
-	if ok {
-		if kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy == nil {
-			kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy = &controlplanev1beta1.RolloutStrategy{}
+		kcpTemplate, ok := obj.(*controlplanev1.KubeadmControlPlaneTemplate)
+		if ok {
+			kcpTemplate.Spec.Template.Spec.Rollout.Strategy.Type = controlplanev1.RollingUpdateStrategyType
+			kcpTemplate.Spec.Template.Spec.Rollout.Strategy.RollingUpdate.MaxSurge = &kubeadmControlPlaneMaxSurgeIntOrString
 		}
-		if kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate == nil {
-			kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate = &controlplanev1beta1.RollingUpdate{}
-		}
-		kcpTemplateV1Beta1.Spec.Template.Spec.RolloutStrategy.RollingUpdate.MaxSurge = &kubeadmControlPlaneMaxSurgeIntOrString
-		return nil
 	}
 
-	kcpTemplate, ok := obj.(*controlplanev1.KubeadmControlPlaneTemplate)
-	if ok {
-		kcpTemplate.Spec.Template.Spec.Rollout.Strategy.Type = controlplanev1.RollingUpdateStrategyType
-		kcpTemplate.Spec.Template.Spec.Rollout.Strategy.RollingUpdate.MaxSurge = &kubeadmControlPlaneMaxSurgeIntOrString
+	// 3) Set files
+	files := []fileVariable{}
+	err = topologymutation.GetObjectVariableInto(templateVariables, "files", &files)
+	if err != nil && !topologymutation.IsNotFoundError(err) {
+		return errors.Wrap(err, "could not set KubeadmControlPlaneTemplate files")
+	}
+	if len(files) > 0 {
+		kcpTemplateV1Beta1, ok := obj.(*controlplanev1beta1.KubeadmControlPlaneTemplate)
+		if ok {
+			kcpTemplateV1Beta1.Spec.Template.Spec.KubeadmConfigSpec.Files = append(kcpTemplateV1Beta1.Spec.Template.Spec.KubeadmConfigSpec.Files,
+				convertToKubeadmConfigV1Beta1Files(files)...)
+		}
+		kcpTemplate, ok := obj.(*controlplanev1.KubeadmControlPlaneTemplate)
+		if ok {
+			kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.Files = append(kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.Files,
+				convertToKubeadmConfigFiles(files)...)
+		}
 	}
 
 	return nil
 }
 
 // patchKubeadmConfigTemplate patches the ControlPlaneTemplate.
-func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, _ map[string]apiextensionsv1.JSON) {
+func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, templateVariables map[string]apiextensionsv1.JSON) error {
 	// 1) Set extraArgs
 	switch obj := obj.(type) {
 	case *bootstrapv1beta1.KubeadmConfigTemplate:
@@ -261,6 +281,61 @@ func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, _ map[str
 	case *bootstrapv1.KubeadmConfigTemplate:
 		obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = append(obj.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs, bootstrapv1.Arg{Name: "v", Value: ptr.To("2")})
 	}
+
+	files := []fileVariable{}
+	err := topologymutation.GetObjectVariableInto(templateVariables, "files", &files)
+	if err != nil && !topologymutation.IsNotFoundError(err) {
+		return errors.Wrap(err, "could not set KubeadmConfigTemplate files")
+	}
+	if len(files) > 0 {
+		kcpTemplateV1Beta1, ok := obj.(*bootstrapv1beta1.KubeadmConfigTemplate)
+		if ok {
+			kcpTemplateV1Beta1.Spec.Template.Spec.Files = append(kcpTemplateV1Beta1.Spec.Template.Spec.Files,
+				convertToKubeadmConfigV1Beta1Files(files)...)
+		}
+		kcpTemplate, ok := obj.(*bootstrapv1.KubeadmConfigTemplate)
+		if ok {
+			kcpTemplate.Spec.Template.Spec.Files = append(kcpTemplate.Spec.Template.Spec.Files,
+				convertToKubeadmConfigFiles(files)...)
+		}
+	}
+
+	return nil
+}
+
+type fileVariable struct {
+	Path    string `json:"path,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+func convertToKubeadmConfigV1Beta1Files(files []fileVariable) []bootstrapv1beta1.File {
+	kubeadmConfigV1Beta1Files := []bootstrapv1beta1.File{}
+	for _, f := range files {
+		kubeadmConfigV1Beta1Files = append(kubeadmConfigV1Beta1Files,
+			bootstrapv1beta1.File{
+				Path:        f.Path,
+				Content:     f.Content,
+				Owner:       "root:root",
+				Permissions: "0600",
+			},
+		)
+	}
+	return kubeadmConfigV1Beta1Files
+}
+
+func convertToKubeadmConfigFiles(files []fileVariable) []bootstrapv1.File {
+	kubeadmConfigFiles := []bootstrapv1.File{}
+	for _, f := range files {
+		kubeadmConfigFiles = append(kubeadmConfigFiles,
+			bootstrapv1.File{
+				Path:        f.Path,
+				Content:     f.Content,
+				Owner:       "root:root",
+				Permissions: "0600",
+			},
+		)
+	}
+	return kubeadmConfigFiles
 }
 
 // patchDockerMachineTemplate patches the DockerMachineTemplate.
@@ -409,6 +484,26 @@ func (h *ExtensionHandlers) DiscoverVariables(ctx context.Context, _ *runtimehoo
 						{
 							Rule:              "self == \"\" || self != \"\"",
 							MessageExpression: "'just a test expression, got %s'.format([self])",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:     "files",
+			Required: false,
+			Schema: clusterv1beta1.VariableSchema{
+				OpenAPIV3Schema: clusterv1beta1.JSONSchemaProps{
+					Type: "array",
+					Items: &clusterv1beta1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]clusterv1beta1.JSONSchemaProps{
+							"path": {
+								Type: "string",
+							},
+							"content": {
+								Type: "string",
+							},
 						},
 					},
 				},

--- a/test/go.mod
+++ b/test/go.mod
@@ -23,6 +23,7 @@ require (
 	go.etcd.io/etcd/api/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
 	golang.org/x/net v0.46.0
+	gomodules.xyz/jsonpatch/v2 v2.5.0
 	google.golang.org/grpc v1.72.3
 	k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver v0.34.1
@@ -159,7 +160,6 @@ require (
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/protobuf v1.36.7 // indirect


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12291

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->