### PR TITLE
🐛 Allow adding spec via ClusterClass JSON patches

### DIFF
--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -331,12 +331,12 @@ func validateJSONPatches(jsonPatches []clusterv1.JSONPatch, variables []clusterv
 				))
 		}
 
-		if !strings.HasPrefix(jsonPatch.Path, "/spec/") {
+		if !strings.HasPrefix(jsonPatch.Path, "/spec") {
 			allErrs = append(allErrs,
 				field.Invalid(
 					path.Index(i).Child("path"),
 					prettyPrint(jsonPatch),
-					"jsonPatch path must start with \"/spec/\"",
+					"jsonPatch path must start with \"/spec\"",
 				))
 		}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
It should be allowed to have template objects without spec in the ClusterClass and then add spec via JSON patches, e.g. via:
```yaml
            - op: add
              path: /spec
              value:
                template:
                  spec: {}
```

The current CC validating webhook blocks this though.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->