### PR TITLE
🐛 Fix exponential backoff with ReconcilerRateLimiting

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -75,6 +75,7 @@ const (
 
 	// ReconcilerRateLimiting is a feature gate that controls if reconcilers are rate-limited.
 	// Note: Currently the feature gate is rate-limiting to 1 request / 1 second.
+	// Note: If this feature gate is enabled the PriorityQueue feature gate must be enabled as well.
 	//
 	// alpha: v1.12
 	// beta: v1.13

--- a/util/controller/builder.go
+++ b/util/controller/builder.go
@@ -17,7 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
+	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/cache"
 	predicatesutil "sigs.k8s.io/cluster-api/util/predicates"
 )
@@ -156,6 +160,10 @@ func (blder *Builder) Complete(r reconcile.TypedReconciler[reconcile.Request]) e
 
 // Build builds the Application Controller and returns the Controller it created.
 func (blder *Builder) Build(r reconcile.TypedReconciler[reconcile.Request]) (Controller, error) {
+	if feature.Gates.Enabled(feature.ReconcilerRateLimiting) && !feature.Gates.Enabled(feature.PriorityQueue) {
+		return nil, errors.New("if feature gate ReconcilerRateLimiting is enabled, feature gate PriorityQueue must be enabled as well")
+	}
+
 	// Get GVK of the for object.
 	var gvk schema.GroupVersionKind
 	hasGVK := blder.forObject != nil
@@ -214,17 +222,24 @@ func (blder *Builder) Build(r reconcile.TypedReconciler[reconcile.Request]) (Con
 		rateLimitInterval = blder.rateLimitInterval
 	}
 
+	var queueRateLimiter *typedItemExponentialFailureRateLimiter[reconcile.Request]
+	if feature.Gates.Enabled(feature.ReconcilerRateLimiting) {
+		queueRateLimiter = newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second)
+		blder.options.RateLimiter = queueRateLimiter
+	}
+
 	// Passing the options to the underlying builder here because we modified them above.
 	blder.builder.WithOptions(blder.options)
 
 	// Create reconcileCache.
 	reconcileCache := cache.New[reconcileCacheEntry](cache.DefaultTTL)
 
-	c, err := blder.builder.Build(reconcilerWrapper{
+	c, err := blder.builder.Build(&reconcilerWrapper{
 		name:              controllerName,
 		reconciler:        r,
 		reconcileCache:    reconcileCache,
 		rateLimitInterval: rateLimitInterval,
+		queueRateLimiter:  queueRateLimiter,
 	})
 	if err != nil {
 		return nil, err
@@ -242,4 +257,66 @@ func (blder *Builder) Build(r reconcile.TypedReconciler[reconcile.Request]) (Con
 		TypedController: c,
 		reconcileCache:  reconcileCache,
 	}, nil
+}
+
+func newTypedItemExponentialFailureRateLimiter[T comparable](rateLimitInterval time.Duration, baseDelay time.Duration, maxDelay time.Duration) *typedItemExponentialFailureRateLimiter[T] {
+	return &typedItemExponentialFailureRateLimiter[T]{
+		failures:          map[T]int{},
+		rateLimitInterval: rateLimitInterval,
+		baseDelay:         baseDelay,
+		maxDelay:          maxDelay,
+	}
+}
+
+// typedItemExponentialFailureRateLimiter does a simple baseDelay*2^<num-failures> limit
+// dealing with max failures and expiration are up to the caller.
+// Note: In addition to the upstream TypedItemExponentialFailureRateLimiter it adds
+// rateLimitInterval to the backoff duration and it changes the behavior of the Forget method.
+// The Forget method is now a no-op and the ActualForget must be used to forget an item.
+// This is done to ensure the reconcileWrapper has full control over forget and the forget calls
+// in controller-runtime are no-ops.
+type typedItemExponentialFailureRateLimiter[T comparable] struct {
+	failuresLock sync.Mutex
+	failures     map[T]int
+
+	rateLimitInterval time.Duration
+	baseDelay         time.Duration
+	maxDelay          time.Duration
+}
+
+func (r *typedItemExponentialFailureRateLimiter[T]) When(item T) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	exp := r.failures[item]
+	r.failures[item]++
+
+	// The backoff is capped such that 'calculated' value never overflows.
+	backoff := float64(r.rateLimitInterval) + float64(r.baseDelay.Nanoseconds())*math.Pow(2, float64(exp))
+	if backoff > math.MaxInt64 {
+		return r.maxDelay
+	}
+
+	calculated := time.Duration(backoff)
+	if calculated > r.maxDelay {
+		return r.maxDelay
+	}
+
+	return calculated
+}
+
+func (r *typedItemExponentialFailureRateLimiter[T]) NumRequeues(item T) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *typedItemExponentialFailureRateLimiter[T]) Forget(_ T) {}
+
+func (r *typedItemExponentialFailureRateLimiter[T]) ActualForget(item T) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	delete(r.failures, item)
 }

