### PR TITLE
🌱 Implement .status.failureDomain for DockerMachine & DevMachine

### DIFF
--- a/test/infrastructure/docker/api/v1beta1/conversion.go
+++ b/test/infrastructure/docker/api/v1beta1/conversion.go
@@ -100,6 +100,9 @@ func (src *DockerMachine) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Status.Initialization = initialization
 	}
 
+	if ok {
+		dst.Status.FailureDomain = restored.Status.FailureDomain
+	}
 	return nil
 }
 
@@ -221,6 +224,9 @@ func (src *DevMachine) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Status.Initialization = initialization
 	}
 
+	if ok {
+		dst.Status.FailureDomain = restored.Status.FailureDomain
+	}
 	return nil
 }
 

--- a/test/infrastructure/docker/api/v1beta1/zz_generated.conversion.go
+++ b/test/infrastructure/docker/api/v1beta1/zz_generated.conversion.go
@@ -1176,6 +1176,7 @@ func autoConvert_v1beta2_DevMachineStatus_To_v1beta1_DevMachineStatus(in *v1beta
 	}
 	// WARNING: in.Initialization requires manual conversion: does not exist in peer-type
 	out.Addresses = *(*[]corev1beta1.MachineAddress)(unsafe.Pointer(&in.Addresses))
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.Backend = (*DevMachineBackendStatus)(unsafe.Pointer(in.Backend))
 	// WARNING: in.Deprecated requires manual conversion: does not exist in peer-type
 	return nil
