### PR TITLE
⚠️ Remove deprecated provider CRD migration from clusterctl upgrade

### DIFF
--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -125,9 +125,6 @@ type ApplyUpgradeOptions struct {
 
 	// WaitProviderTimeout sets the timeout per provider upgrade.
 	WaitProviderTimeout time.Duration
-
-	// EnableCRDStorageVersionMigration enables storage version migration of CRDs.
-	EnableCRDStorageVersionMigration bool
 }
 
 func (c *clusterctlClient) ApplyUpgrade(ctx context.Context, options ApplyUpgradeOptions) error {
@@ -177,9 +174,8 @@ func (c *clusterctlClient) ApplyUpgrade(ctx context.Context, options ApplyUpgrad
 		len(options.AddonProviders) > 0
 
 	opts := cluster.UpgradeOptions{
-		WaitProviders:                    options.WaitProviders,
-		WaitProviderTimeout:              options.WaitProviderTimeout,
-		EnableCRDStorageVersionMigration: options.EnableCRDStorageVersionMigration,
+		WaitProviders:       options.WaitProviders,
+		WaitProviderTimeout: options.WaitProviderTimeout,
 	}
 
 	// If we are upgrading a specific set of providers only, process the providers and call ApplyCustomPlan.

--- a/cmd/clusterctl/cmd/upgrade_apply.go
+++ b/cmd/clusterctl/cmd/upgrade_apply.go
@@ -28,19 +28,18 @@ import (
 )
 
 type upgradeApplyOptions struct {
-	kubeconfig                       string
-	kubeconfigContext                string
-	contract                         string
-	coreProvider                     string
-	bootstrapProviders               []string
-	controlPlaneProviders            []string
-	infrastructureProviders          []string
-	ipamProviders                    []string
-	runtimeExtensionProviders        []string
-	addonProviders                   []string
-	waitProviders                    bool
-	waitProviderTimeout              int
-	enableCRDStorageVersionMigration bool
+	kubeconfig                string
+	kubeconfigContext         string
+	contract                  string
+	coreProvider              string
+	bootstrapProviders        []string
+	controlPlaneProviders     []string
+	infrastructureProviders   []string
+	ipamProviders             []string
+	runtimeExtensionProviders []string
+	addonProviders            []string
+	waitProviders             bool
+	waitProviderTimeout       int
 }
 
 var ua = &upgradeApplyOptions{}
@@ -94,10 +93,6 @@ func init() {
 		"Wait for providers to be upgraded.")
 	upgradeApplyCmd.Flags().IntVar(&ua.waitProviderTimeout, "wait-provider-timeout", 5*60,
 		"Wait timeout per provider upgrade in seconds. This value is ignored if --wait-providers is false")
-	upgradeApplyCmd.Flags().BoolVar(&ua.enableCRDStorageVersionMigration, "enable-crd-storage-version-migration", false,
-		"Enable CRD storage version migration")
-	_ = upgradeApplyCmd.Flags().MarkDeprecated("enable-crd-storage-version-migration",
-		"Storage version migration during upgrades has been deprecated and will be removed in Cluster API v1.13")
 }
 
 func runUpgradeApply() error {
@@ -124,17 +119,16 @@ func runUpgradeApply() error {
 	}
 
 	return c.ApplyUpgrade(ctx, client.ApplyUpgradeOptions{
-		Kubeconfig:                       client.Kubeconfig{Path: ua.kubeconfig, Context: ua.kubeconfigContext},
-		Contract:                         ua.contract,
-		CoreProvider:                     ua.coreProvider,
-		BootstrapProviders:               ua.bootstrapProviders,
-		ControlPlaneProviders:            ua.controlPlaneProviders,
-		InfrastructureProviders:          ua.infrastructureProviders,
-		IPAMProviders:                    ua.ipamProviders,
-		RuntimeExtensionProviders:        ua.runtimeExtensionProviders,
-		AddonProviders:                   ua.addonProviders,
-		WaitProviders:                    ua.waitProviders,
-		WaitProviderTimeout:              time.Duration(ua.waitProviderTimeout) * time.Second,
-		EnableCRDStorageVersionMigration: ua.enableCRDStorageVersionMigration,
+		Kubeconfig:                client.Kubeconfig{Path: ua.kubeconfig, Context: ua.kubeconfigContext},
+		Contract:                  ua.contract,
+		CoreProvider:              ua.coreProvider,
+		BootstrapProviders:        ua.bootstrapProviders,
+		ControlPlaneProviders:     ua.controlPlaneProviders,
+		InfrastructureProviders:   ua.infrastructureProviders,
+		IPAMProviders:             ua.ipamProviders,
+		RuntimeExtensionProviders: ua.runtimeExtensionProviders,
+		AddonProviders:            ua.addonProviders,
+		WaitProviders:             ua.waitProviders,
+		WaitProviderTimeout:       time.Duration(ua.waitProviderTimeout) * time.Second,
 	})
 }

--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -51,6 +51,7 @@ Any feedback or contributions to improve following documentation is welcome!
 
 ## Removals
 
+- Remove deprecated `--enable-crd-storage-version-migration` flag for `clusterctl upgrade` and corresponding provider CRD storage version migration code
 - The deprecated `--disable-grouping` flag for `clusterctl describe cluster` has been removed.
 - The deprecated `ClusterCache.GetClientCertificatePrivateKey` method has been removed.
 - The deprecated `--cluster-concurrency` CABPK command-line flag has been removed 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->