--- a/util/controller/builder_test.go
+++ b/util/controller/builder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/config"
@@ -92,6 +93,52 @@ func TestBuilder(t *testing.T) {
 		"controllerGroup", "cluster.x-k8s.io",
 		"controllerKind", "Cluster",
 	}))
+}
+
+func TestTypedItemExponentialFailureRateLimiter(t *testing.T) {
+	g := NewWithT(t)
+
+	rateLimitInterval := 1 * time.Second
+	rateLimiter := newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cluster-1",
+		},
+	}
+
+	durations := make([]time.Duration, 0, 100)
+	for range 100 {
+		durations = append(durations, rateLimiter.When(req))
+	}
+	// rateLimitInterval + exp. backoff
+	expectedDurations := []time.Duration{
+		1*time.Second + 5*time.Millisecond,
+		1*time.Second + 10*time.Millisecond,
+		1*time.Second + 20*time.Millisecond,
+		1*time.Second + 40*time.Millisecond,
+		1*time.Second + 80*time.Millisecond,
+		1*time.Second + 160*time.Millisecond,
+		1*time.Second + 320*time.Millisecond,
+		1*time.Second + 640*time.Millisecond,
+		1*time.Second + 1280*time.Millisecond,
+		1*time.Second + 2560*time.Millisecond,
+		1*time.Second + 5120*time.Millisecond,
+		1*time.Second + 10240*time.Millisecond,
+		1*time.Second + 20480*time.Millisecond,
+		1*time.Second + 40960*time.Millisecond,
+		1*time.Second + 1*time.Minute + 21*time.Second + 920*time.Millisecond,
+		1*time.Second + 2*time.Minute + 43*time.Second + 840*time.Millisecond,
+		1*time.Second + 5*time.Minute + 27*time.Second + 680*time.Millisecond,
+		1*time.Second + 10*time.Minute + 55*time.Second + 360*time.Millisecond,
+		16*time.Minute + 40*time.Second, // max: 1000 seconds
+	}
+	for i := len(expectedDurations); i < len(durations); i++ {
+		expectedDurations = append(expectedDurations, 16*time.Minute+40*time.Second) // max: 1000 seconds
+	}
+
+	g.Expect(durations).To(Equal(expectedDurations))
 }
 
 type fakeManager struct {

--- a/util/controller/controller.go
+++ b/util/controller/controller.go
@@ -36,9 +36,14 @@ type reconcilerWrapper struct {
 	reconcileCache    cache.Cache[reconcileCacheEntry]
 	reconciler        reconcile.Reconciler
 	rateLimitInterval time.Duration
+	queueRateLimiter  *typedItemExponentialFailureRateLimiter[reconcile.Request]
 }
 
-func (r reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	if !feature.Gates.Enabled(feature.ReconcilerRateLimiting) {
+		return r.reconciler.Reconcile(ctx, req)
+	}
+
 	reconcileStartTime := time.Now()
 
 	// Check reconcileCache to ensure we won't run reconcile too frequently.
@@ -48,13 +53,11 @@ func (r reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request)
 		}
 	}
 
