### PR TITLE
🐛 Fix in-memory watch unit test

### DIFF
--- a/test/infrastructure/inmemory/pkg/server/mux_test.go
+++ b/test/infrastructure/inmemory/pkg/server/mux_test.go
@@ -415,8 +415,11 @@ func TestAPI_corev1_Watch(t *testing.T) {
 
 	nodeBookmarkEvent := false
 	podBookmarkEvent := false
-	expectedEvents := []string{"ADDED/foo", "MODIFIED/foo", "DELETED/foo", "ADDED/bar", "MODIFIED/bar", "DELETED/bar"}
-	receivedEvents := []string{}
+	expectedEvents := map[string][]string{
+		"foo": {"ADDED/foo", "MODIFIED/foo", "DELETED/foo"},
+		"bar": {"ADDED/bar", "MODIFIED/bar", "DELETED/bar"},
+	}
+	receivedEvents := map[string][]string{}
 	done := make(chan bool)
 	go func() {
 		for {
@@ -430,7 +433,7 @@ func TestAPI_corev1_Watch(t *testing.T) {
 				if !ok {
 					return
 				}
-				receivedEvents = append(receivedEvents, fmt.Sprintf("%s/%s", event.Type, o.GetName()))
+				receivedEvents[o.GetName()] = append(receivedEvents[o.GetName()], fmt.Sprintf("%s/%s", event.Type, o.GetName()))
 			case event := <-podWatcher.ResultChan():
 				if event.Type == watch.Bookmark {
 					podBookmarkEvent = true
@@ -440,7 +443,7 @@ func TestAPI_corev1_Watch(t *testing.T) {
 				if !ok {
 					return
 				}
-				receivedEvents = append(receivedEvents, fmt.Sprintf("%s/%s", event.Type, o.GetName()))
+				receivedEvents[o.GetName()] = append(receivedEvents[o.GetName()], fmt.Sprintf("%s/%s", event.Type, o.GetName()))
 			case <-done:
 				nodeWatcher.Stop()
 				podWatcher.Stop()


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Looks like ordering across objects is not guaranteed: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/2033465410208141312

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->