### PR TITLE
🌱  Migrate from Requeue to RequeueAfter in MachinePool tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -274,12 +274,6 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: .*\.Deprecated\.V1Beta1.* is deprecated'
-        # CR v0.21 deprecated Result.Requeue, will be fixed incrementally and tracked via https://github.com/kubernetes-sigs/cluster-api/issues/12272
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*(res|result|i|j)\.Requeue is deprecated: Use `RequeueAfter` instead'
-        # TODO: Remove Requeue step by step
-        path: internal/controllers/machinepool
       # TODO: var-naming: avoid meaningless package names by revive
       #   * test/infrastructure/docker/internal/docker/types/
       #   * bootstrap/kubeadm/types/

--- a/internal/controllers/machinepool/machinepool_controller_phases_test.go
+++ b/internal/controllers/machinepool/machinepool_controller_phases_test.go
@@ -147,7 +147,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -190,7 +190,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhasePending))
@@ -230,7 +230,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioning))
@@ -286,7 +286,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -358,7 +358,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -408,7 +408,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioned))
@@ -461,7 +461,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -531,7 +531,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		// Set ReadyReplicas
 		machinepool.Status.Deprecated = &clusterv1.MachinePoolDeprecatedStatus{
@@ -607,7 +607,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseDeleting))
@@ -681,7 +681,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -701,7 +701,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		// Reconcile again. The new bootstrap config should be used.
 		res, err = doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(*machinePool.Spec.Template.Spec.Bootstrap.DataSecretName).To(Equal("secret-data-new"))
@@ -777,7 +777,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 		g.Expect(machinePool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -801,7 +801,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		// Controller should wait until bootstrap provider reports ready bootstrap config
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinePool)
 
@@ -1858,7 +1858,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -1926,7 +1926,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
@@ -1977,7 +1977,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -2024,7 +2024,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 
@@ -2093,7 +2093,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 		res, err := doReconcile(ctx, scope, reconcileNormalFuncsForTest(r))
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(res.Requeue).To(BeFalse())
+		g.Expect(res.RequeueAfter).To(Equal(time.Duration(0)))
 
 		r.reconcilePhase(machinepool)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of  #12272 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->