### PR TITLE
🌱 Improve condition if CAPD Machine is not yet ready for bootstrap exec

### DIFF
--- a/test/infrastructure/docker/api/v1beta2/devmachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/devmachine_types.go
@@ -137,6 +137,10 @@ const (
 	// completed bootstrap exec commands.
 	DevMachineDockerContainerBootstrapExecSucceededReason string = "Succeeded"
 
+	// DevMachineDockerContainerBootstrapExecWaitingForMultiUserTargetReason documents the container for a DevMachine's docker backend not having
+	// completed bootstrap exec commands because it is waiting for the multi-user target.
+	DevMachineDockerContainerBootstrapExecWaitingForMultiUserTargetReason string = "WaitingForMultiUserTarget"
+
 	// DevMachineDockerContainerBootstrapExecNotSucceededReason documents the container for a DevMachine's docker backend not having
 	// completed bootstrap exec commands.
 	DevMachineDockerContainerBootstrapExecNotSucceededReason string = "NotSucceeded"

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -301,8 +301,19 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 				}
 			}()
 
+			if err := externalMachine.WaitForMultiUserTarget(timeoutCtx, r.ContainerRuntime); err != nil {
+				v1beta1conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition, infrav1.BootstrapFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Waiting for multi-user target: %s", err.Error())
+				conditions.Set(dockerMachine, metav1.Condition{
+					Type:    infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  infrav1.DevMachineDockerContainerBootstrapExecWaitingForMultiUserTargetReason,
+					Message: fmt.Sprintf("Waiting for multi-user target: %s", err.Error()),
+				})
+				return ctrl.Result{}, errors.Wrap(err, "waiting for multi-user target")
+			}
+
 			// Run the bootstrap script. Simulates cloud-init/Ignition.
-			if err := externalMachine.ExecBootstrap(timeoutCtx, r.ContainerRuntime, bootstrapData, format, version, dockerMachine.Spec.Backend.Docker.CustomImage); err != nil {
+			if err := externalMachine.ExecBootstrap(timeoutCtx, bootstrapData, format, version, dockerMachine.Spec.Backend.Docker.CustomImage); err != nil {
 				v1beta1conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition, infrav1.BootstrapFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Repeating bootstrap")
 				conditions.Set(dockerMachine, metav1.Condition{
 					Type:    infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -341,21 +341,30 @@ func (m *Machine) PreloadLoadImages(ctx context.Context, images []string) error 
 // Note: See https://github.com/kubernetes-sigs/kind/pull/2421 for more context.
 var waitUntilLogRegExp = regexp.MustCompile("Reached target .*Multi-User System.*")
 
-// ExecBootstrap runs bootstrap on a node, this is generally `kubeadm <init|join>`.
-func (m *Machine) ExecBootstrap(ctx context.Context, containerRuntime container.Runtime, data string, format bootstrapv1.Format, version string, image string) error {
-	log := ctrl.LoggerFrom(ctx)
-
+// WaitForMultiUserTarget checks if the multi-user target is reached to figure out if the container is ready for bootstrap exec.
+func (m *Machine) WaitForMultiUserTarget(ctx context.Context, containerRuntime container.Runtime) error {
 	if m.container == nil {
-		return errors.New("unable to set ExecBootstrap. the container hosting this machine does not exists")
+		return errors.New("the container hosting this machine does not exist")
 	}
 
 	logs, err := containerRuntime.GetContainerLogs(ctx, m.container.Name)
 	if err != nil {
-		return errors.Wrap(err, "failed to check if container is ready for DockerMachine bootstrap exec")
+		return err
 	}
 
 	if !waitUntilLogRegExp.MatchString(logs) {
-		return errors.New("container is not yet ready for DockerMachine bootstrap exec (Multi-User System target not reached yet)")
+		return errors.New("multi-user target not reached yet")
+	}
+
+	return nil
+}
+
+// ExecBootstrap runs bootstrap on a node, this is generally `kubeadm <init|join>`.
+func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstrapv1.Format, version string, image string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if m.container == nil {
+		return errors.New("unable to set ExecBootstrap. the container hosting this machine does not exist")
 	}
 
 	// Get the kindMapping for the target K8s version.
@@ -397,6 +406,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, containerRuntime container.
 	var outErr bytes.Buffer
 	var outStd bytes.Buffer
 	for _, command := range commands {
+		log.Info("Running command", "instance", m.Name(), "command", command)
 		cmd := m.container.Commander.Command(command.Cmd, command.Args...)
 		cmd.SetStderr(&outErr)
 		cmd.SetStdout(&outStd)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->