### PR TITLE
🌱 Remove deprecated ClusterResourceSet feature gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -261,10 +261,6 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: (clusterv1alpha3.*|clusterv1alpha4.*) is deprecated: This type will be removed in one of the next releases.'
-        # Specific exclude rules for deprecated feature flags
-      - linters:
-          - staticcheck
-        text: 'SA1019: feature.ClusterResourceSet is deprecated: ClusterResourceSet feature is now GA and the corresponding feature flag will be removed in 1.12 release.'
         # v1Beta1 deprecated fields
       - linters:
           - staticcheck

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=false},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false}"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=false},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false}"
           image: controller:latest
           name: manager
           env:

--- a/docs/book/src/tasks/cluster-resource-set.md
+++ b/docs/book/src/tasks/cluster-resource-set.md
@@ -3,12 +3,6 @@
 The `ClusterResourceSet` feature is introduced to provide a way to automatically apply a set of resources (such as CNI/CSI) defined by users to matching newly-created/existing clusters.
 `ClusterResourceSet` provides a basic solution for installing & managing resources, while for advanced use cases an addon provider must be used.
 
-**Feature gate name**: `ClusterResourceSet`
-
-**Variable name to enable/disable the feature gate**: `EXP_CLUSTER_RESOURCE_SET`
-
-The `ClusterResourceSet` feature is now GA and is enabled by default, but can be disabled by setting the `EXP_CLUSTER_RESOURCE_SET` environment variable to `false`.
-
 More details on `ClusterResourceSet` can be found at:
 [ClusterResourceSet CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20200220-cluster-resource-set.md)
 

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -35,15 +35,6 @@ const (
 	// beta: v1.7
 	MachinePool featuregate.Feature = "MachinePool"
 
-	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
-	//
-	// alpha: v0.3
-	// beta: v0.4
-	// GA: v1.10
-	//
-	// Deprecated: ClusterResourceSet feature is now GA and the corresponding feature flag will be removed in 1.12 release.
-	ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
-
 	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
 	//
 	// alpha: v0.4
@@ -91,7 +82,6 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
-	ClusterResourceSet:        {Default: true, PreRelease: featuregate.GA},
 	MachinePool:               {Default: true, PreRelease: featuregate.Beta},
 	MachineSetPreflightChecks: {Default: true, PreRelease: featuregate.Beta},
 	MachineWaitForVolumeDetachConsiderVolumeAttachments: {Default: true, PreRelease: featuregate.Beta},

--- a/internal/webhooks/clusterresourceset.go
+++ b/internal/webhooks/clusterresourceset.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
-	"sigs.k8s.io/cluster-api/feature"
 )
 
 // ClusterResourceSet implements a validation and defaulting webhook for ClusterResourceSet.
@@ -92,15 +91,6 @@ func (webhook *ClusterResourceSet) ValidateDelete(_ context.Context, _ runtime.O
 
 func (webhook *ClusterResourceSet) validate(oldCRS, newCRS *addonsv1.ClusterResourceSet) error {
 	var allErrs field.ErrorList
-
-	// NOTE: ClusterResourceSet is behind ClusterResourceSet feature gate flag; the web hook
-	// must prevent creating new objects when the feature flag is disabled.
-	if !feature.Gates.Enabled(feature.ClusterResourceSet) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the ClusterResourceSet feature flag is enabled",
-		)
-	}
 
 	// Validate selector parses as Selector
 	selector, err := metav1.LabelSelectorAsSelector(&newCRS.Spec.ClusterSelector)

--- a/internal/webhooks/clusterresourcesetbinding.go
+++ b/internal/webhooks/clusterresourcesetbinding.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	addonsv1 "sigs.k8s.io/cluster-api/api/addons/v1beta2"
-	"sigs.k8s.io/cluster-api/feature"
 )
 
 func (webhook *ClusterResourceSetBinding) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -74,15 +73,6 @@ func (webhook *ClusterResourceSetBinding) ValidateDelete(_ context.Context, _ ru
 
 func (webhook *ClusterResourceSetBinding) validate(oldCRSB, newCRSB *addonsv1.ClusterResourceSetBinding) error {
 	var allErrs field.ErrorList
-
-	// NOTE: ClusterResourceSet is behind ClusterResourceSet feature gate flag; the web hook
-	// must prevent creating new objects in case the feature flag is disabled.
-	if !feature.Gates.Enabled(feature.ClusterResourceSet) {
-		return field.Forbidden(
-			field.NewPath("spec"),
-			"can be set only if the ClusterResourceSet feature flag is enabled",
-		)
-	}
 
 	if oldCRSB != nil && oldCRSB.Spec.ClusterName != "" && oldCRSB.Spec.ClusterName != newCRSB.Spec.ClusterName {
 		allErrs = append(allErrs,

--- a/main.go
+++ b/main.go
@@ -731,22 +731,20 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 		}
 	}
 
-	if feature.Gates.Enabled(feature.ClusterResourceSet) {
-		if err := (&controllers.ClusterResourceSetReconciler{
-			Client:           mgr.GetClient(),
-			ClusterCache:     clusterCache,
-			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency), partialSecretCache); err != nil {
-			setupLog.Error(err, "Unable to create controller", "controller", "ClusterResourceSet")
-			os.Exit(1)
-		}
-		if err := (&controllers.ClusterResourceSetBindingReconciler{
-			Client:           mgr.GetClient(),
-			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
-			setupLog.Error(err, "Unable to create controller", "controller", "ClusterResourceSetBinding")
-			os.Exit(1)
-		}
+	if err := (&controllers.ClusterResourceSetReconciler{
+		Client:           mgr.GetClient(),
+		ClusterCache:     clusterCache,
+		WatchFilterValue: watchFilterValue,
+	}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency), partialSecretCache); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", "ClusterResourceSet")
+		os.Exit(1)
+	}
+	if err := (&controllers.ClusterResourceSetBindingReconciler{
+		Client:           mgr.GetClient(),
+		WatchFilterValue: watchFilterValue,
+	}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
+		setupLog.Error(err, "Unable to create controller", "controller", "ClusterResourceSetBinding")
+		os.Exit(1)
 	}
 
 	if err := (&controllers.MachineHealthCheckReconciler{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR removes the deprecated ClusterResourceSet feature gate, which has been GA since v1.11.

Ref: [Remove previously deprecated code](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/role-handbooks/release-lead#track-remove-previously-deprecated-code)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Task of #12771
Fixes #11114

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->