### PR TITLE
📖 Document removal of clusterctl alpha topology plan

### DIFF
--- a/docs/proposals/20220330-topology-mutation-hook.md
+++ b/docs/proposals/20220330-topology-mutation-hook.md
@@ -207,6 +207,9 @@ to avoid duplication.
 
 We want to be able to use `clusterctl alpha topology plan` to validate External Patch Extensions. To make this possible we will extend the command so users can point to locally running External Patch Extensions without having to deploy a full management cluster.
 
+NOTE: `clusterctl alpha topology plan` was dropped due to limitations / lack of interest from the community (see. [#10138](https://github.com/kubernetes-sigs/cluster-api/issues/10138)). 
+Local testing with Kind or unit tests can be used as a more effective and developer friendly alternatives.
+
 ### Security Model
 
 For the general Runtime Extension security model please refer to the [developer guide in the Runtime SDK proposal](https://github.com/kubernetes-sigs/cluster-api/blob/75b39db545ae439f4f6203b5e07496d3b0a6aa75/docs/proposals/20220221-runtime-SDK.md#security-model).
@@ -287,6 +290,7 @@ See [upgrade strategy](#upgrade-strategy).
 * [x] 2022-03-21: Opened corresponding [issue](https://github.com/kubernetes-sigs/cluster-api/issues/6319)
 * [x] 2022-03-23: Presented proposal at a [community meeting]
 * [x] 2022-03-30: Opened proposal PR
+* [x] 2025-02-12: Document removal of clusterctl alpha topology plan
 
 <!-- Links -->
 [community meeting]: https://docs.google.com/document/d/1ushaVqAKYnZ2VN_aa3GyKlS4kEd6bSug13xaXOakAQI/edit#heading=h.pxsq37pzkbdq


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I noticed that the topology mutation hook proposal still refers to a command that has been removed to a later stage. Adding a note.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area documentation