### PR TITLE
🌱 Harden git workflows

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -20,6 +20,8 @@ jobs:
           - hack/tools
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+        with:
+          persist-credentials: false
       - name: Calculate go version
         id: vars
         run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+      with:
+        persist-credentials: false
     - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # tag=v1.1.2
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -1,13 +1,10 @@
 name: PR title verifier
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
-# Runs in pull_request_target context. Only reads PR title and checks
-# out base ref; no API writes.
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   verify:
@@ -15,7 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
-
+        with:
+          persist-credentials: false
       - name: Check if PR title is valid
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # tag=v1.1.2
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
       with:
         ref: ${{ matrix.branch }}
+        persist-credentials: false
     - name: Calculate go version
       id: vars
       run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
+          persist-credentials: false
       - name: Set env
         run:  echo "RELEASE_TAG=v9.9.9-fake" >> $GITHUB_ENV
       - name: Set fake tag for release


### PR DESCRIPTION
🌱 Harden GitHub Actions workflows

**What this PR does / why we need it**:

Hardens several CI workflows against credential leakage and privilege escalation:

1. **`persist-credentials: false`** added to all `actions/checkout` steps that do not require pushing back to the repository. By default, `actions/checkout` persists the `GITHUB_TOKEN` in `.git/config`, which can be inadvertently leaked if a workflow uploads artifacts.

2. **`pr-verify.yaml`: `pull_request_target` replaced with `pull_request`** :  this is the most significant fix. `pull_request_target` runs with base-repo privileges and access to secrets. Since this workflow checks out repo code and executes `./hack/verify-pr-title.sh`, a malicious fork PR could modify that script and run arbitrary code with elevated privileges. Switching to `pull_request` removes that risk entirely, as title validation requires no elevated permissions.

3. **`permissions: {}`** added to `pr-verify.yaml` which was missing an explicit permissions block.

4. **`fetch-depth: 1`** added to `weekly-md-link-check.yaml` and `weekly-security-scan.yaml` as full git history is unnecessary for link checking and security scanning.

**Which issue(s) this PR fixes**:
Fixes #

**Changes**:
| File | Change |
|---|---|
| `pr-golangci-lint.yaml` | `persist-credentials: false` |
| `pr-md-link-check.yaml` | `persist-credentials: false` |
| `pr-verify.yaml` | `pull_request_target` replaced by `pull_request`, `permissions: {}`, `persist-credentials: false` |
| `weekly-md-link-check.yaml` | `persist-credentials: false` |
| `weekly-security-scan.yaml` | `persist-credentials: false` |
| `weekly-test-release.yaml` | `persist-credentials: false` |

/area ci