### PR TITLE
🌱 Use nodeDeletionTimeoutSeconds: 0 in e2e tests

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
@@ -28,7 +28,7 @@ spec:
           # Note: this annotation is propagated to Nodes.
           Cluster.topology.controlPlane.annotation.node.cluster.x-k8s.io: "Cluster.topology.controlPlane.nodeAnnotationValue"
       deletion:
-        nodeDeletionTimeoutSeconds: 30
+        nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
         nodeVolumeDetachTimeoutSeconds: 300
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
@@ -45,7 +45,7 @@ spec:
             # Note: this annotation is propagated to Nodes. Shortened due to name length limitations
             Cluster.topology.md.annotation.node.cluster.x-k8s.io: "Cluster.topology.machineDeployment.nodeAnnotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}
@@ -67,7 +67,7 @@ spec:
           annotations:
             Cluster.topology.machinePool.annotation: "Cluster.topology.machinePool.annotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-autoscaler/cluster-autoscaler.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-autoscaler/cluster-autoscaler.yaml
@@ -18,14 +18,14 @@ spec:
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       deletion:
-        nodeDeletionTimeoutSeconds: 30
+        nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
       machineDeployments:
         - class: "default-worker"
           name: "md-0"
           deletion:
-            nodeDeletionTimeoutSeconds: 30
+            nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           failureDomain: fd4
           metadata:
             annotations:
@@ -35,7 +35,7 @@ spec:
         - class: "default-worker"
           name: "mp-0"
           deletion:
-            nodeDeletionTimeoutSeconds: 30
+            nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           failureDomains:
           - fd4
     variables:

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
@@ -19,14 +19,14 @@ spec:
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       deletion:
-        nodeDeletionTimeoutSeconds: 30
+        nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
       machineDeployments:
         - class: "default-worker"
           name: "md-0"
           deletion:
-            nodeDeletionTimeoutSeconds: 30
+            nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
             nodeVolumeDetachTimeoutSeconds: 300
           minReadySeconds: 5
           replicas: ${WORKER_MACHINE_COUNT}
@@ -35,7 +35,7 @@ spec:
         - class: "default-worker"
           name: "mp-0"
           deletion:
-            nodeDeletionTimeoutSeconds: 30
+            nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
             nodeVolumeDetachTimeoutSeconds: 300
           minReadySeconds: 5
           replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-docker/v1.11/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.11/bases/cluster-with-topology.yaml
@@ -28,7 +28,7 @@ spec:
           # Note: this annotation is propagated to Nodes.
           Cluster.topology.controlPlane.annotation.node.cluster.x-k8s.io: "Cluster.topology.controlPlane.nodeAnnotationValue"
       deletion:
-        nodeDeletionTimeoutSeconds: 30
+        nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
         nodeVolumeDetachTimeoutSeconds: 300
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
@@ -45,7 +45,7 @@ spec:
             # Note: this annotation is propagated to Nodes. Shortened due to name length limitations
             Cluster.topology.md.annotation.node.cluster.x-k8s.io: "Cluster.topology.machineDeployment.nodeAnnotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}
@@ -67,7 +67,7 @@ spec:
           annotations:
             Cluster.topology.machinePool.annotation: "Cluster.topology.machinePool.annotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-docker/v1.12/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.12/bases/cluster-with-topology.yaml
@@ -28,7 +28,7 @@ spec:
           # Note: this annotation is propagated to Nodes.
           Cluster.topology.controlPlane.annotation.node.cluster.x-k8s.io: "Cluster.topology.controlPlane.nodeAnnotationValue"
       deletion:
-        nodeDeletionTimeoutSeconds: 30
+        nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
         nodeVolumeDetachTimeoutSeconds: 300
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
@@ -45,7 +45,7 @@ spec:
             # Note: this annotation is propagated to Nodes. Shortened due to name length limitations
             Cluster.topology.md.annotation.node.cluster.x-k8s.io: "Cluster.topology.machineDeployment.nodeAnnotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}
@@ -67,7 +67,7 @@ spec:
           annotations:
             Cluster.topology.machinePool.annotation: "Cluster.topology.machinePool.annotationValue"
         deletion:
-          nodeDeletionTimeoutSeconds: 30
+          nodeDeletionTimeoutSeconds: 0 # using 0 so Node deletion doesn't time out, and we don't get test failures because of additional Nodes
           nodeVolumeDetachTimeoutSeconds: 300
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
A single-node self-hosted cluster upgrade failed with `etcdImageTagCondition: expected 1 pods, got 2`.
Root cause is that Node deletion didn't go through because nodeDeletionTimeoutSeconds was set to 30s.
Accordingly Node deletion timed out (when scaling down from 2 to 1), then we got an additional Node and 2 etcd Pods instead of 1.

Also getting this on KCP conditions: "Control plane Node self-hosted-u2g52k-gbkxl-pmkl4 does not have a corresponding Machine"

This PR changes nodeDeletionTimeoutSeconds to use 0, so Node deletion never times out and we don't hit issues because of that in CI.

xref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-main/2029794751309418496

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->