### PR TITLE
✨ Extend conversion tests to cover the "no spec" case

### DIFF
--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -18,6 +18,7 @@ limitations under the License.
 package conversion
 
 import (
+	"maps"
 	"math/rand"
 	"testing"
 
@@ -199,6 +200,18 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 				// First convert hub to spoke
 				dstCopy := input.Spoke.DeepCopyObject().(conversion.Convertible)
 				g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+
+				// Note: The check here is needed because not all runtime.Objects are metav1.Objects (e.g. CABPK ClusterConfiguration)
+				if _, ok := dstCopy.(metav1.Object); ok {
+					// Sometimes the apiserver sends us objects without a spec (likely in the context of managedField conversion)
+					// This test verifies that the ConvertTo code can handle this scenario (i.e. it doesn't return an error
+					// and it doesn't panic)
+					// Note: It's important that this test is run here, because dstCopy.ConvertTo below clears the restore annotation from dstCopy.
+					dstCopyNoSpec := input.Spoke.DeepCopyObject().(conversion.Convertible)
+					dstCopyNoSpec.(metav1.Object).SetLabels(maps.Clone(dstCopy.(metav1.Object).GetLabels()))
+					dstCopyNoSpec.(metav1.Object).SetAnnotations(maps.Clone(dstCopy.(metav1.Object).GetAnnotations()))
+					g.Expect(dstCopyNoSpec.ConvertTo(input.Hub.DeepCopyObject().(conversion.Hub))).To(gomega.Succeed())
+				}
 
 				// Convert spoke back to hub and check if the resulting hub is equal to the hub before the round trip
 				hubAfter := input.Hub.DeepCopyObject().(conversion.Hub)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
As written in the godoc. Sometimes the apiserver sends us objects with a restore annotation but without any spec.
Very likely this is in cases where the apiserver has to convert managedFields.

This new check now also covers that scenario. I also tested that it would have caught the panic fixed in #13383


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/13383

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->