### PR TITLE
🌱 Improve KCP etcd client crt/key caching

### DIFF
--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -161,10 +161,6 @@ func TestGetWorkloadCluster(t *testing.T) {
 			secret.KubeconfigDataName: testEnvKubeconfig,
 		},
 	}
-	clusterKey := client.ObjectKey{
-		Name:      "my-cluster",
-		Namespace: ns.Name,
-	}
 
 	tests := []struct {
 		name       string
@@ -173,40 +169,34 @@ func TestGetWorkloadCluster(t *testing.T) {
 		expectErr  bool
 	}{
 		{
-			name:       "returns a workload cluster",
-			clusterKey: clusterKey,
-			objs:       []client.Object{etcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
-			expectErr:  false,
+			name:      "returns a workload cluster",
+			objs:      []client.Object{etcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
+			expectErr: false,
 		},
 		{
-			name:       "returns error if cannot get rest.Config from kubeconfigSecret",
-			clusterKey: clusterKey,
-			objs:       []client.Object{etcdSecret.DeepCopy()},
-			expectErr:  true,
+			name:      "returns error if cannot get rest.Config from kubeconfigSecret",
+			objs:      []client.Object{etcdSecret.DeepCopy()},
+			expectErr: true,
 		},
 		{
-			name:       "returns error if unable to find the etcd secret",
-			clusterKey: clusterKey,
-			objs:       []client.Object{kubeconfigSecret.DeepCopy()},
-			expectErr:  true,
+			name:      "returns error if unable to find the etcd secret",
+			objs:      []client.Object{kubeconfigSecret.DeepCopy()},
+			expectErr: true,
 		},
 		{
-			name:       "returns error if unable to find the certificate in the etcd secret",
-			clusterKey: clusterKey,
-			objs:       []client.Object{emptyCrtEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
-			expectErr:  true,
+			name:      "returns error if unable to find the certificate in the etcd secret",
+			objs:      []client.Object{emptyCrtEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
+			expectErr: true,
 		},
 		{
-			name:       "returns error if unable to find the key in the etcd secret",
-			clusterKey: clusterKey,
-			objs:       []client.Object{emptyKeyEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
-			expectErr:  true,
+			name:      "returns error if unable to find the key in the etcd secret",
+			objs:      []client.Object{emptyKeyEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
+			expectErr: true,
 		},
 		{
-			name:       "returns error if unable to generate client cert",
-			clusterKey: clusterKey,
-			objs:       []client.Object{badCrtEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
-			expectErr:  true,
+			name:      "returns error if unable to generate client cert",
+			objs:      []client.Object{badCrtEtcdSecret.DeepCopy(), kubeconfigSecret.DeepCopy()},
+			expectErr: true,
 		},
 	}
 
@@ -250,7 +240,7 @@ func TestGetWorkloadCluster(t *testing.T) {
 			})
 			g.Expect(err).ToNot(HaveOccurred())
 
-			workloadCluster, err := m.GetWorkloadCluster(ctx, tt.clusterKey, bootstrapv1.EncryptionAlgorithmRSA2048)
+			workloadCluster, err := m.GetWorkloadCluster(ctx, cluster, bootstrapv1.EncryptionAlgorithmRSA2048)
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(workloadCluster).To(BeNil())

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -394,7 +394,7 @@ func (c *ControlPlane) GetWorkloadCluster(ctx context.Context) (WorkloadCluster,
 		return c.workloadCluster, nil
 	}
 
-	workloadCluster, err := c.managementCluster.GetWorkloadCluster(ctx, client.ObjectKeyFromObject(c.Cluster), c.GetKeyEncryptionAlgorithm())
+	workloadCluster, err := c.managementCluster.GetWorkloadCluster(ctx, c.Cluster, c.GetKeyEncryptionAlgorithm())
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/kubeadm/internal/controllers/fakes_test.go
+++ b/controlplane/kubeadm/internal/controllers/fakes_test.go
@@ -49,7 +49,7 @@ func (f *fakeManagementCluster) List(ctx context.Context, list client.ObjectList
 	return f.Reader.List(ctx, list, opts...)
 }
 
-func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ client.ObjectKey, _ bootstrapv1.EncryptionAlgorithmType) (internal.WorkloadCluster, error) {
+func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ *clusterv1.Cluster, _ bootstrapv1.EncryptionAlgorithmType) (internal.WorkloadCluster, error) {
 	return f.Workload, f.WorkloadErr
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Before this PR it could happen that etcd client crt/key were still cached even if a Cluster was re-created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->