### PR TITLE
✨Add event constants for certificate-related automatic actions

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -69,6 +69,20 @@ const (
 	kcpManagerName          = "capi-kubeadmcontrolplane"
 	kcpMetadataManagerName  = "capi-kubeadmcontrolplane-metadata"
 	kubeadmControlPlaneKind = "KubeadmControlPlane"
+
+	// Event reasons for certificate-related automatic actions.
+
+	// EventKubeconfigCertificateRotated is emitted when kubeconfig certificate
+	// is automatically rotated due to approaching expiry.
+	EventKubeconfigCertificateRotated = "KubeconfigCertificateRotated"
+
+	// EventKubeconfigCertificateRotationFailed is emitted when kubeconfig
+	// certificate rotation fails.
+	EventKubeconfigCertificateRotationFailed = "KubeconfigCertificateRotationFailed"
+
+	// EventCertificateExpiryTriggeredRollout is emitted when a machine is marked
+	// for rollout due to certificate expiry approaching the threshold.
+	EventCertificateExpiryTriggeredRollout = "CertificateExpiryTriggeredRollout"
 )
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch


### PR DESCRIPTION
This commit adds event constant definitions that will be used to emit events for automatic certificate-related actions in KubeadmControlPlane:

- EventKubeconfigCertificateRotated: Emitted when kubeconfig certificate is automatically rotated due to approaching expiry
- EventKubeconfigCertificateRotationFailed: Emitted when kubeconfig certificate rotation fails
- EventCertificateExpiryTriggeredRollout: Emitted when a machine is marked for rollout due to certificate expiry approaching the threshold

These constants provide a foundation for improved observability and monitoring of automatic certificate management operations.
In reference with #13242 
and Issue #12930 
