### PR TITLE
🌱 Postpone date when we stop serving v1beta1

### DIFF
--- a/docs/book/src/developer/providers/contracts/bootstrap-config.md
+++ b/docs/book/src/developer/providers/contracts/bootstrap-config.md
@@ -272,7 +272,7 @@ on Machine's corresponding fields at the same time.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to initialization completed:
 
@@ -312,7 +312,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to conditions:
 
@@ -337,7 +337,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to terminal failures:
 

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -280,7 +280,7 @@ the implementer should exit reconciliation until it sees Cluster's `spec.control
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 ```go
 type FooControlPlaneSpec struct {
@@ -376,7 +376,7 @@ documentation][scale].
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to v1beta1 replica counters, the Cluster controller with temporarily continue to read
 `status.readyReplicas`,  `status.updatedReplicas` and `status.unavailableReplicas`, even if the semantic of the 
@@ -504,7 +504,7 @@ See [In place propagation of changes affecting Kubernetes objects only] as well 
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 For reference. The v1beta1 contract had `nodeDrainTimeout`, `nodeVolumeDetachTimeout`, `nodeDeletionTimeout` fields
 of type `*metav1.Duration` instead of the new fields with `Seconds` suffix of type `*int32`.
@@ -641,7 +641,7 @@ If defined, also ControlPlane's `spec.controlPlaneEndpoint` will be surfaced on 
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to initialization completed:
 
@@ -718,7 +718,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to conditions:
 
@@ -743,7 +743,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to terminal failures:
 
@@ -870,7 +870,7 @@ propagated to Kubernetes Nodes.
 
 <h1>Heads up! this will change with the v1beta2 contract</h1>
 
-When the v1beta2 contract will be released (tentative Apr 2025), Cluster API is going to standardize how
+When the v1beta2 contract will be released (August 2025), Cluster API is going to standardize how
 machines determine if they are available or up to date with the spec of the owner resource.
 
 In order to ensure a nice and consistent user experience across the entire Cluster, also ControlPlane providers

--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -263,7 +263,7 @@ the implementer should exit reconciliation until it sees Cluster's `spec.control
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 ```go
 type FooClusterSpec struct {
@@ -320,7 +320,7 @@ the Cluster controller will surface this info in Cluster's `status.failureDomain
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 For reference, with the v1beta1 contract the field is of type `clusterv1beta1.FailureDomains`, which is a map defined as 
 `map[string]clusterv1beta1.FailureDomainSpec`. A unique key must be used for each `FailureDomainSpec`.
@@ -365,7 +365,7 @@ and `status.failureDomains` will be surfaced on Cluster's corresponding fields a
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to initialization completed:
 
@@ -405,7 +405,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to conditions:
 
