### PR TITLE
🌱 Drop handling of old cert-manager annotation in clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -43,12 +43,6 @@ const (
 	waitCertManagerInterval = 1 * time.Second
 
 	certManagerNamespace = "cert-manager"
-
-	// This is maintained only for supporting upgrades from cluster created with clusterctl v1alpha3.
-	//
-	// Deprecated: Use clusterctlv1.CertManagerVersionAnnotation instead.
-	// TODO: Remove once upgrades from v1alpha3 are no longer supported.
-	certManagerVersionAnnotation = "certmanager.clusterctl.cluster.x-k8s.io/version"
 )
 
 var (
@@ -358,13 +352,9 @@ func (cm *certManagerClient) shouldUpgrade(desiredVersion string, objs, installO
 		// if there is no version annotation, this means the obj is cert-manager v0.11.0 (installed with older version of clusterctl)
 		objVersion, ok := obj.GetAnnotations()[clusterctlv1.CertManagerVersionAnnotation]
 		if !ok {
-			// try the old annotation name
-			objVersion, ok = obj.GetAnnotations()[certManagerVersionAnnotation]
-			if !ok {
-				currentVersion = "v0.11.0"
-				needUpgrade = true
-				break
-			}
+			currentVersion = "v0.11.0"
+			needUpgrade = true
+			break
 		}
 
 		objSemVersion, err := semver.ParseTolerant(objVersion)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #11919

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->