### PR TITLE
🌱  use select with time.After instead of time.Sleep

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -284,19 +284,20 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 			// (either because canceled intentionally due to machine deletion or canceled by the defer cancel()
 			// call when exiting from this func).
 			go func() {
+				ticker := time.NewTicker(5 * time.Second)
 				for {
 					select {
 					case <-timeoutCtx.Done():
 						return
-					default:
-						updatedDockerMachine := &infrav1.DockerMachine{}
-						if err := r.Get(ctx, client.ObjectKeyFromObject(dockerMachine), updatedDockerMachine); err == nil &&
-							!updatedDockerMachine.DeletionTimestamp.IsZero() {
-							log.Info("Cancelling Bootstrap because the underlying machine has been deleted")
-							cancel()
-							return
-						}
-						time.Sleep(5 * time.Second)
+					case <-ticker.C:
+					}
+
+					updatedDockerMachine := &infrav1.DockerMachine{}
+					if err := r.Get(ctx, client.ObjectKeyFromObject(dockerMachine), updatedDockerMachine); err == nil &&
+						!updatedDockerMachine.DeletionTimestamp.IsZero() {
+						log.Info("Cancelling Bootstrap because the underlying machine has been deleted")
+						cancel()
+						return
 					}
 				}
 			}()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

use time.After instead of time.Sleep for receiving context cancellation while sleeping.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->