### PR TITLE
📖 Add release note about new ReconcilerRateLimiting constraint

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
+++ b/docs/book/src/developer/providers/migrations/v1.12-to-v1.13.md
@@ -29,6 +29,13 @@ Any feedback or contributions to improve following documentation is welcome!
 - The Controller Runtime version used by Cluster API is v0.22.x
 - The version of the Kubernetes libraries used by Cluster API is v1.34.x
 
+## Graduation
+
+- Both the PriorityQueue and the ReconcilerRateLimiting graduated to beta and are enabled by default
+  - Starting from this release ReconcilerRateLimiting feature also requires PriorityQueue to be enabled.
+  - The same constraint has been backported on the CAPI 1.12 branch starting from v1.12.4 in order
+    to ensure that ReconcilerRateLimiting works consistently with controller runtime exponential backoff.
+
 ## Implemented proposal
 
 -

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -20,6 +20,7 @@ Currently Cluster API has the following experimental features:
     The feature gate was added to allow to opt-out in case unforeseen issues occur with `VolumeAttachments`.
 * `PriorityQueue` (env var: `EXP_PRIORITY_QUEUE`): Enables the usage of the controller-runtime PriorityQueue: https://github.com/kubernetes-sigs/controller-runtime/issues/2374
 * `ReconcilerRateLimiting` (env var: `EXP_RECONCILER_RATE_LIMITING`): Enables reconciler rate-limiting: https://github.com/kubernetes-sigs/cluster-api/issues/13005
+  * Note: starting from CAPI v1.12.4 `ReconcilerRateLimiting` also requires `PriorityQueue`
 * `RuntimeSDK` (env var: `EXP_RUNTIME_SDK`): [RuntimeSDK](./runtime-sdk/index.md)
 
 ## Enabling Experimental Features for Management Clusters Started with clusterctl


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->