### PR TITLE
🐛  fix flaky by waiting for CRD finalizer processing

### DIFF
--- a/controllers/crdmigrator/crd_migrator_test.go
+++ b/controllers/crdmigrator/crd_migrator_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -163,7 +164,14 @@ func TestReconcile(t *testing.T) {
 			defer func() {
 				crd := &apiextensionsv1.CustomResourceDefinition{}
 				crd.SetName(crdName)
-				g.Expect(env.CleanupAndWait(ctx, crd)).To(Succeed())
+				g.Expect(env.Cleanup(ctx, crd)).To(Succeed())
+				// Wait for the CRD to be fully deleted. CRDs have a built-in finalizer
+				// (customresourcecleanup.apiextensions.k8s.io) processed by the API server,
+				// which can take longer than cacheSyncBackoff under heavy load.
+				g.Eventually(func(g Gomega) {
+					err := env.Get(ctx, client.ObjectKeyFromObject(crd), crd)
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "CRD %s still exists: %v", crdName, err)
+				}).WithTimeout(1 * time.Minute).WithPolling(100 * time.Millisecond).Should(Succeed())
 			}()
 
 			t.Logf("T1: Install CRDs")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The test cleanup uses env.CleanupAndWait, which waits up to ~4.5s (cacheSyncBackoff with Steps=8) for the CRD to be fully deleted. However, CRDs have a built-in finalizer (customresourcecleanup.apiextensions.k8s.io) processed by the API server, and under heavy CI load (24 envtest packages running in parallel with -race), this finalizer processing can exceed the backoff timeout.
This PR replaces env.CleanupAndWait with env.Cleanup + g.Eventually (up to 1 minute) in the crdmigrator test, so the cleanup reliably waits for the CRD finalizer to be fully processed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12757

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->