### PR TITLE
🌱 Simplify GetUpgradePlanFromClusterClassVersions

### DIFF
--- a/exp/topology/desiredstate/upgrade_plan_test.go
+++ b/exp/topology/desiredstate/upgrade_plan_test.go
@@ -1090,6 +1090,21 @@ func TestGetUpgradePlanFromClusterClassVersions(t *testing.T) {
 			wantWorkersUpgradePlan:      nil,
 			wantErr:                     false,
 		},
+		{
+			name: "version with not sortable build tags",
+			clusterClassVersions: []string{
+				"v1.31.0+a", "v1.31.0+b", "v1.31.0+c", // this is the same minor of currentControlPlaneVersion, everything should be ignored.
+				"v1.31.1+a",
+				"v1.32.0+a", "v1.32.0+b", "v1.32.0+c",
+				"v1.33.0+b",
+				"v1.33.1+a", "v1.33.1+b", "v1.33.1+c", // desiredVersion ends with +b, +c should be ignored.
+			},
+			desiredVersion:              "v1.33.1+b",
+			currentControlPlaneVersion:  "v1.31.0+b",
+			wantControlPlaneUpgradePlan: []string{"v1.32.0+c", "v1.33.1+b"},
+			wantWorkersUpgradePlan:      nil,
+			wantErr:                     false,
+		},
 
 		// Kubernetes versions in CC is set when clusters already exists
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
follow up of https://github.com/kubernetes-sigs/cluster-api/pull/12726#discussion_r2333579519

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->