### PR TITLE
✨ Promote MachineWaitForVolumeDetachConsiderVolumeAttachments feature to GA

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -268,6 +268,10 @@ linters:
       - linters:
           - errcheck
         text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+        # deprecated feature gates
+      - linters:
+          - staticcheck
+        text: 'SA1019: feature.MachineWaitForVolumeDetachConsiderVolumeAttachments is deprecated'
         # v1beta1 deprecated util packages
       - linters:
           - staticcheck

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -61,6 +61,9 @@ const (
 	// also considers VolumeAttachments in addition to Nodes.status.volumesAttached when waiting for volumes to be detached.
 	//
 	// beta: v1.9
+	// GA: v1.13
+	//
+	// Deprecated: MachineWaitForVolumeDetachConsiderVolumeAttachments feature is now GA and the corresponding feature flag will be removed in the v1.15 release.
 	MachineWaitForVolumeDetachConsiderVolumeAttachments featuregate.Feature = "MachineWaitForVolumeDetachConsiderVolumeAttachments"
 
 	// PriorityQueue is a feature gate that controls if the controller uses the controller-runtime PriorityQueue
@@ -94,9 +97,9 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
-	MachinePool:               {Default: true, PreRelease: featuregate.Beta},
-	MachineSetPreflightChecks: {Default: true, PreRelease: featuregate.Beta},
-	MachineWaitForVolumeDetachConsiderVolumeAttachments: {Default: true, PreRelease: featuregate.Beta},
+	MachineWaitForVolumeDetachConsiderVolumeAttachments: {Default: true, PreRelease: featuregate.GA},
+	MachinePool:                    {Default: true, PreRelease: featuregate.Beta},
+	MachineSetPreflightChecks:      {Default: true, PreRelease: featuregate.Beta},
 	PriorityQueue:                  {Default: true, PreRelease: featuregate.Beta},
 	ReconcilerRateLimiting:         {Default: false, PreRelease: featuregate.Alpha},
 	ClusterTopology:                {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->