### PR TITLE
🌱 Stop using patch helper when enforcing finalizers

### DIFF
--- a/util/finalizers/finalizers.go
+++ b/util/finalizers/finalizers.go
@@ -22,8 +22,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"sigs.k8s.io/cluster-api/util/patch"
 )
 
 // EnsureFinalizer adds a finalizer if the object doesn't have a deletionTimestamp set
@@ -40,14 +38,10 @@ func EnsureFinalizer(ctx context.Context, c client.Client, o client.Object, fina
 		return false, nil
 	}
 
-	patchHelper, err := patch.NewHelper(o, c)
-	if err != nil {
-		return false, err
-	}
-
+	original := o.DeepCopyObject().(client.Object)
 	controllerutil.AddFinalizer(o, finalizer)
 
-	if err := patchHelper.Patch(ctx, o); err != nil {
+	if err := c.Patch(ctx, o, client.MergeFrom(original)); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
EnsureFinalizer is patching only a field, patch helper is overkill

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area util