### PR TITLE
📖  docs: fix broken paths to proposal files

### DIFF
--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -7,7 +7,7 @@ Currently Cluster API has the following experimental features:
 * `ClusterTopology` (env var: `CLUSTER_TOPOLOGY`): [ClusterClass](./cluster-class/index.md)
 * `InPlaceUpdates` (env var: `EXP_IN_PLACE_UPDATES`):
   * Allows users to execute changes on existing machines without deleting the Machine and creating a new one.
-  * See the [proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/20240807-in-place-updates.md) for more details.
+  * See the [proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240807-in-place-updates.md) for more details.
 * `KubeadmBootstrapFormatIgnition` (env var: `EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION`): [Ignition](./ignition.md)
 * `MachinePool` (env var: `EXP_MACHINE_POOL`): [MachinePools](./machine-pools.md)
 * `MachineSetPreflightChecks` (env var: `EXP_MACHINE_SET_PREFLIGHT_CHECKS`): [MachineSetPreflightChecks](./machineset-preflight-checks.md)

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-in-place-update-hooks.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-in-place-update-hooks.md
@@ -10,7 +10,7 @@ Please note Runtime SDK is an advanced feature. If implemented incorrectly, a fa
 
 ## Introduction
 
-The proposal for [in-place updates in Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/20240807-in-place-updates.md)
+The proposal for [in-place updates in Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240807-in-place-updates.md)
 introduced extensions allowing users to execute changes on existing machines without deleting the Machine and creating a new one.
 
 Notably, the Cluster API user experience remains the same as of today no matter of the in-place update feature is enabled 
@@ -43,7 +43,7 @@ options like MaxSurge/MaxUnavailable. With this regard:
 
 Cluster API will call the in-place extensions only if the `InPlaceUpdates` feature flag is enabled.
 
-Also, please note that the current implementation of the [in-place updates proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/20240807-in-place-updates.md) only allows registering one extension for the `CanUpdateMachine`, `CanUpdateMachineSet` and `UpdateMachine` hooks.
+Also, please note that the current implementation of the [in-place updates proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240807-in-place-updates.md) only allows registering one extension for the `CanUpdateMachine`, `CanUpdateMachineSet` and `UpdateMachine` hooks.
 
 </aside>
 

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-lifecycle-hooks.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-lifecycle-hooks.md
@@ -14,7 +14,7 @@ The lifecycle hooks allow hooking into the Cluster lifecycle. The following diag
 
 ![Lifecycle Hooks overview](../../../images/runtime-sdk-lifecycle-hooks.png)
 
-Please see the corresponding [CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20220414-runtime-hooks.md) as well as the proposal for [Chained and efficient upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/20250513-chained-and-efficient-upgrades-for-clusters-with-managed-topologies.md)
+Please see the corresponding [CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20220414-runtime-hooks.md) as well as the proposal for [Chained and efficient upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20250513-chained-and-efficient-upgrades-for-clusters-with-managed-topologies.md)
 for additional background information.
 
 <!-- TOC -->

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-upgrade-plan-hooks.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-upgrade-plan-hooks.md
@@ -10,7 +10,7 @@ Please note Runtime SDK is an advanced feature. If implemented incorrectly, a fa
 
 ## Introduction
 
-The proposal for [Chained and efficient upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/20250513-chained-and-efficient-upgrades-for-clusters-with-managed-topologies.md)
+The proposal for [Chained and efficient upgrades](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20250513-chained-and-efficient-upgrades-for-clusters-with-managed-topologies.md)
 introduced support for upgrading by more than one minor when working with Clusters using managed topologies.
 
 According to the proposal, there are two ways to provide Cluster API the information required to compute the upgrade plan:


### PR DESCRIPTION
**What this PR does**:

The linked paths from the `experimental-features` documents to the corresponding `proposal `documents are broken. The commit includes some path fixes.