### PR TITLE
🌱 Add structure for area/machinepool ownership in OWNERS files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -71,6 +71,13 @@ aliases:
   - Jont828
 
   # -----------------------------------------------------------
+  # OWNER_ALIASES for internal/controllers/machinepool
+  # -----------------------------------------------------------
+
+  cluster-api-machinepool-maintainers:
+  cluster-api-machinepool-reviewers:
+
+  # -----------------------------------------------------------
   # OWNER_ALIASES for test
   # -----------------------------------------------------------
 

--- a/internal/controllers/machinepool/OWNERS
+++ b/internal/controllers/machinepool/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-machinepool-maintainers
+
+reviewers:
+  - cluster-api-reviewers
+  - cluster-api-machinepool-reviewers


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I suggested in the office hours to become a reviewer for the area/machinepool codebase. Since there are no such aliases yet, I'm adding the structure here first before suggesting people for the list. It's adapted from other files.



<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation
/area machinepool