@@ -430,7 +430,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to terminal failures:
 

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -261,7 +261,7 @@ type FooMachineStatus struct {
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regard to failure domain:
 
@@ -332,7 +332,7 @@ be surfaced on Machine's corresponding fields at the same time.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regard to initialization completed:
 
@@ -372,7 +372,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to conditions:
 
@@ -397,7 +397,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to terminal failures:
 

--- a/docs/book/src/developer/providers/contracts/infra-machinepool.md
+++ b/docs/book/src/developer/providers/contracts/infra-machinepool.md
@@ -339,7 +339,7 @@ Once `status.initialization.provisioned` is set, the MachinePool "core" controll
 
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
-In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_ preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_ preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regard to initialization completed:
 
@@ -384,7 +384,7 @@ See [Improving status in CAPI resources] for more context.
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
 In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_
-preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to conditions:
 
@@ -424,7 +424,7 @@ See [Improving status in CAPI resources] for more context.
 
 <h1>Compatibility with the deprecated v1beta1 contract</h1>
 
-In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_ preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in Apr 2027.
+In order to ease the transition for providers, the v1beta2 version of the Cluster API contract _temporarily_ preserves compatibility with the deprecated v1beta1 contract; compatibility will be removed tentatively in April 2027.
 
 With regards to terminal failures:
 

--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -69,10 +69,10 @@ Any feedback or contributions to improve following documentation is welcome!
 
 As documented in [Suggested changes for providers](#suggested-changes-for-providers), it is highly recommended to start planning for future removals:
 
-- v1beta1 API version will be removed tentatively in Apr 2027 (instead of the original Aug 2026)
-- Starting from the CAPI release when v1beta1 removal will happen, tentatively Apr 2027, the Cluster API project
+- v1beta1 API version will be removed tentatively in April 2027 (instead of the original August 2026)
+- Starting from the CAPI release when v1beta1 removal will happen, tentatively April 2027, the Cluster API project
   will remove the Cluster API condition type, the `util/conditions/deprecated/v1beta1` package,
   the `util/deprecated/v1beta1` package, the code handling old conditions in `util/patch.Helper`
   and everything related to the custom Cluster API custom condition type.
-- All the `status.deprecated` fields will be removed tentatively in Apr 2027.
-- Compatibility support for the v1beta1 version of the Cluster API contract will be removed tentatively in Apr 2027
+- All the `status.deprecated` fields will be removed tentatively in April 2027.
+- Compatibility support for the v1beta1 version of the Cluster API contract will be removed tentatively in April 2027

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -156,10 +156,10 @@ An API version is considered deprecated when a new API version is published.
 API deprecation and removal follow the [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/);
 Cluster API maintainers might decide to support API versions longer than what is defined in the Kubernetes policy.
 
-| API Version | Status      | Supported Until                                                                  |
-|-------------|-------------|----------------------------------------------------------------------------------|
-| v1beta2     | Supported   | at least 9 months or 3 minor releases after a newer API version will be released |
-| v1beta1     | Deprecated  | Deprecated since CAPI v1.11; in v1.19, Apr 27 v1beta1 will stop to be served     |
+| API Version | Status     | Supported Until                                                                  |
+|-------------|------------|----------------------------------------------------------------------------------|
+| v1beta2     | Supported  | at least 9 months or 3 minor releases after a newer API version will be released |
+| v1beta1     | Deprecated | Deprecated since CAPI v1.11; in v1.16, April 2027 v1beta1 will stop to be served |
 
 See [11920](https://github.com/kubernetes-sigs/cluster-api/issues/11920) for details about the v1beta1 removal plan.
 
@@ -218,10 +218,10 @@ providers of an older contract version) e.g.
 
 </aside>
 
-| Contract Version | Compatible with contract versions | Status      | Supported Until                                                                                              |
-|------------------|-----------------------------------|-------------|--------------------------------------------------------------------------------------------------------------|
-| v1beta2          | v1beta1 (temporarily)             | Supported   | After a newer API contract will be released                                                                  |
-| v1beta1          |                                   | Deprecated  | Deprecated since CAPI v1.11; in v1.19, Apr 27 compatibility with the v1beta1 contract will be considered EOL |
+| Contract Version | Compatible with contract versions | Status     | Supported Until                                                                                                  |
+|------------------|-----------------------------------|------------|------------------------------------------------------------------------------------------------------------------|
+| v1beta2          | v1beta1 (temporarily)             | Supported  | After a newer API contract will be released                                                                      |
+| v1beta1          |                                   | Deprecated | Deprecated since CAPI v1.11; in v1.16, April 2027 compatibility with the v1beta1 contract will be considered EOL |
 
 See [11920](https://github.com/kubernetes-sigs/cluster-api/issues/11920) for details about the v1beta1 removal plan.
 

--- a/docs/proposals/20200506-conditions.md
+++ b/docs/proposals/20200506-conditions.md
@@ -20,14 +20,14 @@ The [Improve Status in CAPI resources](20240916-improve-status-in-CAPI-resources
 implementing Cluster API v1beta2 APIs, while "legacy" conditions described in this document are used in v1beta1 API version.
 
 The v1beta1 API types, including the "legacy" condition types described in this document are going to be deprecated
-when v1beta2 will be released (tentative Apr 2025).
+when v1beta2 will be released (August 2025).
 
 Providers implementing conditions won't be required to do the transition from "legacy" Cluster API Condition type
 to Kubernetes `metav1.Conditions` type, but this transition is recommended because it improves the consistency of each provider
 with Kubernetes, Cluster API and the ecosystem.
 
 However, providers choosing to keep using Cluster API "legacy" conditions should be aware that starting from the
-CAPI release when v1beta1 removal will happen (tentative Apr 2027), the Cluster API project will remove the
+CAPI release when v1beta1 removal will happen (tentative April 2027), the Cluster API project will remove the
 Cluster API "legacy" condition types, the "legacy" `util/conditions` package, the code handling "legacy" conditions in
 `util/patch.Helper` and everything related to the "legacy" Cluster API `v1beta.Condition` type.
 

--- a/docs/proposals/20240916-improve-status-in-CAPI-resources.md
+++ b/docs/proposals/20240916-improve-status-in-CAPI-resources.md
@@ -321,18 +321,18 @@ type MachineInitializationStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)            | v1beta2 (tentative Aug 2025)                               | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|-------------------------------|------------------------------------------------------------|----------------------------------------------------|
-|                               | `Initialization` (new)                                     | `Initialization`                                   |
-| `BootstrapReady`              | `Initialization.BootstrapDataSecretCreated` (renamed)      | `Initialization.BootstrapDataSecretCreated`        |
-| `InfrastructureReady`         | `Initialization.InfrastructureProvisioned` (renamed)       | `Initialization.InfrastructureProvisioned`         |
-| `V1Beta2` (new)               | (removed)                                                  | (removed)                                          |
-| `V1Beta2.Conditions` (new)    | `Conditions` (renamed)                                     | `Conditions`                                       |
-|                               | `Deprecated.V1Beta1` (new)                                 | (removed)                                          |
-| `FailureReason` (deprecated)  | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)  | (removed)                                          |
-| `FailureMessage` (deprecated) | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated) | (removed)                                          |
-| `Conditions` (deprecated)     | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)     | (removed)                                          |
-| other fields...               | other fields...                                            | other fields...                                    |
+| v1beta1 (CAPI 1.9)            | v1beta2 (August 2025)                                      | v1beta2 after v1beta1 removal (tentative April 2027) |
+|-------------------------------|------------------------------------------------------------|------------------------------------------------------|
+|                               | `Initialization` (new)                                     | `Initialization`                                     |
+| `BootstrapReady`              | `Initialization.BootstrapDataSecretCreated` (renamed)      | `Initialization.BootstrapDataSecretCreated`          |
+| `InfrastructureReady`         | `Initialization.InfrastructureProvisioned` (renamed)       | `Initialization.InfrastructureProvisioned`           |
+| `V1Beta2` (new)               | (removed)                                                  | (removed)                                            |
+| `V1Beta2.Conditions` (new)    | `Conditions` (renamed)                                     | `Conditions`                                         |
+|                               | `Deprecated.V1Beta1` (new)                                 | (removed)                                            |
+| `FailureReason` (deprecated)  | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)  | (removed)                                            |
+| `FailureMessage` (deprecated) | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated) | (removed)                                            |
+| `Conditions` (deprecated)     | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)     | (removed)                                            |
+| other fields...               | other fields...                                            | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields. 
@@ -423,11 +423,11 @@ type MachineReadinessGate struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)     | v1Beta2 (tentative Aug 2025) | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------|------------------------------|----------------------------------------------------|
-|                        | `MinReadySeconds` (renamed)  | `MinReadySeconds`                                  |
-| `ReadinessGates` (new) | `ReadinessGates`             | `ReadinessGates`                                   |
-| other fields...        | other fields...              | other fields...                                    |
+| v1beta1 (CAPI 1.9)     | v1beta2 (August 2025)       | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------|-----------------------------|------------------------------------------------------|
+|                        | `MinReadySeconds` (renamed) | `MinReadySeconds`                                    |
+| `ReadinessGates` (new) | `ReadinessGates`            | `ReadinessGates`                                     |
+| other fields...        | other fields...             | other fields...                                      |
 
 Notes:
 - As of today v1beta1 MachineDeployments, MachineSets, MachinePools already have a `spec.MinReadySeconds` field. 
