### PR TITLE
🌱 Add AndiDog as machine pool area reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -76,6 +76,7 @@ aliases:
 
   cluster-api-machinepool-maintainers:
   cluster-api-machinepool-reviewers:
+  - AndiDog
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

As discussed in office hours, the machine pool area should have more contributors overall, and adding someone with a reviewer role could lead to improving this situation.

In my job, I regularly work on CAPA machine pool support, and therefore also worked on the generic parts in CAPI. Overall, there were probably more than contributed 10 PRs relating to that area. I've been a CAPA maintainer since 2024-07, reviewer since 2023-12. My work included major features such as [AWSMachinePool machines support](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5319) (CAPA) or [MachineHealthCheck remediation support for machine pool machines](https://github.com/kubernetes-sigs/cluster-api/pull/11392) (CAPI; pending review by the working group). I'm in office hours somewhat regularly and try to discuss important topics – until now particularly topics around machine pool API, contract and expected behavior (example from ~2023: how/whether to roll machine pool machines on `KubeadmConfig` changes). I've worked on, or looked into, the machine pool and machine controller codebase often enough to be pretty familiar.

My current goal as reviewer would be to help the working group stabilize and document the API and contract well, then later add or fix reasonable features.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->