### PR TITLE
🌱 Avoid KCP rollouts if only ControlPlaneComponentHealthCheckSeconds is changed

### DIFF
--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -695,6 +695,11 @@ type Discovery struct {
 	TLSBootstrapToken string `json:"tlsBootstrapToken,omitempty"`
 }
 
+// IsDefined returns true if the Discovery is defined.
+func (r *Discovery) IsDefined() bool {
+	return !reflect.DeepEqual(r, &Discovery{})
+}
+
 // BootstrapTokenDiscovery is used to set the options for bootstrap token based discovery.
 // +kubebuilder:validation:MinProperties=1
 type BootstrapTokenDiscovery struct {

--- a/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
@@ -619,6 +619,12 @@ func Test_createRequest(t *testing.T) {
 				},
 			},
 			JoinConfiguration: bootstrapv1.JoinConfiguration{
+				// This field is technically set by CABPK, but adding it here so that matchesKubeadmConfig detects this correctly as a join KubeadmConfig.
+				Discovery: bootstrapv1.Discovery{
+					BootstrapToken: bootstrapv1.BootstrapTokenDiscovery{
+						APIServerEndpoint: "1.2.3.4:6443",
+					},
+				},
 				NodeRegistration: bootstrapv1.NodeRegistrationOptions{
 					KubeletExtraArgs: []bootstrapv1.Arg{{
 						Name:  "v",
@@ -635,6 +641,7 @@ func Test_createRequest(t *testing.T) {
 	currentKubeadmConfigCleanedUp.SetGroupVersionKind(bootstrapv1.GroupVersion.WithKind("KubeadmConfig")) // cleanupKubeadmConfig adds GVK.
 	currentKubeadmConfigCleanedUp.Status = bootstrapv1.KubeadmConfigStatus{}                              // cleanupKubeadmConfig drops status.
 	defaulting.ApplyPreviousKubeadmConfigDefaults(&currentKubeadmConfigCleanedUp.Spec)                    // PrepareKubeadmConfigsForDiff applies defaults.
+	currentKubeadmConfigCleanedUp.Spec.JoinConfiguration.Discovery = bootstrapv1.Discovery{}              // PrepareKubeadmConfigsForDiff cleans up Discovery.
 	currentKubeadmConfigWithOutdatedLabelsAndAnnotations := currentKubeadmConfig.DeepCopy()
 	currentKubeadmConfigWithOutdatedLabelsAndAnnotations.Labels["outdated-label-1"] = "outdated-label-value-1"
 	currentKubeadmConfigWithOutdatedLabelsAndAnnotations.Annotations["outdated-annotation-1"] = "outdated-annotation-value-1"
@@ -648,6 +655,7 @@ func Test_createRequest(t *testing.T) {
 	desiredKubeadmConfigCleanedUp.SetGroupVersionKind(bootstrapv1.GroupVersion.WithKind("KubeadmConfig")) // cleanupKubeadmConfig adds GVK.
 	desiredKubeadmConfigCleanedUp.Status = bootstrapv1.KubeadmConfigStatus{}                              // cleanupKubeadmConfig drops status.
 	defaulting.ApplyPreviousKubeadmConfigDefaults(&desiredKubeadmConfigCleanedUp.Spec)                    // PrepareKubeadmConfigsForDiff applies defaults.
+	desiredKubeadmConfigCleanedUp.Spec.JoinConfiguration.Discovery = bootstrapv1.Discovery{}              // PrepareKubeadmConfigsForDiff cleans up Discovery.
 
 	currentInfraMachine := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -341,6 +341,16 @@ func PrepareKubeadmConfigsForDiff(desiredKubeadmConfig, currentKubeadmConfig *bo
 	desiredKubeadmConfig.Spec.JoinConfiguration.Discovery = bootstrapv1.Discovery{}
 	currentKubeadmConfig.Spec.JoinConfiguration.Discovery = bootstrapv1.Discovery{}
 
+	// Cleanup ControlPlaneComponentHealthCheckSeconds from desiredKubeadmConfig and currentKubeadmConfig,
+	// because through conversion apiServer.timeoutForControlPlane in v1beta1 is converted to
+	// initConfiguration/joinConfiguration.timeouts.controlPlaneComponentHealthCheckSeconds in v1beta2 and
+	// this can lead to a diff here that would lead to a rollout.
+	// Note: Changes to ControlPlaneComponentHealthCheckSeconds will apply for the next join, but they will not lead to a rollout.
+	desiredKubeadmConfig.Spec.InitConfiguration.Timeouts.ControlPlaneComponentHealthCheckSeconds = nil
+	desiredKubeadmConfig.Spec.JoinConfiguration.Timeouts.ControlPlaneComponentHealthCheckSeconds = nil
+	currentKubeadmConfig.Spec.InitConfiguration.Timeouts.ControlPlaneComponentHealthCheckSeconds = nil
+	currentKubeadmConfig.Spec.JoinConfiguration.Timeouts.ControlPlaneComponentHealthCheckSeconds = nil
+
 	// If KCP JoinConfiguration.ControlPlane is nil and the Machine JoinConfiguration.ControlPlane is empty,
 	// set Machine JoinConfiguration.ControlPlane to nil.
 	// NOTE: This is required because CABPK applies an empty JoinConfiguration.ControlPlane in case it is nil.
@@ -531,12 +541,16 @@ func dropOmittableFields(spec *bootstrapv1.KubeadmConfigSpec) {
 
 // isKubeadmConfigForJoin returns true if the KubeadmConfig is for a control plane
 // or a worker machine that joined an existing cluster.
-// Note: this check is based on the assumption that KubeadmConfig for joining
-// control plane and workers nodes always have a non-empty join configuration, while
-// instead the join configuration for the first control plane machine in the
+// Note: This check is based on the assumption that KubeadmConfig for joining
+// control plane and workers nodes always have a non-empty JoinConfiguration.Discovery, while
+// instead the JoinConfiguration for the first control plane machine in the
 // cluster is emptied out by KCP.
+// Note: Previously we checked if the entire JoinConfiguration is defined, but that
+// is not safe because apiServer.timeoutForControlPlane in v1beta1 is also converted to
+// joinConfiguration.timeouts.controlPlaneComponentHealthCheckSeconds in v1beta2 and
+// accordingly we would also detect init KubeadmConfigs as join.
 func isKubeadmConfigForJoin(c *bootstrapv1.KubeadmConfig) bool {
-	return c.Spec.JoinConfiguration.IsDefined()
+	return c.Spec.JoinConfiguration.Discovery.IsDefined()
 }
 
 // isKubeadmConfigForInit returns true if the KubeadmConfig is for the first control plane

--- a/test/e2e/data/infrastructure-docker/v1.10/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.10/clusterclass-quick-start.yaml
@@ -554,6 +554,7 @@ spec:
           apiServer:
             extraArgs:
               v: "0"
+            timeoutForControlPlane: 4m
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, host.docker.internal, "::", "::1", "127.0.0.1", "0.0.0.0"]
         initConfiguration:

--- a/test/e2e/data/infrastructure-docker/v1.9/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.9/clusterclass-quick-start.yaml
@@ -554,6 +554,7 @@ spec:
           apiServer:
             extraArgs:
               v: "0"
+            timeoutForControlPlane: 4m
             # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
             certSANs: [localhost, host.docker.internal, "::", "::1", "127.0.0.1", "0.0.0.0"]
         initConfiguration:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13017

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->