### PR TITLE
🐛 Enforce rollout strategy/type consistency and warn on disabled topology MHC overrides

### DIFF
--- a/core/webhooks/admission/cluster.go
+++ b/core/webhooks/admission/cluster.go
@@ -287,7 +287,14 @@ func (webhook *Cluster) validateTopology(ctx context.Context, oldCluster, newClu
 	// metadata in topology should be valid
 	allErrs = append(allErrs, validateTopologyMetadata(newCluster.Spec.Topology, fldPath)...)
 
-	allErrs = append(allErrs, validateTopologyRollout(newCluster.Spec.Topology, fldPath)...)
+	var oldTopology *clusterv1.Topology
+	if oldCluster != nil && oldCluster.Spec.Topology.IsDefined() {
+		oldTopology = &oldCluster.Spec.Topology
+	}
+	rolloutWarnings, rolloutErrs := validateTopologyRollout(oldTopology, newCluster.Spec.Topology, fldPath)
+	allWarnings = append(allWarnings, rolloutWarnings...)
+	allErrs = append(allErrs, rolloutErrs...)
+	allWarnings = append(allWarnings, machineHealthCheckDisabledWarnings(newCluster)...)
 
 	allErrs = append(allErrs, validateTopologyTaints(newCluster.Spec.Topology, fldPath)...)
 
@@ -643,15 +650,50 @@ func validateTopologyMachinePoolVersions(ctx context.Context, ctrlClient client.
 	return nil
 }
 
-func validateTopologyRollout(topology clusterv1.Topology, fldPath *field.Path) field.ErrorList {
-	var allErrs field.ErrorList //nolint:prealloc // Not all paths append
+// validateTopologyRollout validates MachineDeployment rollout strategy fields in a Cluster topology.
+// It returns warnings when unchanged pre-existing invalid rollingUpdate values are ratchet-allowed.
+func validateTopologyRollout(oldTopology *clusterv1.Topology, topology clusterv1.Topology, fldPath *field.Path) (admission.Warnings, field.ErrorList) {
+	var allWarnings admission.Warnings
+	var allErrs field.ErrorList
 
 	for _, md := range topology.Workers.MachineDeployments {
 		fldPath := fldPath.Child("workers", "machineDeployments").Key(md.Name).Child("rollout")
-		allErrs = append(allErrs, validateRolloutStrategy(fldPath.Child("strategy"), md.Rollout.Strategy.RollingUpdate.MaxUnavailable, md.Rollout.Strategy.RollingUpdate.MaxSurge)...)
+		enforceTypeMismatchValidation := true
+		if oldTopology != nil {
+			if oldMD := machineDeploymentTopologyOfName(oldTopology, md.Name); oldMD != nil {
+				enforceTypeMismatchValidation = shouldEnforceRolloutStrategyTypeMismatchValidation(
+					md.Rollout.Strategy.Type,
+					md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+					md.Rollout.Strategy.RollingUpdate.MaxSurge,
+					oldMD.Rollout.Strategy.Type,
+					oldMD.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+					oldMD.Rollout.Strategy.RollingUpdate.MaxSurge,
+				)
+			}
+		}
+		rolloutStrategyPath := fldPath.Child("strategy")
+		rolloutStrategyTypeMismatchErrs := field.ErrorList{}
+		if enforceTypeMismatchValidation {
+			rolloutStrategyTypeMismatchErrs = validateRolloutStrategyTypeMismatch(
+				rolloutStrategyPath,
+				md.Rollout.Strategy.Type,
+				md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				md.Rollout.Strategy.RollingUpdate.MaxSurge,
+			)
+			allErrs = append(allErrs, rolloutStrategyTypeMismatchErrs...)
+		} else {
+			allWarnings = append(allWarnings, rolloutStrategyTypeMismatchWarning(rolloutStrategyPath, md.Rollout.Strategy.Type))
+		}
+		if len(rolloutStrategyTypeMismatchErrs) == 0 {
+			allErrs = append(allErrs, validateRolloutStrategy(
+				rolloutStrategyPath,
+				md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				md.Rollout.Strategy.RollingUpdate.MaxSurge,
+			)...)
+		}
 	}
 
-	return allErrs
+	return allWarnings, allErrs
 }
 
 func validateTopologyTaints(topology clusterv1.Topology, fldPath *field.Path) field.ErrorList {
@@ -670,6 +712,23 @@ func validateTopologyTaints(topology clusterv1.Topology, fldPath *field.Path) fi
 	}
 
 	return allErrs
+}
+
+// machineDeploymentTopologyOfName finds a MachineDeploymentTopology of the given name in the provided topology.
+// Returns nil if it can not find one.
+func machineDeploymentTopologyOfName(topology *clusterv1.Topology, name string) *clusterv1.MachineDeploymentTopology {
+	for i := range topology.Workers.MachineDeployments {
+		if topology.Workers.MachineDeployments[i].Name == name {
+			return &topology.Workers.MachineDeployments[i]
+		}
+	}
+	return nil
+}
+
+// rolloutStrategyTypeMismatchWarning returns the warning shown when an unchanged invalid rollingUpdate configuration is
+// ratchet-allowed.
+func rolloutStrategyTypeMismatchWarning(fldPath *field.Path, strategyType clusterv1.MachineDeploymentRolloutStrategyType) string {
+	return fmt.Sprintf("%s: rollingUpdate configuration is ignored while type is %s; remove rollingUpdate fields", fldPath.Child("rollingUpdate").String(), strategyType)
 }
 
 func validateMachineHealthChecks(cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
@@ -735,6 +794,30 @@ func validateMachineHealthChecks(cluster *clusterv1.Cluster, clusterClass *clust
 	}
 
 	return allErrs
+}
+
+// machineHealthCheckDisabledWarnings returns warnings, not errors, for MachineHealthCheck overrides set while enabled is false.
+// Setting overrides while remediation is disabled is legitimate when temporarily pausing remediation without losing
+// configuration, so rejecting it would break existing Clusters and that workflow.
+func machineHealthCheckDisabledWarnings(cluster *clusterv1.Cluster) admission.Warnings {
+	var allWarnings admission.Warnings
+
+	controlPlaneHealthCheck := &cluster.Spec.Topology.ControlPlane.HealthCheck
+	if controlPlaneHealthCheck.Enabled != nil && !*controlPlaneHealthCheck.Enabled && controlPlaneHealthCheck.IsDefined() {
+		fldPath := field.NewPath("spec", "topology", "controlPlane", "healthCheck")
+		allWarnings = append(allWarnings, fmt.Sprintf("%s: checks and remediation are ignored while enabled is false", fldPath.String()))
+	}
+
+	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
+		md := cluster.Spec.Topology.Workers.MachineDeployments[i]
+		mdHealthCheck := &md.HealthCheck
+		if mdHealthCheck.Enabled != nil && !*mdHealthCheck.Enabled && mdHealthCheck.IsDefined() {
+			fldPath := field.NewPath("spec", "topology", "workers", "machineDeployments").Key(md.Name).Child("healthCheck")
+			allWarnings = append(allWarnings, fmt.Sprintf("%s: checks and remediation are ignored while enabled is false", fldPath.String()))
+		}
+	}
+
+	return allWarnings
 }
 
 // machineDeploymentClassOfName find a MachineDeploymentClass of the given name in the provided ClusterClass.

