### PR TITLE
✨ Improve logs, errors and conditions

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2400,9 +2400,10 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 					Message: "Waiting for a Node with spec.providerID foo to exist",
 				},
 				{
-					Type:   clusterv1.MachineUpToDateCondition,
-					Status: metav1.ConditionFalse,
-					Reason: clusterv1.MachineUpToDateUpdatingReason,
+					Type:    clusterv1.MachineUpToDateCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  clusterv1.MachineUpToDateUpdatingReason,
+					Message: "* In-place update in progress",
 				},
 			},
 		},

--- a/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine.go
@@ -45,7 +45,7 @@ func (r *KubeadmControlPlaneReconciler) canUpdateMachine(ctx context.Context, ma
 		return r.overrideCanUpdateMachineFunc(ctx, machine, machineUpToDateResult)
 	}
 
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(machine))
 
 	// Machine cannot be updated in-place if the feature gate is not enabled.
 	if !feature.Gates.Enabled(feature.InPlaceUpdates) {
@@ -79,7 +79,7 @@ func (r *KubeadmControlPlaneReconciler) canUpdateMachine(ctx context.Context, ma
 		return false, err
 	}
 	if !canUpdateMachine {
-		log.Info(fmt.Sprintf("Machine cannot be updated in-place by extensions: %s", strings.Join(reasons, ",")), "Machine", klog.KObj(machine))
+		log.Info(fmt.Sprintf("Machine %s cannot be updated in-place by extensions", machine.Name), "reason", strings.Join(reasons, ","))
 		return false, nil
 	}
 	return true, nil

--- a/controlplane/kubeadm/internal/controllers/inplace_trigger.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_trigger.go
@@ -40,8 +40,8 @@ func (r *KubeadmControlPlaneReconciler) triggerInPlaceUpdate(ctx context.Context
 		return r.overrideTriggerInPlaceUpdate(ctx, machine, machineUpToDateResult)
 	}
 
-	log := ctrl.LoggerFrom(ctx)
-	log.Info("Triggering in-place update", "Machine", klog.KObj(machine))
+	log := ctrl.LoggerFrom(ctx).WithValues("Machine", klog.KObj(machine))
+	log.Info(fmt.Sprintf("Triggering in-place update for Machine %s", machine.Name))
 
 	// Mark Machine for in-place update.
 	// Note: Once we write UpdateInProgressAnnotation we will always continue with the in-place update.
@@ -133,7 +133,7 @@ func (r *KubeadmControlPlaneReconciler) triggerInPlaceUpdate(ctx context.Context
 		return errors.Wrapf(err, "failed to complete triggering in-place update for Machine %s", klog.KObj(machine))
 	}
 
-	log.Info("Completed triggering in-place update", "Machine", klog.KObj(machine))
+	log.Info(fmt.Sprintf("Completed triggering in-place update for Machine %s", machine.Name))
 	r.recorder.Event(machine, corev1.EventTypeNormal, "SuccessfulStartInPlaceUpdate", "Machine starting in-place update")
 
 	// Wait until the cache observed the Machine with PendingHooksAnnotation to ensure subsequent reconciles

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -53,7 +53,7 @@ func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Conte
 	}
 
 	log.WithValues(controlPlane.StatusToLogKeyAndValues(newMachine, nil)...).
-		Info("Machine created (init)",
+		Info(fmt.Sprintf("Machine %s created (init)", newMachine.Name),
 			"Machine", klog.KObj(newMachine),
 			newMachine.Spec.InfrastructureRef.Kind, klog.KRef(newMachine.Namespace, newMachine.Spec.InfrastructureRef.Name),
 			newMachine.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(newMachine.Namespace, newMachine.Spec.Bootstrap.ConfigRef.Name))
@@ -87,7 +87,7 @@ func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context,
 	}
 
 	log.WithValues(controlPlane.StatusToLogKeyAndValues(newMachine, nil)...).
