### PR TITLE
:bug: Add wait-resource-versions-{become,remain}-stable intervals to e2e config

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -39,7 +39,15 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with Runt
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "k8s-upgrade-with-runtimesdk"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor: ptr.To("upgrades-runtimesdk"),
@@ -65,7 +73,15 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass in a diff
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "k8s-upgrade-with-runtimesdk"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor:                                ptr.To("upgrades-runtimesdk"),
@@ -93,7 +109,15 @@ var _ = Describe("When performing chained upgrades for workload cluster using Cl
 			PostUpgrade: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "k8s-upgrade-with-runtimesdk"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 			// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 			Flavor:                                ptr.To("upgrades-runtimesdk"),

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -724,7 +724,14 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			// continuous reconciles when everything should be stable.
 			if i == len(input.Upgrades)-1 {
 				Byf("[%d] Checking that resourceVersions are stable", i)
-				framework.ValidateResourceVersionStable(ctx, managementClusterProxy, workloadCluster.Namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(workloadCluster.Name))
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             managementClusterProxy,
+					Namespace:                workloadCluster.Namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(workloadCluster.Name),
+					WaitToBecomeStable:       input.E2EConfig.GetIntervals(specName, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       input.E2EConfig.GetIntervals(specName, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 
 				// NOTE: Checks on conditions works on v1beta2 only, so running this checks only in the last step which is
 				// always current version.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -268,6 +268,8 @@ intervals:
   default/wait-nodes-ready: ["10m", "10s"]
   default/wait-machine-remediation: ["5m", "10s"]
   default/wait-autoscaler: ["5m", "10s"]
+  default/wait-resource-versions-become-stable: ["2m", "15s"]
+  default/wait-resource-versions-remain-stable: ["2m", "5s"]
   node-drain/wait-deployment-available: ["3m", "10s"]
   node-drain/wait-control-plane: ["15m", "10s"]
   node-drain/wait-machine-deleted: ["2m", "10s"]

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -69,7 +69,15 @@ var _ = Describe("When following the Cluster API quick-start", func() {
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
 				By("Checking that resourceVersions are stable")
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "quick-start"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 		}
 	})
@@ -116,7 +124,15 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass [
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
 				By("Checking that resourceVersions are stable")
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "quick-start"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 		}
 	})
@@ -141,7 +157,15 @@ var _ = Describe("When following the Cluster API quick-start with v1beta1 Cluste
 				// This check ensures that the resourceVersions are stable, i.e. it verifies there are no
 				// continuous reconciles when everything should be stable.
 				By("Checking that resourceVersions are stable")
-				framework.ValidateResourceVersionStable(ctx, proxy, namespace, clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName))
+				spec := "quick-start"
+				resourceVersionInput := framework.ValidateResourceVersionStableInput{
+					ClusterProxy:             proxy,
+					Namespace:                namespace,
+					OwnerGraphFilterFunction: clusterctlcluster.FilterClusterObjectsWithNameFilter(clusterName),
+					WaitToBecomeStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-become-stable"),
+					WaitToRemainStable:       e2eConfig.GetIntervals(spec, "wait-resource-versions-remain-stable"),
+				}
+				framework.ValidateResourceVersionStable(ctx, resourceVersionInput)
 			},
 		}
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The default wait intervals used during clusterctl upgrade tests to check for the stability of resource versions do not work when there is high latency between the test binary and the management clusters. This PR makes those timeouts configurable via new `wait-resource-versions-become-stable` and `wait-resource-versions-remain-stable` interval configurations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13262

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area e2e-testing