### PR TITLE
🌱 e2e: use crane to pre-pull images instead of docker pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,11 @@ GOVULNCHECK_VER := v1.1.4
 GOVULNCHECK := $(abspath $(TOOLS_BIN_DIR)/$(GOVULNCHECK_BIN)-$(GOVULNCHECK_VER))
 GOVULNCHECK_PKG := golang.org/x/vuln/cmd/govulncheck
 
+CRANE_BIN := crane
+CRANE_VER := v0.20.7
+CRANE := $(abspath $(TOOLS_BIN_DIR)/$(CRANE_BIN)-$(CRANE_VER))
+CRANE_PKG := github.com/google/go-containerregistry/cmd/crane
+
 IMPORT_BOSS_BIN := import-boss
 IMPORT_BOSS_VER := v0.28.1
 IMPORT_BOSS := $(abspath $(TOOLS_BIN_DIR)/$(IMPORT_BOSS_BIN))
@@ -1445,6 +1450,9 @@ $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint.
 .PHONY: $(GOVULNCHECK_BIN)
 $(GOVULNCHECK_BIN): $(GOVULNCHECK) ## Build a local copy of govulncheck.
 
+.PHONY: $(CRANE_BIN)
+$(CRANE_BIN): $(CRANE) ## Build a local copy of crane.
+
 .PHONY: $(IMPORT_BOSS_BIN)
 $(IMPORT_BOSS_BIN): $(IMPORT_BOSS)
 
@@ -1505,6 +1513,9 @@ $(GOLANGCI_LINT_KAL): $(GOLANGCI_LINT) # Build golangci-lint-kal from custom con
 
 $(GOVULNCHECK): # Build govulncheck.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOVULNCHECK_PKG) $(GOVULNCHECK_BIN) $(GOVULNCHECK_VER)
+
+$(CRANE): # Build crane.
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(CRANE_PKG) $(CRANE_BIN) $(CRANE_VER)
 
 $(IMPORT_BOSS): # Build import-boss
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(IMPORT_BOSS_PKG) $(IMPORT_BOSS_BIN) $(IMPORT_BOSS_VER)

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -270,14 +270,29 @@ kind:prepullAdditionalImages () {
 
 # kind:prepullImage pre-pull a docker image if no already present locally.
 # The result will be available in the retVal value which is accessible from the caller.
+# This uses crane to pull images instead of docker pull because loading images otherwise fails beginning with docker 29.
+# - related kind issue: https://github.com/kubernetes-sigs/kind/issues/3795#issuecomment-3276124207
+# - related containerd issue: https://github.com/containerd/containerd/issues/11344
 kind::prepullImage () {
+  make crane
+
   local image=$1
   image="${image//+/_}"
 
   retVal=0
   if [[ "$(docker images -q "$image" 2> /dev/null)" == "" ]]; then
+    TMPFILE="$(mktemp)"
+  
     echo "+ Pulling $image"
-    docker pull "$image" || retVal=$?
+
+    crane pull "$image" "${TMPFILE}" || retVal=$?
+    if [[ $retVal -gt 0 ]]; then
+      return
+    fi
+
+    docker load -i "${TMPFILE}" || retVal=$?
+
+    rm "${TMPFILE}"
   else
     echo "+ image $image already present in the system, skipping pre-pull"
   fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

test-infra images were bumped to newer docker versions. Because of that we seem to hit this related kind issue: https://github.com/kubernetes-sigs/kind/issues/3795

NOTE: CAPI has its own implementation and does not directly use kind here.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area e2e-testing