### PR TITLE
🌱 Revive the debug endpoint for CAPDev in-memory

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/api/debug.go
+++ b/test/infrastructure/inmemory/pkg/server/api/debug.go
@@ -114,7 +114,11 @@ func (h *debugHandler) getCluster(req *restful.Request, resp *restful.Response) 
 func (h *debugHandler) startOrStopListener(req *restful.Request, resp *restful.Response) {
 	defer func() { _ = req.Request.Body.Close() }()
 
-	reqBody, _ := io.ReadAll(req.Request.Body)
+	reqBody, err := io.ReadAll(req.Request.Body)
+	if err != nil {
+		_ = resp.WriteHeaderAndEntity(http.StatusInternalServerError, err.Error())
+		return
+	}
 
 	switch action := string(reqBody); strings.ToLower(action) {
 	case "start":

--- a/test/infrastructure/inmemory/pkg/server/listener.go
+++ b/test/infrastructure/inmemory/pkg/server/listener.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
@@ -158,14 +159,19 @@ func (tc *trackedConn) Close() error {
 	return tc.Conn.Close()
 }
 
-func (tl *trackingListener) CloseAll() {
+func (tl *trackingListener) CloseAll() error {
 	// Stop accepting new connections first
-	_ = tl.Listener.Close()
+	if err := tl.Listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
 
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
 
 	for conn := range tl.conns {
-		_ = conn.Close() // This triggers the underlying TCP close
+		if err := conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) { // This triggers the underlying TCP close
+			return err
+		}
 	}
+	return nil
 }

--- a/test/infrastructure/inmemory/pkg/server/mux.go
+++ b/test/infrastructure/inmemory/pkg/server/mux.go
@@ -536,7 +536,7 @@ func (m *WorkloadClustersMux) StartListener(wclName string) error {
 
 	wcl, ok := m.workloadClusterListeners[wclName]
 	if !ok {
-		return errors.Errorf("workloadClusterListener with name %s must be initialized before being stopped", wclName)
+		return errors.Errorf("workloadClusterListener with name %s must be initialized before being started", wclName)
 	}
 
 	if wcl.listener != nil {
@@ -571,7 +571,9 @@ func (m *WorkloadClustersMux) DeleteAPIServer(wclName, podName string) error {
 	m.log.Info("APIServer instance removed from the workloadClusterListener", "listenerName", wclName, "address", wcl.Address(), "podName", podName)
 
 	if wcl.apiServers.Len() < 1 && wcl.listener != nil {
-		wcl.listener.CloseAll()
+		if err := wcl.listener.CloseAll(); err != nil {
+			return errors.Wrapf(err, "failed to stop WorkloadClusterListener %s, %s", wclName, wcl.HostPort())
+		}
 		wcl.listener = nil
 		m.log.Info("WorkloadClusterListener stopped because there are no APIServer left", "listenerName", wclName, "address", wcl.Address())
 	}
@@ -592,7 +594,9 @@ func (m *WorkloadClustersMux) StopListener(wclName string) error {
 		return nil
 	}
 
-	wcl.listener.CloseAll()
+	if err := wcl.listener.CloseAll(); err != nil {
+		return errors.Wrapf(err, "failed to stop WorkloadClusterListener %s, %s", wclName, wcl.HostPort())
+	}
 	wcl.listener = nil
 	m.log.Info("WorkloadClusterListener stopped", "listenerName", wclName, "address", wcl.Address())
 	return nil
@@ -720,7 +724,9 @@ func (m *WorkloadClustersMux) DeleteWorkloadClusterListener(wclName string) erro
 	}
 
 	if wcl.listener != nil {
-		wcl.listener.CloseAll()
+		if err := wcl.listener.CloseAll(); err != nil {
+			return errors.Wrapf(err, "failed to stop WorkloadClusterListener %s, %s", wclName, wcl.HostPort())
+		}
 	}
 
 	delete(m.workloadClusterListeners, wclName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Revive and improve the debug endpoint for the in memory fake api server, adding also the capability to simulate remote connection down scenarios

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->