@@ -499,21 +499,21 @@ type MachineSetStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)                  | v1beta2 (tentative Aug 2025)                                     | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|-------------------------------------|------------------------------------------------------------------|----------------------------------------------------|
-| `V1Beta2` (new)                     | (removed)                                                        | (removed)                                          |
-| `V1Beta2.Conditions` (new)          | `Conditions` (renamed)                                           | `Conditions`                                       |
-| `V1Beta2.ReadyReplicas` (new)       | `ReadyReplicas` (renamed)                                        | `ReadyReplicas`                                    |
-| `V1Beta2.AvailableReplicas` (new)   | `AvailableReplicas` (renamed)                                    | `AvailableReplicas`                                |
-| `V1Beta2.UpToDateReplicas` (new)    | `UpToDateReplicas` (renamed)                                     | `UpToDateReplicas`                                 |
-|                                     | `Deprecated.V1Beta1` (new)                                       | (removed)                                          |
-| `ReadyReplicas` (deprecated)        | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)        | (removed)                                          |
-| `AvailableReplicas` (deprecated)    | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)    | (removed)                                          |
-| `FullyLabeledReplicas` (deprecated) | `Deprecated.V1Beta1.FullyLabeledReplicas` (renamed) (deprecated) | (removed)                                          |
-| `FailureReason` (deprecated)        | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)        | (removed)                                          |
-| `FailureMessage` (deprecated)       | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)       | (removed)                                          |
-| `Conditions` (deprecated)           | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)           | (removed)                                          |
-| other fields...                     | other fields...                                                  | other fields...                                    |
+| v1beta1 (CAPI 1.9)                  | v1beta2 (August 2025)                                            | v1beta2 after v1beta1 removal (tentative April 2027) |
+|-------------------------------------|------------------------------------------------------------------|------------------------------------------------------|
+| `V1Beta2` (new)                     | (removed)                                                        | (removed)                                            |
+| `V1Beta2.Conditions` (new)          | `Conditions` (renamed)                                           | `Conditions`                                         |
+| `V1Beta2.ReadyReplicas` (new)       | `ReadyReplicas` (renamed)                                        | `ReadyReplicas`                                      |
+| `V1Beta2.AvailableReplicas` (new)   | `AvailableReplicas` (renamed)                                    | `AvailableReplicas`                                  |
+| `V1Beta2.UpToDateReplicas` (new)    | `UpToDateReplicas` (renamed)                                     | `UpToDateReplicas`                                   |
+|                                     | `Deprecated.V1Beta1` (new)                                       | (removed)                                            |
+| `ReadyReplicas` (deprecated)        | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)        | (removed)                                            |
+| `AvailableReplicas` (deprecated)    | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)    | (removed)                                            |
+| `FullyLabeledReplicas` (deprecated) | `Deprecated.V1Beta1.FullyLabeledReplicas` (renamed) (deprecated) | (removed)                                            |
+| `FailureReason` (deprecated)        | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)        | (removed)                                            |
+| `FailureMessage` (deprecated)       | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)       | (removed)                                            |
+| `Conditions` (deprecated)           | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)           | (removed)                                            |
+| other fields...                     | other fields...                                                  | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields.
@@ -560,10 +560,10 @@ Following changes are implemented to MachineSet's spec:
 
 Below you can find a summary table that also shows how changes will be rolled out according to K8s deprecation rules.
 
