### PR TITLE
🐛 Tolerate NotFound errors during Namespace deletion in scale test cleanup

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -570,11 +570,15 @@ func ScaleSpec(ctx context.Context, inputGetter func() ScaleSpecInput) {
 			})
 			if deployClusterInSeparateNamespaces {
 				for _, clusterName := range clusterNames {
-					namespaceName := clusterName
-					framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
-						Deleter: input.BootstrapClusterProxy.GetClient(),
-						Name:    namespaceName,
-					})
+					ns := &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: clusterName,
+						},
+					}
+					log.Logf("Deleting namespace %s", ns.Name)
+					Eventually(func() error {
+						return client.IgnoreNotFound(input.BootstrapClusterProxy.GetClient().Delete(ctx, ns))
+					}, 10*time.Second, 1*time.Second).Should(Succeed(), "Failed to delete namespace %s", ns.Name)
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Noticed these errors when running the scale test in CAPV: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-vsphere/3879/pull-cluster-api-provider-vsphere-e2e-vcsim-govmomi-main/2031691700010749952

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->