### PR TITLE
🐛 Release notes for rc0 shall be generated as other RC builds

### DIFF
--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -277,13 +277,14 @@ func defaultBranchForNewTag(newTag semver.Version) string {
 		if len(newTag.Pre) == 0 {
 			// for new minor releases, use the release branch
 			return releaseBranchForVersion(newTag)
-		} else if len(newTag.Pre) == 2 && newTag.Pre[0].VersionStr == "rc" && newTag.Pre[1].VersionNum >= 1 {
-			// for the second or later RCs, we use the release branch since we cut this branch with the first RC
+		} else if len(newTag.Pre) == 2 && newTag.Pre[0].VersionStr == "rc" {
+			// for all RCs (including rc.0), we use the release branch so notes are generated
+			// the same way: previous minor to release branch (not previous minor to main)
 			return releaseBranchForVersion(newTag)
 		}
 
 		// for any other pre release, we always cut from main
-		// this includes all beta releases and the first RC
+		// this includes all beta releases
 		return "main"
 	}
 

--- a/hack/tools/release/notes/main_test.go
+++ b/hack/tools/release/notes/main_test.go
@@ -129,7 +129,7 @@ func Test_defaultBranchForNewTag(t *testing.T) {
 		{
 			name:       "first RC",
 			newVersion: "v1.6.0-rc.0",
-			want:       "main",
+			want:       "release-1.6",
 		},
 		{
 			name:       "second RC",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The release notes for first RC builds i.e. rc0 is generated by comparing to main which has led to issues in past. This PR modifies that to generate the release notes for rc0 the same as the rest of the RC builds. 

```
% RELEASE_TAG=v1.10.0-rc.0 make release-notes
fatal: No names found, cannot describe anything.
go build -C hack/tools -o /Users/ira/OpenSource/cluster-api/bin/notes -tags tools sigs.k8s.io/cluster-api/hack/tools/release/notes
./bin/notes --release v1.10.0-rc.0 --previous-release-version "" > CHANGELOG/v1.10.0-rc.0.md
2026/02/03 14:07:07 Computing diff between tags/v1.9.0 and heads/release-1.10
```

**Computing diff between tags/v1.9.0 and heads/release-1.10**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12277 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release
/area testing