--- a/core/webhooks/admission/cluster_test.go
+++ b/core/webhooks/admission/cluster_test.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -4088,6 +4090,210 @@ func TestValidateAutoscalerAnnotationsForCluster(t *testing.T) {
 				g.Expect(err).ToNot(BeEmpty())
 			} else {
 				g.Expect(err).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestMachineHealthCheckDisabledWarnings(t *testing.T) {
+	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
+
+	tests := []struct {
+		name         string
+		mutate       func(*clusterv1.Cluster)
+		wantPathPart string
+	}{
+		{
+			name: "Should warn when control plane healthCheck overrides are set while healthCheck is disabled",
+			mutate: func(cluster *clusterv1.Cluster) {
+				cluster.Spec.Topology.ControlPlane.HealthCheck = clusterv1.ControlPlaneTopologyHealthCheck{
+					Enabled: ptr.To(false),
+					Checks: clusterv1.ControlPlaneTopologyHealthCheckChecks{
+						NodeStartupTimeoutSeconds: ptr.To[int32](30),
+					},
+				}
+			},
+			wantPathPart: "spec.topology.controlPlane.healthCheck",
+		},
+		{
+			name: "Should warn when MachineDeployment healthCheck overrides are set while healthCheck is disabled",
+			mutate: func(cluster *clusterv1.Cluster) {
+				cluster.Spec.Topology.Workers.MachineDeployments[0].HealthCheck = clusterv1.MachineDeploymentTopologyHealthCheck{
+					Enabled: ptr.To(false),
+					Checks: clusterv1.MachineDeploymentTopologyHealthCheckChecks{
+						NodeStartupTimeoutSeconds: ptr.To[int32](30),
+					},
+				}
+			},
+			wantPathPart: "spec.topology.workers.machineDeployments[workers1].healthCheck",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cluster := builder.Cluster("ns", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("class1").
+					WithVersion("v1.29.0").
+					WithMachineDeployment(builder.MachineDeploymentTopology("workers1").
+						WithClass("md-class-1").
+						Build()).
+					Build()).
+				Build()
+			clusterClass := builder.ClusterClass("ns", "class1").
+				WithControlPlaneInfrastructureMachineTemplate(builder.InfrastructureMachineTemplate("ns", "cp-machine-template").Build()).
+				WithWorkerMachineDeploymentClasses(*builder.MachineDeploymentClass("md-class-1").Build()).
+				Build()
+			conditions.Set(clusterClass, metav1.Condition{
+				Type:   clusterv1.ClusterClassVariablesReadyCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.ClusterClassVariablesReadyReason,
+			})
+
+			tt.mutate(cluster)
+
+			// Disabled MHC with config overrides is allowed to support temporarily pausing remediation.
+			g.Expect(validateMachineHealthChecks(cluster, clusterClass)).To(BeEmpty())
+
+			warnings := machineHealthCheckDisabledWarnings(cluster)
+			g.Expect(warnings).To(HaveLen(1))
+			g.Expect(warnings[0]).To(ContainSubstring(tt.wantPathPart))
+			g.Expect(warnings[0]).To(ContainSubstring("checks and remediation are ignored while enabled is false"))
+
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(clusterClass).
+				WithScheme(fakeScheme).
+				Build()
+			webhook := &Cluster{Client: fakeClient}
+
+			warnings, err := webhook.ValidateCreate(ctx, cluster)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(warnings).To(HaveLen(1))
+			g.Expect(warnings[0]).To(ContainSubstring(tt.wantPathPart))
+			g.Expect(warnings[0]).To(ContainSubstring("checks and remediation are ignored while enabled is false"))
+		})
+	}
+}
+
+func TestValidateTopologyRolloutStrategyTypeMismatch(t *testing.T) {
+	maxSurge1 := intstr.FromInt32(1)
+	maxSurge2 := intstr.FromInt32(2)
+
+	topologyWithRolloutStrategy := func(name string, strategy clusterv1.MachineDeploymentTopologyRolloutStrategy) *clusterv1.Topology {
+		topology := builder.ClusterTopology().
+			WithMachineDeployment(builder.MachineDeploymentTopology(name).Build()).
+			Build()
+		topology.Workers.MachineDeployments[0].Rollout = clusterv1.MachineDeploymentTopologyRolloutSpec{
+			Strategy: strategy,
+		}
+		return topology
+	}
+
+	rollingUpdateTopology := topologyWithRolloutStrategy("workers1", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+		RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+			MaxSurge: &maxSurge1,
+		},
+	})
+	onDeleteTopology := topologyWithRolloutStrategy("workers1", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+		RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+			MaxSurge: &maxSurge1,
+		},
+	})
+	changedOnDeleteTopology := topologyWithRolloutStrategy("workers1", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+		RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+			MaxSurge: &maxSurge2,
+		},
+	})
+	fixedOnDeleteTopology := topologyWithRolloutStrategy("workers1", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+	})
+	renamedOnDeleteTopology := topologyWithRolloutStrategy("workers2", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+		RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+			MaxSurge: &maxSurge1,
+		},
+	})
+	emptyTypeTopology := topologyWithRolloutStrategy("workers1", clusterv1.MachineDeploymentTopologyRolloutStrategy{
+		RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+			MaxSurge: &maxSurge1,
+		},
+	})
+
+	tests := []struct {
+		name        string
+		oldTopology *clusterv1.Topology
+		topology    *clusterv1.Topology
+		wantErr     bool
+		wantWarning bool
+	}{
+		{
+			name:     "Should reject rollingUpdate fields when creating topology with OnDelete rollout strategy",
+			topology: onDeleteTopology,
+			wantErr:  true,
+		},
+		{
+			name:        "Should reject rollingUpdate fields when updating topology from RollingUpdate to OnDelete rollout strategy",
+			oldTopology: rollingUpdateTopology,
+			topology:    onDeleteTopology,
+			wantErr:     true,
+		},
+		{
+			name:        "Should allow unchanged pre-existing invalid rollout strategy on update",
+			oldTopology: onDeleteTopology,
+			topology:    onDeleteTopology,
+			wantWarning: true,
+		},
+		{
+			name:        "Should reject changed pre-existing invalid rollout strategy on update",
+			oldTopology: onDeleteTopology,
+			topology:    changedOnDeleteTopology,
+			wantErr:     true,
+		},
+		{
+			name:        "Should allow fixing pre-existing invalid rollout strategy on update",
+			oldTopology: onDeleteTopology,
+			topology:    fixedOnDeleteTopology,
+		},
+		{
+			name:        "Should reject invalid rollout strategy when MachineDeployment topology is renamed",
+			oldTopology: onDeleteTopology,
+			topology:    renamedOnDeleteTopology,
+			wantErr:     true,
+		},
+		{
+			name:     "Should allow rollingUpdate fields when rollout strategy type is empty",
+			topology: emptyTypeTopology,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var oldTopology *clusterv1.Topology
+			if tt.oldTopology != nil {
+				oldTopology = tt.oldTopology.DeepCopy()
+			}
+			warnings, errs := validateTopologyRollout(oldTopology, *tt.topology.DeepCopy(), field.NewPath("spec", "topology"))
+			if tt.wantErr {
+				g.Expect(errs).ToNot(BeEmpty())
+				g.Expect(errs.ToAggregate()).ToNot(Succeed())
+				g.Expect(errs.ToAggregate().Error()).To(ContainSubstring("rollingUpdate"))
+				g.Expect(errs.ToAggregate().Error()).To(ContainSubstring("can be set only if type is \"RollingUpdate\""))
+			} else {
+				g.Expect(errs).To(BeEmpty())
+			}
+			if tt.wantWarning {
+				g.Expect(warnings).To(HaveLen(1))
+				g.Expect(warnings[0]).To(ContainSubstring("rollingUpdate configuration is ignored while type is OnDelete"))
+				g.Expect(warnings[0]).To(ContainSubstring("remove rollingUpdate fields"))
+			} else {
+				g.Expect(warnings).To(BeEmpty())
 			}
 		})
 	}

