### PR TITLE
[release-1.12] 🐛 Fix WaitForMachinesReady interval

### DIFF
--- a/test/framework/machines.go
+++ b/test/framework/machines.go
@@ -102,7 +102,7 @@ type WaitForMachinesReadyInput struct {
 	Intervals []interface{}
 }
 
-func WaitForMachinesReady(ctx context.Context, input WaitForMachinesReadyInput, intervals ...interface{}) {
+func WaitForMachinesReady(ctx context.Context, input WaitForMachinesReadyInput) {
 	By("Waiting for the machines' Ready condition to be true")
 	machineList := &clusterv1.MachineList{}
 
@@ -127,5 +127,5 @@ func WaitForMachinesReady(ctx context.Context, input WaitForMachinesReadyInput, 
 			}
 			g.Expect(readyConditionFound).To(BeTrue(), "Machine %q should have a Ready condition", machine.Name)
 		}
-	}, intervals...).Should(Succeed(), "Failed to wait for Machines Ready condition for Cluster %s", klog.KRef(input.Namespace, input.Name))
+	}, input.Intervals...).Should(Succeed(), "Failed to wait for Machines Ready condition for Cluster %s", klog.KRef(input.Namespace, input.Name))
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/13050

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->