### PR TITLE
🌱 Add safeguard to patchHelper to avoid sending empty patches to the apiserver

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package patch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"reflect"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -201,7 +203,17 @@ func (h *Helper) patch(ctx context.Context, obj client.Object) error {
 	if err != nil {
 		return err
 	}
-	return h.client.Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+
+	// Check for empty patches as a safeguard to avoid continuously sending empty patches to the apiserver.
+	data, err := client.MergeFrom(beforeObject).Data(afterObject)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(data, []byte("{}")) {
+		return nil
+	}
+
+	return h.client.Patch(ctx, afterObject, client.RawPatch(types.MergePatchType, data))
 }
 
 // patchStatus issues a patch if the status has changed.
@@ -213,7 +225,22 @@ func (h *Helper) patchStatus(ctx context.Context, obj client.Object) error {
 	if err != nil {
 		return err
 	}
-	return h.client.Status().Patch(ctx, afterObject, client.MergeFrom(beforeObject))
+
+	// Check for empty patches as a safeguard to avoid continuously sending empty patches to the apiserver.
+	// Additionally, there is a known case that if there are only changes for status.conditions
+	// patchStatus is accidentally executed as well because of limitations of calculateChanges.
+	data, err := client.MergeFrom(beforeObject).Data(afterObject)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(data, []byte("{}")) ||
+		// The following two cases occur if conditions are written for the first time on an object.
+		bytes.Equal(data, []byte(`{"status":{"v1beta2":{}}}`)) ||
+		bytes.Equal(data, []byte(`{"status":{"deprecated":{"v1beta1":{}}}}`)) {
+		return nil
+	}
+
+	return h.client.Status().Patch(ctx, afterObject, client.RawPatch(types.MergePatchType, data))
 }
 
 // patchStatusConditions issues a patch if there are any changes to the conditions slice under

--- a/util/patch/test/patch_test.go
+++ b/util/patch/test/patch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,6 +51,56 @@ func TestPatchHelper(t *testing.T) {
 		}
 	}()
 
