### PR TITLE
✨ Allow overriding image name in clusterctl config

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -61,7 +61,7 @@ var certManagerNamespaceYaml = []byte("apiVersion: v1\n" +
 func Test_getManifestObjs(t *testing.T) {
 	g := NewWithT(t)
 
-	defaultConfigClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "")))
+	defaultConfigClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "")))
 	g.Expect(err).ToNot(HaveOccurred())
 
 	type fields struct {
@@ -109,7 +109,7 @@ func Test_getManifestObjs(t *testing.T) {
 			name: "successfully gets the cert-manager components for a custom release",
 			fields: fields{
 				configClient: func() config.Client {
-					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "").WithCertManager("", "v1.0.0", "")))
+					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "").WithCertManager("", "v1.0.0", "")))
 					g.Expect(err).ToNot(HaveOccurred())
 					return configClient
 				}(),

--- a/cmd/clusterctl/client/config/imagemeta_client.go
+++ b/cmd/clusterctl/client/config/imagemeta_client.go
@@ -125,6 +125,9 @@ type imageMeta struct {
 	// repository sets the container registry to pull images from.
 	Repository string `json:"repository,omitempty"`
 
+	// Name allows to specify a different name for the image.
+	Name string `json:"name,omitempty"`
+
 	// Tag allows to specify a tag for the images.
 	Tag string `json:"tag,omitempty"`
 }
