### PR TITLE
:seedling: build: avoid building if LDFLAGS returns error checking for SemVer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,14 @@ export DBG ?= 0
 LDFLAGS := $(shell hack/version.sh)
 GCFLAGS := $(shell hack/gogcflags.sh)
 
+# Check if LDFLAGS was able to identify a Semantic Version tag in the repository, or not;
+# avoid building if that's true (see hack/version.sh for more information).
+SEMVER_CHECK = $(findstring GIT_VERSION should be a valid Semantic Version, $(LDFLAGS))
+ifneq ($(SEMVER_CHECK),)
+    $(warning SEMVER_CHECK: $(LDFLAGS))
+    $(error Build halted)
+endif
+
 #
 # Ginkgo configuration.
 #


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

`hack/version.sh` doesn't properly block the build if a SemVer is not found in git tags; it returns an erros via `exit 1` but still passes its value to `go build` and it tries to move further with the build process - unnecessarily. 

by merging this change, we:
  - fix properly halting build if SemVer is not found directly in the `Makefile`;
  - check if LDFLAGS was able to identify a Semantic Version tag in the repository;
  - avoid passing broken string values to `go build`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

* **before patching**

```
$ git tag -s v99.rs.belgrade
$ make clusterctl
go build -trimpath -ldflags "GIT_VERSION should be a valid Semantic Version. Current value: v99.rs.belgrade-dirty Please see more details here: https://semver.org" -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
invalid value "GIT_VERSION should be a valid Semantic Version. Current value: v99.rs.belgrade-dirty Please see more details here: https://semver.org" for flag -ldflags: missing =<value> in <pattern>=<value>
usage: go build [-o output] [build flags] [packages]
Run 'go help build' for details.
make: *** [clusterctl] Error 2
```

* **after patching**

```
$ git tag -s v99.br.rio-de-janeiro
$ make clusterctl
Makefile:268: SEMVER_CHECK: GIT_VERSION should be a valid Semantic Version. Current value: v99.br.rio-de-janeiro Please see more details here: https://semver.org
Makefile:269: *** Build halted.  Stop.
```

```
$ git tag -s v99.123.0
$ make clusterctl
go build -trimpath -ldflags "-X 'sigs.k8s.io/cluster-api/version.buildDate=2026-03-08T08:30:39Z' -X 'sigs.k8s.io/cluster-api/version.gitCommit=82699d020ac47d94061afd0bc62dfe7f0c23a858' -X 'sigs.k8s.io/cluster-api/version.gitTreeState=clean' -X 'sigs.k8s.io/cluster-api/version.gitMajor=99' -X 'sigs.k8s.io/cluster-api/version.gitMinor=123' -X 'sigs.k8s.io/cluster-api/version.gitVersion=v99.123.0' -X 'sigs.k8s.io/cluster-api/version.gitReleaseCommit=82699d020ac47d94061afd0bc62dfe7f0c23a858'" -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
```

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->