### PR TITLE
✨ tilt-prepare: add a flag to skip image preloading

### DIFF
--- a/docs/book/src/developer/core/tilt.md
+++ b/docs/book/src/developer/core/tilt.md
@@ -177,6 +177,8 @@ for more details.
 
 **enable_core_provider** (bool, default=true): By default, the `core` provider is enabled. This allows to disable it.
 
+**preload_images** (bool, default=true): By default, images are preloaded into the kind cluster. This works on most platforms but can fail on Apple Silicon or Docker v29+. Set this to false to skip preloading and let the kubelet pull images on demand.
+
 **template_dirs** (Map{String: Array[]String}, default={"docker": [
 "./test/infrastructure/docker/templates"]}): A map of providers to directories containing cluster templates. An example of the field is given below. See [Deploying a workload cluster](#deploying-a-workload-cluster) for how this is used.
 

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -115,6 +115,7 @@ type tiltSettings struct {
 	AllowedContexts          []string                           `json:"allowed_contexts,omitempty"`
 	ProviderRepos            []string                           `json:"provider_repos,omitempty"`
 	AdditionalKustomizations map[string]string                  `json:"additional_kustomizations,omitempty"`
+	PreloadImages            *bool                              `json:"preload_images,omitempty"`
 }
 
 type tiltSettingsDebugConfig struct {
@@ -298,9 +299,15 @@ func tiltResources(ctx context.Context, ts *tiltSettings) error {
 		// The images can only be preloaded when the cluster is a kind cluster.
 		// Note: Not repeating the validation on the config already done in allowK8sConfig here.
 		if strings.HasPrefix(cfg.Contexts[cfg.CurrentContext].Cluster, "kind-") {
-			tasks["cert-manager-cainjector"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-cainjector:%s", config.CertManagerDefaultVersion))
-			tasks["cert-manager-webhook"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-webhook:%s", config.CertManagerDefaultVersion))
-			tasks["cert-manager-controller"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-controller:%s", config.CertManagerDefaultVersion))
+			preloadImages := true
+			if ts.PreloadImages != nil {
+				preloadImages = *ts.PreloadImages
+			}
+			if preloadImages {
+				tasks["cert-manager-cainjector"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-cainjector:%s", config.CertManagerDefaultVersion))
+				tasks["cert-manager-webhook"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-webhook:%s", config.CertManagerDefaultVersion))
+				tasks["cert-manager-controller"] = preLoadImageTask(fmt.Sprintf("quay.io/jetstack/cert-manager-controller:%s", config.CertManagerDefaultVersion))
+			}
 		}
 		tasks["cert-manager"] = certManagerTask()
 	}
@@ -533,9 +540,13 @@ func makeTask(name string) taskFunction {
 	}
 }
 
-// preLoadImageTask generates a task for pre-loading an image into kind.
 func preLoadImageTask(image string) taskFunction {
 	return func(ctx context.Context, prefix string, errCh chan error) {
+		// Note: `kind load docker-image` can fail for multi-arch images like cert-manager on some
+		// configurations (e.g. Apple Silicon, Docker CE >= v29) due to
+		// https://github.com/kubernetes-sigs/kind/issues/3795.
+		// In such cases, users can disable preloading via tilt-settings.yaml and let the
+		// Kubelet pull images on-demand.
 		docker, err := container.NewDockerClient()
 		if err != nil {
 			errCh <- errors.Wrapf(err, "[%s] failed to create docker client", prefix)


### PR DESCRIPTION
**What this PR does / why we need it**:

On Apple Silicon Macs, `kind load docker-image` fails for multi-arch images (like cert-manager) because Docker Desktop only stores the `arm64` layers locally. This causes `ctr` to fail when it tries to import all architectures, resulting in a "content digest not found" error that blocks `tilt up`.
This PR updates `tilt-prepare` to skip the preloading step specifically on `darwin/arm64`. Instead of preloading, we rely on the Kubelet to pull the images on-demand when the pods start. This bypasses the kind/docker import issue and allows the development environment to start correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13142 
Refs: https://github.com/kubernetes-sigs/kind/issues/3795

/area devtools