### PR TITLE
🌱 Drop security scan on 1.10

### DIFF
--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11, release-1.10 ]
+        branch: [ main, release-1.12, release-1.11 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11, release-1.10 ]
+        branch: [ main, release-1.12, release-1.11 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11, release-1.10 ]
+        branch: [ main, release-1.12, release-1.11 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -51,9 +51,12 @@ The Cluster API team actively supports the latest two minor releases (N, N-1); s
 - Accept bug fixes, perform golang or dependency bumps, etc. 
 - Periodically cut patch releases
 
-On top of supporting the N and N-1 releases, the Cluster API team also maintains CI signal for the Cluster API N-2 releases 
-in case we have to do an emergency patch release.  
-- If there is a need for an emergency patch, e.g. to fix a critical security issue, please bring this up to maintainers
+On top of supporting the N and N-1 releases, the Cluster API team also maintains a partial CI signal for the Cluster API N-2 releases 
+in case we have to do an emergency patch release. Please note that:
+- Even if a subset of the CI signal for the N-2 branch is preserved, the N-2 branch is considered in maintenance mode and
+  no change is back-ported proactively.
+- Security scans will be disabled (this signal does not make sense considering that CVE are not going to be fixed proactively)
+- If there is a need for an emergency patch, e.g. to fix a critical issue, please bring this up to maintainers
   and it will be considered on a case-by-case basis. 
 
 All considered, each Cluster API minor release is supported for a period of roughly 12 months:

--- a/docs/release/role-handbooks/release-lead/README.md
+++ b/docs/release/role-handbooks/release-lead/README.md
@@ -78,7 +78,7 @@ Here's an example of how to do this for the `v1.11` release cycle. That means `v
             version of kubernetes that `v1.9` supports, which would be `1.32`. You can't just use the very latest version of k8s `1.32.X` that exists, because the e2e tests use the
             version of kind inside the `release-1.9` branch. So you have to use the latest version of k8s `1.32` that is in the `release-1.9` branch's `test/infrastructure/kind/mapper.go`
             file. Which would be `1.32.0` as of this writing.
-            2. You may even have to delay using the latest verison of k8s for the version of CAPI that just released until kind is updated with an image of that new version.
+            2. You may even have to delay using the latest version of k8s for the version of CAPI that just released until kind is updated with an image of that new version.
             So for `v1.10`, which supports k8s `v1.33`, we had to use `1.32.2` at first, as that was the latest version of `1.32` that was in the `release-1.10` branch's
             `test/infrastructure/kind/mapper.go` file. We usually add a comment in the test case to remind us to update `release-1.10`'s kind and use `1.33.X` later.
        2. :warning: Please ping maintainers after these changes are made for a first round of feedback before continuing with the steps below.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We keep CI for the N-2 branch which is in maintenance mode, but considering the fact that we are not backporting CVE fixes, the signal of the security scan does not make much sense

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->