-	if feature.Gates.Enabled(feature.ReconcilerRateLimiting) {
-		// Add entry to the reconcileCache so we won't run Reconcile more than once per second.
-		// Under certain circumstances the ReconcileAfter time will be set to a later time via DeferNextReconcile /
-		// DeferNextReconcileForObject, e.g. when we're waiting for Pods to terminate during node drain or
-		// volumes to detach. This is done to ensure we're not spamming the workload cluster API server.
-		r.reconcileCache.Add(reconcileCacheEntry{Request: req, ReconcileAfter: reconcileStartTime.Add(r.rateLimitInterval)})
-	}
+	// Add entry to the reconcileCache so we won't run Reconcile more than once per second.
+	// Under certain circumstances the ReconcileAfter time will be set to a later time via DeferNextReconcile /
+	// DeferNextReconcileForObject, e.g. when we're waiting for Pods to terminate during node drain or
+	// volumes to detach. This is done to ensure we're not spamming the workload cluster API server.
+	r.reconcileCache.Add(reconcileCacheEntry{Request: req, ReconcileAfter: reconcileStartTime.Add(r.rateLimitInterval)})
 
 	// Update metrics after processing each item
 	defer func() {
@@ -73,10 +76,25 @@ func (r reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request)
 	case err != nil:
 		reconcileTotal.WithLabelValues(r.name, labelError).Inc()
 	case result.RequeueAfter > 0:
+		// It does not make sense to use a requeueAfter that is lower than the rate-limiting enforced via
+		// the reconcileCache, so we use that as a minimum.
+		// Note: Evaluating this here includes the reconcileCache entry set above, but also the entry that
+		// might have been added during Reconcile via DeferNextReconcile / DeferNextReconcileForObject.
+		// TODO: It would also be possible to extend r.queueRateLimiter to set a request-specific minimum requeueAfter.
+		// This would allow us to also enforce a minimum requeueAfter for the err != nil and Requeue cases.
+		minimumRequeueAfter := r.rateLimitInterval
+		if cacheEntry, ok := r.reconcileCache.Has(reconcileCacheEntry{Request: req}.Key()); ok {
+			if requeueAfter, requeue := cacheEntry.ShouldRequeue(time.Now()); requeue {
+				minimumRequeueAfter = requeueAfter
+			}
+		}
+		result.RequeueAfter = max(result.RequeueAfter, minimumRequeueAfter)
+		r.queueRateLimiter.ActualForget(req)
 		reconcileTotal.WithLabelValues(r.name, labelRequeueAfter).Inc()
 	case result.Requeue: //nolint: staticcheck // We have to handle Requeue until it is removed
 		reconcileTotal.WithLabelValues(r.name, labelRequeue).Inc()
 	default:
+		r.queueRateLimiter.ActualForget(req)
 		reconcileTotal.WithLabelValues(r.name, labelSuccess).Inc()
 	}
 
@@ -88,14 +106,14 @@ type controllerWrapper struct {
 	reconcileCache cache.Cache[reconcileCacheEntry]
 }
 
-func (c controllerWrapper) DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time) {
+func (c *controllerWrapper) DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time) {
 	c.reconcileCache.Add(reconcileCacheEntry{
 		Request:        req,
 		ReconcileAfter: reconcileAfter,
 	})
 }
 
