### PR TITLE
🌱 Drop unused e2e test template & handling for Kubernetes < v1.25 in e2e CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,6 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	echo "---" >> $(DOCKER_TEMPLATES)/main/cluster-template-kcp-adoption.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-kcp-adoption/step2 --load-restrictor LoadRestrictionsNone >> $(DOCKER_TEMPLATES)/main/cluster-template-kcp-adoption.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-machine-pool --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-machine-pool.yaml
-	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-upgrades --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-upgrades.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-upgrades-runtimesdk --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-upgrades-runtimesdk.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-kcp-pre-drain --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-kcp-pre-drain.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-kcp-scale-in.yaml

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -185,7 +185,6 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-kcp-adoption.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-machine-pool.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-kcp-pre-drain.yaml"
-    - sourcePath: "../data/infrastructure-docker/main/cluster-template-upgrades.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-kcp-scale-in.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-ipv6.yaml"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-pre-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-pre-drain/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-  - ../cluster-template-upgrades
+  - ../cluster-template-topology
 patches:
 - path: cluster.yaml

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades/kustomization.yaml
@@ -1,3 +1,0 @@
-resources:
-  - ../bases/cluster-with-topology.yaml
-  - ../bases/crs.yaml

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -411,7 +411,7 @@ spec:
                 plugins:
                 - name: PodSecurity
                   configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25-0" .builtin.controlPlane.version }}beta1{{ end }}
+                    apiVersion: pod-security.admission.config.k8s.io/v1
                     kind: PodSecurityConfiguration
                     defaults:
                       enforce: "baseline"

--- a/test/e2e/data/infrastructure-docker/v1.10/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.10/clusterclass-quick-start.yaml
@@ -399,7 +399,7 @@ spec:
                 plugins:
                 - name: PodSecurity
                   configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                    apiVersion: pod-security.admission.config.k8s.io/v1
                     kind: PodSecurityConfiguration
                     defaults:
                       enforce: "baseline"

--- a/test/e2e/data/infrastructure-docker/v1.11/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.11/clusterclass-quick-start.yaml
@@ -407,7 +407,7 @@ spec:
                 plugins:
                 - name: PodSecurity
                   configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25-0" .builtin.controlPlane.version }}beta1{{ end }}
+                    apiVersion: pod-security.admission.config.k8s.io/v1
                     kind: PodSecurityConfiguration
                     defaults:
                       enforce: "baseline"

--- a/test/e2e/data/infrastructure-docker/v1.12/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.12/clusterclass-quick-start.yaml
@@ -411,7 +411,7 @@ spec:
                 plugins:
                 - name: PodSecurity
                   configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25-0" .builtin.controlPlane.version }}beta1{{ end }}
+                    apiVersion: pod-security.admission.config.k8s.io/v1
                     kind: PodSecurityConfiguration
                     defaults:
                       enforce: "baseline"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->