-		Info("Machine created (scale up)",
+		Info(fmt.Sprintf("Machine %s created (scale up)", newMachine.Name),
 			"Machine", klog.KObj(newMachine),
 			newMachine.Spec.InfrastructureRef.Kind, klog.KRef(newMachine.Namespace, newMachine.Spec.InfrastructureRef.Name),
 			newMachine.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(newMachine.Namespace, newMachine.Spec.Bootstrap.ConfigRef.Name))
@@ -144,7 +144,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 	// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.
 	// Also, setting DeletionTimestamp doesn't mean the Machine is actually deleted (deletion takes some time).
 	log.WithValues(controlPlane.StatusToLogKeyAndValues(nil, machineToDelete)...).
-		Info("Deleting Machine (scale down)", "Machine", klog.KObj(machineToDelete))
+		Info(fmt.Sprintf("Machine %s deleting (scale down)", machineToDelete.Name), "Machine", klog.KObj(machineToDelete))
 
 	// Requeue the control plane, in case there are additional operations to perform
 	return ctrl.Result{Requeue: true}, nil

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -668,7 +668,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 	// We only delete the node after the underlying infrastructure is gone.
 	// https://github.com/kubernetes-sigs/cluster-api/issues/2565
 	if isDeleteNodeAllowed {
-		log.Info("Deleting node", "Node", klog.KRef("", m.Status.NodeRef.Name))
+		log.Info("Deleting Node", "Node", klog.KRef("", m.Status.NodeRef.Name))
 
 		var deleteNodeErr error
 		waitErr := wait.PollUntilContextTimeout(ctx, 2*time.Second, r.nodeDeletionRetryTimeout, true, func(ctx context.Context) (bool, error) {
@@ -678,9 +678,9 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result
 			return true, nil
 		})
 		if waitErr != nil {
-			log.Error(deleteNodeErr, "Timed out deleting node", "Node", klog.KRef("", m.Status.NodeRef.Name))
+			log.Error(deleteNodeErr, "Timed out deleting Node", "Node", klog.KRef("", m.Status.NodeRef.Name))
 			v1beta1conditions.MarkFalse(m, clusterv1.MachineNodeHealthyV1Beta1Condition, clusterv1.DeletionFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "")
-			r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedDeleteNode", "error deleting Machine's node: %v", deleteNodeErr)
+			r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedDeleteNode", "error deleting Machine's Node: %v", deleteNodeErr)
 
 			// If the node deletion timeout is not expired yet, requeue the Machine for reconciliation.
 			if m.Spec.Deletion.NodeDeletionTimeoutSeconds == nil || *m.Spec.Deletion.NodeDeletionTimeoutSeconds == 0 || m.DeletionTimestamp.Add(time.Duration(*m.Spec.Deletion.NodeDeletionTimeoutSeconds)*time.Second).After(time.Now()) {

--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -70,7 +70,6 @@ func (r *Reconciler) reconcileNode(ctx context.Context, s *scope) (ctrl.Result, 
 
 	// Check that the Machine has a valid ProviderID.
 	if machine.Spec.ProviderID == "" {
-		log.Info("Waiting for infrastructure provider to report spec.providerID", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Namespace, machine.Spec.InfrastructureRef.Name))
 		v1beta1conditions.MarkFalse(machine, clusterv1.MachineNodeHealthyV1Beta1Condition, clusterv1.WaitingForNodeRefV1Beta1Reason, clusterv1.ConditionSeverityInfo, "")
 		return ctrl.Result{}, nil
 	}
@@ -96,7 +95,7 @@ func (r *Reconciler) reconcileNode(ctx context.Context, s *scope) (ctrl.Result, 
 				return ctrl.Result{}, errors.Wrapf(err, "no matching Node for Machine %q in namespace %q", machine.Name, machine.Namespace)
 			}
 			v1beta1conditions.MarkFalse(machine, clusterv1.MachineNodeHealthyV1Beta1Condition, clusterv1.NodeProvisioningV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Waiting for a node with matching ProviderID to exist")
-			log.Info("Infrastructure provider reporting spec.providerID, matching Kubernetes node is not yet available", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Namespace, machine.Spec.InfrastructureRef.Name), "providerID", machine.Spec.ProviderID)
+			log.Info("Infrastructure provider reporting spec.providerID, matching Kubernetes Node is not yet available", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Namespace, machine.Spec.InfrastructureRef.Name), "providerID", machine.Spec.ProviderID)
 			// No need to requeue here. Nodes emit an event that triggers reconciliation.
 			return ctrl.Result{}, nil
 		}
@@ -112,7 +111,7 @@ func (r *Reconciler) reconcileNode(ctx context.Context, s *scope) (ctrl.Result, 
 		machine.Status.NodeRef = clusterv1.MachineNodeReference{
 			Name: s.node.Name,
 		}
-		log.Info("Infrastructure provider reporting spec.providerID, Kubernetes node is now available", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Namespace, machine.Spec.InfrastructureRef.Name), "providerID", machine.Spec.ProviderID, "Node", klog.KRef("", machine.Status.NodeRef.Name))
+		log.Info("Infrastructure provider reporting spec.providerID, Kubernetes Node is now available", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Namespace, machine.Spec.InfrastructureRef.Name), "providerID", machine.Spec.ProviderID, "Node", klog.KRef("", machine.Status.NodeRef.Name))
 		r.recorder.Event(machine, corev1.EventTypeNormal, "SuccessfulSetNodeRef", machine.Status.NodeRef.Name)
 	}
 

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -680,7 +680,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 		},
 		{
-			name:     "infra machine ready and no provider ID, it should fail",
+			name:     "should do nothing if infra machine ready and no provider ID",
 			contract: "v1beta1",
 			machine:  defaultMachine.DeepCopy(),
 			infraMachine: map[string]interface{}{
@@ -697,7 +697,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 			infraMachineGetError: nil,
 			expectResult:         ctrl.Result{},
-			expectError:          true,
+			expectError:          false,
 		},
 		{
 			name:     "should never revert back to infrastructure not ready",

--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -642,6 +642,9 @@ func setUpdatingCondition(_ context.Context, machine *clusterv1.Machine, updatin
 		if updatingReason == "" {
 			updatingReason = clusterv1.MachineInPlaceUpdatingReason
 		}
+		if updatingMessage == "" {
+			updatingMessage = "In-place update in progress"
+		}
 		conditions.Set(machine, metav1.Condition{
 			Type:    clusterv1.MachineUpdatingCondition,
 			Status:  metav1.ConditionTrue,
@@ -714,11 +717,16 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 		return
 	}
 
-	if conditions.IsTrue(m, clusterv1.MachineUpdatingCondition) {
+	if c := conditions.Get(m, clusterv1.MachineUpdatingCondition); c != nil && c.Status == metav1.ConditionTrue {
+		msg := "* In-place update in progress"
+		if c.Message != "" {
+			msg = fmt.Sprintf("* %s", c.Message)
+		}
 		conditions.Set(m, metav1.Condition{
-			Type:   clusterv1.MachineUpToDateCondition,
-			Status: metav1.ConditionFalse,
-			Reason: clusterv1.MachineUpToDateUpdatingReason,
+			Type:    clusterv1.MachineUpToDateCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  clusterv1.MachineUpToDateUpdatingReason,
+			Message: msg,
 		})
 		return
 	}

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -1579,9 +1579,49 @@ func TestSetUpToDateCondition(t *testing.T) {
 				},
 			},
 			expectCondition: &metav1.Condition{
-				Type:   clusterv1.MachineUpToDateCondition,
-				Status: metav1.ConditionFalse,
-				Reason: clusterv1.MachineUpToDateUpdatingReason,
+				Type:    clusterv1.MachineUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineUpToDateUpdatingReason,
+				Message: "* In-place update in progress",
+			},
+		},
+		{
+			name: "updating (message from Updating)",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    clusterv1.MachineUpdatingCondition,
+							Status:  metav1.ConditionTrue,
+							Reason:  clusterv1.MachineInPlaceUpdatingReason,
+							Message: "In-place update in progress: Extension is updating Machine",
+						},
+					},
+				},
+			},
+			expectCondition: &metav1.Condition{
+				Type:    clusterv1.MachineUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineUpToDateUpdatingReason,
+				Message: "* In-place update in progress: Extension is updating Machine",
 			},
 		},
 		{

--- a/internal/controllers/machinedeployment/machinedeployment_canupdatemachineset.go
+++ b/internal/controllers/machinedeployment/machinedeployment_canupdatemachineset.go
@@ -42,7 +42,7 @@ func (p *rolloutPlanner) canUpdateMachineSetInPlace(ctx context.Context, oldMS, 
 		return p.overrideCanUpdateMachineSetInPlace(ctx, oldMS, newMS)
 	}
 
-	log := ctrl.LoggerFrom(ctx)
+	log := ctrl.LoggerFrom(ctx).WithValues("MachineSet", klog.KObj(oldMS))
 
 	templateObjects, err := p.getTemplateObjects(ctx, oldMS, newMS)
 	if err != nil {
@@ -77,9 +77,10 @@ func (p *rolloutPlanner) canUpdateMachineSetInPlace(ctx context.Context, oldMS, 
 		return false, err
 	}
 	if !canUpdateMachineSet {
-		log.Info(fmt.Sprintf("MachineSet cannot be updated in-place by extensions: %s", strings.Join(reasons, ",")), "MachineSet", klog.KObj(oldMS))
+		log.Info(fmt.Sprintf("MachineSet %s cannot be updated in-place by extensions", oldMS.Name), "reason", strings.Join(reasons, ","))
 		return false, nil
 	}
+	log.Info(fmt.Sprintf("MachineSet %s can be updated in-place by extensions", oldMS.Name))
 	return true, nil
 }
 

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
@@ -24,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -129,7 +127,7 @@ func (p *rolloutPlanner) init(ctx context.Context, md *clusterv1.MachineDeployme
 	}
 
 	if !mdTemplateExists {
-		return errors.New("cannot create a new MachineSet when templates do not exist")
+		return errors.New("cannot create a MachineSet when templates do not exist")
 	}
 
 	// Compute a new MachineSet with mandatory labels, fields in-place propagated from the MachineDeployment etc.
@@ -200,7 +198,6 @@ func (p *rolloutPlanner) computeDesiredOldMS(ctx context.Context, currentOldMS *
 // computeDesiredMS computes the desired MachineSet, which could be either a newly created newMS, or the new desired version of an existing newMS/OldMS.
 // Note: because we are using Server-Side-Apply we always have to calculate the full object.
 func computeDesiredMS(ctx context.Context, deployment *clusterv1.MachineDeployment, currentMS *clusterv1.MachineSet) (*clusterv1.MachineSet, error) {
-	log := ctrl.LoggerFrom(ctx)
 	var name string
 	var uid types.UID
 	var finalizers []string
@@ -230,7 +227,6 @@ func computeDesiredMS(ctx context.Context, deployment *clusterv1.MachineDeployme
 		replicas = 0
 		machineTemplateSpec = *deployment.Spec.Template.Spec.DeepCopy()
 		creationTimestamp = metav1.NewTime(time.Now())
-		log.V(5).Info(fmt.Sprintf("Computing new MachineSet %s with %d replicas", name, replicas), "MachineSet", klog.KRef(deployment.Namespace, name))
 	} else {
 		// For updating an existing MachineSet use name, uid, finalizers, replicas, uniqueIdentifier and machine template spec from existingMS.
 		// Note: We use the uid, to ensure that the Server-Side-Apply only updates the existingMS.

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -483,7 +483,7 @@ func FindNewAndOldMachineSets(deployment *clusterv1.MachineDeployment, msList []
 				// No need to set an additional condition message, it is not used anywhere.
 				upToDateResults[ms.Name] = upToDateResult
 			}
-			diffs = append(diffs, fmt.Sprintf("MachineSet %s: diff: %s", ms.Name, strings.Join(upToDateResult.LogMessages, ", ")))
+			diffs = append(diffs, fmt.Sprintf("MachineSet %s needs rollout: %s", ms.Name, strings.Join(upToDateResult.LogMessages, ", ")))
 		}
 	}
 

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -469,7 +469,7 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 					EligibleForInPlaceUpdate: true,
 				},
 			},
