### PR TITLE
✨ Add conditions filter for clusterctl describe

### DIFF
--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -35,7 +35,7 @@ type DescribeClusterOptions struct {
 	ClusterName string
 
 	// ShowOtherConditions is a list of comma separated kind or kind/name for which we should add the ShowObjectConditionsAnnotation
-	// to signal to the presentation layer to show all the conditions for the objects.
+	// to signal to the presentation layer to show conditions for the objects.
 	ShowOtherConditions string
 
 	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.

--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -36,7 +36,7 @@ import (
 // DiscoverOptions define options for the discovery process.
 type DiscoverOptions struct {
 	// ShowOtherConditions is a list of comma separated kind or kind/name for which we should add the ShowObjectConditionsAnnotation
-	// to signal to the presentation layer to show all the conditions for the objects.
+	// to signal to the presentation layer to show conditions for the objects.
 	ShowOtherConditions string
 
 	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/fatih/color"
@@ -26,6 +27,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd/internal/templates"
 	cmdtree "sigs.k8s.io/cluster-api/internal/util/tree"
 )
@@ -93,7 +95,7 @@ func init() {
 		"The namespace where the workload cluster is located. If unspecified, the current namespace will be used.")
 
 	describeClusterClusterCmd.Flags().StringVar(&dc.showOtherConditions, "show-conditions", "",
-		"list of comma separated kind or kind/name for which the command should show all the object's conditions (use 'all' to show conditions for everything).")
+		fmt.Sprintf("list of comma separated kind or kind/name for which the command should show all the object's conditions (use 'all' to show conditions for everything, use the %s suffix to show only non-zero conditions).", tree.ShowNonZeroConditionsSuffix))
 	describeClusterClusterCmd.Flags().BoolVar(&dc.showMachineSets, "show-machinesets", false,
 		"Show MachineSet objects.")
 	describeClusterClusterCmd.Flags().BoolVar(&dc.showClusterResourceSets, "show-resourcesets", false,

--- a/internal/util/tree/tree_test.go
+++ b/internal/util/tree/tree_test.go
@@ -210,15 +210,15 @@ func Test_V1Beta1TreePrefix(t *testing.T) {
 			name: "Conditions should get the right prefix",
 			objectTree: func() *tree.ObjectTree {
 				root := fakeObject("root")
-				obectjTree := tree.NewObjectTree(root, tree.ObjectTreeOptions{})
+				obectjTree := tree.NewObjectTree(root, tree.ObjectTreeOptions{
+					ShowOtherConditions: "All",
+				})
 
 				o1 := fakeObject("child1",
-					withAnnotation(tree.ShowObjectConditionsAnnotation, "True"),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C1.1")),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C1.2")),
 				)
 				o2 := fakeObject("child2",
-					withAnnotation(tree.ShowObjectConditionsAnnotation, "True"),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C2.1")),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C2.2")),
 				)
@@ -240,17 +240,17 @@ func Test_V1Beta1TreePrefix(t *testing.T) {
 			name: "Conditions should get the right prefix if the object has a child",
 			objectTree: func() *tree.ObjectTree {
 				root := fakeObject("root")
-				obectjTree := tree.NewObjectTree(root, tree.ObjectTreeOptions{})
+				obectjTree := tree.NewObjectTree(root, tree.ObjectTreeOptions{
+					ShowOtherConditions: "All",
+				})
 
 				o1 := fakeObject("child1",
-					withAnnotation(tree.ShowObjectConditionsAnnotation, "True"),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C1.1")),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C1.2")),
 				)
 				o1_1 := fakeObject("child1.1")
 
 				o2 := fakeObject("child2",
-					withAnnotation(tree.ShowObjectConditionsAnnotation, "True"),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C2.1")),
 					withV1Beta1Condition(v1beta1conditions.TrueCondition("C2.2")),
 				)
@@ -289,7 +289,8 @@ func Test_V1Beta1TreePrefix(t *testing.T) {
 			// Compare the output with the expected prefix.
 			// We only check whether the output starts with the expected prefix,
 			// meaning expectPrefix does not contain the full expected output.
-			g.Expect(output.String()).Should(MatchTable(tt.expectPrefix))
+			outputString := output.String()
+			g.Expect(outputString).Should(MatchTable(tt.expectPrefix))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a condition filter for clusterctl describe

e.g. `clusterctl describe cluster quick-start --show-conditions=cluster+`

The + suffix after the kind will instruct clusterctl to show only non-zero conditions, which can  help to keep the output concise and readable when looking at conditions across many resources

/area clusterctl