### PR TITLE
🐛 Fix UpToDate calculation for rolloutAfter

### DIFF
--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -690,11 +690,9 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 
 	upToDate, notUpToDateResult := mdutil.MachineTemplateUpToDate(current, desired)
 
-	if !md.Spec.Rollout.After.IsZero() {
-		if md.Spec.Rollout.After.Time.Before(time.Now()) && !ms.CreationTimestamp.After(md.Spec.Rollout.After.Time) {
-			upToDate = false
-			notUpToDateResult.ConditionMessages = append(notUpToDateResult.ConditionMessages, "MachineDeployment spec.rolloutAfter expired")
-		}
+	if !md.Spec.Rollout.After.IsZero() && md.Spec.Rollout.After.Before(ptr.To(metav1.Now())) && ms.CreationTimestamp.Before(ptr.To(md.Spec.Rollout.After)) {
+		upToDate = false
+		notUpToDateResult.ConditionMessages = append(notUpToDateResult.ConditionMessages, "MachineDeployment spec.rolloutAfter expired")
 	}
 
 	if !upToDate {

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -1652,6 +1652,39 @@ func TestSetUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "up-to-date, rollout After expired and a new MS created at rollout after time",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Rollout: clusterv1.MachineDeploymentRolloutSpec{
+						After: metav1.Time{Time: reconciliationTime.Add(-1 * time.Hour)}, // rollout after expired
+					},
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.Time{Time: reconciliationTime.Add(-1 * time.Hour)}, // MS created at rollout after
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{},
+			expectCondition: &metav1.Condition{
+				Type:   clusterv1.MachineUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachineUpToDateReason,
+			},
+		},
+		{
 			name: "not up-to-date, rollout After expired",
 			machineDeployment: &clusterv1.MachineDeployment{
 				Spec: clusterv1.MachineDeploymentSpec{

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -477,7 +477,7 @@ func FindNewAndOldMachineSets(deployment *clusterv1.MachineDeployment, msList []
 		} else {
 			oldMSs = append(oldMSs, ms)
 			// Override the EligibleForInPlaceUpdate decision if rollout after is expired.
-			if !deployment.Spec.Rollout.After.IsZero() && deployment.Spec.Rollout.After.Before(&reconciliationTime) && !ms.CreationTimestamp.After(deployment.Spec.Rollout.After.Time) {
+			if !deployment.Spec.Rollout.After.IsZero() && deployment.Spec.Rollout.After.Before(&reconciliationTime) && ms.CreationTimestamp.Before(ptr.To(deployment.Spec.Rollout.After)) {
 				upToDateResult.EligibleForInPlaceUpdate = false
 				upToDateResult.LogMessages = append(upToDateResult.LogMessages, "MachineDeployment spec.rolloutAfter expired")
 				// No need to set an additional condition message, it is not used anywhere.
@@ -517,7 +517,7 @@ func FindNewAndOldMachineSets(deployment *clusterv1.MachineDeployment, msList []
 
 	// Pick the first matching MachineSet that has been created at RolloutAfter or later.
 	for _, ms := range newMSCandidates {
-		if newMS == nil && ms.CreationTimestamp.Sub(deployment.Spec.Rollout.After.Time) >= 0 {
+		if newMS == nil && !ms.CreationTimestamp.Before(ptr.To(deployment.Spec.Rollout.After)) {
 			newMS = ms
 			continue
 		}

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -425,11 +425,17 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 	oldMSCreatedThreeBeforeRolloutAfter := *oldMS.DeepCopy()
 	oldMSCreatedThreeBeforeRolloutAfter.CreationTimestamp = threeBeforeRolloutAfter
 
+	oldMSCreatedAtRolloutAfter := *oldMS.DeepCopy()
+	oldMSCreatedAtRolloutAfter.CreationTimestamp = rolloutAfter
+
 	msCreatedThreeBeforeRolloutAfter := generateMS(deployment)
 	msCreatedThreeBeforeRolloutAfter.CreationTimestamp = threeBeforeRolloutAfter
 
 	msCreatedTwoBeforeRolloutAfter := generateMS(deployment)
 	msCreatedTwoBeforeRolloutAfter.CreationTimestamp = twoBeforeRolloutAfter
+
+	msCreatedAtRolloutAfter := generateMS(deployment)
+	msCreatedAtRolloutAfter.CreationTimestamp = rolloutAfter
 
 	msCreatedAfterRolloutAfter := generateMS(deployment)
 	msCreatedAfterRolloutAfter.CreationTimestamp = oneAfterRolloutAfter
@@ -574,6 +580,26 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s needs rollout: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required, MachineDeployment spec.rolloutAfter expired`, oldMS.Name),
 		},
 		{
+			Name:               "Get nil if no MachineSet matches the desired intent of the MachineDeployment, reconciliationTime is > rolloutAfter, MachineSet created at rolloutAfter",
+			deployment:         *deploymentWithRolloutAfter,
+			msList:             []*clusterv1.MachineSet{&oldMSCreatedAtRolloutAfter},
+			reconciliationTime: oneAfterRolloutAfter,
+			expectedNewMS:      nil,
+			expectedOldMSs:     []*clusterv1.MachineSet{&oldMSCreatedAtRolloutAfter},
+			expectedUpToDateResults: map[string]UpToDateResult{
+				oldMS.Name: {
+					ConditionMessages: []string{"InfrastructureMachine is not up-to-date"},
+					LogMessages: []string{
+						// No additional message must be added to old machine sets when reconciliationTime is > rolloutAfter but MachineSet is created at rolloutAfter.
+						"spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required",
+					},
+					// EligibleForInPlaceUpdate decision should not change for oldMS when reconciliationTime is > rolloutAfter but MachineSet is created at rolloutAfter.
+					EligibleForInPlaceUpdate: true,
+				},
+			},
+			expectedCreateReason: fmt.Sprintf(`couldn't find MachineSet matching MachineDeployment spec template: MachineSet %s needs rollout: spec.infrastructureRef InfrastructureMachineTemplate old-infra-ref, InfrastructureMachineTemplate new-infra-ref required`, oldMS.Name),
+		},
+		{
 			Name:               "Get the MachineSet if reconciliationTime < rolloutAfter",
 			deployment:         *deploymentWithRolloutAfter,
 			msList:             []*clusterv1.MachineSet{&msCreatedTwoBeforeRolloutAfter, &msCreatedThreeBeforeRolloutAfter},
@@ -628,6 +654,22 @@ func TestFindNewAndOldMachineSets(t *testing.T) {
 					EligibleForInPlaceUpdate: false,
 				},
 				msCreatedAfterRolloutAfter.Name: {
+					EligibleForInPlaceUpdate: false,
+				},
+			},
+		},
+		{
+			Name:               "Get MachineSet created at RolloutAfter if reconciliationTime is > rolloutAfter",
+			deployment:         *deploymentWithRolloutAfter,
+			msList:             []*clusterv1.MachineSet{&msCreatedAtRolloutAfter, &msCreatedTwoBeforeRolloutAfter},
+			reconciliationTime: twoAfterRolloutAfter,
+			expectedNewMS:      &msCreatedAtRolloutAfter,
+			expectedOldMSs:     []*clusterv1.MachineSet{&msCreatedTwoBeforeRolloutAfter},
+			expectedUpToDateResults: map[string]UpToDateResult{
+				msCreatedTwoBeforeRolloutAfter.Name: {
+					EligibleForInPlaceUpdate: false,
+				},
+				msCreatedAtRolloutAfter.Name: {
 					EligibleForInPlaceUpdate: false,
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13182

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->