### PR TITLE
🐛 Fix v1beta1 ControlPlane contract to handle .status.initialized correctly

### DIFF
--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -618,10 +618,10 @@ preserves compatibility with the deprecated v1beta1 contract; compatibility will
 
 With regards to initialization completed:
 
-Cluster API will continue to temporarily support ControlPlane resource using `status.initialize` and the `status.ready` field to
+Cluster API will continue to temporarily support ControlPlane resource using the `status.initialized` field to
 report initialization completed.
 
-After compatibility with the deprecated v1beta1 contract will be removed, `status.initialize` and `status.ready` fields in
+After compatibility with the deprecated v1beta1 contract will be removed, the `status.initialized` field in
 the ControlPlane resource will be ignored.
 
 </aside>

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -102,7 +102,7 @@ func (c *ControlPlaneContract) StatusVersion() *String {
 func (c *ControlPlaneContract) Initialized(contractVersion string) *Bool {
 	if contractVersion == "v1beta1" {
 		return &Bool{
-			path: []string{"status", "ready"},
+			path: []string{"status", "initialized"},
 		}
 	}
 

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -70,7 +70,7 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(BeTrue())
 
-		g.Expect(ControlPlane().Initialized("v1beta1").Path()).To(Equal(Path{"status", "ready"}))
+		g.Expect(ControlPlane().Initialized("v1beta1").Path()).To(Equal(Path{"status", "initialized"}))
 
 		objV1beta1 := &unstructured.Unstructured{Object: map[string]interface{}{}}
 		err = ControlPlane().Initialized("v1beta1").Set(objV1beta1, true)


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13184

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->