### PR TITLE
🌱  api: relax validation for Machine .status.addresses to maximum of 256 instead of 128 items

### DIFF
--- a/api/core/v1beta2/common_types.go
+++ b/api/core/v1beta2/common_types.go
@@ -309,7 +309,7 @@ type MachineAddress struct {
 }
 
 // MachineAddresses is a slice of MachineAddress items to be used by infrastructure providers.
-// +kubebuilder:validation:MaxItems=128
+// +kubebuilder:validation:MaxItems=256
 // +listType=atomic
 type MachineAddresses []MachineAddress
 

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -1048,7 +1048,7 @@ spec:
                   - address
                   - type
                   type: object
-                maxItems: 128
+                maxItems: 256
                 type: array
                 x-kubernetes-list-type: atomic
               certificatesExpiryDate:


### PR DESCRIPTION
… 
**What this PR does / why we need it**:

This PR relaxes even more the validation which was added in v1.11 to allow more entries in the Machine's .status.addresses slice.
- Before: maximum of 128 items
- After: maximum of 256 items

I've encountered this validation error while trying to upgrade a cluster from `1.32` to `1.34`. I did upgrade capi providers which introduced this initial validation in `v1.11`

I am using Azure's CNI as per my network provider with a `networkInterfaces.privateIPConfigs` of 180 and a `max-pods` of 180 in the kubeletExtraArgs opts.

In fact, the following error:
```
E0302 13:39:37.204234       1 controller.go:353] "Reconciler error" err="failed to patch Machine k991azc/k991azc-control-plane-btxqm: Machine.cluster.x-k8s.io \"k991azc-control-plane-btxqm\" is invalid: status.addresses: Too many: 181: must have at most 128 items" controller="machine" controllerGroup="cluster.x-k8s.io" controllerKind="Machine" Machine="k991azc/k991azc-control-plane-btxqm" namespace="k991azc" name="k991azc-control-plane-btxqm" reconcileID="cdaadd25-7728-44f1-9fa3-e09854d41ff6"
```

was blocking any kind of other patches ~ in my case, the nodeRef value allowing capi to understand a node has successfully rolled out. (with a side effect of never beeing able fully upgrade a cluster)

I am still not sure why they're putting all pods IPs inside the machine's `status.addresses` though...

This PR is a follow up of https://github.com/kubernetes-sigs/cluster-api/pull/13060

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area api