### PR TITLE
🐛 Add MachinesUpToDate condition handling in MachinePool controller

### DIFF
--- a/internal/controllers/machinepool/machinepool_controller.go
+++ b/internal/controllers/machinepool/machinepool_controller.go
@@ -202,6 +202,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			}},
 			patch.WithOwnedConditions{Conditions: []string{
 				clusterv1.PausedCondition,
+				clusterv1.MachinesUpToDateCondition,
 			}},
 		}
 		if reterr == nil {

--- a/internal/controllers/machinepool/machinepool_controller_status.go
+++ b/internal/controllers/machinepool/machinepool_controller_status.go
@@ -19,7 +19,9 @@ package machinepool
 import (
 	"context"
 	"fmt"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -41,7 +43,8 @@ func (r *Reconciler) updateStatus(ctx context.Context, s *scope) error {
 
 	setReplicas(s.machinePool, hasMachinePoolMachines, s.machines)
 
-	// TODO: in future add setting conditions here
+	// Set MachinesUpToDate condition to surface when machines are not up-to-date with the spec.
+	setMachinesUpToDateCondition(ctx, s.machinePool, s.machines, hasMachinePoolMachines)
 
 	return nil
 }
@@ -72,4 +75,79 @@ func setReplicas(mp *clusterv1.MachinePool, hasMachinePoolMachines bool, machine
 	mp.Status.ReadyReplicas = ptr.To(readyReplicas)
 	mp.Status.AvailableReplicas = ptr.To(availableReplicas)
 	mp.Status.UpToDateReplicas = ptr.To(upToDateReplicas)
+}
+
+// setMachinesUpToDateCondition sets the MachinesUpToDate condition on the MachinePool.
+func setMachinesUpToDateCondition(ctx context.Context, mp *clusterv1.MachinePool, machines []*clusterv1.Machine, hasMachinePoolMachines bool) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// For MachinePool providers that don't use Machine objects (like managed pools),
+	// we derive the MachinesUpToDate condition from the infrastructure status.
+	// If InfrastructureProvisioned is False, machines are not up-to-date.
+	if !hasMachinePoolMachines {
+		// Check if infrastructure is ready by looking at the initialization status
+		if !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
+			log.V(4).Info("setting MachinesUpToDate to false for machineless MachinePool: infrastructure not yet provisioned")
+			conditions.Set(mp, metav1.Condition{
+				Type:    clusterv1.MachinesUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.NotUpToDateReason,
+				Message: "Infrastructure is not yet provisioned",
+			})
+			return
+		}
+
+		conditions.Set(mp, metav1.Condition{
+			Type:   clusterv1.MachinesUpToDateCondition,
+			Status: metav1.ConditionTrue,
+			Reason: clusterv1.UpToDateReason,
+		})
+		return
+	}
+
+	// Only consider Machines that have an UpToDate condition or are older than 10s.
+	// This is done to ensure the MachinesUpToDate condition doesn't flicker after a new Machine is created,
+	// because it can take a bit until the UpToDate condition is set on a new Machine.
+	filteredMachines := make([]*clusterv1.Machine, 0, len(machines))
+	for _, machine := range machines {
+		if conditions.Has(machine, clusterv1.MachineUpToDateCondition) || time.Since(machine.CreationTimestamp.Time) > 10*time.Second {
+			filteredMachines = append(filteredMachines, machine)
+		}
+	}
+
+	if len(filteredMachines) == 0 {
+		conditions.Set(mp, metav1.Condition{
+			Type:   clusterv1.MachinesUpToDateCondition,
+			Status: metav1.ConditionTrue,
+			Reason: clusterv1.NoReplicasReason,
+		})
+		return
+	}
+
+	upToDateCondition, err := conditions.NewAggregateCondition(
+		filteredMachines, clusterv1.MachineUpToDateCondition,
+		conditions.TargetConditionType(clusterv1.MachinesUpToDateCondition),
+		// Using a custom merge strategy to override reasons applied during merge.
+		conditions.CustomMergeStrategy{
+			MergeStrategy: conditions.DefaultMergeStrategy(
+				conditions.ComputeReasonFunc(conditions.GetDefaultComputeMergeReasonFunc(
+					clusterv1.NotUpToDateReason,
+					clusterv1.UpToDateUnknownReason,
+					clusterv1.UpToDateReason,
+				)),
+			),
+		},
+	)
+	if err != nil {
+		log.Error(err, "Failed to aggregate Machine's UpToDate conditions")
+		conditions.Set(mp, metav1.Condition{
+			Type:    clusterv1.MachinesUpToDateCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.InternalErrorReason,
+			Message: "Please check controller logs for errors",
+		})
+		return
+	}
+
+	conditions.Set(mp, *upToDateCondition)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
MachinePool lacks clear status signal during upgrades. When spec.version changes (generation increments), status.observedGeneration updates immediately to match, but Ready/InfrastructureReady conditions only flip to False ~10s later. See the linked Github issue for more details.

Following the pattern established in `MachineDeployment`, this PR adds a `MachinesUpToDate` condition to `MachinePool` that provides an immediate, reliable signal for upgrade status:

- For MachinePools with Machine objects: Aggregates `MachineUpToDateCondition` from individual Machines
- For managed MachinePools (like AKS): Derives the condition from `InfrastructureProvisioned` status
- 10-second grace period: Filters out very new Machines to prevent condition flickering

<details>
<summary> See the new <b>condition</b> in the MachinePool status </summary>
<pre>
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2026-01-14T12:39:46Z"
    message: ""
    observedGeneration: 9
    reason: UpToDate
    status: "True"
    type: MachinesUpToDate
  - lastTransitionTime: "2026-01-14T11:36:09Z"
    message: ""
    observedGeneration: 9
    reason: NotPaused
    status: "False"
    type: Paused
  deprecated:
    v1beta1:
      availableReplicas: 1
      conditions:
      - lastTransitionTime: "2026-01-14T12:39:46Z"
        status: "True"
        type: Ready
      - lastTransitionTime: "2026-01-14T11:36:09Z"
        status: "True"
        type: BootstrapReady
      - lastTransitionTime: "2026-01-14T12:39:46Z"
        status: "True"
        type: InfrastructureReady
      - lastTransitionTime: "2026-01-14T11:45:50Z"
        status: "True"
        type: ReplicasReady
      readyReplicas: 1
  initialization:
    bootstrapDataSecretCreated: true
    infrastructureProvisioned: true
  nodeRefs:
  - apiVersion: v1
    kind: Node
    name: aks-pool2-34400930-vmss000000
    uid: 953a05d8-8b81-421e-bfca-4c500f3c0f68
  observedGeneration: 9
  phase: Running
  readyReplicas: 1
  replicas: 1
  upToDateReplicas: 1
</pre>
</details>

Fixes #10059

/area machinepool