### PR TITLE
🌱 Bump Go to v1.24.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.24.10
+GO_VERSION ?= 1.24.11
 GO_DIRECTIVE_VERSION ?= 1.24.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -172,7 +172,7 @@ def load_provider_tilt_files():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.24.10 as tilt-helper
+FROM golang:1.24.11 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24
 # Support live reloading with Tilt
@@ -183,7 +183,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.24.10 as tilt
+FROM golang:1.24.11 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.24.10"
+    GO_VERSION = "1.24.11"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Updates the Go compiler and tools to v1.24.11.

> go1.24.11 (released 2025-12-02) includes two security fixes to the `crypto/x509` package, as well as bug fixes to the runtime. See the [Go 1.24.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.11+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:

N/A, but see #12962 for prior art.

/area dependency