-func (c controllerWrapper) DeferNextReconcileForObject(obj metav1.Object, reconcileAfter time.Time) {
+func (c *controllerWrapper) DeferNextReconcileForObject(obj metav1.Object, reconcileAfter time.Time) {
 	c.DeferNextReconcile(reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: obj.GetNamespace(),

--- a/util/controller/controller_test.go
+++ b/util/controller/controller_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -28,9 +30,14 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/feature"
@@ -50,19 +57,49 @@ func TestReconcile(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		g := NewWithT(t)
 
-		var reconcileCounter int
-		r := reconcilerWrapper{
+		rateLimitInterval := 1 * time.Second
+
+		var reconcileCounter atomic.Int64
+		r := &reconcilerWrapper{
 			name:           "cluster",
 			reconcileCache: reconcileCache,
 			reconciler: reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
-				reconcileCounter++
+				reconcileCounter.Add(1)
 				return reconcile.Result{}, nil
 			}),
-			rateLimitInterval: 1 * time.Second,
+			rateLimitInterval: rateLimitInterval,
+			queueRateLimiter:  newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second),
 		}
 		c := controllerWrapper{
 			reconcileCache: reconcileCache,
 		}
+
+		// Setup an entire controller so that we can also test how the controller interacts with the queue during exponential backoff.
+		ctrl, err := controller.NewTypedUnmanaged("cluster", controller.Options{
+			Reconciler:  r,
+			RateLimiter: r.queueRateLimiter,
+		})
+		g.Expect(err).ToNot(HaveOccurred())
+		sourceChannel := make(chan event.GenericEvent, 1)
+		defer func() {
+			close(sourceChannel)
+		}()
+		g.Expect(ctrl.Watch(source.Channel(sourceChannel, handler.Funcs{
+			GenericFunc: func(_ context.Context, e event.TypedGenericEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+				q.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: e.Object.GetNamespace(),
+						Name:      e.Object.GetName(),
+					},
+				})
+			},
+		}))).To(Succeed())
+
+		ctrlCtx, ctrlCancel := context.WithCancel(t.Context())
+		defer ctrlCancel()
+		go func() {
+			_ = ctrl.Start(ctrlCtx)
+		}()
 
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -73,19 +110,22 @@ func TestReconcile(t *testing.T) {
 		req := reconcile.Request{
 			NamespacedName: client.ObjectKeyFromObject(cluster),
 		}
+		genericEvent := event.TypedGenericEvent[client.Object]{
+			Object: cluster,
+		}
 
 		// Reconcile will reconcile and defer next reconcile by 1s.
 		res, err := r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.IsZero()).To(BeTrue())
-		g.Expect(reconcileCounter).To(Equal(1))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(1)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 
 		// Reconcile will not reconcile and return RequeueAfter 1s.
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.RequeueAfter).To(Equal(1 * time.Second))
-		g.Expect(reconcileCounter).To(Equal(1))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(1)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 
 		time.Sleep(1 * time.Second)
@@ -94,7 +134,7 @@ func TestReconcile(t *testing.T) {
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.IsZero()).To(BeTrue())
-		g.Expect(reconcileCounter).To(Equal(2))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(2)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(2))
 
 		// Defer next Reconcile by 11s.
@@ -104,7 +144,7 @@ func TestReconcile(t *testing.T) {
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.RequeueAfter).To(Equal(11 * time.Second))
-		g.Expect(reconcileCounter).To(Equal(2))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(2)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(2))
 
 		time.Sleep(4 * time.Second)
@@ -113,7 +153,7 @@ func TestReconcile(t *testing.T) {
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.RequeueAfter).To(Equal(7 * time.Second))
-		g.Expect(reconcileCounter).To(Equal(2))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(2)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(2))
 
 		time.Sleep(7 * time.Second)
@@ -122,7 +162,7 @@ func TestReconcile(t *testing.T) {
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.IsZero()).To(BeTrue())
-		g.Expect(reconcileCounter).To(Equal(3))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(3)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(3))
 
 		// Defer next Reconcile by 55s.