-| v1beta1 (CAPI 1.9)     | v1beta2 (tentative Aug 2025)                   | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------|------------------------------------------------|----------------------------------------------------|
-| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`               |
-| other fields...        | other fields...                                | other fields...                                    |
+| v1beta1 (CAPI 1.9)     | v1beta2 (August 2025)                          | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------|------------------------------------------------|------------------------------------------------------|
+| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`                 |
+| other fields...        | other fields...                                | other fields...                                      |
 
 #### MachineSet Print columns
 
@@ -626,20 +626,20 @@ type MachineDeploymentStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)                 | v1beta2 (tentative Aug 2025)                                    | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------------------|-----------------------------------------------------------------|----------------------------------------------------|
-| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                          |
-| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                       |
-| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                    |
-| `V1Beta2.AvilableReplicas` (new)   | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                |
-| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                 |
-|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                          |
-| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                          |
-| `AvailableReplicas` (deprecated)   | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)   | (removed)                                          |
-| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                          |
-| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                          |
-| `UpdatedReplicas` (deprecated)     | `Deprecated.V1Beta1.UpdatedReplicas` (renamed) (deprecated)     | (removed)                                          |
-| other fields...                    | other fields...                                                 | other fields...                                    |
+| v1beta1 (CAPI 1.9)                 | v1beta2 (August 2025)                                           | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------------------|-----------------------------------------------------------------|------------------------------------------------------|
+| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                            |
+| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                         |
+| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                      |
+| `V1Beta2.AvilableReplicas` (new)   | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                  |
+| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                   |
+|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                            |
+| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                            |
+| `AvailableReplicas` (deprecated)   | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)   | (removed)                                            |
+| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                            |
+| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                            |
+| `UpdatedReplicas` (deprecated)     | `Deprecated.V1Beta1.UpdatedReplicas` (renamed) (deprecated)     | (removed)                                            |
+| other fields...                    | other fields...                                                 | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields.
@@ -677,10 +677,10 @@ Following changes are implemented to MachineDeployment's spec:
 
 Below you can find a summary table that also shows how changes will be rolled out according to K8s deprecation rules.
 
-| v1beta1 (CAPI 1.9)     | v1beta2 (tentative Aug 2025)                   | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------|------------------------------------------------|----------------------------------------------------|
-| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`               |
-| other fields...        | other fields...                                | other fields...                                    |
+| v1beta1 (CAPI 1.9)     | v1beta2 (August 2025)                          | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------|------------------------------------------------|------------------------------------------------------|
+| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`                 |
+| other fields...        | other fields...                                | other fields...                                      |
 
 #### MachineDeployment Print columns
 
