### PR TITLE
🌱 Fix inMemory watch

### DIFF
--- a/test/infrastructure/inmemory/pkg/runtime/cache/cache.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/cache.go
@@ -48,6 +48,8 @@ type Cache interface {
 	Update(resourceGroup string, obj client.Object) error
 	Patch(resourceGroup string, obj client.Object, patch client.Patch) error
 
+	GetBookmarkResourceVersion(resourceGroup string) (string, error)
+
 	GetInformer(ctx context.Context, obj client.Object) (Informer, error)
 	GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error)
 }

--- a/test/infrastructure/inmemory/pkg/runtime/cache/client.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/client.go
@@ -79,6 +79,22 @@ func (c *cache) Get(resourceGroup string, objKey client.ObjectKey, obj client.Ob
 	return nil
 }
 
+func (c *cache) GetBookmarkResourceVersion(resourceGroup string) (string, error) {
+	if resourceGroup == "" {
+		return "", apierrors.NewBadRequest("resourceGroup must not be empty")
+	}
+
+	tracker := c.resourceGroupTracker(resourceGroup)
+	if tracker == nil {
+		return "", apierrors.NewBadRequest(fmt.Sprintf("resourceGroup %s does not exist", resourceGroup))
+	}
+
+	tracker.lock.RLock()
+	defer tracker.lock.RUnlock()
+
+	return fmt.Sprintf("%d", tracker.lastResourceVersion), nil
+}
+
 func (c *cache) List(resourceGroup string, list client.ObjectList, opts ...client.ListOption) error {
 	if resourceGroup == "" {
 		return apierrors.NewBadRequest("resourceGroup must not be empty")

--- a/test/infrastructure/inmemory/pkg/runtime/cache/client_test.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/client_test.go
@@ -277,6 +277,49 @@ func Test_cache_client(t *testing.T) {
 		})
 	})
 
+	t.Run("Get bookmark resourceVersion", func(t *testing.T) {
+		c := NewCache(scheme).(*cache)
+		c.AddResourceGroup("foo")
+
+		t.Run("fails if resourceGroup is empty", func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, err := c.GetBookmarkResourceVersion("")
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+		})
+
+		t.Run("fails if resourceGroup doesn't exist", func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, err := c.GetBookmarkResourceVersion("bar")
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+		})
+
+		t.Run("get when no objects exists", func(t *testing.T) {
+			g := NewWithT(t)
+
+			v, err := c.GetBookmarkResourceVersion("foo")
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Check all the computed fields are as expected.
+			g.Expect(v).To(Equal("0"), "resourceVersion must be set")
+		})
+
+		t.Run("get when objects exists", func(t *testing.T) {
+			g := NewWithT(t)
+
+			createMachine(t, c, "foo", "bar")
+
+			v, err := c.GetBookmarkResourceVersion("foo")
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Check all the computed fields are as expected.
+			g.Expect(v).To(Equal("1"), "resourceVersion must be set")
+		})
+	})
+
 	t.Run("list objects", func(t *testing.T) {
 		c := NewCache(scheme).(*cache)
 		c.AddResourceGroup("foo")

--- a/test/infrastructure/inmemory/pkg/server/listener.go
+++ b/test/infrastructure/inmemory/pkg/server/listener.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"sigs.k8s.io/cluster-api/util/certs"
 )
@@ -118,29 +116,4 @@ func (s *WorkloadClusterListener) RESTConfig() (*rest.Config, error) {
 	}
 
 	return restConfig, nil
-}
-
-// GetClient returns a client for a WorkloadClusterListener.
-func (s *WorkloadClusterListener) GetClient() (client.WithWatch, error) {
-	restConfig, err := s.RESTConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient, err := rest.HTTPClientFor(restConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, httpClient)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := client.NewWithWatch(restConfig, client.Options{Scheme: s.scheme, Mapper: mapper})
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR fixed the error "Timeout: failed waiting for *v1.Service Informer to sync" which happens when the cache is created before an object of a given gvk exists + it makes watches in the in memory serve to behave more alike real watches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
