### PR TITLE
📖  docs: minor fix for Bash syntax

### DIFF
--- a/docs/book/src/tasks/diagnostics.md
+++ b/docs/book/src/tasks/diagnostics.md
@@ -22,8 +22,8 @@ To continue serving metrics via http the following configuration can be used:
 
 The same can be achieved via clusterctl:
 ```bash
-export CAPI_DIAGNOSTICS_ADDRESS: "localhost:8080"
-export CAPI_INSECURE_DIAGNOSTICS: "true"
+export CAPI_DIAGNOSTICS_ADDRESS="localhost:8080"
+export CAPI_INSECURE_DIAGNOSTICS="true"
 clusterctl init ...
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This minor commit fixes the syntax for some Bash `export` commands on the diagnostics page.

/area documentation