### PR TITLE
🐛 Fix "Failed to exec DockerMachine bootstrap" errors in CAPD

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -328,6 +328,25 @@ func (d *dockerRuntime) GetContainerIPs(ctx context.Context, containerName strin
 	return "", "", nil
 }
 
+// GetContainerLogs gets container logs.
+func (d *dockerRuntime) GetContainerLogs(ctx context.Context, containerName string) (string, error) {
+	logsReader, err := d.dockerClient.ContainerLogs(ctx, containerName, dockercontainer.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get container logs")
+	}
+	defer logsReader.Close()
+
+	logs, err := io.ReadAll(logsReader)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read container logs")
+	}
+
+	return string(logs), nil
+}
+
 // ContainerDebugInfo gets the container metadata and logs from the runtime (docker inspect, docker logs).
 func (d *dockerRuntime) ContainerDebugInfo(ctx context.Context, containerName string, w io.Writer) error {
 	containerInfo, err := d.dockerClient.ContainerInspect(ctx, containerName)

--- a/test/infrastructure/container/fake.go
+++ b/test/infrastructure/container/fake.go
@@ -152,6 +152,10 @@ func (f *FakeRuntime) GetContainerIPs(_ context.Context, containerName string) (
 	return containerName + "IPv4", containerName + "IPv6", nil
 }
 
+func (f *FakeRuntime) GetContainerLogs(_ context.Context, _ string) (string, error) {
+	return "", nil
+}
+
 // ContainerDebugInfo gets the container metadata and logs from the runtime (docker inspect, docker logs).
 func (f *FakeRuntime) ContainerDebugInfo(_ context.Context, _ string, _ io.Writer) error {
 	return nil

--- a/test/infrastructure/container/interface.go
+++ b/test/infrastructure/container/interface.go
@@ -41,6 +41,7 @@ type Runtime interface {
 	ImageExistsLocally(ctx context.Context, image string) (bool, error)
 	GetHostPort(ctx context.Context, containerName, portAndProtocol string) (string, error)
 	GetContainerIPs(ctx context.Context, containerName string) (string, string, error)
+	GetContainerLogs(ctx context.Context, containerName string) (string, error)
 	ExecContainer(ctx context.Context, containerName string, config *ExecContainerInput, command string, args ...string) error
 	RunContainer(ctx context.Context, runConfig *RunContainerInput, output io.Writer) error
 	ListContainers(ctx context.Context, filters FilterBuilder) ([]Container, error)

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -302,7 +302,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 			}()
 
 			// Run the bootstrap script. Simulates cloud-init/Ignition.
-			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format, version, dockerMachine.Spec.Backend.Docker.CustomImage); err != nil {
+			if err := externalMachine.ExecBootstrap(timeoutCtx, r.ContainerRuntime, bootstrapData, format, version, dockerMachine.Spec.Backend.Docker.CustomImage); err != nil {
 				v1beta1conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition, infrav1.BootstrapFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Repeating bootstrap")
 				conditions.Set(dockerMachine, metav1.Condition{
 					Type:    infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -337,12 +338,24 @@ func (m *Machine) PreloadLoadImages(ctx context.Context, images []string) error 
 	return nil
 }
 
+// Note: See https://github.com/kubernetes-sigs/kind/pull/2421 for more context.
+var waitUntilLogRegExp = regexp.MustCompile("Reached target .*Multi-User System.*")
+
 // ExecBootstrap runs bootstrap on a node, this is generally `kubeadm <init|join>`.
-func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstrapv1.Format, version string, image string) error {
+func (m *Machine) ExecBootstrap(ctx context.Context, containerRuntime container.Runtime, data string, format bootstrapv1.Format, version string, image string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if m.container == nil {
 		return errors.New("unable to set ExecBootstrap. the container hosting this machine does not exists")
+	}
+
+	logs, err := containerRuntime.GetContainerLogs(ctx, m.container.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to check if container is ready for DockerMachine bootstrap exec")
+	}
+
+	if !waitUntilLogRegExp.MatchString(logs) {
+		return errors.New("container is not yet ready for DockerMachine bootstrap exec (Multi-User System target not reached yet)")
 	}
 
 	// Get the kindMapping for the target K8s version.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
If it works out this fixes most of our flaky e2e tests

Heavily inspired by https://github.com/kubernetes-sigs/kind/pull/2421

Kudos to @chrischdi  > https://github.com/kubernetes-sigs/cluster-api/issues/12886#issuecomment-3481437424

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->