### PR TITLE
🌱 KCP should read only KCP machines

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -43,6 +43,7 @@ import (
 type ManagementCluster interface {
 	client.Reader
 
+	GetControlPlaneMachinesForCluster(ctx context.Context, cluster *clusterv1.Cluster) (collections.Machines, error)
 	GetMachinesForCluster(ctx context.Context, cluster *clusterv1.Cluster, filters ...collections.Func) (collections.Machines, error)
 	GetMachinePoolsForCluster(ctx context.Context, cluster *clusterv1.Cluster) (*clusterv1.MachinePoolList, error)
 	GetWorkloadCluster(ctx context.Context, cluster *clusterv1.Cluster, keyEncryptionAlgorithm bootstrapv1.EncryptionAlgorithmType) (WorkloadCluster, error)
@@ -92,6 +93,11 @@ func (m *Management) Get(ctx context.Context, key client.ObjectKey, obj client.O
 // List implements client.Reader.
 func (m *Management) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	return m.Client.List(ctx, list, opts...)
+}
+
+// GetControlPlaneMachinesForCluster returns a list of control plane machines.
+func (m *Management) GetControlPlaneMachinesForCluster(ctx context.Context, cluster *clusterv1.Cluster) (collections.Machines, error) {
+	return collections.GetControlPlaneMachinesForCluster(ctx, m.Client, cluster)
 }
 
 // GetMachinesForCluster returns a list of machines that can be filtered or not.

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -308,7 +308,7 @@ func (r *KubeadmControlPlaneReconciler) initControlPlaneScope(ctx context.Contex
 	}
 
 	// Read control plane machines
-	controlPlaneMachines, err := r.managementClusterUncached.GetMachinesForCluster(ctx, cluster, collections.ControlPlaneMachines(cluster.Name))
+	controlPlaneMachines, err := r.managementClusterUncached.GetControlPlaneMachinesForCluster(ctx, cluster)
 	if err != nil {
 		log.Error(err, "Failed to retrieve control plane machines for cluster")
 		return nil, false, err

--- a/controlplane/kubeadm/internal/controllers/fakes_test.go
+++ b/controlplane/kubeadm/internal/controllers/fakes_test.go
@@ -52,9 +52,16 @@ func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ *cluster
 	return f.Workload, f.WorkloadErr
 }
 
-func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, cluster *clusterv1.Cluster, filters ...collections.Func) (collections.Machines, error) {
+func (f *fakeManagementCluster) GetControlPlaneMachinesForCluster(ctx context.Context, cluster *clusterv1.Cluster) (collections.Machines, error) {
 	if f.Management != nil {
-		return f.Management.GetMachinesForCluster(c, cluster, filters...)
+		return f.Management.GetControlPlaneMachinesForCluster(ctx, cluster)
+	}
+	return f.Machines, nil
+}
+
+func (f *fakeManagementCluster) GetMachinesForCluster(ctx context.Context, cluster *clusterv1.Cluster, filters ...collections.Func) (collections.Machines, error) {
+	if f.Management != nil {
+		return f.Management.GetMachinesForCluster(ctx, cluster, filters...)
 	}
 	return f.Machines, nil
 }

--- a/util/collections/helpers.go
+++ b/util/collections/helpers.go
@@ -44,3 +44,21 @@ func GetFilteredMachinesForCluster(ctx context.Context, c client.Reader, cluster
 	machines := FromMachineList(ml)
 	return machines.Filter(filters...), nil
 }
+
+// GetControlPlaneMachinesForCluster returns a list of control plane machines.
+func GetControlPlaneMachinesForCluster(ctx context.Context, c client.Reader, cluster *clusterv1.Cluster) (Machines, error) {
+	ml := &clusterv1.MachineList{}
+	if err := c.List(
+		ctx,
+		ml,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{
+			clusterv1.ClusterNameLabel:         cluster.Name,
+			clusterv1.MachineControlPlaneLabel: "",
+		},
+	); err != nil {
+		return nil, errors.Wrap(err, "failed to list control plane machines")
+	}
+
+	return FromMachineList(ml), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
KCP is reading control plane machines using an uncached client; this PR ensures that only CP machines are included in the result

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