@@ -816,30 +816,30 @@ type WorkersStatus struct {
 // NOTE: `FailureReason`, `FailureMessage` fields won't be there anymore
 ```
 
-| v1beta1 (CAPI 1.9)                             | v1beta2 (tentative Aug 2025)                               | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------------------------------|------------------------------------------------------------|----------------------------------------------------|
-|                                                | `Initialization` (new)                                     | `Initialization`                                   |
-| `InfrastructureReady`                          | `Initialization.InfrastructureProvisioned` (renamed)       | `Initialization.InfrastructureProvisioned`         |
-| `ControlPlaneReady`                            | `Initialization.ControlPlaneInitialized` (renamed)         | `Initialization.ControlPlaneInitialized`           |
-| `V1Beta2` (new)                                | (removed)                                                  | (removed)                                          |
-| `V1Beta2.Conditions` (new)                     | `Conditions` (renamed)                                     | `Conditions`                                       |
-| `V1Beta2.ControlPlane` (new)                   | `ControlPlane` (renamed)                                   | `ControlPlane`                                     |
-| `V1Beta2.ControlPlane.DesiredReplicas` (new)   | `ControlPlane.DesiredReplicas` (renamed)                   | `ControlPlane.DesiredReplicas`                     |
-| `V1Beta2.ControlPlane.Replicas` (new)          | `ControlPlane.Replicas` (renamed)                          | `ControlPlane.Replicas`                            |
-| `V1Beta2.ControlPlane.ReadyReplicas` (new)     | `ControlPlane.ReadyReplicas` (renamed)                     | `ControlPlane.ReadyReplicas`                       |
-| `V1Beta2.ControlPlane.UpToDateReplicas` (new)  | `ControlPlane.UpToDateReplicas` (renamed)                  | `ControlPlane.UpToDateReplicas`                    |
-| `V1Beta2.ControlPlane.AvailableReplicas` (new) | `ControlPlane.AvailableReplicas` (renamed)                 | `ControlPlane.AvailableReplicas`                   |
-| `V1Beta2.Workers` (new)                        | `Workers` (renamed)                                        | `Workers`                                          |
-| `V1Beta2.Workers.DesiredReplicas` (new)        | `Workers.DesiredReplicas` (renamed)                        | `Workers.DesiredReplicas`                          |
-| `V1Beta2.Workers.Replicas` (new)               | `Workers.Replicas` (renamed)                               | `Workers.Replicas`                                 |
-| `V1Beta2.Workers.ReadyReplicas` (new)          | `Workers.ReadyReplicas` (renamed)                          | `Workers.ReadyReplicas`                            |
-| `V1Beta2.Workers.UpToDateReplicas` (new)       | `Workers.UpToDateReplicas` (renamed)                       | `Workers.UpToDateReplicas`                         |
-| `V1Beta2.Workers.AvailableReplicas` (new)      | `Workers.AvailableReplicas` (renamed)                      | `Workers.AvailableReplicas`                        |
-|                                                | `Deprecated.V1Beta1` (new)                                 | (removed)                                          |
-| `FailureReason` (deprecated)                   | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)  | (removed)                                          |
-| `FailureMessage` (deprecated)                  | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated) | (removed)                                          |
-| `Conditions` (deprecated)                      | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)     | (removed)                                          |
-| other fields...                                | other fields...                                            | other fields...                                    |
+| v1beta1 (CAPI 1.9)                             | v1beta2 (August 2025)                                      | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------------------------------|------------------------------------------------------------|------------------------------------------------------|
+|                                                | `Initialization` (new)                                     | `Initialization`                                     |
+| `InfrastructureReady`                          | `Initialization.InfrastructureProvisioned` (renamed)       | `Initialization.InfrastructureProvisioned`           |
+| `ControlPlaneReady`                            | `Initialization.ControlPlaneInitialized` (renamed)         | `Initialization.ControlPlaneInitialized`             |
+| `V1Beta2` (new)                                | (removed)                                                  | (removed)                                            |
+| `V1Beta2.Conditions` (new)                     | `Conditions` (renamed)                                     | `Conditions`                                         |
+| `V1Beta2.ControlPlane` (new)                   | `ControlPlane` (renamed)                                   | `ControlPlane`                                       |
+| `V1Beta2.ControlPlane.DesiredReplicas` (new)   | `ControlPlane.DesiredReplicas` (renamed)                   | `ControlPlane.DesiredReplicas`                       |
+| `V1Beta2.ControlPlane.Replicas` (new)          | `ControlPlane.Replicas` (renamed)                          | `ControlPlane.Replicas`                              |
+| `V1Beta2.ControlPlane.ReadyReplicas` (new)     | `ControlPlane.ReadyReplicas` (renamed)                     | `ControlPlane.ReadyReplicas`                         |
+| `V1Beta2.ControlPlane.UpToDateReplicas` (new)  | `ControlPlane.UpToDateReplicas` (renamed)                  | `ControlPlane.UpToDateReplicas`                      |
+| `V1Beta2.ControlPlane.AvailableReplicas` (new) | `ControlPlane.AvailableReplicas` (renamed)                 | `ControlPlane.AvailableReplicas`                     |
+| `V1Beta2.Workers` (new)                        | `Workers` (renamed)                                        | `Workers`                                            |
+| `V1Beta2.Workers.DesiredReplicas` (new)        | `Workers.DesiredReplicas` (renamed)                        | `Workers.DesiredReplicas`                            |
+| `V1Beta2.Workers.Replicas` (new)               | `Workers.Replicas` (renamed)                               | `Workers.Replicas`                                   |
+| `V1Beta2.Workers.ReadyReplicas` (new)          | `Workers.ReadyReplicas` (renamed)                          | `Workers.ReadyReplicas`                              |
+| `V1Beta2.Workers.UpToDateReplicas` (new)       | `Workers.UpToDateReplicas` (renamed)                       | `Workers.UpToDateReplicas`                           |
+| `V1Beta2.Workers.AvailableReplicas` (new)      | `Workers.AvailableReplicas` (renamed)                      | `Workers.AvailableReplicas`                          |
+|                                                | `Deprecated.V1Beta1` (new)                                 | (removed)                                            |
+| `FailureReason` (deprecated)                   | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)  | (removed)                                            |
+| `FailureMessage` (deprecated)                  | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated) | (removed)                                            |
+| `Conditions` (deprecated)                      | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)     | (removed)                                            |
+| other fields...                                | other fields...                                            | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields.
@@ -915,10 +915,10 @@ type ClusterAvailabilityGate struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)        | v1Beta2 (tentative Aug 2025) | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|---------------------------|------------------------------|----------------------------------------------------|
-| `AvailabilityGates` (new) | `AvailabilityGates`          | `AvailabilityGates`                                |
-| other fields...           | other fields...              | other fields...                                    |
+| v1beta1 (CAPI 1.9)        | v1beta2 (August 2025) | v1beta2 after v1beta1 removal (tentative April 2027) |
+|---------------------------|-----------------------|------------------------------------------------------|
+| `AvailabilityGates` (new) | `AvailabilityGates`   | `AvailabilityGates`                                  |
+| other fields...           | other fields...       | other fields...                                      |
 
 #### Cluster Print columns
 
@@ -992,22 +992,22 @@ type KubeadmControlPlaneStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)                 | v1beta2 (tentative Aug 2025)                                    | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------------------|-----------------------------------------------------------------|----------------------------------------------------|
-| `Ready` (deprecated)               | `Ready` (deprecated)                                            | (removed)                                          |
-| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                          |
-| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                       |
-| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                    |
-| `V1Beta2.AvailableReplicas` (new)  | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                |
-| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                 |
-|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                          |
-| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                          |
-| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                          |
-| `FailureReason` (deprecated)       | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)       | (removed)                                          |
-| `FailureMessage` (deprecated)      | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)      | (removed)                                          |
-| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                          |
-| `UpdatedReplicas` (deprecated)     | `Deprecated.V1Beta1.UpdatedReplicas` (renamed) (deprecated)     | (removed)                                          |
-| other fields...                    | other fields...                                                 | other fields...                                    |
+| v1beta1 (CAPI 1.9)                 | v1beta2 (August 2025)                                           | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------------------|-----------------------------------------------------------------|------------------------------------------------------|
+| `Ready` (deprecated)               | `Ready` (deprecated)                                            | (removed)                                            |
+| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                            |
+| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                         |
+| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                      |
+| `V1Beta2.AvailableReplicas` (new)  | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                  |
+| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                   |
+|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                            |
+| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                            |
+| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                            |
+| `FailureReason` (deprecated)       | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)       | (removed)                                            |
+| `FailureMessage` (deprecated)      | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)      | (removed)                                            |
+| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                            |
+| `UpdatedReplicas` (deprecated)     | `Deprecated.V1Beta1.UpdatedReplicas` (renamed) (deprecated)     | (removed)                                            |
+| other fields...                    | other fields...                                                 | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields.
@@ -1138,24 +1138,24 @@ type MachinePoolInitializationStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)                 | v1beta2 (tentative Aug 2025)                                    | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------------------|-----------------------------------------------------------------|----------------------------------------------------|
-|                                    | `Initialization` (new)                                          | `Initialization`                                   |
-| `BootstrapReady`                   | `Initialization.BootstrapDataSecretCreated` (renamed)           | `Initialization.BootstrapDataSecretCreated`        |
-| `InfrastructureReady`              | `Initialization.InfrastructureProvisioned` (renamed)            | `Initialization.InfrastructureProvisioned`         |
-| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                          |
-| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                       |
-| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                 |
-| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                    |
-| `V1Beta2.AvailableReplicas` (new)  | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                |
-|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                          |
-| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                          |
-| `AvailableReplicas` (deprecated)   | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)   | (removed)                                          |
-| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                          |
-| `FailureReason` (deprecated)       | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)       | (removed)                                          |
-| `FailureMessage` (deprecated)      | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)      | (removed)                                          |
-| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                          |
-| other fields...                    | other fields...                                                 | other fields...                                    |
+| v1beta1 (CAPI 1.9)                 | v1beta2 (August 2025)                                           | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------------------|-----------------------------------------------------------------|------------------------------------------------------|
+|                                    | `Initialization` (new)                                          | `Initialization`                                     |
+| `BootstrapReady`                   | `Initialization.BootstrapDataSecretCreated` (renamed)           | `Initialization.BootstrapDataSecretCreated`          |
+| `InfrastructureReady`              | `Initialization.InfrastructureProvisioned` (renamed)            | `Initialization.InfrastructureProvisioned`           |
+| `V1Beta2` (new)                    | (removed)                                                       | (removed)                                            |
+| `V1Beta2.Conditions` (new)         | `Conditions` (renamed)                                          | `Conditions`                                         |
+| `V1Beta2.UpToDateReplicas` (new)   | `UpToDateReplicas` (renamed)                                    | `UpToDateReplicas`                                   |
+| `V1Beta2.ReadyReplicas` (new)      | `ReadyReplicas` (renamed)                                       | `ReadyReplicas`                                      |
+| `V1Beta2.AvailableReplicas` (new)  | `AvailableReplicas` (renamed)                                   | `AvailableReplicas`                                  |
+|                                    | `Deprecated.V1Beta1` (new)                                      | (removed)                                            |
+| `ReadyReplicas` (deprecated)       | `Deprecated.V1Beta1.ReadyReplicas` (renamed) (deprecated)       | (removed)                                            |
+| `AvailableReplicas` (deprecated)   | `Deprecated.V1Beta1.AvailableReplicas` (renamed) (deprecated)   | (removed)                                            |
+| `UnavailableReplicas` (deprecated) | `Deprecated.V1Beta1.UnavailableReplicas` (renamed) (deprecated) | (removed)                                            |
+| `FailureReason` (deprecated)       | `Deprecated.V1Beta1.FailureReason` (renamed) (deprecated)       | (removed)                                            |
+| `FailureMessage` (deprecated)      | `Deprecated.V1Beta1.FailureMessage` (renamed) (deprecated)      | (removed)                                            |
+| `Conditions` (deprecated)          | `Deprecated.V1Beta1.Conditions` (renamed) (deprecated)          | (removed)                                            |
+| other fields...                    | other fields...                                                 | other fields...                                      |
 
 Notes:
 - The `V1Beta2` struct is going to be added to in v1beta1 types in order to provide a preview of changes coming with the v1beta2 types, but without impacting the semantic of existing fields.
@@ -1196,10 +1196,10 @@ Following changes are implemented to MachinePool's spec:
 
 Below you can find a summary table that also shows how changes will be rolled out according to K8s deprecation rules.
 
-| v1beta1 (CAPI 1.9)     | v1beta2 (tentative Aug 2025)                   | v1beta2 after v1beta1 removal (tentative Apr 2027) |
-|------------------------|------------------------------------------------|----------------------------------------------------|
-| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`               |
-| other fields...        | other fields...                                | other fields...                                    |
+| v1beta1 (CAPI 1.9)     | v1beta2 (August 2025)                          | v1beta2 after v1beta1 removal (tentative April 2027) |
+|------------------------|------------------------------------------------|------------------------------------------------------|
+| `Spec.MinReadySeconds` | `Spec.Template.Spec.MinReadySeconds` (renamed) | `Spec.Template.Spec.MinReadySeconds`                 |
+| other fields...        | other fields...                                | other fields...                                      |
 
 #### MachinePool Print columns
 
@@ -1246,9 +1246,9 @@ a mechanism that allows providers to adapt to a new contract incrementally, more
   Cluster API's v1beta2 release.
 
 - Each provider can implement changes described in the following paragraphs at its own pace, but the transition
-  _must be completed_ before v1beta1 removal (tentative Apr 2027).
+  _must be completed_ before v1beta1 removal (tentative April 2027).
 
-- Starting from the CAPI release when v1beta1 removal will happen (tentative Apr 2027), providers which are implementing
+- Starting from the CAPI release when v1beta1 removal will happen (tentative April 2027), providers which are implementing
   the v1beta1 contract will stop to work (they will work only with older versions of Cluster API).
 
 Additionally:
@@ -1258,7 +1258,7 @@ Additionally:
   with Kubernetes, Cluster API and the ecosystem).
 
 - However, providers choosing to keep using Cluster API custom conditions should be aware that starting from the