--- a/core/webhooks/admission/clusterclass.go
+++ b/core/webhooks/admission/clusterclass.go
@@ -62,12 +62,12 @@ var _ admission.Validator[*clusterv1.ClusterClass] = &ClusterClass{}
 
 // ValidateCreate implements validation for ClusterClass create.
 func (webhook *ClusterClass) ValidateCreate(ctx context.Context, in *clusterv1.ClusterClass) (admission.Warnings, error) {
-	return nil, webhook.validate(ctx, nil, in)
+	return webhook.validate(ctx, nil, in)
 }
 
 // ValidateUpdate implements validation for ClusterClass update.
 func (webhook *ClusterClass) ValidateUpdate(ctx context.Context, oldClusterClass, newClusterClass *clusterv1.ClusterClass) (admission.Warnings, error) {
-	return nil, webhook.validate(ctx, oldClusterClass, newClusterClass)
+	return webhook.validate(ctx, oldClusterClass, newClusterClass)
 }
 
 // ValidateDelete implements validation for ClusterClass delete.
@@ -87,11 +87,13 @@ func (webhook *ClusterClass) ValidateDelete(ctx context.Context, clusterClass *c
 	return nil, nil
 }
 
-func (webhook *ClusterClass) validate(ctx context.Context, oldClusterClass, newClusterClass *clusterv1.ClusterClass) error {
+func (webhook *ClusterClass) validate(ctx context.Context, oldClusterClass, newClusterClass *clusterv1.ClusterClass) (admission.Warnings, error) {
+	var allWarnings admission.Warnings
+
 	// NOTE: ClusterClass and managed topologies are behind ClusterTopology feature gate flag; the web hook
 	// must prevent creating new objects when the feature flag is disabled.
 	if !feature.Gates.Enabled(feature.ClusterTopology) {
-		return field.Forbidden(
+		return allWarnings, field.Forbidden(
 			field.NewPath("spec"),
 			"can be set only if the ClusterTopology feature flag is enabled",
 		)
@@ -107,7 +109,9 @@ func (webhook *ClusterClass) validate(ctx context.Context, oldClusterClass, newC
 	// Ensure all MachinePool classes are unique.
 	allErrs = append(allErrs, check.MachinePoolClassesAreUnique(newClusterClass)...)
 
-	allErrs = append(allErrs, validateClusterClassRollout(newClusterClass)...)
+	rolloutWarnings, rolloutErrs := validateClusterClassRollout(oldClusterClass, newClusterClass)
+	allWarnings = rolloutWarnings
+	allErrs = append(allErrs, rolloutErrs...)
 
 	// Ensure MachineHealthChecks are valid.
 	allErrs = append(allErrs, validateMachineHealthCheckClasses(newClusterClass)...)
@@ -146,7 +150,7 @@ func (webhook *ClusterClass) validate(ctx context.Context, oldClusterClass, newC
 		if err != nil {
 			allErrs = append(allErrs, field.InternalError(field.NewPath(""),
 				pkgerrors.Wrapf(err, "Clusters using ClusterClass %v can not be retrieved", oldClusterClass.Name)))
-			return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), newClusterClass.Name, allErrs)
+			return allWarnings, apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), newClusterClass.Name, allErrs)
 		}
 
 		// Ensure New ClusterClass contains Kubernetes versions of all the Clusters of ClusterClass.
@@ -170,9 +174,9 @@ func (webhook *ClusterClass) validate(ctx context.Context, oldClusterClass, newC
 	}
 
 	if len(allErrs) > 0 {
-		return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), newClusterClass.Name, allErrs)
+		return allWarnings, apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), newClusterClass.Name, allErrs)
 	}