@@ -134,6 +137,9 @@ type imageMeta struct {
 func (i *imageMeta) Union(other *imageMeta) {
 	if other.Repository != "" {
 		i.Repository = other.Repository
+	}
+	if other.Name != "" {
+		i.Name = other.Name
 	}
 	if other.Tag != "" {
 		i.Tag = other.Tag
@@ -145,6 +151,9 @@ func (i *imageMeta) ApplyToImage(image container.Image) string {
 	// apply transformations
 	if i.Repository != "" {
 		image.Repository = strings.TrimSuffix(i.Repository, "/")
+	}
+	if i.Name != "" {
+		image.Name = i.Name
 	}
 	if i.Tag != "" {
 		image.Tag = i.Tag

--- a/cmd/clusterctl/client/config/imagemeta_client_test.go
+++ b/cmd/clusterctl/client/config/imagemeta_client_test.go
@@ -55,7 +55,7 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 		{
 			name: "image config for cert-manager/cert-manager-cainjector: image for the cert-manager/cert-manager-cainjector should be changed",
 			fields: fields{
-				reader: test.NewFakeReader().WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag"),
+				reader: test.NewFakeReader().WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -67,7 +67,7 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 		{
 			name: "image config for cert-manager/cert-manager-cainjector: image for the cert-manager/cert-manager-webhook should not be changed",
 			fields: fields{
-				reader: test.NewFakeReader().WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag"),
+				reader: test.NewFakeReader().WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -79,7 +79,7 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 		{
 			name: "image config for cert-manager: images for the cert-manager should be changed",
 			fields: fields{
-				reader: test.NewFakeReader().WithImageMeta(CertManagerImageComponent, "foo-repository.io", "foo-tag"),
+				reader: test.NewFakeReader().WithImageMeta(CertManagerImageComponent, "foo-repository.io", "", "foo-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -92,8 +92,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector and for cert-manager: images for the cert-manager/cert-manager-cainjector should be changed according to the most specific",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag").
-					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "bar-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag").
+					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "", "bar-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -106,8 +106,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector and for cert-manager: images for the cert-manager/cert-manager-cainjector should be changed according to the most specific (mixed case)",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "").
-					WithImageMeta(CertManagerImageComponent, "", "bar-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "").
+					WithImageMeta(CertManagerImageComponent, "", "", "bar-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -120,8 +120,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector and for cert-manager: images for the cert-manager/cert-manager-webhook should be changed according to the most generic",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag").
-					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "bar-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag").
+					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "", "bar-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -133,7 +133,7 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 		{
 			name: "image config for all: images for the cert-manager should be changed",
 			fields: fields{
-				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-repository.io", "foo-tag"),
+				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-repository.io", "", "foo-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -146,8 +146,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for all and for cert-manager: images for the cert-manager should be changed according to the most specific",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(allImageConfig, "foo-repository.io", "foo-tag").
-					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "bar-tag"),
+					WithImageMeta(allImageConfig, "foo-repository.io", "", "foo-tag").
+					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "", "bar-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -160,8 +160,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for all and for cert-manager: images for the cert-manager should be changed according to the most specific (mixed case)",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(allImageConfig, "foo-repository.io", "").
-					WithImageMeta(CertManagerImageComponent, "", "bar-tag"),
+					WithImageMeta(allImageConfig, "foo-repository.io", "", "").
+					WithImageMeta(CertManagerImageComponent, "", "", "bar-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -174,9 +174,9 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector, for cert-manager and for all: images for the cert-manager/cert-manager-cainjector should be changed according to the most specific",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag").
-					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "bar-tag").
-					WithImageMeta(allImageConfig, "baz-repository.io", "baz-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag").
+					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "", "bar-tag").
+					WithImageMeta(allImageConfig, "baz-repository.io", "", "baz-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -189,9 +189,9 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector, for cert-manager and for all: images for the cert-manager/cert-manager-cainjector should be changed according to the most specific (mixed case)",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "").
-					WithImageMeta(CertManagerImageComponent, "", "bar-tag").
-					WithImageMeta(allImageConfig, "baz-repository.io", "baz-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "").
+					WithImageMeta(CertManagerImageComponent, "", "", "bar-tag").
+					WithImageMeta(allImageConfig, "baz-repository.io", "", "baz-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -204,9 +204,9 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			name: "image config for cert-manager/cert-manager-cainjector, for cert-manager and for all: images for the cert-manager/cert-manager-webhook should be changed according to the most generic",
 			fields: fields{
 				reader: test.NewFakeReader().
-					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "foo-tag").
-					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "").
-					WithImageMeta(allImageConfig, "baz-repository.io", "baz-tag"),
+					WithImageMeta(fmt.Sprintf("%s/cert-manager-cainjector", CertManagerImageComponent), "foo-repository.io", "", "foo-tag").
+					WithImageMeta(CertManagerImageComponent, "bar-repository.io", "", "").
+					WithImageMeta(allImageConfig, "baz-repository.io", "", "baz-tag"),
 			},
 			args: args{
 				component: CertManagerImageComponent,
@@ -230,7 +230,7 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 		{
 			name: "fails if wrong image name",
 			fields: fields{
-				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-Repository.io", ""),
+				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-Repository.io", "", ""),
 			},
 			args: args{
 				component: "any",
@@ -238,6 +238,56 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			},
 			want:    "",
 			wantErr: true,
+		},
+		{
+			name: "image config for cluster-api/cluster-api-controller with name override only: only image name should be changed",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta("cluster-api/cluster-api-controller", "", "custom-cluster-api-controller", ""),
+			},
+			args: args{
+				component: "cluster-api",
+				image:     "registry.k8s.io/cluster-api/cluster-api-controller:v1.8.0",
+			},
+			want:    "registry.k8s.io/cluster-api/custom-cluster-api-controller:v1.8.0",
+			wantErr: false,
+		},
+		{
+			name: "image config for cluster-api/cluster-api-controller with repository and name override: repository and name should be changed, tag preserved",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta("cluster-api/cluster-api-controller", "myorg.io/mirror", "custom-cluster-api-controller", ""),
+			},
+			args: args{
+				component: "cluster-api",
+				image:     "registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6",
+			},
+			want:    "myorg.io/mirror/custom-cluster-api-controller:v1.10.6",
+			wantErr: false,
+		},
+		{
+			name: "image config for cluster-api/cluster-api-controller with specific name override and generic repository from all: both should be applied",
+			fields: fields{
+				reader: test.NewFakeReader().
+					WithImageMeta(allImageConfig, "myorg.io/mirror", "", "").
+					WithImageMeta("cluster-api/cluster-api-controller", "", "custom-cluster-api-controller", ""),
+			},
+			args: args{
+				component: "cluster-api",
+				image:     "registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6",
+			},
+			want:    "myorg.io/mirror/custom-cluster-api-controller:v1.10.6",
+			wantErr: false,
+		},
+		{
+			name: "image config for cluster-api/cluster-api-controller with repository, name and tag override: all fields should be changed",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta("cluster-api/cluster-api-controller", "myorg.io/mirror", "custom-cluster-api-controller", "v1.5.0"),
+			},
+			args: args{
+				component: "cluster-api",
+				image:     "registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6",
+			},
+			want:    "myorg.io/mirror/custom-cluster-api-controller:v1.5.0",
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -54,6 +54,7 @@ type configCertManager struct {
 // avoid circular dependencies between pkg/client/config and pkg/internal/test.
 type imageMeta struct {
 	Repository string `json:"repository,omitempty"`
+	Name       string `json:"name,omitempty"`
 	Tag        string `json:"tag,omitempty"`
 }
 
@@ -119,9 +120,10 @@ func (f *FakeReader) WithCertManager(url, version, timeout string) *FakeReader {
 	return f
 }
 
-func (f *FakeReader) WithImageMeta(component, repository, tag string) *FakeReader {
+func (f *FakeReader) WithImageMeta(component, repository, name, tag string) *FakeReader {
 	f.imageMetas[component] = imageMeta{
 		Repository: repository,
+		Name:       name,
 		Tag:        tag,
 	}
 

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -261,6 +261,33 @@ images:
     tag: v1.5.3
 ```
 
+Additionally, you can override the image name itself. This is useful when images
+have been mirrored with different names:
+
+```yaml
+images:
+  all:
+    repository: myorg.io/local-repo
+  cluster-api:
+    name: mirrored-cluster-api-controller
+```
+
+This would transform `registry.k8s.io/cluster-api/cluster-api-controller:v1.10.6` into
+`myorg.io/local-repo/mirrored-cluster-api-controller:v1.10.6`.
+
+Or you can specify all three fields to completely override the image:
+
+```yaml
+images:
+  cluster-api:
+    repository: myorg.io/local-repo
+    name: mirrored-cluster-api-controller
+    tag: v1.10.6
+```
+
+This would transform `registry.k8s.io/cluster-api/cluster-api-controller:v1.8.0` into
+`myorg.io/local-repo/mirrored-cluster-api-controller:v1.10.6`, replacing both the image location and version.
+
 ## Debugging/Logging
 
 To have more verbose logs you can use the `-v` flag when running the `clusterctl` and set the level of the logging verbose with a positive integer number, ie. `-v 3`.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: 
This PR adds a name override option for the `clusterctl` config:
```yaml
images:
  cluster-api:
    repository: myorg.io/local-repo
    name: mirrored-cluster-api-controller
    tag: v1.10.6
```

We have use-case where using `clusterctl` config is the best option to override CAPI image name for some air-gapped scenarios where image is retagged with a slightly different name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl