### PR TITLE
🌱 e2e: do not expect Machines for MachinePools not supporting Machines

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -1043,6 +1043,11 @@ func calculateExpectedMachinePoolMachineCount(ctx context.Context, c client.Clie
 				return 0, err
 			}
 
+			// The MachinePool does not support machines if the field does not exist.
+			if errors.Is(err, util.ErrUnstructuredFieldNotFound) {
+				continue
+			}
+
 			replicas, found, err := unstructured.NestedInt64(mp.Object, "spec", "replicas")
 			if err == nil && found {
 				expectedMachinePoolMachineCount += replicas


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

When running tests e.g. for AKS and re-using the clusterctl upgrade test: there may not be any Machines to verify Readyness.

The test started to expect to always have Machines, which would not be the case for an use-case like AKS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing