### PR TITLE
[release-1.10] 🌱 Bump Go to v1.24.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.24.11
+GO_VERSION ?= 1.24.12
 GO_DIRECTIVE_VERSION ?= 1.23.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -172,7 +172,7 @@ def load_provider_tilt_files():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.24.11 as tilt-helper
+FROM golang:1.24.12 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.24
 # Support live reloading with Tilt
@@ -183,7 +183,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.24.11 as tilt
+FROM golang:1.24.12 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.24.11"
+    GO_VERSION = "1.24.12"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Manual cherry-pick of #13241

Updates the Go compiler and tools to v1.24.12.

> go1.24.12 (released 2026-01-15) includes security fixes to the go command, and the `archive/zip`, `crypto/tls`, and `net/url` packages, as well as bug fixes to the compiler, the runtime, and the `crypto/tls` and `os` packages. See the [Go 1.24.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.12+label%3ACherryPickApproved) on our issue tracker for details.

**Which issue(s) this PR fixes**:

N/A, but see #13106 for prior art.

/area dependency