### PR TITLE
🐛 Wait for CAPD Cluster dependecies deletion

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -566,6 +567,9 @@ func (r *MachineBackendReconciler) getUnsafeLoadBalancerConfigTemplate(ctx conte
 		Namespace: dockerCluster.Namespace,
 	}
 	if err := r.Get(ctx, key, cm); err != nil {
+		if apierrors.IsNotFound(err) && !dockerCluster.DeletionTimestamp.IsZero() {
+			return "", nil
+		}
 		return "", errors.Wrapf(err, "failed to retrieve custom HAProxy configuration ConfigMap %s", key)
 	}
 	template, ok := cm.Data["value"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

We've noticed an issue in the CAPRKE2 tests with the deletion of a CAPD cluster. When not done in the correct order, the CAPD cluster can be deleted before the machines, this is blocking machine deletion. This PR introduces similar logic that already exists in CAPA to wait for dependent objects to be deleted before removing the infrastructure cluster.
CAPA PR for reference: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5365

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area provider/infrastructure-docker