### PR TITLE
✨ Add Machine status.failureDomain

### DIFF
--- a/api/core/v1beta1/conversion.go
+++ b/api/core/v1beta1/conversion.go
@@ -413,6 +413,7 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 		// won't be able to write the Phase field. But that's okay as the only client writing the Phase
 		// field should be the Machine controller.
 		dst.Status.Phase = restored.Status.Phase
+		dst.Status.FailureDomain = restored.Status.FailureDomain
 	}
 
 	return nil

--- a/api/core/v1beta1/zz_generated.conversion.go
+++ b/api/core/v1beta1/zz_generated.conversion.go
@@ -3224,6 +3224,7 @@ func autoConvert_v1beta2_MachineStatus_To_v1beta1_MachineStatus(in *v1beta2.Mach
 	out.NodeInfo = (*corev1.NodeSystemInfo)(unsafe.Pointer(in.NodeInfo))
 	// WARNING: in.LastUpdated requires manual conversion: inconvertible types (k8s.io/apimachinery/pkg/apis/meta/v1.Time vs *k8s.io/apimachinery/pkg/apis/meta/v1.Time)
 	out.Addresses = *(*MachineAddresses)(unsafe.Pointer(&in.Addresses))
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.Phase = in.Phase
 	// WARNING: in.CertificatesExpiryDate requires manual conversion: inconvertible types (k8s.io/apimachinery/pkg/apis/meta/v1.Time vs *k8s.io/apimachinery/pkg/apis/meta/v1.Time)
 	out.ObservedGeneration = in.ObservedGeneration

--- a/api/core/v1beta2/machine_types.go
+++ b/api/core/v1beta2/machine_types.go
@@ -589,6 +589,12 @@ type MachineStatus struct {
 	// +optional
 	Addresses MachineAddresses `json:"addresses,omitempty"`
 
+	// failureDomain is the failure domain where the Machine has been scheduled.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	FailureDomain string `json:"failureDomain,omitempty"`
+
 	// phase represents the current phase of machine actuation.
 	// +optional
 	// +kubebuilder:validation:Enum=Pending;Provisioning;Provisioned;Running;Updating;Deleting;Deleted;Failed;Unknown
@@ -783,6 +789,7 @@ type Bootstrap struct {
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterName",description="Cluster"
 // +kubebuilder:printcolumn:name="Node Name",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine"
 // +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="Failure domain",type="string",JSONPath=".status.failureDomain",description="The failure domain where the Machine has been scheduled"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Machine pass all readiness checks"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=`.status.conditions[?(@.type=="Available")].status`,description="Machine is Ready for at least MinReadySeconds"
 // +kubebuilder:printcolumn:name="Up-to-date",type="string",JSONPath=`.status.conditions[?(@.type=="UpToDate")].status`,description=" Machine spec matches the spec of the Machine's owner resource, e.g. MachineDeployment"

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -6265,6 +6265,13 @@ func schema_cluster_api_api_core_v1beta2_MachineStatus(ref common.ReferenceCallb
 							},
 						},
 					},
+					"failureDomain": {
+						SchemaProps: spec.SchemaProps{
+							Description: "failureDomain is the failure domain where the Machine has been scheduled.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
 							Description: "phase represents the current phase of machine actuation.",

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -663,6 +663,10 @@ spec:
       name: Provider ID
       priority: 10
       type: string
+    - description: The failure domain where the Machine has been scheduled
+      jsonPath: .status.failureDomain
+      name: Failure domain
+      type: string
     - description: Machine pass all readiness checks
       jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
@@ -1256,6 +1260,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              failureDomain:
+                description: failureDomain is the failure domain where the Machine
+                  has been scheduled.
+                maxLength: 256
+                minLength: 1
+                type: string
               initialization:
                 description: |-
                   initialization provides observations of the Machine initialization process.

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -238,28 +238,13 @@ In case you are developing an infrastructure provider which has a notion of fail
 placed in, the InfraMachine resource MUST comply to the value that exists in the `spec.failureDomain` field of the Machine
 (in other words, the InfraMachine MUST be placed in the failure domain specified at Machine level).
 
-Please note, that for allowing a transparent transition from when there was no failure domain support in Cluster API
-and InfraMachine was authoritative WRT to failure domain placement (before CAPI v0.3.0),
-Cluster API still supports a _deprecated_ reverse process for failure domain management.
-
-In the _deprecated_ reverse process, the failure domain where the machine should be placed is defined in the InfraMachine's 
-`spec.failureDomain` field; the value of this field is then surfaced on the corresponding field at Machine level.
-
-<aside class="note warning">
-
-<h1>Heads up! this will change with the v1beta2 contract</h1>
-
-Machine's controller will stop supporting the _deprecated_ reverse process; the InfraMachine's `spec.failureDomain`,
-if still present, will be ignored.
-
-However, InfraMachine will be allowed to surface the failure domain where the machine is actually placed in by 
-implementing a new, optional `status.failureDomain`; this info, if present, will then surface at Machine level in a 
-new corresponding field (also in status).
+Also, InfraMachine providers are allowed to surface the failure domain where the machine is actually placed by
+implementing the `status.failureDomain` field; this info, if present, will then surface at Machine level in a 
+corresponding field (also in status).
 
 ```go
 type FooMachineStatus struct {
     // failureDomain is the unique identifier of the failure domain where this Machine has been placed in.
-    // For this Foo infrastructure provider, the name is equivalent to the name of one of the available regions.
     // +optional
     // +kubebuilder:validation:MinLength=1
     // +kubebuilder:validation:MaxLength=256
@@ -269,6 +254,22 @@ type FooMachineStatus struct {
     // Other fields SHOULD be added based on the needs of your provider.
 }
 ```
+
+<aside class="note warning">
+
+<h1>Compatibility with the deprecated v1beta1 contract</h1>
+
+In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in August 2026.
+
+With regard to failure domain:
+
+Cluster API will continue to temporarily support InfraMachine resource using `spec.failureDomain` to
+set the failure domain. Note that this field has been preserved only for allowing transparent transition from when there 
+was no failure domain support in Cluster API and InfraMachine was authoritative WRT to failure domain placement (before CAPI v0.3.0).
+
+After compatibility with the deprecated v1beta1 contract will be removed, `spec.failureDomain` field in
+the InfraMachine resource will be ignored.
 
 </aside>
 
@@ -322,7 +323,7 @@ type FooMachineInitializationStatus struct {
 ```
 
 Once `status.initialization.provisioned` is set the Machine "core" controller will bubble up this info in Machine's
-`status.initialization.infrastructureProvisioned`; also InfraMachine's `spec.providerID` and `status.addresses` will 
+`status.initialization.infrastructureProvisioned`; also InfraMachine's `spec.providerID`, `status.failureDomain` and `status.addresses` will 
 be surfaced on Machine's corresponding fields at the same time.
 
 <aside class="note warning">
@@ -332,7 +333,7 @@ be surfaced on Machine's corresponding fields at the same time.
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
 preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in August 2026.
 
-With regards to initialization completed:
+With regard to initialization completed:
 
 Cluster API will continue to temporarily support InfraMachine resource using `status.ready` field to
 report initialization completed.
@@ -614,7 +615,7 @@ is implemented in InfraMachine controllers:
 1. Set `spec.providerID` to the provider-specific identifier for the provider's machine instance
 1. Set `status.infrastructure.provisioned` to `true`
 1. Set `status.addresses` to the provider-specific set of instance addresses (optional)
-1. Set `spec.failureDomain` to the provider-specific failure domain the instance is running in (optional)
+1. Set `status.failureDomain` to the provider-specific failure domain the instance is running in (optional)
 1. Patch the resource to persist changes
 
 ### Deleted resource

--- a/internal/contract/infrastructure_machine.go
+++ b/internal/contract/infrastructure_machine.go
@@ -92,10 +92,17 @@ func (m *InfrastructureMachineContract) ProviderID() *String {
 	}
 }
 
-// FailureDomain provides access to the spec.failureDomain field in an InfrastructureMachine object. Note that this field is optional.
-func (m *InfrastructureMachineContract) FailureDomain() *String {
+// DeprecatedFailureDomain provides access to the spec.failureDomain field in an InfrastructureMachine object. Note that this field is optional.
+func (m *InfrastructureMachineContract) DeprecatedFailureDomain() *String {
 	return &String{
 		path: []string{"spec", "failureDomain"},
+	}
+}
+
+// FailureDomain provides access to the status.failureDomain field in an InfrastructureMachine object. Note that this field is optional.
+func (m *InfrastructureMachineContract) FailureDomain() *String {
+	return &String{
+		path: []string{"status", "failureDomain"},
 	}
 }
 

--- a/internal/contract/infrastructure_machine_test.go
+++ b/internal/contract/infrastructure_machine_test.go
@@ -117,7 +117,20 @@ func TestInfrastructureMachine(t *testing.T) {
 	t.Run("Manages optional spec.failureDomain", func(t *testing.T) {
 		g := NewWithT(t)
 
-		g.Expect(InfrastructureMachine().FailureDomain().Path()).To(Equal(Path{"spec", "failureDomain"}))
+		g.Expect(InfrastructureMachine().DeprecatedFailureDomain().Path()).To(Equal(Path{"spec", "failureDomain"}))
+
+		err := InfrastructureMachine().DeprecatedFailureDomain().Set(obj, "fake-failure-domain")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := InfrastructureMachine().DeprecatedFailureDomain().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal("fake-failure-domain"))
+	})
+	t.Run("Manages optional status.failureDomain", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(InfrastructureMachine().FailureDomain().Path()).To(Equal(Path{"status", "failureDomain"}))
 
 		err := InfrastructureMachine().FailureDomain().Set(obj, "fake-failure-domain")
 		g.Expect(err).ToNot(HaveOccurred())

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -536,7 +536,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 		},
 		{
-			name:     "infra machine ready and with optional failure domain, it should reconcile and data should surface on the machine",
+			name:     "infra machine ready and with optional failure domain (deprecated), it should reconcile and data should surface on the machine",
 			contract: "v1beta1",
 			machine:  defaultMachine.DeepCopy(),
 			infraMachine: map[string]interface{}{
@@ -561,6 +561,35 @@ func TestReconcileInfrastructure(t *testing.T) {
 				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
+				g.Expect(m.Status.Addresses).To(BeNil())
+			},
+		},
+		{
+			name:     "infra machine ready and with optional failure domain, it should reconcile and data should surface on the machine",
+			contract: "v1beta1",
+			machine:  defaultMachine.DeepCopy(),
+			infraMachine: map[string]interface{}{
+				"kind":       "GenericInfrastructureMachine",
+				"apiVersion": clusterv1.GroupVersionInfrastructure.String(),
+				"metadata": map[string]interface{}{
+					"name":      "infra-config1",
+					"namespace": metav1.NamespaceDefault,
+				},
+				"spec": map[string]interface{}{
+					"providerID": "test://id-1",
+				},
+				"status": map[string]interface{}{
+					"ready":         true,
+					"failureDomain": "foo",
+				},
+			},
+			infraMachineGetError: nil,
+			expectResult:         ctrl.Result{},
+			expectError:          false,
+			expected: func(g *WithT, m *clusterv1.Machine) {
+				g.Expect(ptr.Deref(m.Status.Initialization.InfrastructureProvisioned, false)).To(BeTrue())
+				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
+				g.Expect(m.Status.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(BeNil())
 			},
 		},
@@ -629,6 +658,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 							"address": "10.0.0.2",
 						},
 					},
+					"failureDomain": "bar",
 				},
 			},
 			infraMachineGetError: nil,
@@ -639,6 +669,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 				g.Expect(m.Spec.ProviderID).To(Equal("test://id-1"))
 				g.Expect(m.Spec.FailureDomain).To(Equal("foo"))
 				g.Expect(m.Status.Addresses).To(HaveLen(2))
+				g.Expect(m.Status.FailureDomain).To(Equal("bar"))
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This is a follow up of the work for v1beta2 contract work.

Infra provider are now allowed to surface the failureDomain where a machine is placed in InfraMachine.status.failureDomain, and the information is then surfaced in Machine.status.failureDomain

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area machine