### PR TITLE
[release-1.11] 🌱 e2e: allow usage of v1beta1 and v1beta2 for MachinePools in clusterctl upgrade

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -1009,7 +1009,7 @@ func calculateExpectedMachinePoolMachineCount(ctx context.Context, c client.Clie
 			var infraMachinePool *unstructured.Unstructured
 
 			// Fallback to v1beta1's objectReference
-			if clusterv1.GroupVersion.Version == "v1beta1" {
+			if coreCAPIStorageVersion == "v1beta1" {
 				ref := &corev1.ObjectReference{}
 				err = util.UnstructuredUnmarshalField(&mp, ref, "spec", "template", "spec", "infrastructureRef")
 				if err != nil && !errors.Is(err, util.ErrUnstructuredFieldNotFound) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Required for:
- https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5979

Partial cherry-pick of: #12723

Cherry-picks commits:
- https://github.com/kubernetes-sigs/cluster-api/pull/12723/commits/26cef8036c0cb545f6f44ad5f0588b24c4d9e55e
- https://github.com/kubernetes-sigs/cluster-api/pull/12723/commits/ff929dc67e7a4356fdbdebe1d4c0d824556bbb38

This is required for CAPZ to bump to v1.11 without loosing test-coverage.

It has an additional test for clusterctl upgrade which updates CAPZ while having CAPI at v1.11 before and after.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing