### PR TITLE
🐛 Fix unit test flakes, improve clusterctl download error in e2e tests

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -1529,7 +1529,7 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 			KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{},
 		},
 	}
-	g.Expect(env.Create(ctx, kcp)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, kcp)).To(Succeed())
 
 	corednsCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -217,8 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (retres ct
 
 	cluster, err := util.GetClusterByName(ctx, r.Client, m.Namespace, m.Spec.ClusterName)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to get cluster %q for machine %q in namespace %q",
-			m.Spec.ClusterName, m.Name, m.Namespace)
+		return ctrl.Result{}, err
 	}
 
 	// Initialize the patch helper

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -273,10 +273,10 @@ func TestWatchesDelete(t *testing.T) {
 		},
 	}
 
-	g.Expect(env.Create(ctx, testCluster)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
 	g.Expect(env.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
-	g.Expect(env.Create(ctx, defaultBootstrap)).To(Succeed())
-	g.Expect(env.Create(ctx, infraMachine)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, defaultBootstrap)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, infraMachine)).To(Succeed())
 
 	defer func(do ...client.Object) {
 		g.Expect(env.Cleanup(ctx, do...)).To(Succeed())

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -854,6 +854,8 @@ func downloadToTmpFile(ctx context.Context, url string) string {
 	Expect(err).ToNot(HaveOccurred(), "failed to get clusterctl")
 	defer resp.Body.Close()
 
+	Expect(resp.StatusCode).To(Equal(http.StatusOK), "unexpected status code when downloading clusterctl")
+
 	// Write the body to file
 	_, err = io.Copy(tmpFile, resp.Body)
 	Expect(err).ToNot(HaveOccurred(), "failed to write temporary file")

--- a/util/util.go
+++ b/util/util.go
@@ -180,7 +180,7 @@ func GetClusterByName(ctx context.Context, c client.Client, namespace, name stri
 	}
 
 	if err := c.Get(ctx, key, cluster); err != nil {
-		return nil, errors.Wrapf(err, "failed to get Cluster/%s", name)
+		return nil, errors.Wrapf(err, "failed to get Cluster %s", klog.KRef(namespace, name))
 	}
 
 	return cluster, nil


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Notes:
* Fixes a few flakes:
  * https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-main/1989215747397652480
  * https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-main/1992798392245293056
* Checks the status code when downloading clusterctl, should avoid format exec errors when trying to execute whatever we get when the clusterctl download fails

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->