### PR TITLE
🌱 Bump golangci-lint v2.7.0

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # tag=v9.1.0
         with:
-          version: v2.4.0
+          version: v2.7.0
           working-directory: ${{matrix.working-directory}}
       - name: Lint API
         run: make lint-api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -407,6 +407,22 @@ linters:
           - staticcheck
         path: (.+)\.go$
         text: 'QF1008: could remove embedded field'
+      - linters:
+          - revive
+        path: errors/.*\.go$
+        text: 'var-naming: avoid package names that conflict with Go standard library package names'
+      - linters:
+          - revive
+        path: internal/util/hash/.*\.go$
+        text: 'var-naming: avoid package names that conflict with Go standard library package names'
+      - linters:
+          - revive
+        path: internal/controllers/topology/cluster/patches/api/.*\.go$
+        text: 'var-naming: avoid meaningless package names'
+      - linters:
+          - revive
+        path: test/infrastructure/inmemory/pkg/server/api/.*\.go$
+        text: 'var-naming: avoid meaningless package names'
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -86,17 +86,20 @@ const (
 
 	// ClusterTopologyReconciledControlPlaneUpgradePendingReason documents reconciliation of a Cluster topology
 	// not yet completed because Control Plane is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledControlPlaneUpgradePendingReason = "ControlPlaneUpgradePending"
 
 	// ClusterTopologyReconciledMachineDeploymentsCreatePendingReason documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachineDeployments is yet to be created.
 	// This generally happens because new MachineDeployment creations are held off while the ControlPlane is not stable.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledMachineDeploymentsCreatePendingReason = "MachineDeploymentsCreatePending"
 
 	// ClusterTopologyReconciledMachineDeploymentsUpgradePendingReason documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachineDeployments is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledMachineDeploymentsUpgradePendingReason = "MachineDeploymentsUpgradePending"
 
@@ -106,12 +109,14 @@ const (
 
 	// ClusterTopologyReconciledMachinePoolsUpgradePendingReason documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachinePools is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledMachinePoolsUpgradePendingReason = "MachinePoolsUpgradePending"
 
 	// ClusterTopologyReconciledMachinePoolsCreatePendingReason documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachinePools is yet to be created.
 	// This generally happens because new MachinePool creations are held off while the ControlPlane is not stable.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledMachinePoolsCreatePendingReason = "MachinePoolsCreatePending"
 
@@ -121,6 +126,7 @@ const (
 
 	// ClusterTopologyReconciledHookBlockingReason documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the lifecycle hooks is blocking.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	ClusterTopologyReconciledHookBlockingReason = "LifecycleHookBlocking"
 

--- a/api/core/v1beta2/v1beta1_condition_consts.go
+++ b/api/core/v1beta2/v1beta1_condition_consts.go
@@ -306,17 +306,20 @@ const (
 
 	// TopologyReconciledControlPlaneUpgradePendingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because Control Plane is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledControlPlaneUpgradePendingV1Beta1Reason = "ControlPlaneUpgradePending"
 
 	// TopologyReconciledMachineDeploymentsCreatePendingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachineDeployments is yet to be created.
 	// This generally happens because new MachineDeployment creations are held off while the ControlPlane is not stable.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledMachineDeploymentsCreatePendingV1Beta1Reason = "MachineDeploymentsCreatePending"
 
 	// TopologyReconciledMachineDeploymentsUpgradePendingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachineDeployments is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledMachineDeploymentsUpgradePendingV1Beta1Reason = "MachineDeploymentsUpgradePending"
 
@@ -326,12 +329,14 @@ const (
 
 	// TopologyReconciledMachinePoolsUpgradePendingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachinePools is not yet updated to match the desired topology spec.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledMachinePoolsUpgradePendingV1Beta1Reason = "MachinePoolsUpgradePending"
 
 	// TopologyReconciledMachinePoolsCreatePendingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the MachinePools is yet to be created.
 	// This generally happens because new MachinePool creations are held off while the ControlPlane is not stable.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledMachinePoolsCreatePendingV1Beta1Reason = "MachinePoolsCreatePending"
 
@@ -341,6 +346,7 @@ const (
 
 	// TopologyReconciledHookBlockingV1Beta1Reason (Severity=Info) documents reconciliation of a Cluster topology
 	// not yet completed because at least one of the lifecycle hooks is blocking.
+	//
 	// Deprecated: please use ClusterUpgrading instead.
 	TopologyReconciledHookBlockingV1Beta1Reason = "LifecycleHookBlocking"
 

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,4 +1,4 @@
-version: v2.5.0
+version: v2.7.0
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
@@ -111,7 +111,7 @@ func (p *rolloutPlanner) reconcileOldMachineSetsOnDelete(ctx context.Context) {
 		scaleDownCount := max(ptr.Deref(oldMS.Spec.Replicas, 0)-ptr.Deref(oldMS.Status.Replicas, 0), 0)
 		if scaleDownCount > 0 {
 			newScaleIntent := max(ptr.Deref(oldMS.Spec.Replicas, 0)-scaleDownCount, 0)
-			p.addNote(oldMS, "scale down to align to existing Machines")
+			p.addNotef(oldMS, "scale down to align to existing Machines")
 			log.V(5).Info(fmt.Sprintf("Setting scale down intent for MachineSet %s to %d replicas (-%d)", oldMS.Name, newScaleIntent, scaleDownCount), "MachineSet", klog.KObj(oldMS))
 			p.scaleIntents[oldMS.Name] = newScaleIntent
 
@@ -139,7 +139,7 @@ func (p *rolloutPlanner) reconcileOldMachineSetsOnDelete(ctx context.Context) {
 		scaleDownCount := min(scaleIntent, totalScaleDownCount)
 		if scaleDownCount > 0 {
 			newScaleIntent := max(ptr.Deref(oldMS.Spec.Replicas, 0)-scaleDownCount, 0)
-			p.addNote(oldMS, "scale down to align MachineSet spec.replicas to MachineDeployment spec.replicas")
+			p.addNotef(oldMS, "scale down to align MachineSet spec.replicas to MachineDeployment spec.replicas")
 			log.V(5).Info(fmt.Sprintf("Setting scale down intent for MachineSet %s to %d replicas (-%d)", oldMS.Name, newScaleIntent, scaleDownCount), "MachineSet", klog.KObj(oldMS))
 			p.scaleIntents[oldMS.Name] = newScaleIntent
 

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
@@ -133,7 +133,7 @@ func (p *rolloutPlanner) init(ctx context.Context, md *clusterv1.MachineDeployme
 		// the new revision number is also surfaced in p.revision, and thus we are using this information
 		// to determine when to add this note.
 		if oldRevision != p.revision {
-			p.addNote(p.newMS, "this is now the current MachineSet")
+			p.addNotef(p.newMS, "this is now the current MachineSet")
 		}
 		return nil
 	}
@@ -340,7 +340,7 @@ func computeDesiredMS(ctx context.Context, deployment *clusterv1.MachineDeployme
 	return desiredMS, nil
 }
 
-func (p *rolloutPlanner) addNote(ms *clusterv1.MachineSet, format string, a ...any) {
+func (p *rolloutPlanner) addNotef(ms *clusterv1.MachineSet, format string, a ...any) {
 	msg := fmt.Sprintf(format, a...)
 	for _, note := range p.notes[ms.Name] {
 		if note == msg {

--- a/util/collections/machine_filters_test.go
+++ b/util/collections/machine_filters_test.go
@@ -55,7 +55,7 @@ func TestAnd(t *testing.T) {
 	t.Run("returns true if both given machine filters return true", func(t *testing.T) {
 		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(collections.And(trueFilter, trueFilter)(m)).To(BeTrue())
+		g.Expect(collections.And(trueFilter, trueFilter)(m)).To(BeTrue()) //nolint:gocritic
 	})
 	t.Run("returns false if either given machine filter returns false", func(t *testing.T) {
 		g := NewWithT(t)
@@ -73,7 +73,7 @@ func TestOr(t *testing.T) {
 	t.Run("returns false if both given machine filter returns false", func(t *testing.T) {
 		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(collections.Or(falseFilter, falseFilter)(m)).To(BeFalse())
+		g.Expect(collections.Or(falseFilter, falseFilter)(m)).To(BeFalse()) //nolint:gocritic
 	})
 }
 

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -130,7 +130,7 @@ func (v buildIdentifiers) compare(o buildIdentifiers) int {
 	}
 
 	// if everything is equal till now the longer is greater
-	if i == len(v) && i == len(o) { //nolint: gocritic
+	if i == len(v) && i == len(o) {
 		return 0
 	} else if i == len(v) && i < len(o) {
 		return -1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Github actions had been updated to a newer git cli version.

This broke golangcli-lint when building custom plugins like KAL:

https://github.com/golangci/golangci-lint/issues/6205
v2.7.0 fixed this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci