### PR TITLE
🌱 Remove stack traces from ClusterCache errors

### DIFF
--- a/controllers/clustercache/cluster_accessor.go
+++ b/controllers/clustercache/cluster_accessor.go
@@ -373,7 +373,7 @@ func (ca *clusterAccessor) GetClient(ctx context.Context) (client.Client, error)
 	defer ca.rUnlock(ctx)
 
 	if ca.lockedState.connection == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting client")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting client")
 	}
 
 	return ca.lockedState.connection.cachedClient, nil
@@ -384,7 +384,7 @@ func (ca *clusterAccessor) GetReader(ctx context.Context) (client.Reader, error)
 	defer ca.rUnlock(ctx)
 
 	if ca.lockedState.connection == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting client reader")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting client reader")
 	}
 
 	return ca.lockedState.connection.cachedClient, nil
@@ -396,7 +396,7 @@ func (ca *clusterAccessor) GetUncachedClient(ctx context.Context) (client.Client
 	defer ca.rUnlock(ctx)
 
 	if ca.lockedState.connection == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting uncached client")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting uncached client")
 	}
 
 	return ca.lockedState.connection.uncachedClient, nil
@@ -407,7 +407,7 @@ func (ca *clusterAccessor) GetRESTConfig(ctx context.Context) (*rest.Config, err
 	defer ca.rUnlock(ctx)
 
 	if ca.lockedState.connection == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting REST config")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting REST config")
 	}
 
 	return ca.lockedState.connection.restConfig, nil
@@ -423,7 +423,7 @@ func (ca *clusterAccessor) Watch(ctx context.Context, watcher Watcher) error {
 	}
 
 	if !ca.Connected(ctx) {
-		return errors.Wrapf(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
+		return errors.WithMessagef(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
 	}
 
 	log := ctrl.LoggerFrom(ctx)
@@ -436,7 +436,7 @@ func (ca *clusterAccessor) Watch(ctx context.Context, watcher Watcher) error {
 
 	// Checking connection again while holding the lock, because maybe Disconnect was called since checking above.
 	if ca.lockedState.connection == nil {
-		return errors.Wrapf(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
+		return errors.WithMessagef(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
 	}
 
 	// Return early if the watch was already added.
@@ -447,7 +447,7 @@ func (ca *clusterAccessor) Watch(ctx context.Context, watcher Watcher) error {
 
 	log.Info(fmt.Sprintf("Creating watch %s for %T", watcher.Name(), watcher.Object()))
 	if err := watcher.Watch(ca.lockedState.connection.cache); err != nil {
-		return errors.Wrapf(err, "error creating watch %s for %T", watcher.Name(), watcher.Object())
+		return errors.WithMessagef(err, "error creating watch %s for %T", watcher.Name(), watcher.Object())
 	}
 
 	ca.lockedState.connection.watches.Insert(watcher.Name())

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -180,7 +180,7 @@ type HealthCheckingState struct {
 
 // ErrClusterNotConnected is returned by the ClusterCache when e.g. a Client cannot be returned
 // because there is no connection to the workload cluster.
-var ErrClusterNotConnected = errors.New("connection to the workload cluster is down")
+var ErrClusterNotConnected = fmt.Errorf("connection to the workload cluster is down")
 
 // Watcher is an interface that can start a Watch.
 type Watcher interface {
@@ -326,7 +326,7 @@ func SetupWithManager(ctx context.Context, mgr manager.Manager, options Options,
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log, options.WatchFilterValue)).
 		Complete(cc)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed setting up ClusterCache with a controller manager")
+		return nil, errors.WithMessage(err, "failed setting up ClusterCache with a controller manager")
 	}
 
 	return cc, nil
@@ -377,7 +377,7 @@ type clusterSource struct {
 func (cc *clusterCache) GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
 	accessor := cc.getClusterAccessor(cluster)
 	if accessor == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting client")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting client")
 	}
 	return accessor.GetClient(ctx)
 }
@@ -385,7 +385,7 @@ func (cc *clusterCache) GetClient(ctx context.Context, cluster client.ObjectKey)
 func (cc *clusterCache) GetReader(ctx context.Context, cluster client.ObjectKey) (client.Reader, error) {
 	accessor := cc.getClusterAccessor(cluster)
 	if accessor == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting client reader")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting client reader")
 	}
 	return accessor.GetReader(ctx)
 }
@@ -395,7 +395,7 @@ func (cc *clusterCache) GetReader(ctx context.Context, cluster client.ObjectKey)
 func (cc *clusterCache) GetUncachedClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
 	accessor := cc.getClusterAccessor(cluster)
 	if accessor == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting uncached client")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting uncached client")
 	}
 	return accessor.GetUncachedClient(ctx)
 }
@@ -403,7 +403,7 @@ func (cc *clusterCache) GetUncachedClient(ctx context.Context, cluster client.Ob
 func (cc *clusterCache) GetRESTConfig(ctx context.Context, cluster client.ObjectKey) (*rest.Config, error) {
 	accessor := cc.getClusterAccessor(cluster)
 	if accessor == nil {
-		return nil, errors.Wrapf(ErrClusterNotConnected, "error getting REST config")
+		return nil, errors.WithMessage(ErrClusterNotConnected, "error getting REST config")
 	}
 	return accessor.GetRESTConfig(ctx)
 }
@@ -411,7 +411,7 @@ func (cc *clusterCache) GetRESTConfig(ctx context.Context, cluster client.Object
 func (cc *clusterCache) Watch(ctx context.Context, cluster client.ObjectKey, watcher Watcher) error {
 	accessor := cc.getClusterAccessor(cluster)
 	if accessor == nil {
-		return errors.Wrapf(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
+		return errors.WithMessagef(ErrClusterNotConnected, "error creating watch %s for %T", watcher.Name(), watcher.Object())
 	}
 	return accessor.Watch(ctx, watcher)
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->