### PR TITLE
🌱 tilt: add labels to cluster deployment form fields

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -570,7 +570,7 @@ def deploy_clusterclass(clusterclass_name, label, filename, substitutions):
         icon_name = "note_add",
         text = "Apply `" + clusterclass_name + "` ClusterClass",
         inputs = [
-            text_input("NAMESPACE", default = substitutions.get("NAMESPACE")),
+            text_input("NAMESPACE", label = "NAMESPACE", default = substitutions.get("NAMESPACE")),
         ],
     )
 
@@ -582,7 +582,7 @@ def deploy_clusterclass(clusterclass_name, label, filename, substitutions):
         icon_name = "delete_forever",
         text = "Delete `" + clusterclass_name + "` ClusterClass",
         inputs = [
-            text_input("NAMESPACE", default = substitutions.get("NAMESPACE")),
+            text_input("NAMESPACE", label = "NAMESPACE", default = substitutions.get("NAMESPACE")),
         ],
     )
 
@@ -607,10 +607,10 @@ def deploy_cluster_template(template_name, label, filename, substitutions):
         icon_name = "add_box",
         text = "Create `" + template_name + "` cluster",
         inputs = [
-            text_input("NAMESPACE", default = substitutions.get("NAMESPACE")),
-            text_input("KUBERNETES_VERSION", default = substitutions.get("KUBERNETES_VERSION")),
-            text_input("CONTROL_PLANE_MACHINE_COUNT", default = substitutions.get("CONTROL_PLANE_MACHINE_COUNT")),
-            text_input("WORKER_MACHINE_COUNT", default = substitutions.get("WORKER_MACHINE_COUNT")),
+            text_input("NAMESPACE", label = "NAMESPACE", default = substitutions.get("NAMESPACE")),
+            text_input("KUBERNETES_VERSION", label = "KUBERNETES_VERSION", default = substitutions.get("KUBERNETES_VERSION")),
+            text_input("CONTROL_PLANE_MACHINE_COUNT", label = "CONTROL_PLANE_MACHINE_COUNT", default = substitutions.get("CONTROL_PLANE_MACHINE_COUNT")),
+            text_input("WORKER_MACHINE_COUNT", label = "WORKER_MACHINE_COUNT", default = substitutions.get("WORKER_MACHINE_COUNT")),
         ],
     )
 
@@ -622,7 +622,7 @@ def deploy_cluster_template(template_name, label, filename, substitutions):
         icon_name = "delete_forever",
         text = "Delete `" + template_name + "` clusters",
         inputs = [
-            text_input("NAMESPACE", default = substitutions.get("NAMESPACE")),
+            text_input("NAMESPACE", label = "NAMESPACE", default = substitutions.get("NAMESPACE")),
         ],
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing labels to forms for deploying a cluster/clusterclass. 

A question: I chose to use the exact same wording in the label as the variable is. We could also use a more "readable" name like "Namespace" or "Kubernetes Version" instead. I was on the fence. LMK if you prefer to adjust this. 

Before:
<img width="601" height="498" alt="grafik" src="https://github.com/user-attachments/assets/26242a1b-347a-48e2-9b86-f459534cafe6" />


After:
<img width="601" height="594" alt="grafik" src="https://github.com/user-attachments/assets/b40951dc-a7cd-42d3-a47f-462abdfbe330" />


/area devtools