### PR TITLE
⚠️ Remove deprecated --cluster-concurrency flag in CABPK

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -87,7 +87,6 @@ var (
 	managerOptions              = flags.ManagerOptions{}
 	logOptions                  = logs.NewOptions()
 	// CABPK specific flags.
-	clusterConcurrency       int
 	clusterCacheConcurrency  int
 	kubeadmConfigConcurrency int
 	skipCRDMigrationPhases   []string
@@ -129,10 +128,6 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
 		"Enable block profiling")
-
-	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
-		"Number of clusters to process simultaneously")
-	_ = fs.MarkDeprecated("cluster-concurrency", "This flag has no function anymore and is going to be removed in a next release. Use \"--clustercachetracker-concurrency\" instead.")
 
 	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
 		"Number of clusters to process simultaneously")

--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -52,6 +52,7 @@ Any feedback or contributions to improve following documentation is welcome!
 ## Removals
 
 - The deprecated `ClusterCache.GetClientCertificatePrivateKey` method has been removed.
+- The deprecated `--cluster-concurrency` CABPK command-line flag has been removed 
 
 ## Suggested changes for providers
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->