-	return nil
+	return allWarnings, nil
 }
 
 // validateUpdatesToMachineHealthCheckClasses checks if the updates made to MachineHealthChecks are valid.
@@ -377,15 +381,50 @@ func getClusterClassVariablesMapWithReverseIndex(clusterClassVariables []cluster
 	return variablesMap, variablesIndexMap
 }
 
-func validateClusterClassRollout(clusterClass *clusterv1.ClusterClass) field.ErrorList {
-	var allErrs field.ErrorList //nolint:prealloc // Not all paths append
+// validateClusterClassRollout validates MachineDeploymentClass rollout strategy fields in a ClusterClass.
+// It returns warnings when unchanged pre-existing invalid rollingUpdate values are ratchet-allowed.
+func validateClusterClassRollout(oldClusterClass, clusterClass *clusterv1.ClusterClass) (admission.Warnings, field.ErrorList) {
+	var allWarnings admission.Warnings
+	var allErrs field.ErrorList
 
 	for _, md := range clusterClass.Spec.Workers.MachineDeployments {
 		fldPath := field.NewPath("spec", "workers", "machineDeployments").Key(md.Class).Child("rollout")
-		allErrs = append(allErrs, validateRolloutStrategy(fldPath.Child("strategy"), md.Rollout.Strategy.RollingUpdate.MaxUnavailable, md.Rollout.Strategy.RollingUpdate.MaxSurge)...)
+		enforceTypeMismatchValidation := true
+		if oldClusterClass != nil {
+			if oldMDClass := machineDeploymentClassOfName(oldClusterClass, md.Class); oldMDClass != nil {
+				enforceTypeMismatchValidation = shouldEnforceRolloutStrategyTypeMismatchValidation(
+					md.Rollout.Strategy.Type,
+					md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+					md.Rollout.Strategy.RollingUpdate.MaxSurge,
+					oldMDClass.Rollout.Strategy.Type,
+					oldMDClass.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+					oldMDClass.Rollout.Strategy.RollingUpdate.MaxSurge,
+				)
+			}
+		}
+		rolloutStrategyPath := fldPath.Child("strategy")
+		rolloutStrategyTypeMismatchErrs := field.ErrorList{}
+		if enforceTypeMismatchValidation {
+			rolloutStrategyTypeMismatchErrs = validateRolloutStrategyTypeMismatch(
+				rolloutStrategyPath,
+				md.Rollout.Strategy.Type,
+				md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				md.Rollout.Strategy.RollingUpdate.MaxSurge,
+			)
+			allErrs = append(allErrs, rolloutStrategyTypeMismatchErrs...)
+		} else {
+			allWarnings = append(allWarnings, rolloutStrategyTypeMismatchWarning(rolloutStrategyPath, md.Rollout.Strategy.Type))
+		}
+		if len(rolloutStrategyTypeMismatchErrs) == 0 {
+			allErrs = append(allErrs, validateRolloutStrategy(
+				rolloutStrategyPath,
+				md.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				md.Rollout.Strategy.RollingUpdate.MaxSurge,
+			)...)
+		}
 	}
 
-	return allErrs
+	return allWarnings, allErrs
 }
 
 func validateMachineHealthCheckClasses(clusterClass *clusterv1.ClusterClass) field.ErrorList {

--- a/core/webhooks/admission/clusterclass_test.go
+++ b/core/webhooks/admission/clusterclass_test.go
@@ -25,6 +25,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
@@ -145,7 +146,8 @@ func TestClusterClassValidationFeatureGated(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			webhook := &ClusterClass{}
-			err := webhook.validate(ctx, tt.old, tt.in)
+			warnings, err := webhook.validate(ctx, tt.old, tt.in)
+			g.Expect(warnings).To(BeEmpty())
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -1838,7 +1840,8 @@ func TestClusterClassValidation(t *testing.T) {
 
 			// Create the webhook and add the fakeClient as its client.
 			webhook := &ClusterClass{Client: fakeClient}
-			err := webhook.validate(ctx, tt.old, tt.in)
+			warnings, err := webhook.validate(ctx, tt.old, tt.in)
+			g.Expect(warnings).To(BeEmpty())
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -2678,7 +2681,8 @@ func TestClusterClassValidationWithClusterAwareChecks(t *testing.T) {
 
 			// Create the webhook and add the fakeClient as its client.
 			webhook := &ClusterClass{Client: fakeClient}
-			err := webhook.validate(ctx, tt.oldClusterClass, tt.newClusterClass)
+			warnings, err := webhook.validate(ctx, tt.oldClusterClass, tt.newClusterClass)
+			g.Expect(warnings).To(BeEmpty())
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -2839,6 +2843,148 @@ func invalidLabels() map[string]string {
 		"bar":          strings.Repeat("a", 64) + "too-long-value",
 		"/invalid-key": "foo",
 	}
+}
+
+func TestValidateClusterClassRolloutRatcheting(t *testing.T) {
+	maxSurge1 := intstr.FromInt32(1)
+	maxSurge2 := intstr.FromInt32(2)
+
+	tests := []struct {
+		name          string
+		oldCC         *clusterv1.ClusterClass
+		newCC         *clusterv1.ClusterClass
+		expectErr     bool
+		expectWarning bool
+	}{
+		{
+			name: "Should reject rollingUpdate fields when creating ClusterClass with OnDelete rollout strategy",
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Should reject rollingUpdate fields when updating ClusterClass from RollingUpdate to OnDelete rollout strategy",
+			oldCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Should allow unchanged invalid rollout strategy on update",
+			oldCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			expectWarning: true,
+		},
+		{
+			name: "Should reject changed invalid rollout strategy on update",
+			oldCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge2,
+				},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Should allow fixing pre-existing invalid rollout strategy on update",
+			oldCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+			}),
+		},
+		{
+			name: "Should reject invalid rollout strategy when MachineDeploymentClass is renamed",
+			oldCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc2", clusterv1.MachineDeploymentClassRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Should allow rollingUpdate fields when rollout strategy type is empty",
+			newCC: clusterClassWithMachineDeploymentClassRolloutStrategy("class1", "mdc1", clusterv1.MachineDeploymentClassRolloutStrategy{
+				RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var oldCC *clusterv1.ClusterClass
+			if tt.oldCC != nil {
+				oldCC = tt.oldCC.DeepCopy()
+			}
+			warnings, errs := validateClusterClassRollout(oldCC, tt.newCC.DeepCopy())
+			if tt.expectErr {
+				g.Expect(errs).ToNot(BeEmpty())
+				g.Expect(errs.ToAggregate()).ToNot(Succeed())
+				g.Expect(errs.ToAggregate().Error()).To(ContainSubstring("rollingUpdate"))
+			} else {
+				g.Expect(errs).To(BeEmpty())
+			}
+			if tt.expectWarning {
+				g.Expect(warnings).To(HaveLen(1))
+				g.Expect(warnings[0]).To(ContainSubstring("rollingUpdate configuration is ignored while type is OnDelete"))
+				g.Expect(warnings[0]).To(ContainSubstring("remove rollingUpdate fields"))
+			} else {
+				g.Expect(warnings).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func clusterClassWithMachineDeploymentClassRolloutStrategy(clusterClassName, machineDeploymentClassName string, strategy clusterv1.MachineDeploymentClassRolloutStrategy) *clusterv1.ClusterClass {
+	return builder.ClusterClass("ns", clusterClassName).
+		WithWorkerMachineDeploymentClasses(*builder.MachineDeploymentClass(machineDeploymentClassName).
+			WithStrategy(strategy).
+			Build()).
+		Build()
 }
 
 func invalidAnnotations() map[string]string {

--- a/core/webhooks/admission/machinedeployment.go
+++ b/core/webhooks/admission/machinedeployment.go
@@ -19,6 +19,7 @@ package admission
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -223,7 +224,24 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 		)
 	}
 
-	allErrs = append(allErrs, validateRolloutStrategy(specPath.Child("rollout", "strategy"), newMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable, newMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge)...)
+	rolloutStrategyPath := specPath.Child("rollout", "strategy")
+	rolloutStrategyTypeMismatchErrs := field.ErrorList{}
+	if shouldEnforceRolloutStrategyTypeMismatchValidationForMachineDeployment(oldMD, newMD) {
+		rolloutStrategyTypeMismatchErrs = validateRolloutStrategyTypeMismatch(
+			rolloutStrategyPath,
+			newMD.Spec.Rollout.Strategy.Type,
+			newMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+			newMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge,
+		)
+		allErrs = append(allErrs, rolloutStrategyTypeMismatchErrs...)
+	}
+	if len(rolloutStrategyTypeMismatchErrs) == 0 {
+		allErrs = append(allErrs, validateRolloutStrategy(
+			rolloutStrategyPath,
+			newMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+			newMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge,
+		)...)
+	}
 	allErrs = append(allErrs, validateRemediationMaxInFlight(specPath.Child("remediation"), newMD.Spec.Remediation.MaxInFlight)...)
 
 	if newMD.Spec.Template.Spec.Version != "" {
@@ -250,6 +268,7 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("MachineDeployment").GroupKind(), newMD.Name, allErrs)
 }
 
+// validateRolloutStrategy validates the rollingUpdate values for a MachineDeployment rollout strategy.
 func validateRolloutStrategy(fldPath *field.Path, maxUnavailable, maxSurge *intstr.IntOrString) field.ErrorList {
 	var allErrs field.ErrorList
 	if maxUnavailable != nil {
@@ -282,6 +301,79 @@ func validateRolloutStrategy(fldPath *field.Path, maxUnavailable, maxSurge *ints
 		)
 	}
 	return allErrs
+}
+
+// validateRolloutStrategyTypeMismatch rejects rollingUpdate values when the rollout strategy type does not use them.
+func validateRolloutStrategyTypeMismatch(
+	fldPath *field.Path,
+	strategyType clusterv1.MachineDeploymentRolloutStrategyType,
+	maxUnavailable, maxSurge *intstr.IntOrString,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	if isRolloutStrategyTypeMismatch(strategyType, maxUnavailable, maxSurge) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				fldPath.Child("rollingUpdate"),
+				fmt.Sprintf("can be set only if type is %q", clusterv1.RollingUpdateMachineDeploymentStrategyType),
+			),
+		)
+	}
+	return allErrs
+}
+
+// isRolloutStrategyTypeMismatch returns true if rollingUpdate values are set for a non-RollingUpdate strategy type.
+// An empty type never counts as a mismatch because the MachineDeployment defaulting webhook defaults it to RollingUpdate,
+// while topology and ClusterClass fields leave it empty to inherit defaults.
+func isRolloutStrategyTypeMismatch(
+	strategyType clusterv1.MachineDeploymentRolloutStrategyType,
+	maxUnavailable, maxSurge *intstr.IntOrString,
+) bool {
+	return strategyType != "" &&
+		strategyType != clusterv1.RollingUpdateMachineDeploymentStrategyType &&
+		(maxUnavailable != nil || maxSurge != nil)
+}
+
+// shouldEnforceRolloutStrategyTypeMismatchValidationForMachineDeployment returns false only when the invalid configuration
+// is pre-existing and unchanged, so MachineDeployments created before this validation existed can still receive updates to
+// unrelated fields.
+func shouldEnforceRolloutStrategyTypeMismatchValidationForMachineDeployment(oldMD, newMD *clusterv1.MachineDeployment) bool {
+	if oldMD == nil {
+		return true
+	}
+
+	return shouldEnforceRolloutStrategyTypeMismatchValidation(
+		newMD.Spec.Rollout.Strategy.Type,
+		newMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+		newMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge,
+		oldMD.Spec.Rollout.Strategy.Type,
+		oldMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+		oldMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge,
+	)
+}
+
+// shouldEnforceRolloutStrategyTypeMismatchValidation returns false only when the invalid configuration is pre-existing and
+// unchanged, so objects created before this validation existed can still receive updates to unrelated fields.
+func shouldEnforceRolloutStrategyTypeMismatchValidation(
+	newType clusterv1.MachineDeploymentRolloutStrategyType,
+	newMaxUnavailable, newMaxSurge *intstr.IntOrString,
+	oldType clusterv1.MachineDeploymentRolloutStrategyType,
+	oldMaxUnavailable, oldMaxSurge *intstr.IntOrString,
+) bool {
+	if !isRolloutStrategyTypeMismatch(newType, newMaxUnavailable, newMaxSurge) {
+		return true
+	}
+	if !isRolloutStrategyTypeMismatch(oldType, oldMaxUnavailable, oldMaxSurge) {
+		return true
+	}
+
+	// Allow unchanged pre-existing invalid values so users can still update unrelated fields.
+	if oldType == newType &&
+		reflect.DeepEqual(oldMaxUnavailable, newMaxUnavailable) &&
+		reflect.DeepEqual(oldMaxSurge, newMaxSurge) {
+		return false
+	}
+	return true
 }
 
 func validateRemediationMaxInFlight(fldPath *field.Path, maxInFlight *intstr.IntOrString) field.ErrorList {

--- a/core/webhooks/admission/machinedeployment_test.go
+++ b/core/webhooks/admission/machinedeployment_test.go
@@ -588,6 +588,143 @@ func TestMachineDeploymentValidation(t *testing.T) {
 	}
 }
 
+func TestMachineDeploymentRolloutStrategyTypeMismatchValidationTransitions(t *testing.T) {
+	maxSurge1 := intstr.FromInt32(1)
+	maxSurge2 := intstr.FromInt32(2)
+
+	tests := []struct {
+		name            string
+		oldStrategy     clusterv1.MachineDeploymentRolloutStrategy
+		newStrategy     clusterv1.MachineDeploymentRolloutStrategy
+		expectCreateErr bool
+		expectUpdateErr bool
+	}{
+		{
+			name: "Should allow unchanged invalid rollout strategy on update",
+			oldStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			newStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			expectCreateErr: true,
+			expectUpdateErr: false,
+		},
+		{
+			name: "Should reject new invalid rollout strategy on update",
+			oldStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			newStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			expectCreateErr: true,
+			expectUpdateErr: true,
+		},
+		{
+			name: "Should reject changed invalid rollout strategy on update",
+			oldStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			newStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge2,
+				},
+			},
+			expectCreateErr: true,
+			expectUpdateErr: true,
+		},
+		{
+			name: "Should allow fixing invalid rollout strategy on update",
+			oldStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+					MaxSurge: &maxSurge1,
+				},
+			},
+			newStrategy: clusterv1.MachineDeploymentRolloutStrategy{
+				Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+			},
+			expectCreateErr: false,
+			expectUpdateErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			oldMD := newMachineDeploymentForRolloutStrategyValidation("test-md", tt.oldStrategy)
+			newMD := newMachineDeploymentForRolloutStrategyValidation("test-md", tt.newStrategy)
+			scheme := runtime.NewScheme()
+			g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+			webhook := MachineDeployment{
+				decoder: admission.NewDecoder(scheme),
+			}
+
+			warnings, err := webhook.ValidateCreate(ctx, newMD)
+			if tt.expectCreateErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(warnings).To(BeEmpty())
+
+			warnings, err = webhook.ValidateUpdate(ctx, oldMD, newMD)
+			if tt.expectUpdateErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(warnings).To(BeEmpty())
+		})
+	}
+}
+
+func newMachineDeploymentForRolloutStrategyValidation(name string, strategy clusterv1.MachineDeploymentRolloutStrategy) *clusterv1.MachineDeployment {
+	return &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "test-cluster",
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test-cluster",
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To("data-secret"),
+					},
+				},
+			},
+			Rollout: clusterv1.MachineDeploymentRolloutSpec{
+				Strategy: strategy,
+			},
+		},
+	}
+}
+
 func TestMachineDeploymentVersionValidation(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -910,11 +910,16 @@ func (g *generator) computeMachineDeployment(ctx context.Context, s *scope.Scope
 		rollout = clusterv1.MachineDeploymentRolloutSpec{
 			Strategy: clusterv1.MachineDeploymentRolloutStrategy{
 				Type: machineDeploymentClass.Rollout.Strategy.Type,
-				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
-					MaxUnavailable: machineDeploymentClass.Rollout.Strategy.RollingUpdate.MaxUnavailable,
-					MaxSurge:       machineDeploymentClass.Rollout.Strategy.RollingUpdate.MaxSurge,
-				},
 			},
+		}
+		// Pre-existing Clusters or ClusterClasses may carry invalid OnDelete and rollingUpdate combinations
+		// that webhooks ratchet-allow on update. The fields are ignored for OnDelete anyway, and dropping them
+		// here guarantees the topology controller never creates or updates a MachineDeployment its webhook rejects.
+		if shouldPropagateRollingUpdateRolloutStrategy(rollout.Strategy.Type) {
+			rollout.Strategy.RollingUpdate = clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+				MaxUnavailable: machineDeploymentClass.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				MaxSurge:       machineDeploymentClass.Rollout.Strategy.RollingUpdate.MaxSurge,
+			}
 		}
 	}
 	if !reflect.DeepEqual(machineDeploymentTopology.Rollout, clusterv1.MachineDeploymentTopologyRolloutSpec{}) {
@@ -922,11 +927,16 @@ func (g *generator) computeMachineDeployment(ctx context.Context, s *scope.Scope
 			After: machineDeploymentTopology.Rollout.After,
 			Strategy: clusterv1.MachineDeploymentRolloutStrategy{
 				Type: machineDeploymentTopology.Rollout.Strategy.Type,
-				RollingUpdate: clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
-					MaxUnavailable: machineDeploymentTopology.Rollout.Strategy.RollingUpdate.MaxUnavailable,
-					MaxSurge:       machineDeploymentTopology.Rollout.Strategy.RollingUpdate.MaxSurge,
-				},
 			},
+		}
+		// Pre-existing Clusters or ClusterClasses may carry invalid OnDelete and rollingUpdate combinations
+		// that webhooks ratchet-allow on update. The fields are ignored for OnDelete anyway, and dropping them
+		// here guarantees the topology controller never creates or updates a MachineDeployment its webhook rejects.
+		if shouldPropagateRollingUpdateRolloutStrategy(rollout.Strategy.Type) {
+			rollout.Strategy.RollingUpdate = clusterv1.MachineDeploymentRolloutStrategyRollingUpdate{
+				MaxUnavailable: machineDeploymentTopology.Rollout.Strategy.RollingUpdate.MaxUnavailable,
+				MaxSurge:       machineDeploymentTopology.Rollout.Strategy.RollingUpdate.MaxSurge,
+			}
 		}
 	}
 
