### PR TITLE
:seedling: e2e: Add json struct tags to ContainerImage

### DIFF
--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -131,14 +131,14 @@ const (
 // when loading the image.
 type ContainerImage struct {
 	// Name is the fully qualified name of the image.
-	Name string
+	Name string `json:"name"`
 
 	// LoadBehavior may be used to dictate whether a failed load operation
 	// should fail the test run. This is useful when wanting to load images
 	// *if* they exist locally, but not wanting to fail if they don't.
 	//
 	// Defaults to MustLoadImage.
-	LoadBehavior LoadImageBehavior
+	LoadBehavior LoadImageBehavior `json:"loadBehavior,omitempty"`
 }
 
 // ComponentSourceType indicates how a component's source should be obtained.


### PR DESCRIPTION
The ContainerImage struct was missing json struct tags, unlike all other configuration structs in e2e_config.go. While sigs.k8s.io/yaml (used by CAPI) handles this correctly via case-insensitive JSON unmarshaling, adding explicit tags:

- Maintains consistency with other structs in the file
- Documents the expected field names explicitly
- Protects downstream consumers using gopkg.in/yaml.v2 directly

This was identified while fixing a related issue in baremetal-operator where gopkg.in/yaml.v2 failed to unmarshal loadBehavior without tags, causing all image loads to default to MustLoadImage.

Ref: https://github.com/metal3-io/baremetal-operator/pull/2833
