### PR TITLE
🌱 e2e: use wait-machine-upgrade timeout in ClusterClassChanges tests to wait for machines to be ready

### DIFF
--- a/test/e2e/clusterclass_changes.go
+++ b/test/e2e/clusterclass_changes.go
@@ -272,16 +272,17 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 			WaitForMachinePools:                           input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 
+		Byf("Wait for all Machine Ready conditions are true")
+		framework.WaitForMachinesReady(ctx, framework.WaitForMachinesReadyInput{
+			Lister:    input.BootstrapClusterProxy.GetClient(),
+			Name:      clusterResources.Cluster.Name,
+			Namespace: clusterResources.Cluster.Namespace,
+			Intervals: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
+		})
+
 		Byf("Verify Cluster Available condition is true")
 		framework.VerifyClusterAvailable(ctx, framework.VerifyClusterAvailableInput{
 			Getter:    input.BootstrapClusterProxy.GetClient(),
-			Name:      clusterResources.Cluster.Name,
-			Namespace: clusterResources.Cluster.Namespace,
-		})
-
-		Byf("Verify Machines Ready condition is true")
-		framework.VerifyMachinesReady(ctx, framework.VerifyMachinesReadyInput{
-			Lister:    input.BootstrapClusterProxy.GetClient(),
 			Name:      clusterResources.Cluster.Name,
 			Namespace: clusterResources.Cluster.Namespace,
 		})

--- a/test/framework/machines.go
+++ b/test/framework/machines.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -92,4 +93,39 @@ func WaitForClusterMachinesReady(ctx context.Context, input WaitForClusterMachin
 		}
 		return
 	}, intervals...).Should(Equal(len(machines.Items)), "Timed out waiting for %d nodes to be ready", len(machines.Items))
+}
+
+type WaitForMachinesReadyInput struct {
+	Lister    Lister
+	Name      string
+	Namespace string
+	Intervals []interface{}
+}
+
+func WaitForMachinesReady(ctx context.Context, input WaitForMachinesReadyInput, intervals ...interface{}) {
+	By("Waiting for the machines' Ready condition to be true")
+	machineList := &clusterv1.MachineList{}
+
+	// Wait for all machines to have Ready condition set to true.
+	Eventually(func(g Gomega) {
+		g.Expect(input.Lister.List(ctx, machineList, client.InNamespace(input.Namespace),
+			client.MatchingLabels{
+				clusterv1.ClusterNameLabel: input.Name,
+			})).To(Succeed())
+
+		g.Expect(machineList.Items).ToNot(BeEmpty(), "No machines found for cluster %s", input.Name)
+
+		for _, machine := range machineList.Items {
+			readyConditionFound := false
+			for _, condition := range machine.Status.Conditions {
+				if condition.Type == clusterv1.ReadyCondition {
+					readyConditionFound = true
+					g.Expect(condition.Status).To(Equal(metav1.ConditionTrue), "The Ready condition on Machine %q should be set to true; message: %s", machine.Name, condition.Message)
+					g.Expect(condition.Message).To(BeEmpty(), "The Ready condition on Machine %q should have an empty message", machine.Name)
+					break
+				}
+			}
+			g.Expect(readyConditionFound).To(BeTrue(), "Machine %q should have a Ready condition", machine.Name)
+		}
+	}, intervals...).Should(Succeed(), "Failed to wait for Machines Ready condition for Cluster %s", klog.KRef(input.Namespace, input.Name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

While developing: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5720/

We hit the issue of the timeout to verify if machines are ready 

This makes the timeout configurable via `wait-machine-ready`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing