### PR TITLE
[release-1.10] 🌱 Skip test using outdated docker client

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -21,7 +21,6 @@ package e2e
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,6 +39,9 @@ var (
 	providerKubeadmPrefix = "kubeadm:v%s"
 	providerDockerPrefix  = "docker:v%s"
 )
+
+/*
+After test-infra upgrade to docker engine 29.1.2, following tests are failing because the docker client in CAPI 0.3/CAPI0.4 is too old.
 
 // Note: This test should not be changed during "prepare main branch".
 var _ = Describe("When testing clusterctl upgrades (v0.3=>v1.5=>current)", FlakeAttempts(2), func() {
@@ -199,7 +201,8 @@ var _ = Describe("When testing clusterctl upgrades (v0.4=>v1.6=>current)", Flake
 			UseKindForManagementCluster: true,
 		}
 	})
-})
+}).
+*/
 
 // Note: This test should be changed during "prepare main branch", it should test n-3 => current.
 var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.7=>current) [ClusterClass]", Label("ClusterClass"), func() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
manual cherry pick of https://github.com/kubernetes-sigs/cluster-api/pull/13125

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area e2e-testing