### PR TITLE
🌱 api: relax validation for Machine .status.addresses to maximum of 128 instead of 32 items

### DIFF
--- a/api/core/v1beta2/common_types.go
+++ b/api/core/v1beta2/common_types.go
@@ -309,7 +309,7 @@ type MachineAddress struct {
 }
 
 // MachineAddresses is a slice of MachineAddress items to be used by infrastructure providers.
-// +kubebuilder:validation:MaxItems=32
+// +kubebuilder:validation:MaxItems=128
 // +listType=atomic
 type MachineAddresses []MachineAddress
 

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1867,7 +1867,7 @@ spec:
                   - address
                   - type
                   type: object
-                maxItems: 32
+                maxItems: 128
                 type: array
                 x-kubernetes-list-type: atomic
               certificatesExpiryDate:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR relaxes the validation which was added in v1.11 to allow more entries in the Machine's `.status.addresses` slice.

* Before: maximum of 32 items
* After: maximum of 128 items

This came up when trying to bump CAPZ to Cluster API 1.11 at:

https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5979

CAPZ has a test which uses Azure CNI which leads to have 111 entries at `AzureMachine.status.addresses`.

Patching that up to the Machine fails due to the validation added in v1.11.

The entries are:
* 1x `InternalDNS`
* 1x `InternalIP`'s
* 109 additional `InternalIP`'s

To still get more information about the reasoning on why CAPZ has this use case of having more addresses then 32, I asked the question at https://kubernetes.slack.com/archives/CEX9HENG7/p1764231240877609

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area api