### PR TITLE
🐛 Improve client  cert/key rotation of the RuntimeSDK client

### DIFF
--- a/internal/controllers/extensionconfig/warmup_test.go
+++ b/internal/controllers/extensionconfig/warmup_test.go
@@ -78,13 +78,15 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			})
 		}
 
+		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+			Catalog:  cat,
+			Registry: registry,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
 		r := &warmupRunnable{
-			Client:    env.GetClient(),
-			APIReader: env.GetAPIReader(),
-			RuntimeClient: internalruntimeclient.New(internalruntimeclient.Options{
-				Catalog:  cat,
-				Registry: registry,
-			}),
+			Client:        env.GetClient(),
+			APIReader:     env.GetAPIReader(),
+			RuntimeClient: runtimeClient,
 		}
 
 		g.Expect(r.Start(ctx)).To(Succeed())
@@ -128,24 +130,28 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			})
 		}
 
+		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+			Catalog:  cat,
+			Registry: registry,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
 		r := &warmupRunnable{
-			Client:    env.GetClient(),
-			APIReader: env.GetAPIReader(),
-			RuntimeClient: internalruntimeclient.New(internalruntimeclient.Options{
-				Catalog:  cat,
-				Registry: registry,
-			}),
+			Client:        env.GetClient(),
+			APIReader:     env.GetAPIReader(),
+			RuntimeClient: runtimeClient,
 		}
 
+		runtimeClientReadOnly, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+			Catalog:  cat,
+			Registry: registryReadOnly,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
 		rReadOnly := &warmupRunnable{
 			ReadOnly:      true,
 			warmupTimeout: 3 * time.Second, // Use a short timeout so the test doesn't take too long
 			Client:        env.GetClient(),
 			APIReader:     env.GetAPIReader(),
-			RuntimeClient: internalruntimeclient.New(internalruntimeclient.Options{
-				Catalog:  cat,
-				Registry: registryReadOnly,
-			}),
+			RuntimeClient: runtimeClientReadOnly,
 		}
 
 		// Initially warmup should fail if ExtensionConfigs have not been reconciled yet.
@@ -203,13 +209,15 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			g.Expect(env.CreateAndWait(ctx, extensionConfig)).To(Succeed())
 		}
 
+		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+			Catalog:  cat,
+			Registry: registry,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
 		r := &warmupRunnable{
-			Client:    env.GetClient(),
-			APIReader: env.GetAPIReader(),
-			RuntimeClient: internalruntimeclient.New(internalruntimeclient.Options{
-				Catalog:  cat,
-				Registry: registry,
-			}),
+			Client:         env.GetClient(),
+			APIReader:      env.GetAPIReader(),
+			RuntimeClient:  runtimeClient,
 			warmupInterval: 500 * time.Millisecond,
 			warmupTimeout:  5 * time.Second,
 		}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -531,13 +532,25 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespaces map
 	var runtimeClient runtimeclient.Client
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		// This is the creation of the runtimeClient for the controllers, embedding a shared catalog and registry instance.
-		runtimeClient = internalruntimeclient.New(internalruntimeclient.Options{
+		var certWatcher *certwatcher.CertWatcher
+		runtimeClient, certWatcher, err = internalruntimeclient.New(internalruntimeclient.Options{
 			CertFile: runtimeExtensionCertFile,
 			KeyFile:  runtimeExtensionKeyFile,
 			Catalog:  catalog,
 			Registry: runtimeregistry.New(),
 			Client:   mgr.GetClient(),
 		})
+		if err != nil {
+			setupLog.Error(err, "Unable to create RuntimeSDK client")
+			os.Exit(1)
+		}
+		if certWatcher != nil {
+			// Note: certWatcher is managed by the manager to ensure that a certWatcher failure leads to a binary restart.
+			if err := mgr.Add(certWatcher); err != nil {
+				setupLog.Error(err, "Unable to add RuntimeSDK client cert-watcher to the manager")
+				os.Exit(1)
+			}
+		}
 	}
 
 	// Setup a separate cache without label selector for secrets, to be used

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -57,6 +57,9 @@ type Cache[E Entry] interface {
 
 	// Len returns the number of entries in the cache.
 	Len() int
+
+	// DeleteAll deletes all entries from the cache.
+	DeleteAll()
 }
 
 // New creates a new cache.
@@ -106,6 +109,11 @@ func (r *cache[E]) Has(key string) (E, bool) {
 
 func (r *cache[E]) Len() int {
 	return len(r.ListKeys())
+}
+
+func (r *cache[E]) DeleteAll() {
+	// Note: We are intentionally using Replace instead of List + Delete because the latter would be racy.
+	_ = r.Store.Replace(nil, "")
 }
 
 // HookEntry is an Entry for the hook Cache.

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -96,6 +96,10 @@ func TestCache(t *testing.T) {
 			))
 		})
 	}
+
+	g.Expect(c.Len()).To(Equal(1))
+	c.DeleteAll()
+	g.Expect(c.Len()).To(Equal(0))
 }
 
 func TestShouldRequeueDrain(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We noticed that there is an issue with client cert/key rotation in the RuntimeSDK client since:
* https://github.com/kubernetes-sigs/cluster-api/pull/13061
* https://github.com/kubernetes-sigs/cluster-api/pull/13084

The problem is essentially that because the httpClient is cached it can take a long time (a few minutes) for the RuntimeSDK client to use the new client cert/key.

With this change the http client cache is invalidated as soon as client cert/key is rotated and the Runtime SDK client will use the new client cert/key immediately.

(Disclaimer: immediately means once the kubelet updated the files on disk)

Also planning to backport this into all affected branches (v1.12 / v1.11 / v1.10).
v1.10 will require an additional release that was not planned but I think it makes sense given that the last v1.10 patch release introduced that issue and we shouldn't let that stand :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->