@@ -132,15 +172,79 @@ func TestReconcile(t *testing.T) {
 		res, err = r.Reconcile(t.Context(), req)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(res.RequeueAfter).To(Equal(55 * time.Second))
-		g.Expect(reconcileCounter).To(Equal(3))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(3)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(3))
+
+		time.Sleep(55 * time.Second)
+
+		// Reconcile will reconcile and return RequeueAfter 1s (always at least rateLimitInterval)
+		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
+			reconcileCounter.Add(1)
+			return reconcile.Result{RequeueAfter: 1 * time.Millisecond}, nil // RequeueAfter should be at least rateLimitInterval (1s)
+		})
+		res, err = r.Reconcile(t.Context(), req)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.RequeueAfter).To(Equal(rateLimitInterval))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(4)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelRequeueAfter))).To(Equal(1))
+
+		time.Sleep(rateLimitInterval)
+
+		// Reconcile will reconcile and return RequeueAfter 5s (always at least rate-limiting duration)
+		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
+			reconcileCounter.Add(1)
+			c.DeferNextReconcileForObject(cluster, time.Now().Add(5*time.Second))
+			return reconcile.Result{RequeueAfter: 1 * time.Millisecond}, nil // RequeueAfter should be at least rate-limiting duration (5s)
+		})
+		res, err = r.Reconcile(t.Context(), req)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.RequeueAfter).To(Equal(5 * time.Second))
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(5)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelRequeueAfter))).To(Equal(2))
+
+		time.Sleep(5 * time.Second)
+
+		// Reconcile will reconcile and return error which will trigger exponential backoff (rate-limiting should not interfere)
+		// This test is using the sourceChannel to include the controller & the priority queue because this is the only way
+		// to test the exponential backoff that is computed by the priority queue.
+		errorToReturn := errors.New("error")
+		var errorLock sync.Mutex
+		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
+			reconcileCounter.Add(1)
+			errorLock.Lock()
+			defer errorLock.Unlock()
+			return reconcile.Result{}, errorToReturn
+		})
+		// Put the event into the channel
+		sourceChannel <- genericEvent
+		// Wait for go routines to handle the event & verify that counters & rateLimiter go up as expected
+		synctest.Wait()
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(6)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelError))).To(Equal(1))
+		g.Expect(r.queueRateLimiter.NumRequeues(req)).To(Equal(1))
+		// Wait for exp. backoff & go routines to handle the event & verify that counters & rateLimiter go up as expected
+		time.Sleep(rateLimitInterval + 5*time.Millisecond)
+		synctest.Wait()
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(7)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelError))).To(Equal(2))
+		g.Expect(r.queueRateLimiter.NumRequeues(req)).To(Equal(2))
+		// Now make the Reconcile func succeed.
+		errorLock.Lock()
+		errorToReturn = nil
+		errorLock.Unlock()
+		// Wait for exp. backoff & go routines to handle the event & verify that counters go up & rateLimiter gets resetted.
+		time.Sleep(rateLimitInterval + 10*time.Millisecond)
+		synctest.Wait()
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(8)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(4))
+		g.Expect(r.queueRateLimiter.NumRequeues(req)).To(Equal(0))
+
+		ctrlCancel()
 	})
 }
 
 func TestReconcileMetrics(t *testing.T) {
-	// Note: Feature gate is intentionally turned off for additional test coverage and to avoid
-	// having to move the clock forward by 1s after every Reconcile call.
-	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ReconcilerRateLimiting, false)
+	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ReconcilerRateLimiting, true)
 
 	// reconcileCache has to be created outside synctest.Test, otherwise
 	// the test would fail because of the cleanup go routine in the cache.
@@ -149,10 +253,13 @@ func TestReconcileMetrics(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		g := NewWithT(t)
 
+		rateLimitInterval := 1 * time.Second
+
 		r := reconcilerWrapper{
 			name:              "cluster",
 			reconcileCache:    reconcileCache,
-			rateLimitInterval: 1 * time.Second,
+			rateLimitInterval: rateLimitInterval,
+			queueRateLimiter:  newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second),
 		}
 
 		req := reconcile.Request{
@@ -179,6 +286,8 @@ func TestReconcileMetrics(t *testing.T) {
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 		g.Expect(histogramMetricValue(reconcileTime.WithLabelValues(r.name))).To(Equal(1))
 
+		time.Sleep(1 * time.Second)
+
 		// Error
 		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, errors.New("error") // RequeueAfter should be dropped
@@ -193,6 +302,8 @@ func TestReconcileMetrics(t *testing.T) {
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 		g.Expect(histogramMetricValue(reconcileTime.WithLabelValues(r.name))).To(Equal(2))
 
+		time.Sleep(1 * time.Second)
+
 		// RequeueAfter
 		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
@@ -206,6 +317,8 @@ func TestReconcileMetrics(t *testing.T) {
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelRequeue))).To(Equal(0))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 		g.Expect(histogramMetricValue(reconcileTime.WithLabelValues(r.name))).To(Equal(3))
+
+		time.Sleep(1 * time.Second)
 
 		// Requeue
 		r.reconciler = reconcile.Func(func(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We noticed that ReconcilerRateLimiting breaks exponential backoff, i.e. instead of exponential backoff we always requeued every second if we got errors.

This PR fixes that.

To make this feasible we now only support ReconcilerRateLimiting if PriorityQueue is on


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/13005

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->