### PR TITLE
⚠️ Remove deprecated ShouldSkipImmutabilityChecks

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -53,6 +53,7 @@ Any feedback or contributions to improve following documentation is welcome!
 
 - The deprecated `ClusterCache.GetClientCertificatePrivateKey` method has been removed.
 - The deprecated `--cluster-concurrency` CABPK command-line flag has been removed 
+- Remove deprecated `util/topology.ShouldSkipImmutabilityChecks` (use `util/topology.IsDryRunRequest` instead)
 
 ## Suggested changes for providers
 

--- a/util/topology/topology.go
+++ b/util/topology/topology.go
@@ -24,16 +24,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
-// ShouldSkipImmutabilityChecks returns true if it is a dry-run request and the object has the
-// TopologyDryRunAnnotation annotation set, false otherwise.
-// This ensures that the immutability check is skipped only when dry-running and when the operations has been invoked by the topology controller.
-// Instead, kubectl dry-run behavior remains consistent with the one user gets when doing kubectl apply (immutability is enforced).
-//
-// Deprecated: Please use IsDryRunRequest instead.
-func ShouldSkipImmutabilityChecks(req admission.Request, obj metav1.Object) bool {
-	return IsDryRunRequest(req, obj)
-}
-
 // IsDryRunRequest returns true if it is a dry-run request and the object has the
 // TopologyDryRunAnnotation annotation set, false otherwise.
 func IsDryRunRequest(req admission.Request, obj metav1.Object) bool {

--- a/util/topology/topology_test.go
+++ b/util/topology/topology_test.go
@@ -29,7 +29,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
-func TestShouldSkipImmutabilityChecks(t *testing.T) {
+func TestIsDryRunRequest(t *testing.T) {
 	tests := []struct {
 		name string
 		req  admission.Request
@@ -86,7 +86,7 @@ func TestShouldSkipImmutabilityChecks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsDryRunRequest(tt.req, tt.obj); got != tt.want {
-				t.Errorf("ShouldSkipImmutabilityChecks() = %v, want %v", got, tt.want)
+				t.Errorf("IsDryRunRequest() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->