### PR TITLE
📖  docs: add delete-machine info to Scaling Nodes page

### DIFF
--- a/docs/book/src/tasks/automated-machine-management/scaling.md
+++ b/docs/book/src/tasks/automated-machine-management/scaling.md
@@ -6,7 +6,9 @@ Machines can be owned by scalable resources i.e. MachineSet and MachineDeploymen
 
 You can scale MachineSets and MachineDeployments in or out by expressing intent via `.spec.replicas` or updating the scale subresource e.g `kubectl scale machinedeployment foo --replicas=5`.
 
-If you need to prioritize which Machines get deleted during scale-down, add the `cluster.x-k8s.io/delete-machine` label to the Machine. KCP or a MachineSet will delete labeled control plane or worker Machines first, and this label has top priority over all delete policies. Note: The label only affects MachineSet scale-down; in a MachineDeployment, the choice of MachineSet to scale-down may bypass labeled Machines.
+If you need to prioritize which Machines get deleted during scale-down, add the `cluster.x-k8s.io/delete-machine` label to the Machine. KCP or a MachineSet will delete labeled control plane or worker Machines first, and this label has top priority over all delete policies.
+
+**Note**: The label only affects MachineSet scale-down; in a MachineDeployment, the choice of MachineSet to scale-down may bypass labeled Machines.
 
 When you delete a Machine directly or by scaling down, the same process takes place in the same order:
 - The Node backed by that Machine will try to be drained indefinitely and will wait for any volume to be detached from the Node unless you specify a `.spec.nodeDrainTimeout`.


### PR DESCRIPTION
**What this PR does**:

The change adds a brief description of using `cluster.x-k8s.io/delete-machine` labels to control Machine scaling on the [Scaling Nodes](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/scaling) page. The label is mentioned in the [supported labels](https://main.cluster-api.sigs.k8s.io/reference/api/labels-and-annotations.html?highlight=labels#supported-labels) but I think it's relevant to include it in the Scaling Nodes page too.

**Which issue(s) this PR fixes**

Fixes #10306