### PR TITLE
📖 ClusterResourceSet is namespace scoped

### DIFF
--- a/docs/book/src/tasks/cluster-resource-set.md
+++ b/docs/book/src/tasks/cluster-resource-set.md
@@ -3,6 +3,8 @@
 The `ClusterResourceSet` feature is introduced to provide a way to automatically apply a set of resources (such as CNI/CSI) defined by users to matching newly-created/existing clusters.
 `ClusterResourceSet` provides a basic solution for installing & managing resources, while for advanced use cases an addon provider must be used.
 
+`ClusterResourceSet` is namespace-scoped, all resources and clusters referenced in the `ClusterResourceSet` spec need to be in the same namespace as the ClusterResourceSet. 
+
 More details on `ClusterResourceSet` can be found at:
 [ClusterResourceSet CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20200220-cluster-resource-set.md)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I didn't read the CAEP as thoroughly as I should and totally missed this crucial detail, so this clarifies that ClusterResourceSet is namespace-scoped and requires resources and clusters to be in the same namespace.


<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->