@@ -1074,6 +1084,13 @@ func (g *generator) computeMachineDeployment(ctx context.Context, s *scope.Scope
 			checks, remediation)
 	}
 	return desiredMachineDeployment, nil
+}
+
+// shouldPropagateRollingUpdateRolloutStrategy returns true if rollingUpdate fields are valid for the given strategy type.
+// Empty strategy type is treated like RollingUpdate because MachineDeployment defaulting applies RollingUpdate, while
+// topology and ClusterClass use empty values to inherit defaults.
+func shouldPropagateRollingUpdateRolloutStrategy(strategyType clusterv1.MachineDeploymentRolloutStrategyType) bool {
+	return strategyType == "" || strategyType == clusterv1.RollingUpdateMachineDeploymentStrategyType
 }
 
 // computeMachineDeploymentVersion calculates the version of the desired machine deployment.

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -46,6 +46,7 @@ import (
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
+	coreadmission "sigs.k8s.io/cluster-api/core/webhooks/admission"
 	"sigs.k8s.io/cluster-api/core/webhooks/conversion"
 	"sigs.k8s.io/cluster-api/exp/topology/scope"
 	"sigs.k8s.io/cluster-api/feature"
@@ -2091,6 +2092,151 @@ func TestComputeMachineDeployment(t *testing.T) {
 		g.Expect(*actualMd.Spec.Template.Spec.Deletion.NodeDrainTimeoutSeconds).To(Equal(clusterClassDuration))
 		g.Expect(*actualMd.Spec.Template.Spec.Deletion.NodeVolumeDetachTimeoutSeconds).To(Equal(clusterClassDuration))
 		g.Expect(*actualMd.Spec.Template.Spec.Deletion.NodeDeletionTimeoutSeconds).To(Equal(clusterClassDuration))
+	})
+
+	t.Run("Should normalize rollout strategy rollingUpdate fields", func(t *testing.T) {
+		rolloutMaxSurge := intstr.FromInt32(1)
+		rolloutMaxUnavailable := intstr.FromString("25%")
+		rolloutAfter := metav1.NewTime(time.Date(2026, time.July, 9, 0, 0, 0, 0, time.UTC))
+
+		tests := []struct {
+			name                 string
+			clusterClassStrategy clusterv1.MachineDeploymentClassRolloutStrategy
+			topologyRollout      *clusterv1.MachineDeploymentTopologyRolloutSpec
+			wantType             clusterv1.MachineDeploymentRolloutStrategyType
+			wantAfter            metav1.Time
+			wantMaxUnavailable   *intstr.IntOrString
+			wantMaxSurge         *intstr.IntOrString
+		}{
+			{
+				name: "Should not propagate rollingUpdate fields when strategy type is OnDelete from MachineDeploymentClass",
+				clusterClassStrategy: clusterv1.MachineDeploymentClassRolloutStrategy{
+					Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+					RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+						MaxUnavailable: &rolloutMaxUnavailable,
+						MaxSurge:       &rolloutMaxSurge,
+					},
+				},
+				wantType: clusterv1.OnDeleteMachineDeploymentStrategyType,
+			},
+			{
+				name: "Should not propagate rollingUpdate fields when strategy type is OnDelete from topology override",
+				clusterClassStrategy: clusterv1.MachineDeploymentClassRolloutStrategy{
+					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+					RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+						MaxUnavailable: &rolloutMaxUnavailable,
+						MaxSurge:       &rolloutMaxSurge,
+					},
+				},
+				topologyRollout: &clusterv1.MachineDeploymentTopologyRolloutSpec{
+					Strategy: clusterv1.MachineDeploymentTopologyRolloutStrategy{
+						Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+						RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+							MaxUnavailable: &rolloutMaxUnavailable,
+							MaxSurge:       &rolloutMaxSurge,
+						},
+					},
+				},
+				wantType: clusterv1.OnDeleteMachineDeploymentStrategyType,
+			},
+			{
+				name: "Should propagate rollout after while not propagating rollingUpdate fields when strategy type is OnDelete from topology override",
+				clusterClassStrategy: clusterv1.MachineDeploymentClassRolloutStrategy{
+					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+					RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+						MaxUnavailable: &rolloutMaxUnavailable,
+						MaxSurge:       &rolloutMaxSurge,
+					},
+				},
+				topologyRollout: &clusterv1.MachineDeploymentTopologyRolloutSpec{
+					After: rolloutAfter,
+					Strategy: clusterv1.MachineDeploymentTopologyRolloutStrategy{
+						Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+						RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+							MaxUnavailable: &rolloutMaxUnavailable,
+							MaxSurge:       &rolloutMaxSurge,
+						},
+					},
+				},
+				wantType:  clusterv1.OnDeleteMachineDeploymentStrategyType,
+				wantAfter: rolloutAfter,
+			},
+			{
+				name: "Should propagate rollingUpdate fields when strategy type is RollingUpdate",
+				clusterClassStrategy: clusterv1.MachineDeploymentClassRolloutStrategy{
+					Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+				},
+				topologyRollout: &clusterv1.MachineDeploymentTopologyRolloutSpec{
+					Strategy: clusterv1.MachineDeploymentTopologyRolloutStrategy{
+						Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+						RollingUpdate: clusterv1.MachineDeploymentTopologyRolloutStrategyRollingUpdate{
+							MaxUnavailable: &rolloutMaxUnavailable,
+							MaxSurge:       &rolloutMaxSurge,
+						},
+					},
+				},
+				wantType:           clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				wantMaxUnavailable: &rolloutMaxUnavailable,
+				wantMaxSurge:       &rolloutMaxSurge,
+			},
+			{
+				name: "Should propagate rollingUpdate fields when strategy type is empty",
+				clusterClassStrategy: clusterv1.MachineDeploymentClassRolloutStrategy{
+					RollingUpdate: clusterv1.MachineDeploymentClassRolloutStrategyRollingUpdate{
+						MaxUnavailable: &rolloutMaxUnavailable,
+						MaxSurge:       &rolloutMaxSurge,
+					},
+				},
+				wantMaxUnavailable: &rolloutMaxUnavailable,
+				wantMaxSurge:       &rolloutMaxSurge,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+
+				testClusterClass := fakeClass.DeepCopy()
+				testClusterClass.Spec.Workers.MachineDeployments[0].Rollout.Strategy = tt.clusterClassStrategy
+				testClusterClass.Spec.Workers.MachineDeployments[0].Taints = nil
+				testWorkerBootstrapTemplate := workerBootstrapTemplate.DeepCopy()
+				testWorkerInfrastructureMachineTemplate := workerInfrastructureMachineTemplate.DeepCopy()
+				testScope := scope.New(cluster.DeepCopy())
+				testScope.Blueprint = &scope.ClusterBlueprint{
+					Topology:     cluster.Spec.Topology,
+					ClusterClass: testClusterClass,
+					MachineDeployments: map[string]*scope.MachineDeploymentBlueprint{
+						"linux-worker": {
+							BootstrapTemplate:             testWorkerBootstrapTemplate,
+							InfrastructureMachineTemplate: testWorkerInfrastructureMachineTemplate,
+						},
+					},
+				}
+
+				mdTopology := builder.MachineDeploymentTopology("big-pool-of-machines").
+					WithClass("linux-worker").
+					Build()
+				if tt.topologyRollout != nil {
+					mdTopology.Rollout = *tt.topologyRollout.DeepCopy()
+				}
+
+				e := generator{}
+
+				actual, err := e.computeMachineDeployment(ctx, testScope, mdTopology)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				actualMD := actual.Object
+				g.Expect(actualMD.Spec.Rollout.Strategy.Type).To(Equal(tt.wantType))
+				g.Expect(actualMD.Spec.Rollout.After).To(Equal(tt.wantAfter))
+				g.Expect(actualMD.Spec.Rollout.Strategy.RollingUpdate.MaxUnavailable).To(Equal(tt.wantMaxUnavailable))
+				g.Expect(actualMD.Spec.Rollout.Strategy.RollingUpdate.MaxSurge).To(Equal(tt.wantMaxSurge))
+
+				machineDeploymentWebhook := coreadmission.MachineDeployment{}
+				warnings, err := machineDeploymentWebhook.ValidateCreate(ctx, actualMD)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(warnings).To(BeEmpty())
+			})
+		}
 	})
 
 	t.Run("Skips setting readinessGates if not set in Cluster and ClusterClass", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adds missing rollout strategy validation parity for `MachineDeployment`, `Cluster.spec.topology`, and `ClusterClass` (reject rollingUpdate fields when strategy type is `OnDelete`), with ratcheting so unchanged pre-existing invalid values are still allowed on update. It also changes disabled topology MHC override handling to emit webhook warnings (not errors) so users can temporarily disable MHC for troubleshooting without removing config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8721

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->