### PR TITLE
📖 Update note on runtime SDK that in-place updates work for non CC clusters

### DIFF
--- a/docs/book/src/tasks/experimental-features/runtime-sdk/index.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/index.md
@@ -4,8 +4,7 @@ The Runtime SDK feature provides an extensibility mechanism that allows systems,
 
 <aside class="note warning">
 
-All currently implemented hooks require to also enable the [ClusterClass](../cluster-class/index.md) feature.
-Please note that hooks are only invoked for Clusters created using ClusterClass.
+All currently implemented hooks except for [In-Place Update Hooks](./implement-in-place-update-hooks.md) require to also enable the [ClusterClass](../cluster-class/index.md) feature, and are only invoked for Clusters created using ClusterClass.
 
 </aside>
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This pull request clarifies the documentation for the Runtime SDK feature by specifying that only certain hooks require the ClusterClass feature to be enabled. It also notes that In-Place Update Hooks are an exception to this requirement.

Documentation clarification:

* Updated the warning in `index.md` to state that all currently implemented hooks, except for In-Place Update Hooks, require the ClusterClass feature and are only invoked for Clusters created using ClusterClass.

[Reference conversation on slack](https://kubernetes.slack.com/archives/C8TSNPY4T/p1766507942314449)

/area runtime-sdk