### PR TITLE
🌱 Increase envtest manager graceful shutdown timeout & print goroutines on error

### DIFF
--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -366,6 +366,9 @@ func newEnvironment(ctx context.Context, scheme *runtime.Scheme, additionalCRDDi
 				Host:    host,
 			},
 		),
+		// Increase GracefulShutdownTimeout to 90s from the 30s default to tolerate if tests like
+		// TestClusterCacheConcurrency need more time because informers are stuck.
+		GracefulShutdownTimeout: ptr.To(90 * time.Second),
 	}
 
 	mgr, err := ctrl.NewManager(env.Config, options)
@@ -471,6 +474,11 @@ func (e *Environment) start(ctx context.Context) {
 	go func() {
 		fmt.Println("Starting the test environment manager")
 		if err := e.Start(ctx); err != nil {
+			// Print all goroutines to enable debugging in case the manager timed out during shutdown
+			buf := make([]byte, 1<<20)
+			stackLen := goruntime.Stack(buf, true)
+			_, _ = os.Stdout.Write(buf[:stackLen])
+
 			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Once every few weeks the ClusterCache test suite is timing out because the manager shutdown is timing out after 30s.

I suspect the issue is that informers are not shutting down quickly enough. Raising the timeout for now to see if the informers shutdown / timeout if we give them a bit more time

Example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/2028833910590279680

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->