### PR TITLE
🌱 Cleanup TestReconcileMachinePhases

### DIFF
--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -2531,7 +2531,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until InfraMachine has the ownerReference.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(infraMachine), infraMachine); err != nil {
 				return false
 			}
 			g.Expect(infraMachine.GetOwnerReferences()).To(HaveLen(1))
@@ -2574,7 +2574,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhasePending))
@@ -2629,7 +2629,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
@@ -2719,7 +2719,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.Addresses).To(HaveLen(2))
@@ -2799,7 +2799,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2878,7 +2878,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
@@ -2976,7 +2976,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseUpdating))
@@ -3039,7 +3039,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
@@ -3133,7 +3133,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		// Wait until Machine was reconciled.
 		g.Eventually(func(g Gomega) bool {
-			if err := env.DirectAPIServerGet(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
+			if err := env.Get(ctx, client.ObjectKeyFromObject(machine), machine); err != nil {
 				return false
 			}
 			g.Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseDeleting))

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -604,7 +604,7 @@ func (e *Environment) DeleteAndWait(ctx context.Context, obj client.Object, opts
 				}
 				return false, err
 			}
-			if objCopy.GetDeletionTimestamp() != nil {
+			if !objCopy.GetDeletionTimestamp().IsZero() {
 				return true, nil
 			}
 			return false, nil
@@ -658,13 +658,6 @@ func (e *Environment) PatchAndWait(ctx context.Context, obj client.Object, opts 
 		return errors.Wrapf(err, "object %s, %s is not being added to or did not get updated in the testenv client cache", obj.GetObjectKind().GroupVersionKind().String(), key)
 	}
 	return nil
-}
-
-// DirectAPIServerGet gets an object directly from apiserver bypassing informer caches..
-//
-// NOTE: Bypassing cache helps in preventing test flakes due to the cache sync delays but should only be used in validation steps of testing.
-func (e *Environment) DirectAPIServerGet(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	return e.Manager.GetAPIReader().Get(ctx, key, obj, opts...)
 }
 
 // CreateNamespace creates a new namespace with a generated name.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Just a small cleanup. DirectAPIServerGet was introduced when trying to fix a unit test, but the issue turned out to be elsewhere.

Just cleaning this up now as:
* It should not be necessary to use the apireader inside eventually with 10s timeout
* We should use `env.GetAPIReader()` consistently if we want to do live calls

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->