### PR TITLE
🐛 MachineSet/KCP: Preserve existing object names for backward compatibility with pre-v1.7 in-place updates

### DIFF
--- a/controlplane/kubeadm/internal/desiredstate/desired_state.go
+++ b/controlplane/kubeadm/internal/desiredstate/desired_state.go
@@ -241,6 +241,7 @@ func ComputeDesiredKubeadmConfig(kcp *controlplanev1.KubeadmControlPlane, cluste
 		Spec: *spec,
 	}
 	if existingKubeadmConfig != nil {
+		kubeadmConfig.SetName(existingKubeadmConfig.GetName())
 		kubeadmConfig.SetUID(existingKubeadmConfig.GetUID())
 	}
 	return kubeadmConfig, nil
@@ -289,6 +290,7 @@ func ComputeDesiredInfraMachine(ctx context.Context, c client.Client, kcp *contr
 		return nil, errors.Wrap(err, "failed to compute desired InfraMachine")
 	}
 	if existingInfraMachine != nil {
+		infraMachine.SetName(existingInfraMachine.GetName())
 		infraMachine.SetUID(existingInfraMachine.GetUID())
 	}
 	return infraMachine, nil

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -1823,6 +1823,7 @@ func (r *Reconciler) computeDesiredBootstrapConfig(ctx context.Context, ms *clus
 	}
 
 	if existingBootstrapConfig != nil {
+		bootstrapConfig.SetName(existingBootstrapConfig.GetName())
 		bootstrapConfig.SetUID(existingBootstrapConfig.GetUID())
 	}
 	return bootstrapConfig, nil
@@ -1900,6 +1901,7 @@ func (r *Reconciler) computeDesiredInfraMachine(ctx context.Context, ms *cluster
 	}
 
 	if existingInfraMachine != nil {
+		infraMachine.SetName(existingInfraMachine.GetName())
 		infraMachine.SetUID(existingInfraMachine.GetUID())
 	}
 	return infraMachine, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to Cluster API v1.7, infraMachine and bootstrapConfig objects created by MachineSet and KubeadmControlPlane could have names that differed from their associated Machine names. Starting from v1.7 (#9833), these objects consistently use the Machines name.

When performing in-place updates on Machines created before v1.7, we must preserve the existing infraMachine and bootstrapConfig names to avoid breaking associations with existing infrastructure resources.

This commit ensures backward compatibility by preserving existing bootstrapConfig names in computeDesiredBootstrapConfig and existing infraMachine names in computeDesiredInfraMachine.

Part of https://github.com/kubernetes-sigs/cluster-api/issues/12291

/area machineset
/area provider/control-plane-kubeadm

