### PR TITLE
[WIP] 🌱 Stabilize self-hosted e2e tests by disabling MP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,6 +591,7 @@ generate-e2e-templates-main: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv6-primary.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-dualstack-ipv4-primary.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-in-place --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-in-place.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-mp --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-mp.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-no-workers.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-runtimesdk-v1beta1.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/main/cluster-template-topology-kcp-only.yaml

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -191,6 +191,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv6-primary.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-dualstack-ipv4-primary.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-in-place.yaml"
+    - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-no-mp.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-no-workers.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-runtimesdk-v1beta1.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-kcp-only.yaml"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-no-mp/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-no-mp/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - ../bases/cluster-with-topology.yaml
+  - ../bases/crs.yaml
+
+patches:
+- path: remove-topology-workers-mp.yaml
+  target:
+    group: cluster.x-k8s.io
+    version: v1beta2
+    kind: Cluster

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-topology-no-mp/remove-topology-workers-mp.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-topology-no-mp/remove-topology-workers-mp.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/topology/workers/machinePools

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -32,7 +32,7 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters using
 			BootstrapClusterProxy:    bootstrapClusterProxy,
 			ArtifactFolder:           artifactFolder,
 			SkipCleanup:              skipCleanup,
-			Flavor:                   "topology",
+			Flavor:                   "topology-no-mp",
 			ControlPlaneMachineCount: ptr.To[int64](1),
 			WorkerMachineCount:       ptr.To[int64](1),
 		}
@@ -47,7 +47,7 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters using
 			BootstrapClusterProxy:    bootstrapClusterProxy,
 			ArtifactFolder:           artifactFolder,
 			SkipCleanup:              skipCleanup,
-			Flavor:                   "topology",
+			Flavor:                   "topology-no-mp",
 			ControlPlaneMachineCount: ptr.To[int64](3),
 			WorkerMachineCount:       ptr.To[int64](1),
 		}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I went through all self-hosted e2e tests that were failing during the last 2 weeks (https://storage.googleapis.com/k8s-triage/index.html?text=move&job=.*cluster-api.*e2e.*main&xjob=.*-provider-.*) and there were quite a few of them.

In *all* cases the clusterctl move failed because webhooks were unavailable and those webhooks were running on MachinePool worker Nodes.

Accordingly, and considering the maintenance situation around MachinePools, I'm proposing to disable MachinePools for the self-hosted tests.

If someone has the time to troubleshoot this issue and stabilize the tests with MachinePools, happy to reenable in the future.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13235

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->