### PR TITLE
:book: Fix typo in quick-start documentation

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -899,7 +899,7 @@ The `clusterctl generate cluster` command by default uses cluster templates whic
 providers. See the provider's documentation for more information.
 
 See the `clusterctl generate cluster` [command][clusterctl generate cluster] documentation for
-details about how to use alternative sources. for cluster templates.
+details about how to use alternative sources for cluster templates.
 
 </aside>
 


### PR DESCRIPTION
## What this PR does

Removes an errant period in the middle of a sentence in `docs/book/src/user/quick-start.md`.

**Before:** `...how to use alternative sources. for cluster templates.`
**After:** `...how to use alternative sources for cluster templates.`