### PR TITLE
🐛 Fix flaky TestClusterReconciler unit test

### DIFF
--- a/internal/controllers/cluster/cluster_controller_test.go
+++ b/internal/controllers/cluster/cluster_controller_test.go
@@ -262,9 +262,9 @@ func TestClusterReconciler(t *testing.T) {
 			ph, err := patch.NewHelper(cluster, env)
 			g.Expect(err).ToNot(HaveOccurred())
 			conditions.Set(cluster, metav1.Condition{
-				Type:   clusterv1.ClusterInfrastructureReadyCondition,
+				Type:   "CustomType",
 				Status: metav1.ConditionTrue,
-				Reason: clusterv1.ClusterInfrastructureReadyReason,
+				Reason: "CustomReason",
 			})
 			g.Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).To(Succeed())
 			return true
@@ -276,7 +276,7 @@ func TestClusterReconciler(t *testing.T) {
 			if err := env.Get(ctx, key, instance); err != nil {
 				return false
 			}
-			return conditions.IsTrue(cluster, clusterv1.ClusterInfrastructureReadyCondition)
+			return conditions.IsTrue(cluster, "CustomType")
 		}, timeout).Should(BeTrue())
 	})
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
TestClusterReconciler was a bit flaky recently. This PR changes the unit test to use a condition which does not conflict with one of the conditions managed by the Cluster controller

xref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/2002961557285244928

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->