### PR TITLE
🌱 Framework: Improve pod log streaming to avoid duplicate logs

### DIFF
--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -288,6 +288,7 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 			}
 
 			// Retry streaming the logs of the pods unless ctx.Done() or if the pod does not exist anymore.
+			streamed := false
 			err = wait.PollUntilContextCancel(eh.ctx, 2*time.Second, false, func(ctx context.Context) (done bool, err error) {
 				// Wait for pod to be in running state
 				actual, err := eh.input.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
@@ -298,6 +299,14 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 					}
 					// Only log the error to not cause the test to fail via GinkgoRecover
 					log.Logf("Error getting pod %s, container %s: %v", klog.KRef(pod.Namespace, pod.Name), container.Name, err)
+					return true, nil
+				}
+				// On retries, stop if the container has terminated (e.g.
+				// completed init container or pod terminated during upgrade).
+				// This also covers pods in Succeeded/Failed phase.
+				// Skip this check on the first attempt so we still capture
+				// historical logs from already-completed containers.
+				if streamed && containerHasTerminated(actual, container.Name) {
 					return true, nil
 				}
 				// Retry later if pod is currently not running
@@ -319,6 +328,7 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 					// Failing to stream logs should not cause the test to fail
 					log.Logf("Got error while streaming logs for pod %s, container %s: %v", klog.KRef(pod.Namespace, pod.Name), container.Name, err)
 				}
+				streamed = true
 				return false, nil
 			})
 			if err != nil {
@@ -326,6 +336,21 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 			}
 		}(pod, container)
 	}
+}
+
+// containerHasTerminated checks whether a specific container (regular or init)
+// has terminated in the given pod.
+func containerHasTerminated(pod *corev1.Pod, containerName string) bool {
+	// Check pod phase first — if the whole pod is done, all containers are done.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		if cs.Name == containerName {
+			return cs.State.Terminated != nil
+		}
+	}
+	return false
 }
 
 // logMetadata contains metadata about the logs.

--- a/test/framework/deployment_helpers_test.go
+++ b/test/framework/deployment_helpers_test.go
@@ -24,6 +24,132 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func Test_containerHasTerminated(t *testing.T) {
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		containerName string
+		want          bool
+	}{
+		{
+			name: "pod succeeded — all containers are terminated",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			containerName: "any-container",
+			want:          true,
+		},
+		{
+			name: "pod failed — all containers are terminated",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+				},
+			},
+			containerName: "any-container",
+			want:          true,
+		},
+		{
+			name: "running pod with terminated init container",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "init-downloader",
+							State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed"}},
+						},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "init-downloader",
+			want:          true,
+		},
+		{
+			name: "running pod with terminated regular container",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "sidecar",
+							State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed"}},
+						},
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "sidecar",
+			want:          true,
+		},
+		{
+			name: "running pod — container still running",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "main",
+			want:          false,
+		},
+		{
+			name: "running pod — container waiting",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+						},
+					},
+				},
+			},
+			containerName: "main",
+			want:          false,
+		},
+		{
+			name: "container not found in status",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "other",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "missing",
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(containerHasTerminated(tt.pod, tt.containerName)).To(Equal(tt.want))
+		})
+	}
+}
+
 func Test_verifyMetrics(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
**What this PR does / why we need it**:

- Stop streaming when pod or container has terminated, but ensure we stream the logs at least once.
- Add containerHasTerminated helper with tests.

The current behavior is to try again every 2 seconds for terminated containers. This becomes silly for init containers particularly, since we fetch the logs from the beginning for each retry so that we end up with logs repeated again and again.

I have verified this change here: https://github.com/metal3-io/baremetal-operator/pull/3049.
We have an init-container that currently can have >25000 lines in the log file after a test, because the log watcher keep re-fetching the full log again and again. With the changes in this PR, we get just 55 lines.
(Search for `ramdisk-downloader` in the archive if you want to check. This is the init-container.)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


/area testing