@@ -2109,6 +2110,7 @@ func autoConvert_v1beta2_DockerMachineStatus_To_v1beta1_DockerMachineStatus(in *
 	// WARNING: in.Initialization requires manual conversion: does not exist in peer-type
 	out.LoadBalancerConfigured = in.LoadBalancerConfigured
 	out.Addresses = *(*[]corev1beta1.MachineAddress)(unsafe.Pointer(&in.Addresses))
+	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	// WARNING: in.Deprecated requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/test/infrastructure/docker/api/v1beta2/devmachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/devmachine_types.go
@@ -368,6 +368,12 @@ type DevMachineStatus struct {
 	// +optional
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
+	// failureDomain is the unique identifier of the failure domain where this Machine has been placed in.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	FailureDomain string `json:"failureDomain,omitempty"`
+
 	// backend defines backends status for a DevMachine.
 	// +optional
 	Backend *DevMachineBackendStatus `json:"backend,omitempty"`
@@ -425,9 +431,11 @@ type DevMachineV1Beta1DeprecatedStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this DevMachine"
-// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.initialization.provisioned",description="Machine ready status"
+// +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="Failure domain",type="string",JSONPath=".status.failureDomain",description="The failure domain where the VSphereMachine has been scheduled"
+// +kubebuilder:printcolumn:name="IP",type="string",JSONPath=`.status.addresses[?(@.type=="InternalIP")].address`,description="IP of the Machine",priority=10
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="DevMachine is provisioned"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of the DevMachine"
 
 // DevMachine is the schema for the dev machine infrastructure API.

--- a/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
@@ -106,6 +106,12 @@ type DockerMachineStatus struct {
 	// +optional
 	Addresses []clusterv1.MachineAddress `json:"addresses,omitempty"`
 
+	// failureDomain is the unique identifier of the failure domain where this Machine has been placed in.
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=256
+	FailureDomain string `json:"failureDomain,omitempty"`
+
 	// deprecated groups all the status fields that are deprecated and will be removed when all the nested field are removed.
 	// +optional
 	Deprecated *DockerMachineDeprecatedStatus `json:"deprecated,omitempty"`
@@ -144,9 +150,11 @@ type DockerMachineV1Beta1DeprecatedStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
-// +kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this DockerMachine"
-// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.initialization.provisioned",description="Machine ready status"
+// +kubebuilder:printcolumn:name="Provider ID",type="string",JSONPath=".spec.providerID",description="Provider ID",priority=10
+// +kubebuilder:printcolumn:name="Failure domain",type="string",JSONPath=".status.failureDomain",description="The failure domain where the VSphereMachine has been scheduled"
+// +kubebuilder:printcolumn:name="IP",type="string",JSONPath=`.status.addresses[?(@.type=="InternalIP")].address`,description="IP of the Machine",priority=10
+// +kubebuilder:printcolumn:name="Paused",type="string",JSONPath=`.status.conditions[?(@.type=="Paused")].status`,description="Reconciliation paused",priority=10
+// +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=".status.initialization.provisioned",description="DockerMachine is provisioned"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerMachine"
 
 // DockerMachine is the Schema for the dockermachines API.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
@@ -402,17 +402,28 @@ spec:
       jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
       name: Cluster
       type: string
-    - description: Machine object which owns with this DevMachine
-      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
-      name: Machine
-      type: string
     - description: Provider ID
       jsonPath: .spec.providerID
-      name: ProviderID
+      name: Provider ID
+      priority: 10
       type: string
-    - description: Machine ready status
+    - description: The failure domain where the VSphereMachine has been scheduled
+      jsonPath: .status.failureDomain
+      name: Failure domain
+      type: string
+    - description: IP of the Machine
+      jsonPath: .status.addresses[?(@.type=="InternalIP")].address
+      name: IP
+      priority: 10
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: DevMachine is provisioned
       jsonPath: .status.initialization.provisioned
-      name: Ready
+      name: Provisioned
       type: string
     - description: Time duration since creation of the DevMachine
       jsonPath: .metadata.creationTimestamp
@@ -782,6 +793,12 @@ spec:
                         type: array
                     type: object
                 type: object
+              failureDomain:
+                description: failureDomain is the unique identifier of the failure
+                  domain where this Machine has been placed in.
+                maxLength: 256
+                minLength: 1
+                type: string
               initialization:
                 description: |-
                   initialization provides observations of the DevMachine initialization process.

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -287,17 +287,28 @@ spec:
       jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
       name: Cluster
       type: string
-    - description: Machine object which owns with this DockerMachine
-      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
-      name: Machine
-      type: string
     - description: Provider ID
       jsonPath: .spec.providerID
-      name: ProviderID
+      name: Provider ID
+      priority: 10
       type: string
-    - description: Machine ready status
+    - description: The failure domain where the VSphereMachine has been scheduled
+      jsonPath: .status.failureDomain
+      name: Failure domain
+      type: string
+    - description: IP of the Machine
+      jsonPath: .status.addresses[?(@.type=="InternalIP")].address
+      name: IP
+      priority: 10
+      type: string
+    - description: Reconciliation paused
+      jsonPath: .status.conditions[?(@.type=="Paused")].status
+      name: Paused
+      priority: 10
+      type: string
+    - description: DockerMachine is provisioned
       jsonPath: .status.initialization.provisioned
-      name: Ready
+      name: Provisioned
       type: string
     - description: Time duration since creation of DockerMachine
       jsonPath: .metadata.creationTimestamp
@@ -545,6 +556,12 @@ spec:
                         type: array
                     type: object
                 type: object
+              failureDomain:
+                description: failureDomain is the unique identifier of the failure
+                  domain where this Machine has been placed in.
+                maxLength: 256
+                minLength: 1
+                type: string
               initialization:
                 description: |-
                   initialization provides observations of the DockerMachine initialization process.

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -118,6 +118,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		// ensure ready state is set.
 		// This is required after move, because status is not moved to the target cluster.
 		dockerMachine.Status.Initialization.Provisioned = ptr.To(true)
+		dockerMachine.Status.FailureDomain = machine.Spec.FailureDomain
 
 		if externalMachine.Exists() {
 			v1beta1conditions.MarkTrue(dockerMachine, infrav1.ContainerProvisionedV1Beta1Condition)
@@ -368,6 +369,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	// Set ProviderID so the Cluster API Machine Controller can pull it
 	dockerMachine.Spec.ProviderID = externalMachine.ProviderID()
 	dockerMachine.Status.Initialization.Provisioned = ptr.To(true)
+	dockerMachine.Status.FailureDomain = machine.Spec.FailureDomain
 
 	return ctrl.Result{}, nil
 }

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -163,7 +163,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	return res, kerrors.NewAggregate(errs)
 }
 
-func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Context, cluster *clusterv1.Cluster, _ *clusterv1.Machine, inMemoryMachine *infrav1.DevMachine) (_ ctrl.Result, retErr error) {
+func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, inMemoryMachine *infrav1.DevMachine) (_ ctrl.Result, retErr error) {
 	defer func() {
 		if retErr != nil {
 			conditions.Set(inMemoryMachine, metav1.Condition{
@@ -229,6 +229,7 @@ func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Conte
 
 	inMemoryMachine.Spec.ProviderID = calculateProviderID(inMemoryMachine)
 	inMemoryMachine.Status.Initialization.Provisioned = ptr.To(true)
+	inMemoryMachine.Status.FailureDomain = machine.Spec.FailureDomain
 	v1beta1conditions.MarkTrue(inMemoryMachine, infrav1.VMProvisionedCondition)
 	conditions.Set(inMemoryMachine, metav1.Condition{
 		Type:   infrav1.DevMachineInMemoryVMProvisionedCondition,

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -330,9 +330,10 @@ func dockerMachineToDevMachine(dockerMachine *infrav1.DockerMachine) *infrav1.De
 			Initialization: infrav1.DevMachineInitializationStatus{
 				Provisioned: dockerMachine.Status.Initialization.Provisioned,
 			},
-			Addresses:  dockerMachine.Status.Addresses,
-			Conditions: dockerMachine.Status.Conditions,
-			Deprecated: v1Beta1Status,
+			Addresses:     dockerMachine.Status.Addresses,
+			FailureDomain: dockerMachine.Status.FailureDomain,
+			Conditions:    dockerMachine.Status.Conditions,
+			Deprecated:    v1Beta1Status,
 			Backend: &infrav1.DevMachineBackendStatus{
 				Docker: &infrav1.DockerMachineBackendStatus{
 					LoadBalancerConfigured: dockerMachine.Status.LoadBalancerConfigured,
@@ -364,6 +365,7 @@ func devMachineToDockerMachine(devMachine *infrav1.DevMachine, dockerMachine *in
 		Provisioned: devMachine.Status.Initialization.Provisioned,
 	}
 	dockerMachine.Status.Addresses = devMachine.Status.Addresses
+	dockerMachine.Status.FailureDomain = devMachine.Status.FailureDomain
 	dockerMachine.Status.Conditions = devMachine.Status.Conditions
 	dockerMachine.Status.Deprecated = v1Beta1Status
 	dockerMachine.Status.LoadBalancerConfigured = devMachine.Status.Backend.Docker.LoadBalancerConfigured

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -262,7 +262,24 @@ metadata:
   name: quick-start-cluster
 spec:
   template:
-    spec: {}
+    spec:
+      failureDomains:
+        - name: fd1
+          controlPlane: true
+        - name: fd2
+          controlPlane: true
+        - name: fd3
+          controlPlane: true
+        - name: fd4
+          controlPlane: true
+        - name: fd5
+          controlPlane: true
+        - name: fd6
+          controlPlane: false
+        - name: fd7
+          controlPlane: false
+        - name: fd8
+          controlPlane: false
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to #13266

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->