### PR TITLE
[release-1.11]  🌱 Makefile: ensure KAL is compiled using golangci-lint v2.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR := bin
 TEST_DIR := test
 TOOLS_DIR := hack/tools
+TOOLS_DIR_KAL := $(TOOLS_DIR)/kal
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/$(BIN_DIR))
 DOCS_DIR := docs
 E2E_FRAMEWORK_DIR := $(TEST_DIR)/framework
@@ -163,9 +164,14 @@ GOLANGCI_LINT_VER := $(shell cat .github/workflows/pr-golangci-lint.yaml | grep 
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER))
 GOLANGCI_LINT_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
+# Github actions had a breaking change requiring golangci-lint >= v2.7.0 when building the KAL linter.
+TOOLS_BIN_DIR_KAL := $(abspath $(TOOLS_DIR_KAL)/bin)
+GOLANGCI_LINT_270_VER := v2.7.0
+GOLANGCI_LINT_270 := $(abspath $(TOOLS_BIN_DIR_KAL)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_270_VER))
+
 GOLANGCI_LINT_KAL_BIN := golangci-lint-kube-api-linter
-GOLANGCI_LINT_KAL_VER := $(shell cat ./hack/tools/.custom-gcl.yaml | grep version: | sed 's/version: //')
-GOLANGCI_LINT_KAL := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_KAL_BIN))
+GOLANGCI_LINT_KAL_VER := $(shell cat $(TOOLS_DIR_KAL)/.custom-gcl.yaml | grep version: | sed 's/version: //')
+GOLANGCI_LINT_KAL := $(abspath $(TOOLS_BIN_DIR_KAL)/$(GOLANGCI_LINT_KAL_BIN))
 
 GOVULNCHECK_BIN := govulncheck
 GOVULNCHECK_VER := v1.1.4
@@ -1498,8 +1504,11 @@ $(GINKGO): # Build ginkgo from tools folder.
 $(GOLANGCI_LINT): # Build golangci-lint from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOLANGCI_LINT_PKG) $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
-$(GOLANGCI_LINT_KAL): $(GOLANGCI_LINT) # Build golangci-lint-kal from custom configuration.
-	cd $(TOOLS_DIR); $(GOLANGCI_LINT) custom
+$(GOLANGCI_LINT_KAL): $(GOLANGCI_LINT_270) # Build golangci-lint-kal from custom configuration.
+	cd $(TOOLS_DIR_KAL); $(GOLANGCI_LINT_270) custom
+
+$(GOLANGCI_LINT_270):
+	GOBIN=$(TOOLS_BIN_DIR_KAL) $(GO_INSTALL) $(GOLANGCI_LINT_PKG) $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_270_VER)
 
 $(GOVULNCHECK): # Build govulncheck.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOVULNCHECK_PKG) $(GOVULNCHECK_BIN) $(GOVULNCHECK_VER)

--- a/hack/tools/kal/.custom-gcl.yaml
+++ b/hack/tools/kal/.custom-gcl.yaml
@@ -1,4 +1,4 @@
-version: v2.3.0
+version: v2.7.0
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Github actions had been updated to a newer git cli version.

This broke golangcli-lint when building custom plugins like KAL:

- https://github.com/golangci/golangci-lint/issues/6205

v2.7.0 fixed this.

This PR ensures we use the correct version for building KAL, while not bumping golangci-lint used for other linting to control when we do the upgrade and have this as backportable PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area ci