### PR TITLE
🌱 Introduce conversion.MarshalDataUnsafeNoCopy to avoid unnecessary memory allocations during conversion

### DIFF
--- a/api/bootstrap/kubeadm/v1beta1/conversion.go
+++ b/api/bootstrap/kubeadm/v1beta1/conversion.go
@@ -230,7 +230,7 @@ func (dst *KubeadmConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	dropEmptyStringsKubeadmConfigStatus(&dst.Status)
 
 	// Preserve Hub data on down-conversion except for metadata.
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (dst *KubeadmConfigSpec) ConvertFrom(src *bootstrapv1.KubeadmConfigSpec) {
@@ -294,7 +294,7 @@ func (dst *KubeadmConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec.Template.Spec)
 
 	// Preserve Hub data on down-conversion except for metadata.
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func Convert_v1beta2_InitConfiguration_To_v1beta1_InitConfiguration(in *bootstrapv1.InitConfiguration, out *InitConfiguration, s apimachineryconversion.Scope) error {

--- a/api/controlplane/kubeadm/v1beta1/conversion.go
+++ b/api/controlplane/kubeadm/v1beta1/conversion.go
@@ -111,7 +111,7 @@ func (dst *KubeadmControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
 	dropEmptyStringsKubeadmControlPlaneStatus(&dst.Status)
 
 	// Preserve Hub data on down-conversion except for metadata.
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *KubeadmControlPlaneTemplate) ConvertTo(dstRaw conversion.Hub) error {
@@ -159,7 +159,7 @@ func (dst *KubeadmControlPlaneTemplate) ConvertFrom(srcRaw conversion.Hub) error
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec.Template.Spec.KubeadmConfigSpec)
 
 	// Preserve Hub data on down-conversion except for metadata.
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func Convert_v1beta2_KubeadmControlPlaneSpec_To_v1beta1_KubeadmControlPlaneSpec(in *controlplanev1.KubeadmControlPlaneSpec, out *KubeadmControlPlaneSpec, s apimachineryconversion.Scope) error {

--- a/api/core/v1beta1/conversion.go
+++ b/api/core/v1beta1/conversion.go
@@ -151,7 +151,7 @@ func (dst *Cluster) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dropEmptyStringsCluster(dst)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *ClusterClass) ConvertTo(dstRaw conversion.Hub) error {
@@ -407,7 +407,7 @@ func (dst *ClusterClass) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 	dropEmptyStringsClusterClass(dst)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
@@ -464,7 +464,7 @@ func (dst *Machine) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dropEmptyStringsMachineSpec(&dst.Spec)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *MachineSet) ConvertTo(dstRaw conversion.Hub) error {
@@ -513,7 +513,7 @@ func (dst *MachineSet) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dropEmptyStringsMachineSpec(&dst.Spec.Template.Spec)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
@@ -561,7 +561,7 @@ func (dst *MachineDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dropEmptyStringsMachineSpec(&dst.Spec.Template.Spec)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *MachineHealthCheck) ConvertTo(dstRaw conversion.Hub) error {
@@ -597,7 +597,7 @@ func (dst *MachineHealthCheck) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.RemediationTemplate.Namespace = src.Namespace
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
@@ -652,7 +652,7 @@ func (dst *MachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dropEmptyStringsMachineSpec(&dst.Spec.Template.Spec)
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *MachineDrainRule) ConvertTo(dstRaw conversion.Hub) error {

--- a/api/ipam/v1alpha1/conversion.go
+++ b/api/ipam/v1alpha1/conversion.go
@@ -113,10 +113,7 @@ func (dst *IPAddressClaim) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	// Preserve Hub data on down-conversion except for metadata
-	if err := utilconversion.MarshalData(src, dst); err != nil {
-		return err
-	}
-	return nil
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func Convert_v1alpha1_IPAddressSpec_To_v1beta2_IPAddressSpec(in *IPAddressSpec, out *ipamv1.IPAddressSpec, s apimachineryconversion.Scope) error {

--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -64,6 +64,9 @@ Any feedback or contributions to improve following documentation is welcome!
 
 ## Suggested changes for providers
 
+- A new `conversion.MarshalDataUnsafeNoCopy` func was introduced. The difference to `conversion.MarshalData` is that it mutates the passed in source object 
+  before marshaling to avoid additional memory allocations. Usually this is fine because this func is used at the end of `ConvertFrom` methods. Accordingly,
+  we recommend to start using this new func, except if it's not safe in your circumstances.
 - If you are developing a control plane provider with support for machines, please consider adding `spec.machineTemplate.spec.taints` (see [contract](../contracts/control-plane.md#controlplane-machines))
 - Cluster API bumped the default values of `--kube-api-qps` & `--kube-api-burst` to 100/200 in [CAPI-13317](https://github.com/kubernetes-sigs/cluster-api/pull/13317). You might want to consider doing the same.
 

--- a/internal/topology/upgrade/test/t2/v1beta1/conversion.go
+++ b/internal/topology/upgrade/test/t2/v1beta1/conversion.go
@@ -61,7 +61,7 @@ func (dst *TestResourceTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	if dst.Spec.Template.Spec.PtrStringToString != nil && *dst.Spec.Template.Spec.PtrStringToString == "" {
 		dst.Spec.Template.Spec.PtrStringToString = nil
 	}
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *TestResource) ConvertTo(dstRaw conversion.Hub) error {
@@ -99,7 +99,7 @@ func (dst *TestResource) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.PtrStringToString = nil
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func Convert_v1beta1_TestResourceSpec_To_v1beta2_TestResourceSpec(in *TestResourceSpec, out *testv1.TestResourceSpec, s apimachineryconversion.Scope) error {

--- a/test/infrastructure/docker/api/v1beta1/conversion.go
+++ b/test/infrastructure/docker/api/v1beta1/conversion.go
@@ -64,7 +64,7 @@ func (dst *DockerCluster) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DockerClusterTemplate) ConvertTo(dstRaw conversion.Hub) error {
@@ -117,7 +117,7 @@ func (dst *DockerMachine) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.ProviderID = nil
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DockerMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
@@ -152,7 +152,7 @@ func (dst *DockerMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.Template.Spec.ProviderID = nil
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DevCluster) ConvertTo(dstRaw conversion.Hub) error {
@@ -187,7 +187,7 @@ func (dst *DevCluster) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DevClusterTemplate) ConvertTo(dstRaw conversion.Hub) error {
@@ -241,7 +241,7 @@ func (dst *DevMachine) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.ProviderID = nil
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DevMachineTemplate) ConvertTo(dstRaw conversion.Hub) error {
@@ -276,7 +276,7 @@ func (dst *DevMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 		dst.Spec.Template.Spec.ProviderID = nil
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func Convert_v1beta1_ObjectMeta_To_v1beta2_ObjectMeta(in *clusterv1beta1.ObjectMeta, out *clusterv1.ObjectMeta, s apiconversion.Scope) error {
@@ -703,7 +703,7 @@ func (dst *DockerMachinePool) ConvertFrom(srcRaw conversion.Hub) error {
 		clusterv1beta1.Convert_v1beta2_Deprecated_V1Beta1_Conditions_To_v1beta1_Conditions(&src.Status.Deprecated.V1Beta1.Conditions, &dst.Status.Conditions)
 	}
 
-	return utilconversion.MarshalData(src, dst)
+	return utilconversion.MarshalDataUnsafeNoCopy(src, dst)
 }
 
 func (src *DockerMachinePoolTemplate) ConvertTo(dstRaw conversion.Hub) error {

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -18,6 +18,7 @@ limitations under the License.
 package conversion
 
 import (
+	"bytes"
 	"maps"
 	"math/rand"
 	"testing"
@@ -57,6 +58,47 @@ func MarshalData(src metav1.Object, dst metav1.Object) error {
 	if err != nil {
 		return err
 	}
+	annotations := dst.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[DataAnnotation] = string(data)
+	dst.SetAnnotations(annotations)
+	return nil
+}
+
+// MarshalDataUnsafeNoCopy stores the source object as json data in the destination object annotations map.
+// It ignores the metadata of the source object.
+// Note: It also mutates the metadata of the source object.
+func MarshalDataUnsafeNoCopy(src metav1.Object, dst metav1.Object) error {
+	// Remove metadata as it's not needed in the conversion annotation.
+	// Note: Directly modifying src to avoid additional memory allocations
+	// This is fine because MarshalDataUnsafeNoCopy is called at the end of ConvertFrom.
+	src.SetNamespace("")
+	src.SetName("")
+	src.SetGenerateName("")
+	src.SetUID("")
+	src.SetResourceVersion("")
+	src.SetGeneration(0)
+	src.SetSelfLink("")
+	src.SetCreationTimestamp(metav1.Time{})
+	src.SetDeletionTimestamp(nil)
+	src.SetDeletionGracePeriodSeconds(nil)
+	src.SetLabels(nil)
+	src.SetAnnotations(nil)
+	src.SetFinalizers(nil)
+	src.SetOwnerReferences(nil)
+	src.SetManagedFields(nil)
+
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	// If omitzero is not set on the ObjectMeta field the above is not enough to avoid metadata entirely.
+	// So we also have to remove an empty metadata element if it exists.
+	data = bytes.Replace(data, []byte(`"metadata":{},`), []byte(``), 1)
+
 	annotations := dst.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -199,7 +241,9 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 
 				// First convert hub to spoke
 				dstCopy := input.Spoke.DeepCopyObject().(conversion.Convertible)
-				g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+				// DeepCopy hubBefore because otherwise the mutations in MarshalDataUnsafeNoCopy would affect
+				// hubBefore and accordingly the comparison between hubBefore and hubAfter below.
+				g.Expect(dstCopy.ConvertFrom(hubBefore.DeepCopyObject().(conversion.Hub))).To(gomega.Succeed())
 
 				// Note: The check here is needed because not all runtime.Objects are metav1.Objects (e.g. CABPK ClusterConfiguration)
 				if _, ok := dstCopy.(metav1.Object); ok {

--- a/util/conversion/conversion_test.go
+++ b/util/conversion/conversion_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
@@ -36,9 +37,9 @@ var (
 )
 
 func TestMarshalData(t *testing.T) {
-	g := NewWithT(t)
+	t.Run("MarshalData should write source object to destination", func(*testing.T) {
+		g := NewWithT(t)
 
-	t.Run("should write source object to destination", func(*testing.T) {
 		version := "v1.16.4"
 		providerID := "aws://some-id"
 		src := &clusterv1.Machine{
@@ -71,7 +72,66 @@ func TestMarshalData(t *testing.T) {
 		g.Expect(dst.GetAnnotations()[DataAnnotation]).ToNot(ContainSubstring("label1"))
 	})
 
-	t.Run("should append the annotation", func(*testing.T) {
+	t.Run("MarshalDataUnsafeNoCopy should write source object to destination", func(t *testing.T) {
+		g := NewWithT(t)
+
+		version := "v1.16.4"
+		providerID := "aws://some-id"
+		src := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:                       "test-1",
+				GenerateName:               "test-",
+				Namespace:                  "default",
+				SelfLink:                   "test",
+				UID:                        "123456",
+				ResourceVersion:            "123",
+				Generation:                 15,
+				CreationTimestamp:          metav1.Now(),
+				DeletionTimestamp:          ptr.To(metav1.Now()),
+				DeletionGracePeriodSeconds: ptr.To[int64](10),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "test/v1beta1",
+					Kind:       "TestKind",
+					Name:       "name",
+					UID:        "1234567",
+				}},
+				Finalizers: []string{"finalizer"},
+				ManagedFields: []metav1.ManagedFieldsEntry{
+					{
+						Manager: "test-manager",
+					},
+				},
+				Labels: map[string]string{
+					"label1": "",
+				},
+				Annotations: map[string]string{
+					"annotation1": "",
+				},
+			},
+			Spec: clusterv1.MachineSpec{
+				ClusterName: "test-cluster",
+				Version:     version,
+				ProviderID:  providerID,
+			},
+		}
+
+		dst := &unstructured.Unstructured{}
+		dst.SetGroupVersionKind(oldMachineGVK)
+		dst.SetName("test-1")
+
+		g.Expect(MarshalDataUnsafeNoCopy(src, dst)).To(Succeed())
+
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).ToNot(BeEmpty())
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).To(ContainSubstring("test-cluster"))
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).To(ContainSubstring(version))
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).To(ContainSubstring(providerID))
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).ToNot(ContainSubstring("metadata"))
+		g.Expect(dst.GetAnnotations()[DataAnnotation]).ToNot(ContainSubstring("label1"))
+	})
+
+	t.Run("MarshalData should append the annotation", func(*testing.T) {
+		g := NewWithT(t)
+
 		src := &clusterv1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -85,6 +145,25 @@ func TestMarshalData(t *testing.T) {
 		})
 
 		g.Expect(MarshalData(src, dst)).To(Succeed())
+		g.Expect(dst.GetAnnotations()).To(HaveLen(2))
+	})
+
+	t.Run("MarshalDataUnsafeNoCopy should append the annotation", func(*testing.T) {
+		g := NewWithT(t)
+
+		src := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-1",
+			},
+		}
+		dst := &unstructured.Unstructured{}
+		dst.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("Machine"))
+		dst.SetName("test-1")
+		dst.SetAnnotations(map[string]string{
+			"annotation": "1",
+		})
+
+		g.Expect(MarshalDataUnsafeNoCopy(src, dst)).To(Succeed())
 		g.Expect(dst.GetAnnotations()).To(HaveLen(2))
 	})
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->