### PR TITLE
🐛 KCP: Grant `delete` permissions to Secrets.

### DIFF
--- a/controlplane/kubeadm/config/rbac/role.yaml
+++ b/controlplane/kubeadm/config/rbac/role.yaml
@@ -25,6 +25,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -72,7 +72,7 @@ const (
 )
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
**What this PR does / why we need it**:

In clusters with the OwnerReferencesPermissionEnforcement admission controller enabled, the KubeadmControlPlane Controller Manager fails to update the owner references of Secrets:

```
E1128 06:20:28.361646       1 controller.go:353] "Reconciler error" err="error in ensuring cluster certificates ownership: failed to set ownerReference: failed to patch Secret <namespace>/<cluster>-ca: secrets \"<cluster>-ca\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>" controller="kubeadmcontrolplane" controllerGroup="controlplane.cluster.x-k8s.io" controllerKind="KubeadmControlPlane" KubeadmControlPlane="<namespace>/<cluster>" namespace="<namespace>" name="<cluster>" reconcileID="8ebb9dfb-a5f7-40ae-ae13-a3b77fd1af5c"
```

/area provider/control-plane-kubeadm