### PR TITLE
🌱 Fix flaky KCP test

### DIFF
--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -2351,7 +2351,11 @@ func TestTargetEtcdClusterHealthy(t *testing.T) {
 			Machines: collections.FromMachines(m1, m2),
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
-		controlPlane.EtcdMembers[1].IsLearner = true
+		for i := range controlPlane.EtcdMembers {
+			if controlPlane.EtcdMembers[i].Name == "node-m2-etcd-healthy" {
+				controlPlane.EtcdMembers[i].IsLearner = true
+			}
+		}
 
 		canSafelyTransitionToTargetState := r.targetEtcdClusterHealthy(ctx, controlPlane, false, m1.Status.NodeRef.Name)
 		g.Expect(canSafelyTransitionToTargetState).To(BeFalse())
@@ -2366,7 +2370,11 @@ func TestTargetEtcdClusterHealthy(t *testing.T) {
 			Machines: collections.FromMachines(m1, m2),
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
-		controlPlane.EtcdMembers[1].Name = ""
+		for i := range controlPlane.EtcdMembers {
+			if controlPlane.EtcdMembers[i].Name == "node-m2-etcd-healthy" {
+				controlPlane.EtcdMembers[i].Name = ""
+			}
+		}
 
 		canSafelyTransitionToTargetState := r.targetEtcdClusterHealthy(ctx, controlPlane, false, m1.Status.NodeRef.Name)
 		g.Expect(canSafelyTransitionToTargetState).To(BeFalse())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes a unit test flake introduced by #13352

```
{Failed  === RUN   TestTargetEtcdClusterHealthy/Can't_safely_remove_a_member_from_a_CP_with_a_learner_etcd_member
I0223 12:54:22.234195   26795 remediation.go:675] "etcd cluster current state" currentTotalMembers=2 currentMembers=["node-m2-etcd-healthy","node-m1-mhc-unhealthy"]
I0223 12:54:22.234301   26795 remediation.go:785] "etcd cluster considering removal of etcdMember node-m1-mhc-unhealthy" healthyMembers=["node-m2-etcd-healthy (m2-etcd-healthy)"] unhealthyMembers=[] totalMembers=1 totalLearnerMembers=0 totalVotingMembers=1 quorum=1 totalHealthyMembers=1 totalUnhealthyMembers=0 canSafelyTransitionToTargetState=true
    remediation_test.go:2357: 
        Expected
            <bool>: true
        to be false
--- FAIL: TestTargetEtcdClusterHealthy/Can't_safely_remove_a_member_from_a_CP_with_a_learner_etcd_member (0.00s)
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->