+	t.Run("Should not send empty spec or status patches", func(t *testing.T) {
+		g := NewWithT(t)
+		cl := &countingClient{Client: env.Client}
+
+		obj := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cluster-patch-test-",
+				Namespace:    ns.Name,
+				Annotations: map[string]string{
+					"test": "1",
+				},
+			},
+			Spec: clusterv1.ClusterSpec{
+				InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+					APIGroup: "foo.cluster.x-k8s.io",
+					Kind:     "TestCluster",
+					Name:     "infra-1",
+				},
+			},
+		}
+
+		t.Log("Creating a Cluster object")
+		g.Expect(env.Create(ctx, obj)).To(Succeed())
+		defer func() {
+			g.Expect(env.Delete(ctx, obj)).To(Succeed())
+		}()
+		key := client.ObjectKeyFromObject(obj)
+
+		t.Log("Checking that the object has been created")
+		g.Eventually(func() error {
+			obj := obj.DeepCopy()
+			return env.Get(ctx, key, obj)
+		}).Should(Succeed())
+
+		t.Log("Creating a new patch helper")
+		patcher, err := patch.NewHelper(obj, cl)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		t.Log("Setting an empty array in spec (to verify spec no-op safeguard")
+		obj.Spec.Topology.Variables = []clusterv1.ClusterVariable{}
+
+		t.Log("Setting an empty array in status (to verify status no-op safeguard")
+		obj.Status.FailureDomains = []clusterv1.FailureDomain{}
+
+		t.Log("Patching the Cluster (no Patch calls are expected)")
+		g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+		g.Expect(cl.specPatchCalls).To(Equal(0))
+		g.Expect(cl.statusPatchCalls).To(Equal(0))
+	})
+
 	t.Run("should patch an unstructured object", func(t *testing.T) {
 		obj := &unstructured.Unstructured{
 			Object: map[string]interface{}{
@@ -64,6 +115,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("adding an owner reference, preserving its status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			t.Log("Creating the unstructured object")
 			g.Expect(env.Create(ctx, obj)).To(Succeed())
@@ -84,7 +136,7 @@ func TestPatchHelper(t *testing.T) {
 			g.Expect(env.Status().Update(ctx, obj)).To(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Modifying the OwnerReferences")
@@ -100,6 +152,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the unstructured object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating that the status has been preserved")
 			ready, err := external.IsReady(obj)
@@ -120,6 +174,7 @@ func TestPatchHelper(t *testing.T) {
 	t.Run("Should patch conditions", func(t *testing.T) {
 		t.Run("on a corev1.Node object", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			conditionTime := metav1.Date(2015, 1, 1, 12, 0, 0, 0, metav1.Now().Location())
 			obj := &corev1.Node{
@@ -146,7 +201,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Appending a new condition")
@@ -162,6 +217,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the Node")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -190,6 +247,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should mark it ready", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -207,7 +265,7 @@ func TestPatchHelper(t *testing.T) {
 				}).Should(Succeed())
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Marking Ready=True")
@@ -215,6 +273,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(0))
+				g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 				t.Log("Validating the object has been updated")
 				g.Eventually(func() []metav1.Condition {
@@ -228,6 +288,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -254,7 +315,7 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Marking Ready=True")
@@ -262,6 +323,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(0))
+				g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 				t.Log("Validating the object has been updated")
 				g.Eventually(func() bool {
@@ -296,6 +359,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should recover if there is a resolvable conflict, incl. patch spec and status", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -322,7 +386,7 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Changing the object spec, status, and adding Ready=True condition")
@@ -334,6 +398,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(1))
+				g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 				t.Log("Validating the object has been updated")
 				objAfter := obj.DeepCopy()
@@ -370,6 +436,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should return an error if there is an unresolvable conflict", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -396,7 +463,7 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Marking Ready=True")
@@ -404,6 +471,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(0))
+				g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 				t.Log("Validating the object has not been updated")
 				g.Eventually(func() bool {
@@ -425,6 +494,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -451,7 +521,7 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Marking Ready=True")
@@ -459,6 +529,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj, patch.WithOwnedConditions{Conditions: []string{"Ready"}})).To(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(0))
+				g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 				t.Log("Validating the object has been updated")
 				readyBefore := conditions.Get(obj, "Ready")
@@ -474,6 +546,7 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
 				g := NewWithT(t)
+				cl := &countingClient{Client: env.Client}
 
 				obj := obj.DeepCopy()
 
@@ -500,7 +573,7 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 				t.Log("Creating a new patch helper")
-				patcher, err := patch.NewHelper(obj, env)
+				patcher, err := patch.NewHelper(obj, cl)
 				g.Expect(err).ToNot(HaveOccurred())
 
 				t.Log("Marking Ready=True")
@@ -508,6 +581,8 @@ func TestPatchHelper(t *testing.T) {
 
 				t.Log("Patching the object")
 				g.Expect(patcher.Patch(ctx, obj, patch.WithForceOverwriteConditions{})).To(Succeed())
+				g.Expect(cl.specPatchCalls).To(Equal(0))
+				g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 				t.Log("Validating the object has been updated")
 				readyBefore := conditions.Get(obj, "Ready")
@@ -540,6 +615,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("add a finalizer", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -557,7 +633,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Adding a finalizer")
@@ -565,6 +641,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -579,6 +657,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("removing finalizers", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 			obj.Finalizers = append(obj.Finalizers, clusterv1.ClusterFinalizer)
@@ -597,7 +676,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Removing the finalizers")
@@ -605,6 +684,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -619,6 +700,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("updating spec", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -636,7 +718,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object spec")
@@ -649,6 +731,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -664,6 +748,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("updating status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -681,7 +766,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object status")
@@ -689,6 +774,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -702,6 +789,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("updating both spec, status, and adding a condition", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -719,7 +807,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object spec")
@@ -738,6 +826,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -755,6 +845,7 @@ func TestPatchHelper(t *testing.T) {
 
 	t.Run("should patch a corev1.ConfigMap object", func(t *testing.T) {
 		g := NewWithT(t)
+		cl := &countingClient{Client: env.Client}
 
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -783,7 +874,7 @@ func TestPatchHelper(t *testing.T) {
 		}).Should(Succeed())
 
 		t.Log("Creating a new patch helper")
-		patcher, err := patch.NewHelper(obj, env)
+		patcher, err := patch.NewHelper(obj, cl)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		t.Log("Adding a new Data value")
@@ -792,6 +883,8 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Log("Patching the ConfigMap")
 		g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+		g.Expect(cl.specPatchCalls).To(Equal(1))
+		g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 		t.Log("Validating the object has been updated")
 		objAfter := &corev1.ConfigMap{}
@@ -829,6 +922,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("when updating spec", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -846,7 +940,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object spec")
@@ -854,6 +948,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithStatusObservedGeneration{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -869,6 +965,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("when updating spec, status, and metadata", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -886,7 +983,7 @@ func TestPatchHelper(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Updating the object spec")
@@ -903,6 +1000,8 @@ func TestPatchHelper(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithStatusObservedGeneration{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -919,6 +1018,7 @@ func TestPatchHelper(t *testing.T) {
 
 		t.Run("without any changes", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -940,11 +1040,13 @@ func TestPatchHelper(t *testing.T) {
 			g.Expect(env.Status().Update(ctx, obj)).To(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithStatusObservedGeneration{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -1071,6 +1173,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1089,7 +1192,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1097,6 +1200,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -1110,6 +1215,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready when passing Clusterv1ConditionsFieldPath", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1128,7 +1234,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1136,6 +1242,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.Clusterv1ConditionsFieldPath{"status", "conditions"})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -1149,6 +1257,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1175,7 +1284,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1183,6 +1292,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -1217,6 +1328,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict, incl. patch spec and status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1243,7 +1355,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Changing the object spec, status, and adding Ready=True condition")
@@ -1253,6 +1365,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 			t.Log("Validating the object has been updated")
 			objAfter := obj.DeepCopy()
@@ -1288,6 +1402,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1314,7 +1429,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1322,6 +1437,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() bool {
@@ -1343,6 +1460,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict but the condition is owned by the controller", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1369,7 +1487,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1377,6 +1495,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{clusterv1.ConditionType("Ready")}})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			readyBefore := v1beta1conditions.Get(obj, clusterv1.ConditionType("Ready"))
@@ -1392,6 +1512,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1418,7 +1539,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1426,6 +1547,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithForceOverwriteConditions{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			readyBefore := v1beta1conditions.Get(obj, clusterv1.ConditionType("Ready"))
@@ -1450,6 +1573,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready and sort conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1469,7 +1593,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			// Adding Ready first
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking clusterv1.conditions and metav1.conditions Ready=True")
@@ -1478,10 +1602,13 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			// Adding Available as a second condition, but it should be sorted as first
 			t.Log("Creating a new patch helper")
-			patcher, err = patch.NewHelper(obj, env)
+			cl = &countingClient{Client: env.Client}
+			patcher, err = patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking metav1.conditions Available=True")
@@ -1489,6 +1616,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -1516,6 +1645,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready when passing Clusterv1ConditionsFieldPath and Metav1ConditionsFieldPath", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1534,7 +1664,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking clusterv1.conditions and metav1.conditions Ready=True")
@@ -1543,6 +1673,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.Clusterv1ConditionsFieldPath{"status", "conditions"}, patch.Metav1ConditionsFieldPath{"status", "v1beta2", "conditions"})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -1563,6 +1695,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1590,7 +1723,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking clusterv1.conditions and metav1.conditions Ready=True")
@@ -1599,6 +1732,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -1653,6 +1788,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict, incl. patch spec and status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1680,7 +1816,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Changing the object spec, status, and marking clusterv1.condition and metav1.conditions Ready=True")
@@ -1691,6 +1827,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 			t.Log("Validating the object has been updated")
 			objAfter := obj.DeepCopy()
@@ -1747,6 +1885,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict on conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1773,7 +1912,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -1781,6 +1920,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -1794,6 +1935,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict on v1beta2.conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1820,7 +1962,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -1828,6 +1970,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() *builder.Phase1ObjV1Beta2Status {
@@ -1841,6 +1985,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1868,7 +2013,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready clusterv1.condition and metav1.conditions True")
@@ -1877,6 +2022,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{clusterv1.ConditionType("Ready")}}, patch.WithOwnedConditions{Conditions: []string{"Ready"}})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -1911,6 +2058,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -1938,7 +2086,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready clusterv1.condition and metav1.conditions True")
@@ -1947,6 +2095,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithForceOverwriteConditions{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -1990,6 +2140,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready and sort conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2009,7 +2160,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			// Adding Ready first
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition and back compatibility condition Ready=True")
@@ -2018,10 +2169,13 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			// Adding Available as a second condition, but it should be sorted as first
 			t.Log("Creating a new patch helper")
-			patcher, err = patch.NewHelper(obj, env)
+			cl = &countingClient{Client: env.Client}
+			patcher, err = patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Available=True")
@@ -2029,6 +2183,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -2056,6 +2212,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready when passing Clusterv1ConditionsFieldPath and Metav1ConditionsFieldPath", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2074,7 +2231,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition and back compatibility condition Ready=True")
@@ -2083,6 +2240,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.Clusterv1ConditionsFieldPath{"status", "deprecated", "v1beta1", "conditions"}, patch.Metav1ConditionsFieldPath{"status", "conditions"})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -2103,6 +2262,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2130,7 +2290,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition and back compatibility condition Ready=True")
@@ -2139,6 +2299,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2193,6 +2355,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict, incl. patch spec and status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2220,7 +2383,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Changing the object spec, status, and marking condition and back compatibility condition Ready=True")
@@ -2231,6 +2394,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 			t.Log("Validating the object has been updated")
 			objAfter := obj.DeepCopy()
@@ -2287,6 +2452,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict on back compatibility conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2313,7 +2479,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready=True")
@@ -2321,6 +2487,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() clusterv1.Conditions {
@@ -2334,6 +2502,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict on conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2360,7 +2529,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -2368,6 +2537,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() []metav1.Condition {
@@ -2381,6 +2552,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2408,7 +2580,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready condition and back compatibility condition True")
@@ -2417,6 +2589,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{clusterv1.ConditionType("Ready")}}, patch.WithOwnedConditions{Conditions: []string{"Ready"}})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2451,6 +2625,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2478,7 +2653,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready condition and back compatibility condition True")
@@ -2487,6 +2662,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithForceOverwriteConditions{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2530,6 +2707,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready and sort conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2549,7 +2727,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			// Adding Ready first
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -2557,10 +2735,13 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			// Adding Available as a second condition, but it should be sorted as first
 			t.Log("Creating a new patch helper")
-			patcher, err = patch.NewHelper(obj, env)
+			cl = &countingClient{Client: env.Client}
+			patcher, err = patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Available=True")
@@ -2568,6 +2749,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() []metav1.Condition {
@@ -2588,6 +2771,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should mark it ready when passing Metav1ConditionsFieldPath", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2606,7 +2790,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}).Should(Succeed())
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -2614,6 +2798,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.Metav1ConditionsFieldPath{"status", "conditions"})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() []metav1.Condition {
@@ -2627,6 +2813,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2653,7 +2840,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -2661,6 +2848,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2695,6 +2884,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should recover if there is a resolvable conflict, incl. patch spec and status", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2721,7 +2911,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Changing the object spec, status, and marking condition Ready=True")
@@ -2731,6 +2921,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(1))
+			g.Expect(cl.statusPatchCalls).To(Equal(2))
 
 			t.Log("Validating the object has been updated")
 			objAfter := obj.DeepCopy()
@@ -2767,6 +2959,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should return an error if there is an unresolvable conflict on conditions", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2793,7 +2986,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking condition Ready=True")
@@ -2801,6 +2994,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj)).NotTo(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(0))
 
 			t.Log("Validating the object has not been updated")
 			g.Eventually(func() []metav1.Condition {
@@ -2814,6 +3009,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2840,7 +3036,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready condition True")
@@ -2848,6 +3044,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithOwnedConditions{Conditions: []string{"Ready"}})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2872,6 +3070,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 		t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
 			g := NewWithT(t)
+			cl := &countingClient{Client: env.Client}
 
 			obj := obj.DeepCopy()
 
@@ -2898,7 +3097,7 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			g.Expect(obj.ResourceVersion).NotTo(Equal(objCopy.ResourceVersion))
 
 			t.Log("Creating a new patch helper")
-			patcher, err := patch.NewHelper(obj, env)
+			patcher, err := patch.NewHelper(obj, cl)
 			g.Expect(err).ToNot(HaveOccurred())
 
 			t.Log("Marking Ready condition True")
@@ -2906,6 +3105,8 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 
 			t.Log("Patching the object")
 			g.Expect(patcher.Patch(ctx, obj, patch.WithForceOverwriteConditions{})).To(Succeed())
+			g.Expect(cl.specPatchCalls).To(Equal(0))
+			g.Expect(cl.statusPatchCalls).To(Equal(1))
 
 			t.Log("Validating the object has been updated")
 			g.Eventually(func() bool {
@@ -2928,4 +3129,36 @@ func TestPatchHelperForV1beta2Transition(t *testing.T) {
 			}, timeout).Should(BeTrue())
 		})
 	})
+}
+
+type countingClient struct {
+	client.Client
+	specPatchCalls   int
+	statusPatchCalls int
+}
+
+func (c *countingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	c.specPatchCalls++
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+type countingSubResourceClient struct {
+	*countingClient
+	client.SubResourceClient
+}
+
+func (c *countingClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *countingClient) SubResource(subResource string) client.SubResourceClient {
+	return &countingSubResourceClient{
+		countingClient:    c,
+		SubResourceClient: c.Client.SubResource(subResource),
+	}
+}
+
+func (c *countingSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	c.countingClient.statusPatchCalls++
+	return c.SubResourceClient.Patch(ctx, obj, patch, opts...)
 }

--- a/util/patch/utils.go
+++ b/util/patch/utils.go
@@ -35,14 +35,6 @@ const (
 	statusPatch patchType = "status"
 )
 
-var (
-	preserveUnstructuredKeys = map[string]bool{
-		"kind":       true,
-		"apiVersion": true,
-		"metadata":   true,
-	}
-)
-
 // toUnstructured converts an object to Unstructured.
 // We have to pass in a gvk as we can't rely on GVK being set in a runtime.Object.
 func toUnstructured(obj runtime.Object, gvk schema.GroupVersionKind) (*unstructured.Unstructured, error) {
@@ -69,10 +61,15 @@ func toUnstructured(obj runtime.Object, gvk schema.GroupVersionKind) (*unstructu
 func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, clusterv1ConditionsFieldPath, metav1ConditionsFieldPath []string) *unstructured.Unstructured {
 	// Create the return focused-unstructured object with a preallocated map.
 	res := &unstructured.Unstructured{Object: make(map[string]interface{}, len(obj.Object))}
+	// Ensure the minimum relevant fields are always set (especially when focus is statusPatch)
+	res.SetGroupVersionKind(obj.GroupVersionKind())
+	res.SetNamespace(obj.GetNamespace())
+	res.SetName(obj.GetName())
+	res.SetResourceVersion(obj.GetResourceVersion())
 
 	// Ranges over the keys of the unstructured object, think of this as the very top level of an object
 	// when submitting a yaml to kubectl or a client.
-	// These would be keys like `apiVersion`, `kind`, `metadata`, `spec`, `status`, etc.
+	// These would be keys like `metadata`, `spec`, `status`, etc.
 	for key := range obj.Object {
 		value := obj.Object[key]
 
@@ -80,16 +77,15 @@ func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, clu
 		switch focus {
 		case specPatch:
 			// For what we define as `spec` fields, we should preserve everything
-			// that's not `status`.
+			// that's not `status` including things like metadata and data (e.g. for Secrets).
 			preserve = key != string(statusPatch)
 		case statusPatch:
 			// For status, only preserve the status fields.
 			preserve = key == string(focus)
 		}
 
-		// Perform a shallow copy only for the keys we're interested in,
-		// or the ones that should be always preserved (like metadata).
-		if preserve || preserveUnstructuredKeys[key] {
+		// Perform a shallow copy only for the keys we're interested in.
+		if preserve {
 			res.Object[key] = value
 		}
 	}


### PR DESCRIPTION


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->