### PR TITLE
🌱 Update version matrix for GitHub workflows for release 1.12

### DIFF
--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.11, release-1.10, release-1.9 ]
+        branch: [ main, release-1.12, release-1.11, release-1.10 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # tag=v6.0.0

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.11, release-1.10, release-1.9 ]
+        branch: [ main, release-1.12, release-1.11, release-1.10 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.11, release-1.10, release-1.9 ]
+        branch: [ main, release-1.12, release-1.11, release-1.10 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # tag=v6.0.0


### PR DESCRIPTION
Updates the GitHub workflow version matrix to incorporate the new release v1.12.
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/12771
/area testing