### PR TITLE
🐛 fix: CAPD on rootless podman

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -458,7 +458,7 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 	// enable /dev/fuse explicitly for fuse-overlayfs
 	// (Rootless Docker does not automatically mount /dev/fuse with --privileged)
 	if d.mountFuse(info) {
-		hostConfig.Devices = append(hostConfig.Devices, dockercontainer.DeviceMapping{PathOnHost: "/dev/fuse"})
+		hostConfig.Devices = append(hostConfig.Devices, dockercontainer.DeviceMapping{PathOnHost: "/dev/fuse", PathInContainer: "/dev/fuse", CgroupPermissions: "rw"})
 	}
 
 	// Make sure we have the image


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This sets the mount options properly on `/dev/fuse` so that it can be mounted by podman. With this change, I've had success getting CAPD to create additional clusters under rootless podman.

I found that the quick start guide still doesn't work, because the the DockerMachineTemplates also need to mount the podman socket, and these checks need to be ignored on kubelet preflight:
```yaml
ignorePreflightErrors:
- FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml
- FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml
- FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml
- FileAvailable--etc-kubernetes-manifests-etcd.yaml
```

But, with that additional config, everything works as expected.

Fixes #12485 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->