### PR TITLE
:bug: Fix bug while setting status for deprecated fields

### DIFF
--- a/util/deprecated/v1beta1/patch/utils.go
+++ b/util/deprecated/v1beta1/patch/utils.go
@@ -182,7 +182,7 @@ func identifyConditionsFieldsPath(obj runtime.Object) ([]string, []string, error
 			// We assume the type is implemented according to transition guidelines
 			clusterv1ConditionsFields = []string{"status", "deprecated", "v1beta1", "conditions"}
 		} else {
-			if v1Beta1Field := deprecatedElem.FieldByName("V1Beta1"); deprecatedField != (reflect.Value{}) {
+			if v1Beta1Field := deprecatedElem.FieldByName("V1Beta1"); v1Beta1Field != (reflect.Value{}) {
 				if v1Beta1Field.Kind() != reflect.Pointer {
 					return nil, nil, errors.New("obj.status.deprecated.v1beta1 must be a pointer")
 				}

--- a/util/patch/utils.go
+++ b/util/patch/utils.go
@@ -182,7 +182,7 @@ func identifyConditionsFieldsPath(obj runtime.Object) ([]string, []string, error
 			// We assume the type is implemented according to transition guidelines
 			clusterv1ConditionsFields = []string{"status", "deprecated", "v1beta1", "conditions"}
 		} else {
-			if v1Beta1Field := deprecatedElem.FieldByName("V1Beta1"); deprecatedField != (reflect.Value{}) {
+			if v1Beta1Field := deprecatedElem.FieldByName("V1Beta1"); v1Beta1Field != (reflect.Value{}) {
 				if v1Beta1Field.Kind() != reflect.Pointer {
 					return nil, nil, errors.New("obj.status.deprecated.v1beta1 must be a pointer")
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

While setting the deprecated conditions for object where the deprecated condition field is not in standard path (status.deprecated.v1beta1) but instead at different path(status.deprecated.v1beta2)  for whatsoever reason we end up hitting below error

```
E0212 16:37:14.665519      15 controller.go:474] "Reconciler error" err="failed to init patch helper: failed to identify condition fields for object default/ibm-powervs-1-control-plane-lt47g: obj.status.deprecated.v1beta1 must be a pointer" controller="ibmpowervsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="IBMPowerVSMachine" IBMPowerVSMachine="default/ibm-powervs-1-control-plane-lt47g" namespace="default" name="ibm-powervs-1-control-plane-lt47g" reconcileID="e0b8bb3c-68c5-4fda-912d-0d053aee6ebc"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->