### PR TITLE
🐛 Fix webhook envtest tests for Kubernetes < v1.35

### DIFF
--- a/internal/webhooks/test/machinedrainrules_test.go
+++ b/internal/webhooks/test/machinedrainrules_test.go
@@ -190,8 +190,7 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineDrainRule.cluster.x-k8s.io \"mdr\" is invalid: " +
-				"spec.machines: Invalid value: entries in machines must be unique",
+			wantErr: "entries in machines must be unique",
 		},
 		{
 			name: "Return error if pod selectors are not unique",
@@ -232,8 +231,7 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineDrainRule.cluster.x-k8s.io \"mdr\" is invalid: " +
-				"spec.pods: Invalid value: entries in pods must be unique",
+			wantErr: "entries in pods must be unique",
 		},
 	}
 
@@ -245,7 +243,7 @@ func Test_validate(t *testing.T) {
 
 			if tt.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(BeComparableTo(tt.wantErr))
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(env.CleanupAndWait(ctx, tt.machineDrainRule)).To(Succeed())

--- a/internal/webhooks/test/machinehealthcheck_test.go
+++ b/internal/webhooks/test/machinehealthcheck_test.go
@@ -83,8 +83,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineHealthCheck.cluster.x-k8s.io \"mhc\" is invalid: " +
-				"spec.checks.unhealthyMachineConditions[0].type: Invalid value: \"Ready\": type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
+			wantErr: "type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
 		},
 		{
 			name: "Return error if UnhealthyMachineCondition type is 'Available'",
@@ -111,8 +110,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineHealthCheck.cluster.x-k8s.io \"mhc\" is invalid: " +
-				"spec.checks.unhealthyMachineConditions[0].type: Invalid value: \"Available\": type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
+			wantErr: "type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
 		},
 		{
 			name: "Return error if UnhealthyMachineCondition type is 'HealthCheckSucceeded'",
@@ -139,8 +137,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineHealthCheck.cluster.x-k8s.io \"mhc\" is invalid: " +
-				"spec.checks.unhealthyMachineConditions[0].type: Invalid value: \"HealthCheckSucceeded\": type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
+			wantErr: "type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
 		},
 		{
 			name: "Return error if UnhealthyMachineCondition type is 'OwnerRemediated'",
@@ -167,8 +164,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineHealthCheck.cluster.x-k8s.io \"mhc\" is invalid: " +
-				"spec.checks.unhealthyMachineConditions[0].type: Invalid value: \"OwnerRemediated\": type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
+			wantErr: "type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
 		},
 		{
 			name: "Return error if UnhealthyMachineCondition type is 'ExternallyRemediated'",
@@ -195,8 +191,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			wantErr: "MachineHealthCheck.cluster.x-k8s.io \"mhc\" is invalid: " +
-				"spec.checks.unhealthyMachineConditions[0].type: Invalid value: \"ExternallyRemediated\": type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
+			wantErr: "type must not be one of: Ready, Available, HealthCheckSucceeded, OwnerRemediated, ExternallyRemediated",
 		},
 		{
 			name: "Return no error if UnhealthyMachineCondition type is allowed custom type",
@@ -234,7 +229,7 @@ func Test_validateMachineHealthCheck(t *testing.T) {
 
 			if tt.wantErr != "" {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(BeComparableTo(tt.wantErr))
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErr))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(env.CleanupAndWait(ctx, tt.machineHealthCheck)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to #13168 to fix the mink8s-test job.

We forgot to run mink8s on #13168



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->