-			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s: diff: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required`, oldMS.Name),
+			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s needs rollout: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required`, oldMS.Name),
 		},
 		{
 			Name:           "Get the MachineSet with the MachineTemplate that matches the intent of the MachineDeployment",
@@ -550,7 +550,7 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 					EligibleForInPlaceUpdate: true,
 				},
 			},
-			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s: diff: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required`, oldMS.Name),
+			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s needs rollout: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required`, oldMS.Name),
 		},
 		{
 			Name:               "Get nil if no MachineSet matches the desired intent of the MachineDeployment, reconciliationTime is > rolloutAfter",
@@ -571,7 +571,7 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 					EligibleForInPlaceUpdate: false,
 				},
 			},
-			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s: diff: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required, MachineDeployment spec.rolloutAfter expired`, oldMS.Name),
+			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s needs rollout: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required, MachineDeployment spec.rolloutAfter expired`, oldMS.Name),
 		},
 		{
 			Name:               "Get the MachineSet if reconciliationTime < rolloutAfter",

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -211,7 +211,6 @@ func (r *Reconciler) reconcile(ctx context.Context, logger logr.Logger, cluster 
 		var err error
 		remoteClient, err = r.ClusterCache.GetClient(ctx, util.ObjectKey(cluster))
 		if err != nil {
-			logger.Error(err, "Error creating remote cluster cache")
 			return ctrl.Result{}, err
 		}
 
@@ -224,8 +223,7 @@ func (r *Reconciler) reconcile(ctx context.Context, logger logr.Logger, cluster 
 	logger.V(3).Info("Finding targets")
 	targets, err := r.getTargetsFromMHC(ctx, logger, remoteClient, cluster, m)
 	if err != nil {
-		logger.Error(err, "Failed to fetch targets from MachineHealthCheck")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, errors.Wrapf(err, "failed to fetch targets from MachineHealthCheck")
 	}
 	totalTargets := len(targets)
 	m.Status.ExpectedMachines = ptr.To(int32(totalTargets))

--- a/internal/controllers/machineset/machineset_controller_status.go
+++ b/internal/controllers/machineset/machineset_controller_status.go
@@ -199,7 +199,13 @@ func setScalingDownCondition(_ context.Context, ms *clusterv1.MachineSet, machin
 	if !ms.DeletionTimestamp.IsZero() {
 		desiredReplicas = 0
 	}
-	currentReplicas := int32(len(machines))
+	currentReplicas := int32(0)
+	for _, m := range machines {
+		if _, ok := m.Annotations[clusterv1.PendingAcknowledgeMoveAnnotation]; ok {
+			continue
+		}
+		currentReplicas++
+	}
 
 	// Scaling down.
 	if currentReplicas > desiredReplicas {

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -395,7 +395,7 @@ func (c *client) CallExtension(ctx context.Context, hook runtimecatalog.Hook, fo
 	}
 
 	if retryResponse, ok := response.(runtimehooksv1.RetryResponseObject); ok && retryResponse.GetRetryAfterSeconds() != 0 {
-		log.Info(fmt.Sprintf("Extension handler returned blocking response with retryAfterSeconds of %d", retryResponse.GetRetryAfterSeconds()))
+		log.V(4).Info(fmt.Sprintf("Extension handler returned blocking response with retryAfterSeconds of %d", retryResponse.GetRetryAfterSeconds()))
 	} else {
 		log.V(4).Info("Extension handler returned success response")
 	}

--- a/internal/util/tree/tree.go
+++ b/internal/util/tree/tree.go
@@ -646,7 +646,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 		// If the object is a MachineDeployment, returns all the replica counters and pick the Available condition
 		// as the condition to show for this object in case not all the conditions are visualized.
 		if obj.Spec.Replicas != nil {
-			v.replicas = fmt.Sprintf("%d/%d", *obj.Spec.Replicas, ptr.Deref(obj.Status.Replicas, 0))
+			v.replicas = fmt.Sprintf("%d/%d", ptr.Deref(obj.Status.Replicas, 0), ptr.Deref(obj.Spec.Replicas, 0))
 		}
 		if obj.Status.AvailableReplicas != nil {
 			v.availableCounters = fmt.Sprintf("%d", *obj.Status.AvailableReplicas)
@@ -670,7 +670,7 @@ func newRowDescriptor(obj ctrlclient.Object) rowDescriptor {
 		// If the object is a MachineSet, returns all the replica counters; no condition
 		// is shown for this object in case not all the conditions are visualized.
 		if obj.Spec.Replicas != nil {
-			v.replicas = fmt.Sprintf("%d/%d", *obj.Spec.Replicas, ptr.Deref(obj.Status.Replicas, 0))
+			v.replicas = fmt.Sprintf("%d/%d", ptr.Deref(obj.Status.Replicas, 0), ptr.Deref(obj.Spec.Replicas, 0))
 		}
 		if obj.Status.AvailableReplicas != nil {
 			v.availableCounters = fmt.Sprintf("%d", *obj.Status.AvailableReplicas)

--- a/test/extension/handlers/inplaceupdate/handlers.go
+++ b/test/extension/handlers/inplaceupdate/handlers.go
@@ -215,10 +215,10 @@ func (h *ExtensionHandlers) DoUpdateMachine(ctx context.Context, req *runtimehoo
 	// Note: We are intentionally not actually applying any in-place changes we are just faking them,
 	// which is good enough for test purposes.
 	if firstTimeCalled, ok := h.state.Load(key); ok {
-		if time.Since(firstTimeCalled.(time.Time)) > time.Duration(20+rand.Intn(10))*time.Second {
+		if time.Since(firstTimeCalled.(time.Time)) > time.Duration(30+rand.Intn(10))*time.Second {
 			h.state.Delete(key)
 			resp.Status = runtimehooksv1.ResponseStatusSuccess
-			resp.Message = "In-place update is done"
+			resp.Message = "Extension completed updating Machine"
 			resp.RetryAfterSeconds = 0
 			return
 		}
@@ -227,8 +227,8 @@ func (h *ExtensionHandlers) DoUpdateMachine(ctx context.Context, req *runtimehoo
 	}
 
 	resp.Status = runtimehooksv1.ResponseStatusSuccess
-	resp.Message = "In-place update still in progress"
-	resp.RetryAfterSeconds = 5
+	resp.Message = "Extension is updating Machine"
+	resp.RetryAfterSeconds = 15
 }
 
 func (h *ExtensionHandlers) getObjectsFromCanUpdateMachineRequest(req *runtimehooksv1.CanUpdateMachineRequest) (*clusterv1.Machine, *clusterv1.Machine, runtime.Object, runtime.Object, runtime.Object, runtime.Object, error) { //nolint:gocritic // accepting high number of return parameters for now

--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -170,17 +170,17 @@ func (h *Helper) Patch(ctx context.Context, obj client.Object, opts ...Option) e
 	// patching conditions first avoids an extra loop if spec or status patch succeeds first
 	// given that causes the resourceVersion to mutate.
 	if err := h.patchStatusConditions(ctx, obj, options.ForceOverwriteConditions, options.OwnedConditions, options.OwnedV1Beta2Conditions); err != nil {
-		errs = append(errs, err)
+		errs = append(errs, errors.Wrapf(err, "failed to patch status conditions"))
 	}
 	// Then proceed to patch the rest of the object.
 	if err := h.patch(ctx, obj); err != nil {
-		errs = append(errs, err)
+		errs = append(errs, errors.Wrapf(err, "failed to patch spec and metadata"))
 	}
 
 	if err := h.patchStatus(ctx, obj); err != nil {
 		//nolint:staticcheck
 		if !(apierrors.IsNotFound(err) && !obj.GetDeletionTimestamp().IsZero() && len(obj.GetFinalizers()) == 0) {
-			errs = append(errs, err)
+			errs = append(errs, errors.Wrapf(err, "failed to patch status"))
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Did some extensive testing with Fabrizio in the context of in-place updates.

This PR improves logs, errors and conditions across the code base.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->