-  CAPI release when v1beta1 removal will happen (tentative Apr 2027), the Cluster API project will remove the
+  CAPI release when v1beta1 removal will happen (tentative April 2027), the Cluster API project will remove the
   Cluster API condition type, the `util/conditions` package, the code handling conditions in `util/patch.Helper` and
   everything related to the custom Cluster API `v1beta.Condition` type.
   (in other words, Cluster API custom condition must be replaced by provider's own custom conditions).
@@ -1277,7 +1277,7 @@ Following changes are planned for the contract for the InfrastructureCluster res
 - Remove `failureReason` and `failureMessage`.
 - Change `.status.failureDomains` from a map to an array. Also each failure domain has an additional `name` property which replaces the previous map key.
 
-| v1beta1 (CAPI 1.9)                                                    | v1beta2 (tentative Aug 2025)                                                                                     | v1beta2 after v1beta1 removal (tentative Apr 2027)                                         |
+| v1beta1 (CAPI 1.9)                                                    | v1beta2 (August 2025)                                                                                            | v1beta2 after v1beta1 removal (tentative April 2027)                                       |
 |-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
 | `status.ready`, required                                              | `status.ready` (deprecated), one of `status.ready` or `status.initialization.provisioned` required               | (removed)                                                                                  |
 |                                                                       | `status.initialization.provisioned` (new), one of `status.ready` or `status.initialization.provisioned` required | `status.initialization.provisioned`                                                        |
@@ -1305,7 +1305,7 @@ Following changes are planned for the contract for the InfrastructureMachine res
   - Rename `status.ready` into `status.initialization.provisioned`.
 - Remove `failureReason` and `failureMessage`.
 
-| v1beta1 (CAPI 1.9)                                                    | v1beta2 (tentative Aug 2025)                                                                                     | v1beta2 after v1beta1 removal (tentative Apr 2027)                                         |
+| v1beta1 (CAPI 1.9)                                                    | v1beta2 (August 2025)                                                                                            | v1beta2 after v1beta1 removal (tentative April 2027)                                       |
 |-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
 | `status.ready`, required                                              | `status.ready` (deprecated), one of `status.ready` or `status.initialization.provisioned` required               | (removed)                                                                                  |
 |                                                                       | `status.initialization.provisioned` (new), one of `status.ready` or `status.initialization.provisioned` required | `status.initialization.provisioned`                                                        |
@@ -1330,7 +1330,7 @@ Following changes are planned for the contract for the BootstrapConfig resource:
   - Rename `status.ready` into `status.initialization.dataSecretCreated`.
 - Remove `failureReason` and `failureMessage`.
 
-| v1beta1 (CAPI 1.9)                                                    | v1beta2 (tentative Aug 2025)                                                                                                  | v1beta2 after v1beta1 removal (tentative Apr 2027)                                                   |
+| v1beta1 (CAPI 1.9)                                                    | v1beta2 (August 2025)                                                                                                         | v1beta2 after v1beta1 removal (tentative April 2027)                                                 |
 |-----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 | `status.ready`, required                                              | `status.ready` (deprecated), one of `status.ready` or `status.initialization.dataSecretCreated`, required                     | (removed)                                                                                            |
 |                                                                       | `status.initialization.dataSecretCreated` (new), one of `status.ready` or `status.initialization.dataSecretCreated`, required | `status.initialization.dataSecretCreated`, required                                                  |
@@ -1406,7 +1406,7 @@ type KubeadmControlPlaneInitializationStatus struct {
 }
 ```
 
-| v1beta1 (CAPI 1.9)                                                    | v1beta2 (tentative Aug 2025)                                                                                                                                          | v1beta2 after v1beta1 removal (tentative Apr 2027)                                                          |
+| v1beta1 (CAPI 1.9)                                                    | v1beta2 (August 2025)                                                                                                                                                 | v1beta2 after v1beta1 removal (tentative April 2027)                                                        |
 |-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
 | `status.ready`, required                                              | `status.ready` (deprecated), one of `status.ready` or `status.initialization.controlPlaneInitialized` required                                                        | (removed)                                                                                                   |
 |                                                                       | `status.initialization.controlPlaneInitialized` (renamed), one of `status.ready` or `status.initialization.controlPlaneInitialized` required                          | `status.initialization.controlPlaneInitialized`, required                                                   |
@@ -1478,13 +1478,13 @@ _Like any API change, this proposal will have impact on Cluster API users_
 Mitigations:
 
 This proposal abides to Kubernetes deprecation rules, and it also ensures isomorphic conversions to/from v1beta1 APIs
-can be supported (until v1beta1 removal, tentative Apr 2027).
+can be supported (until v1beta1 removal, tentative April 2027).
 
 On top of that, a few design decisions have been made with the specific intent to further minimize impact on
 users and providers e.g.
-- The decision to keep `Deprecated` fields in v1beta2 API (until v1beta1 removal, tentative Apr 2027).
+- The decision to keep `Deprecated` fields in v1beta2 API (until v1beta1 removal, tentative April 2027).
 - The decision to allow providers to adopt the Cluster API v1beta2 contract at their own pace (transition _must be completed_
-  before v1beta1 removal, tentative Apr 2027).
+  before v1beta1 removal, tentative April 2027).
 
 All in all, those decisions are consistent with the fact that in Cluster API we are already treating our APIs
 (and the Cluster API contract) as fully graduated APIs no matter if they are still beta.
@@ -1530,6 +1530,6 @@ Transition from v1beta1 API/contract to v1beta2 contract is detailed in previous
 - [x] 2024-07-17: Present proposal at a [community meeting](https://www.youtube.com/watch?v=frCg522ZfRQ)
   - [10000 feet overview](https://docs.google.com/presentation/d/1hhgCufOIuqHz6YR_RUPGo0uTjfm5YafjCb6JHY1_clY/edit?usp=sharing)
 - [x] 2024-09-16: Proposal approved
-- [x] 2025-01-30: v1beta2 tentative date moved from Apr 2025 to Aug 2025
+- [x] 2025-01-30: v1beta2 tentative date moved from April 2025 to August 2025
 - [x] 2025-07-28: align print columns to v1beta2 API
-- [x] 2026-03-02: v1beta1 removal tentative date moved from Aug 2026 to Apr 2027
+- [x] 2026-03-02: v1beta1 removal tentative date moved from August 2026 to April 2027

--- a/docs/proposals/20250124-From CAPD(docker) to CAPD(dev) .md
+++ b/docs/proposals/20250124-From CAPD(docker) to CAPD(dev) .md
@@ -160,7 +160,7 @@ Please note that at the end of phase 1
 
 Phase 2 consist of the actual removal of `DockerCluster`, `DockerMachine` and `DockerMachinePool`; this phase will happen after maintainers 
 will complete the transition of all the E2E tests to `DevCluster`, `DevMachine` and `DevMachinePool`; considering we have upgrade tests using
-older releases of CAPD, completing this phase would likely require a few release cycles, targeting tentatively Apr 2027.
+older releases of CAPD, completing this phase would likely require a few release cycles.
 
 ## Implementation History
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
As discussed in the CAPI office hours, providers needs some additional time for the transition to v1beta2 API/v1beta2 contract.

In order to help in this transition, with this PR I'm postponing the planned date for stopping serving v1beta1 API/remove the compatibility with the v1beta1 contract from Aug 26 to Apr 27.

With this second postponement, the overall duration of the transition to v1beta2 will last about 3 years, as documented in https://github.com/kubernetes-sigs/cluster-api/issues/11920

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area community
/area api