### PR TITLE
🌱 Dump resources in scale test

### DIFF
--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -33,6 +33,7 @@ var _ = Describe("When testing the machinery for scale testing using in-memory b
 			BootstrapClusterProxy:             bootstrapClusterProxy,
 			ArtifactFolder:                    artifactFolder,
 			Flavor:                            ptr.To("in-memory"),
+			DumpResources:                     true,
 			SkipCleanup:                       skipCleanup,
 			ClusterCount:                      ptr.To[int64](10),
 			Concurrency:                       ptr.To[int64](5),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add a flag to dump resources in E2E tests (it requires opt-in, because it could be really noisy when testing with many clusters).

Note. in the future we can make this more sophisticate and dump resources only for clusters with issues, but this requires to pass the "filter func" down the chain of dump commands + some thinking (how to build the filter func and probably more e.g. what if all the cluster are in the same namespace).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci