### PR TITLE
🌱  Migrate from Requeue to RequeueAfter in extensionconfig

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -272,7 +272,7 @@ linters:
           - staticcheck
         text: 'SA1019: .*(res|result|i|j)\.Requeue is deprecated: Use `RequeueAfter` instead'
         # TODO: Remove Requeue step by step
-        path: internal/controllers/(extensionconfig|machinepool)|util/util.go
+        path: internal/controllers/machinepool
       # TODO: var-naming: avoid meaningless package names by revive
       #   * test/infrastructure/docker/internal/docker/types/
       #   * bootstrap/kubeadm/types/

--- a/internal/controllers/extensionconfig/extensionconfig_controller.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -131,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// Requeue events when the registry is not ready.
 	// The registry will become ready after it is 'warmed up' by warmupRunnable.
 	if !r.RuntimeClient.IsReady() {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	extensionConfig := &runtimev1.ExtensionConfig{}

--- a/internal/controllers/extensionconfig/extensionconfig_controller_test.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller_test.go
@@ -102,7 +102,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).ToNot(HaveOccurred())
 		// If the registry isn't warm the reconcile loop will return Requeue: True
-		g.Expect(res.Requeue).To(BeTrue())
+		g.Expect(res.RequeueAfter).To((Equal(10 * time.Second)))
 	})
 
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(*testing.T) {

--- a/util/util.go
+++ b/util/util.go
@@ -690,6 +690,8 @@ func IsSupportedVersionSkew(a, b semver.Version) bool {
 
 // LowestNonZeroResult compares two reconciliation results
 // and returns the one with lowest requeue time.
+//
+//nolint:staticcheck // SA1019: Requeue is deprecated.
 func LowestNonZeroResult(i, j ctrl.Result) ctrl.Result {
 	switch {
 	case i.IsZero():


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12272

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->