### PR TITLE
:seedling: add build and version information if shallow copy or fork

### DIFF
--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -126,6 +126,12 @@ func (v *versionChecker) Check(ctx context.Context) (string, error) {
 		return "", errors.Wrap(err, "unable to semver parse latest release version")
 	}
 
+	// if we are using a mocked (shallow or fork) build, log it out
+	if v.cliVersion().Major == "0" && v.cliVersion().Minor == "0" {
+		log.V(1).Info("⚠️  Using a development build of clusterctl (mocked, shallow or fork).", "cliVersion", cliVer.String(), "latestGithubRelease", release.Version)
+		return "", nil
+	}
+
 	// if we are using a dirty dev build or go build, just log it out
 	if v.cliVersion().GitVersion == "" || strings.HasSuffix(cliVer.String(), "-dirty") {
 		log.V(1).Info("⚠️  Using a development build of clusterctl.", "cliVersion", cliVer.String(), "latestGithubRelease", release.Version)

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -69,7 +69,7 @@ version::get_version_vars() {
             GIT_MAJOR="0"
             GIT_MINOR="0"
             # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
-            # Try extrating it from a remote with the following format: proto://<server>/<gituser>
+            # Try extracting it from a remote with the following format: proto://<server>/<gituser>
             GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
             # ... otherwise, try using <sshuser>@<server>:<gituser>
             [ -z "${GIT_USER_FORK}" ] && GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
@@ -119,7 +119,7 @@ version::ldflags() {
         add_ldflag "gitShallow" "false"
     fi
 
-    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's cmd/version_checher (gitVersionRegEx).
+    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's cmd/version_checker (gitVersionRegEx).
     if [ "$GIT_MAJOR" -eq 0 ] && [ "$GIT_MINOR" -eq 0 ]; then
         GIT_VERSION="v0.0.0-${GIT_VERSION}"
     fi

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -116,6 +116,9 @@ version::ldflags() {
     add_ldflag "gitVersion" "${GIT_VERSION}"
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
 
+    # Identify a shallow copy of this repository
+    [ -f "$(git rev-parse --git-dir)/shallow" ] && add_ldflag "gitShallow" "true" || add_ldflag "gitShallow" "false"
+
     # The -ldflags parameter takes a single string, so join the output.
     # When DBG is set to 1 include DWARF and symbol table for delve debugging
     if [[ "${DBG:-}" == 1 ]]; then

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -125,7 +125,7 @@ version::ldflags() {
     fi
 
     # Explicitly identify a fork if GIT_USER_FORK is not the official Kubernetes account.
-    if [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
+    if [ -n "${GIT_USER_FORK:-}" ] && [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
         add_ldflag "gitFork" "true"
         GIT_VERSION+="-fork"
     fi

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -112,9 +112,6 @@ version::ldflags() {
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
     add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
 
-    # Explicitly identify a fork if GIT_USER_FORK is not the official account
-    [ "$GIT_USER_FORK" != "kubernetes-sigs" ] && add_ldflag "gitFork" "true"
-
     # Identify a shallow copy of this repository
     if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
         add_ldflag "gitShallow" "true"
@@ -125,6 +122,12 @@ version::ldflags() {
     # Should we be on mocked version, also adjust GIT_VERSION to pass clusterctl's gitVersionRegEx
     if [ "$GIT_MAJOR" == "0.0" ]; then
         GIT_VERSION="v0.0.0-${GIT_VERSION}"
+    fi
+
+    # Explicitly identify a fork if GIT_USER_FORK is not the official account
+    if [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
+        add_ldflag "gitFork" "true"
+        GIT_VERSION+="-${GIT_USER_FORK}"
     fi
 
     # Finally set the version here

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -68,7 +68,6 @@ version::get_version_vars() {
             # Set GIT_VERSION to a value accepted by 'clusterctl/cmd/version_checker' (gitVersionRegEx).
             GIT_MAJOR="0.0"
             GIT_MINOR="0"
-
             # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
             # Try extrating it from a remote with the following format: https://github.com/<username>
             GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -114,7 +114,7 @@ version::ldflags() {
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
 
     # Explicitly identify a fork
-    [ "$GIT_GH_USER" != "kubernetes-sigs" ] && add_flag "gitFork" "true"
+    [ "$GIT_GH_USER" != "kubernetes-sigs" ] && add_ldflag "gitFork" "true"
 
     # Identify a shallow copy of this repository
     if [ -f "$(git rev-parse --git-dir)/shallow" ]; then

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -107,11 +107,10 @@ version::ldflags() {
 
     add_ldflag "buildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
     add_ldflag "gitCommit" "${GIT_COMMIT}"
-    add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
     add_ldflag "gitMajor" "${GIT_MAJOR}"
     add_ldflag "gitMinor" "${GIT_MINOR}"
-    add_ldflag "gitVersion" "${GIT_VERSION}"
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
+    add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
 
     # Explicitly identify a fork
     [ "$GIT_GH_USER" != "kubernetes-sigs" ] && add_ldflag "gitFork" "true"
@@ -122,6 +121,13 @@ version::ldflags() {
     else
         add_ldflag "gitShallow" "false"
     fi
+
+    # Should we be on mocked version, also adjust GIT_VERSION to pass clusterctl's gitVersionRegEx
+    if [ "$GIT_MAJOR" == "0.0" ]; then
+        GIT_VERSION="v0.0.0-${GIT_VERSION}"
+    fi
+    # Finally set the version here
+    add_ldflag "gitVersion" "${GIT_VERSION}"
 
     # The -ldflags parameter takes a single string, so join the output.
     # When DBG is set to 1 include DWARF and symbol table for delve debugging

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -126,7 +126,7 @@ version::ldflags() {
     # Explicitly identify a fork if GIT_USER_FORK is not the official account
     if [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
         add_ldflag "gitFork" "true"
-        GIT_VERSION+="-${GIT_USER_FORK}"
+        GIT_VERSION+="-fork"
     fi
 
     # Finally set the release version here as we do have all necessary tags

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -69,7 +69,10 @@ version::get_version_vars() {
             GIT_MAJOR="0"
             GIT_MINOR="0"
         fi
-
+        # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's cmd/version_checker (gitVersionRegEx).
+        if [ "$GIT_MAJOR" -eq 0 ] && [ "$GIT_MINOR" -eq 0 ]; then
+            GIT_VERSION="v0.0.0-${GIT_VERSION}"
+        fi
         # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
         # Try extracting it from a remote with the following format: proto://<server>/<gituser>
         GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
@@ -77,7 +80,6 @@ version::get_version_vars() {
         if [ -z "${GIT_USER_FORK}" ]; then
             GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
-
         # Check if there are tags present on this repository before proceeding with parsing GIT_VERSION to abort building.
         # Keeping it building fine without them as CI tools can be using shallow copies still; avoid breaking it all.
         if [ "$(git tag --list | wc -l)" -gt 0 ]; then
@@ -121,11 +123,6 @@ version::ldflags() {
         add_ldflag "gitShallow" "true"
     else
         add_ldflag "gitShallow" "false"
-    fi
-
-    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's cmd/version_checker (gitVersionRegEx).
-    if [ "$GIT_MAJOR" -eq 0 ] && [ "$GIT_MINOR" -eq 0 ]; then
-        GIT_VERSION="v0.0.0-${GIT_VERSION}"
     fi
 
     # Explicitly identify a fork if GIT_USER_FORK is not the official Kubernetes account.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -71,11 +71,11 @@ version::get_version_vars() {
         else
             # We are assuming here to be in a shallow copy or perhaps a fork. Define GIT_MAJOR to be the value extracted
             # from GIT_VERSION itself and GIT_MINOR would be the GitHub handler (if present).
-            GIT_MAJOR="0.0.$GIT_VERSION"
+            GIT_MAJOR=$GIT_VERSION
             # Try to set GIT_MINOR from https://github.com/<username>
-            GIT_MINOR="0.$(git config --get remote.origin.url | cut -d/ -f4)"
+            GIT_MINOR=$(git config --get remote.origin.url | cut -d/ -f4)
             # ... otherwise, set it from git@github.com:<username>
-            [ "$GIT_MINOR" == "0." ] && GIT_MINOR="0.$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)"
+            [ "$GIT_MINOR" == "" ] && GIT_MINOR=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
 
         # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -79,7 +79,7 @@ version::get_version_vars() {
         fi
 
         # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION
-        if [ $(git tag --list | wc -l) -gt 0 ]; then
+        if [ "$(git tag --list | wc -l)" -gt 0 ]; then
             # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
             if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
                 echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
@@ -117,7 +117,11 @@ version::ldflags() {
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
 
     # Identify a shallow copy of this repository
-    [ -f "$(git rev-parse --git-dir)/shallow" ] && add_ldflag "gitShallow" "true" || add_ldflag "gitShallow" "false"
+    if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+        add_ldflag "gitShallow" "true"
+    else
+        add_ldflag "gitShallow" "false"
+    fi
 
     # The -ldflags parameter takes a single string, so join the output.
     # When DBG is set to 1 include DWARF and symbol table for delve debugging

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -69,11 +69,11 @@ version::get_version_vars() {
             GIT_MAJOR="0.0"
             GIT_MINOR="0"
 
-            # Set GIT_GH_USER; perhaps we are building on top of a forked repository.
+            # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
             # Try extrating it from a remote with the following format: https://github.com/<username>
-            GIT_GH_USER=$(git config --get remote.origin.url | cut -d/ -f4)
+            GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
             # ... otherwise, try using git@github.com:<username>
-            [ "$GIT_GH_USER" == "" ] && GIT_GH_USER=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
+            [ -z "${GIT_USER_FORK}" ] && GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
         # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION to abort building
         if [ "$(git tag --list | wc -l)" -gt 0 ]; then
@@ -112,8 +112,8 @@ version::ldflags() {
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
     add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
 
-    # Explicitly identify a fork
-    [ "$GIT_GH_USER" != "kubernetes-sigs" ] && add_ldflag "gitFork" "true"
+    # Explicitly identify a fork if GIT_USER_FORK is not the official account
+    [ "$GIT_USER_FORK" != "kubernetes-sigs" ] && add_ldflag "gitFork" "true"
 
     # Identify a shallow copy of this repository
     if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
@@ -126,6 +126,7 @@ version::ldflags() {
     if [ "$GIT_MAJOR" == "0.0" ]; then
         GIT_VERSION="v0.0.0-${GIT_VERSION}"
     fi
+
     # Finally set the version here
     add_ldflag "gitVersion" "${GIT_VERSION}"
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -71,11 +71,11 @@ version::get_version_vars() {
         else
             # We are assuming here to be in a shallow copy or perhaps a fork. Define GIT_MAJOR to be the value extracted
             # from GIT_VERSION itself and GIT_MINOR would be the GitHub handler (if present).
-            GIT_MAJOR=$GIT_VERSION
+            GIT_MAJOR="0.0.$GIT_VERSION"
             # Try to set GIT_MINOR from https://github.com/<username>
-            GIT_MINOR=$(git config --get remote.origin.url | cut -d/ -f4)
+            GIT_MINOR="0.$(git config --get remote.origin.url | cut -d/ -f4)"
             # ... otherwise, set it from git@github.com:<username>
-            [ "$GIT_MINOR" == "" ] && GIT_MINOR=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
+            [ "$GIT_MINOR" == "0." ] && GIT_MINOR="0.$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)"
         fi
 
         # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -69,12 +69,13 @@ version::get_version_vars() {
             GIT_MAJOR="0"
             GIT_MINOR="0"
             # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
-            # Try extrating it from a remote with the following format: https://github.com/<username>
+            # Try extrating it from a remote with the following format: proto://<server>/<gituser>
             GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
-            # ... otherwise, try using git@github.com:<username>
+            # ... otherwise, try using <sshuser>@<server>:<gituser>
             [ -z "${GIT_USER_FORK}" ] && GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
-        # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION to abort building
+        # Check if there are tags present on this repository before proceeding with parsing GIT_VERSION to abort building.
+        # Keeping it building fine without them as CI tools can be using shallow copies still; avoid breaking it all.
         if [ "$(git tag --list | wc -l)" -gt 0 ]; then
             # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
             if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
@@ -85,7 +86,7 @@ version::get_version_vars() {
         fi
     fi
 
-    # This provides the tag identifying a proper release. The code must not be a shallow copy.
+    # This provides the tag identifying a proper release. The code present here must *NOT* be a shallow copy.
     GIT_RELEASE_TAG=$(git describe --always --abbrev=0 --tags)
     GIT_RELEASE_COMMIT=$(git rev-list -n 1  "${GIT_RELEASE_TAG}")
 }
@@ -111,25 +112,25 @@ version::ldflags() {
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
     add_ldflag "gitTreeState" "${GIT_TREE_STATE}"
 
-    # Identify a shallow copy of this repository
+    # Identify a shallow copy of this repository (works for older and newer versions of git).
     if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
         add_ldflag "gitShallow" "true"
     else
         add_ldflag "gitShallow" "false"
     fi
 
-    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's gitVersionRegEx
+    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's cmd/version_checher (gitVersionRegEx).
     if [ "$GIT_MAJOR" -eq 0 ] && [ "$GIT_MINOR" -eq 0 ]; then
         GIT_VERSION="v0.0.0-${GIT_VERSION}"
     fi
 
-    # Explicitly identify a fork if GIT_USER_FORK is not the official account
+    # Explicitly identify a fork if GIT_USER_FORK is not the official Kubernetes account.
     if [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
         add_ldflag "gitFork" "true"
         GIT_VERSION+="-fork"
     fi
 
-    # Finally set the release version here as we do have all necessary tags
+    # Finally set the release version here.
     add_ldflag "gitVersion" "${GIT_VERSION}"
 
     # The -ldflags parameter takes a single string, so join the output.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -57,7 +57,6 @@ version::get_version_vars() {
             # so use our idea of "dirty" from git status instead.
             GIT_VERSION+="-dirty"
         fi
-
         # Try to match the "git describe" output to a regex to try to extract
         # the "major" and "minor" versions and whether this is the exact tagged
         # version or whether the tree is between two tagged versions.
@@ -65,16 +64,18 @@ version::get_version_vars() {
             GIT_MAJOR=${BASH_REMATCH[1]}
             GIT_MINOR=${BASH_REMATCH[2]}
         else
-            # We are assuming here to be in a shallow copy or perhaps a fork. Define GIT_MAJOR to be the value extracted
-            # from GIT_VERSION itself and GIT_MINOR would be the GitHub handler (if present).
-            GIT_MAJOR=$GIT_VERSION
-            # Try to set GIT_MINOR from https://github.com/<username>
-            GIT_MINOR=$(git config --get remote.origin.url | cut -d/ -f4)
-            # ... otherwise, set it from git@github.com:<username>
-            [ "$GIT_MINOR" == "" ] && GIT_MINOR=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
-        fi
+            # We assume to be in a shallow copy or perhaps a fork; mock values for GIT_MAJOR and GIT_MINOR.
+            # Set GIT_VERSION to a value accepted by 'clusterctl/cmd/version_checker' (gitVersionRegEx).
+            GIT_MAJOR="0.0"
+            GIT_MINOR="0"
 
-        # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION
+            # Set GIT_GH_USER; perhaps we are building on top of a forked repository.
+            # Try extrating it from a remote with the following format: https://github.com/<username>
+            GIT_GH_USER=$(git config --get remote.origin.url | cut -d/ -f4)
+            # ... otherwise, try using git@github.com:<username>
+            [ "$GIT_GH_USER" == "" ] && GIT_GH_USER=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
+        fi
+        # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION to abort building
         if [ "$(git tag --list | wc -l)" -gt 0 ]; then
             # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
             if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
@@ -111,6 +112,9 @@ version::ldflags() {
     add_ldflag "gitMinor" "${GIT_MINOR}"
     add_ldflag "gitVersion" "${GIT_VERSION}"
     add_ldflag "gitReleaseCommit" "${GIT_RELEASE_COMMIT}"
+
+    # Explicitly identify a fork
+    [ "$GIT_GH_USER" != "kubernetes-sigs" ] && add_flag "gitFork" "true"
 
     # Identify a shallow copy of this repository
     if [ -f "$(git rev-parse --git-dir)/shallow" ]; then

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -68,12 +68,16 @@ version::get_version_vars() {
             # Set GIT_VERSION to a value accepted by 'clusterctl/cmd/version_checker' (gitVersionRegEx).
             GIT_MAJOR="0"
             GIT_MINOR="0"
-            # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
-            # Try extracting it from a remote with the following format: proto://<server>/<gituser>
-            GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
-            # ... otherwise, try using <sshuser>@<server>:<gituser>
-            [ -z "${GIT_USER_FORK}" ] && GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
+
+        # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
+        # Try extracting it from a remote with the following format: proto://<server>/<gituser>
+        GIT_USER_FORK=$(git config --get remote.origin.url | cut -d/ -f4)
+        # ... otherwise, try using <sshuser>@<server>:<gituser>
+        if [ -z "${GIT_USER_FORK}" ]; then
+            GIT_USER_FORK=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
+        fi
+
         # Check if there are tags present on this repository before proceeding with parsing GIT_VERSION to abort building.
         # Keeping it building fine without them as CI tools can be using shallow copies still; avoid breaking it all.
         if [ "$(git tag --list | wc -l)" -gt 0 ]; then
@@ -125,9 +129,11 @@ version::ldflags() {
     fi
 
     # Explicitly identify a fork if GIT_USER_FORK is not the official Kubernetes account.
-    if [ -n "${GIT_USER_FORK:-}" ] && [ "$GIT_USER_FORK" != "kubernetes-sigs" ]; then
+    if [ -n "${GIT_USER_FORK:-}" ] && [ "${GIT_USER_FORK}" != "kubernetes-sigs" ]; then
         add_ldflag "gitFork" "true"
         GIT_VERSION+="-fork"
+    else
+        add_ldflag "gitFork" "false"
     fi
 
     # Finally set the release version here.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -66,7 +66,7 @@ version::get_version_vars() {
         else
             # We assume to be in a shallow copy or perhaps a fork; mock values for GIT_MAJOR and GIT_MINOR.
             # Set GIT_VERSION to a value accepted by 'clusterctl/cmd/version_checker' (gitVersionRegEx).
-            GIT_MAJOR="0.0"
+            GIT_MAJOR="0"
             GIT_MINOR="0"
             # Set GIT_USER_FORK; perhaps we are building on top of a forked repository.
             # Try extrating it from a remote with the following format: https://github.com/<username>
@@ -118,8 +118,8 @@ version::ldflags() {
         add_ldflag "gitShallow" "false"
     fi
 
-    # Should we be on mocked version, also adjust GIT_VERSION to pass clusterctl's gitVersionRegEx
-    if [ "$GIT_MAJOR" == "0.0" ]; then
+    # Should we be on mocked version (shallow or fork), adjust GIT_VERSION to pass clusterctl's gitVersionRegEx
+    if [ "$GIT_MAJOR" -eq 0 ] && [ "$GIT_MINOR" -eq 0 ]; then
         GIT_VERSION="v0.0.0-${GIT_VERSION}"
     fi
 
@@ -129,7 +129,7 @@ version::ldflags() {
         GIT_VERSION+="-${GIT_USER_FORK}"
     fi
 
-    # Finally set the version here
+    # Finally set the release version here as we do have all necessary tags
     add_ldflag "gitVersion" "${GIT_VERSION}"
 
     # The -ldflags parameter takes a single string, so join the output.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -56,10 +56,12 @@ version::get_version_vars() {
             # that is problematic since new untracked .go files affect the build,
             # so use our idea of "dirty" from git status instead.
             GIT_VERSION+="-dirty"
-            # Check if we are on top of a shallow copy, as that will impact a release tag with
-            # semantic version to be identified.
-            [ -f "$(git rev-parse --git-dir)/shallow" ] && GIT_VERSION+="-shallow"
         fi
+
+        # Check if we are on top of a shallow copy, as that will impact a release tag with
+        # semantic version to be identified.
+        [ -f "$(git rev-parse --git-dir)/shallow" ] && GIT_VERSION+="-shallow"
+
         # Try to match the "git describe" output to a regex to try to extract
         # the "major" and "minor" versions and whether this is the exact tagged
         # version or whether the tree is between two tagged versions.
@@ -72,11 +74,12 @@ version::get_version_vars() {
             GIT_MAJOR=$GIT_VERSION
             # Try to set GIT_MINOR from https://github.com/<username>
             GIT_MINOR=$(git config --get remote.origin.url | cut -d/ -f4)
-            # ...otherwise, set it from git@github.com:<username>
+            # ... otherwise, set it from git@github.com:<username>
             [ "$GIT_MINOR" == "" ] && GIT_MINOR=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
-        # If we are not in a shallow copy that's no need to check for semver; abort build otherwise.
-        if ! [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+
+        # Check if there are at least tags present on this repository before proceeding with parsing GIT_VERSION
+        if [ $(git tag --list | wc -l) -gt 0 ]; then
             # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
             if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
                 echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -58,10 +58,6 @@ version::get_version_vars() {
             GIT_VERSION+="-dirty"
         fi
 
-        # Check if we are on top of a shallow copy, as that will impact a release tag with
-        # semantic version to be identified.
-        [ -f "$(git rev-parse --git-dir)/shallow" ] && GIT_VERSION+="-shallow"
-
         # Try to match the "git describe" output to a regex to try to extract
         # the "major" and "minor" versions and whether this is the exact tagged
         # version or whether the tree is between two tagged versions.

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -33,7 +33,7 @@ version::get_version_vars() {
 
     # stolen from k8s.io/hack/lib/version.sh
     # Use git describe to find the version based on annotated tags.
-    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --always --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
         # This translates the "git describe" to an actual semver.org
         # compatible semantic version that looks something like this:
         #   v1.1.0-alpha.0.6+84c76d1142ea4d
@@ -56,26 +56,38 @@ version::get_version_vars() {
             # that is problematic since new untracked .go files affect the build,
             # so use our idea of "dirty" from git status instead.
             GIT_VERSION+="-dirty"
+            # Check if we are on top of a shallow copy, as that will impact a release tag with
+            # semantic version to be identified.
+            [ -f "$(git rev-parse --git-dir)/shallow" ] && GIT_VERSION+="-shallow"
         fi
-
-
         # Try to match the "git describe" output to a regex to try to extract
         # the "major" and "minor" versions and whether this is the exact tagged
         # version or whether the tree is between two tagged versions.
         if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
             GIT_MAJOR=${BASH_REMATCH[1]}
             GIT_MINOR=${BASH_REMATCH[2]}
+        else
+            # We are assuming here to be in a shallow copy or perhaps a fork. Define GIT_MAJOR to be the value extracted
+            # from GIT_VERSION itself and GIT_MINOR would be the GitHub handler (if present).
+            GIT_MAJOR=$GIT_VERSION
+            # Try to set GIT_MINOR from https://github.com/<username>
+            GIT_MINOR=$(git config --get remote.origin.url | cut -d/ -f4)
+            # ...otherwise, set it from git@github.com:<username>
+            [ "$GIT_MINOR" == "" ] && GIT_MINOR=$(git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1)
         fi
-
-        # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
-        if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
-            echo "Please see more details here: https://semver.org"
-            exit 1
+        # If we are not in a shallow copy that's no need to check for semver; abort build otherwise.
+        if ! [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+            # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+            if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+                echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+                echo "Please see more details here: https://semver.org"
+                exit 1
+            fi
         fi
     fi
 
-    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+    # This provides the tag identifying a proper release. The code must not be a shallow copy.
+    GIT_RELEASE_TAG=$(git describe --always --abbrev=0 --tags)
     GIT_RELEASE_COMMIT=$(git rev-list -n 1  "${GIT_RELEASE_TAG}")
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -56,6 +56,8 @@ func CheckKubernetesVersion(config *rest.Config, minK8sVersion string) error {
 }
 
 var (
+	gitShallow   string // flag the code to be part of a git shallow copy
+	gitFork      string // flag repository as fork of the official owned by 'kubernetes-sigs'
 	gitMajor     string // major version, always numeric
 	gitMinor     string // minor version, numeric possibly followed by "+"
 	gitVersion   string // semantic version, derived by build scripts
@@ -66,6 +68,8 @@ var (
 
 // Info exposes information about the version used for the current running code.
 type Info struct {
+	Shallow      string `json:"shallow,omitempty"`
+	Fork         string `json:"fork,omitempty"`
 	Major        string `json:"major,omitempty"`
 	Minor        string `json:"minor,omitempty"`
 	GitVersion   string `json:"gitVersion,omitempty"`
@@ -80,6 +84,8 @@ type Info struct {
 // Get returns an Info object with all the information about the current running code.
 func Get() Info {
 	return Info{
+		Shallow:      gitShallow,
+		Fork:         gitFork,
 		Major:        gitMajor,
 		Minor:        gitMinor,
 		GitVersion:   gitVersion,

--- a/version/version.go
+++ b/version/version.go
@@ -56,45 +56,45 @@ func CheckKubernetesVersion(config *rest.Config, minK8sVersion string) error {
 }
 
 var (
-	gitShallow   string // flag the code to be part of a git shallow copy
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
 	gitFork      string // flag repository as fork of the official owned by 'kubernetes-sigs'
 	gitMajor     string // major version, always numeric
 	gitMinor     string // minor version, numeric possibly followed by "+"
-	gitVersion   string // semantic version, derived by build scripts
-	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitShallow   string // flag the code to be part of a git shallow copy
 	gitTreeState string // state of git tree, either "clean" or "dirty"
-	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	gitVersion   string // semantic version, derived by build scripts
 )
 
 // Info exposes information about the version used for the current running code.
 type Info struct {
-	Shallow      string `json:"shallow,omitempty"`
+	BuildDate    string `json:"buildDate,omitempty"`
+	Compiler     string `json:"compiler,omitempty"`
 	Fork         string `json:"fork,omitempty"`
-	Major        string `json:"major,omitempty"`
-	Minor        string `json:"minor,omitempty"`
-	GitVersion   string `json:"gitVersion,omitempty"`
 	GitCommit    string `json:"gitCommit,omitempty"`
 	GitTreeState string `json:"gitTreeState,omitempty"`
-	BuildDate    string `json:"buildDate,omitempty"`
+	GitVersion   string `json:"gitVersion,omitempty"`
 	GoVersion    string `json:"goVersion,omitempty"`
-	Compiler     string `json:"compiler,omitempty"`
+	Major        string `json:"major,omitempty"`
+	Minor        string `json:"minor,omitempty"`
 	Platform     string `json:"platform,omitempty"`
+	Shallow      string `json:"shallow,omitempty"`
 }
 
 // Get returns an Info object with all the information about the current running code.
 func Get() Info {
 	return Info{
-		Shallow:      gitShallow,
+		BuildDate:    buildDate,
+		Compiler:     runtime.Compiler,
 		Fork:         gitFork,
-		Major:        gitMajor,
-		Minor:        gitMinor,
-		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
-		BuildDate:    buildDate,
+		GitVersion:   gitVersion,
 		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
+		Major:        gitMajor,
+		Minor:        gitMinor,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Shallow:      gitShallow,
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

by merging this PR, we would:
- keep building normally as usual;
- ensure all changes met shellcheck's criterias;
- fix added **ldflags** via `hack/version.sh`;
- identify detailed version information that built the binaries (e.g.:`clusterctl`);
- log that the binary was built from a development source code.

> tested on Linux and Mac.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

motivation behind these changes should fix:
- the check to abort the build process while no SEMVER was found was broken;
- ldflags didn't get properly added to the go build parameters;
- folks should be given a more precise information of the commit and tag that built the artifacts.

**How to reproduce**

[reproduce.sh](https://github.com/user-attachments/files/25812874/reproduce.sh)
```
/bin/sh reproduce.sh
```

### `clusterctl version` current output

  * **official repo**
```
clusterctl version: &version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.0-rc.0.408-2056a9f66d773d", GitCommit:"2056a9f66d773d7f04e9e0a05afb8c4e5647e4ff", GitTreeState:"clean", BuildDate:"2026-03-07T08:19:35Z", GoVersion:"go1.25.7", Compiler:"gc", Platform:"linux/amd64"}

New clusterctl version available: v1.12.0-rc.0.408-2056a9f66d773d -> v1.12.3
sigs.k8s.io/cluster-api
```
  * **official repo** (SHALLOW)

```
clusterctl version: &version.Info{Major:"", Minor:"", GitVersion:"", GitCommit:"", GitTreeState:"", BuildDate:"", GoVersion:"go1.25.7", Compiler:"gc", Platform:"linux/amd64"}
```

### `clusterctl version` proposed output, if shallow or fork

```
clusterctl version: &version.Info{Major:"0", Minor:"0", GitVersion:"v0.0.0-fb881cc2b88072-fork", GitCommit:"fb881cc2b88072c42016a84f0e33ceeae79929d1", GitTreeState:"clean", BuildDate:"2026-03-07T08:25:50Z", GoVersion:"go1.25.7", Compiler:"gc", Platform:"linux/amd64"}
```

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area clusterctl
-->

### `managers` build target gets also the benefits of proposed changes

```
$ make clusterctl managers
$ find bin
bin
bin/kubeadm-control-plane-manager
bin/clusterctl
bin/manager
bin/capd-manager
bin/kubeadm-bootstrap-manager
```
* **before**
```
"Version:  (git commit: )" logger="setup"
```
* **after**
```
 "Version: v0.0.0-fb881cc2b88072-fork (git commit: fb881cc2b88072c42016a84f0e33ceeae79929d1)" logger="setup"
```