### PR TITLE
🌱 fix reconcileDelete returning unnecessary error

### DIFF
--- a/internal/controllers/machinepool/machinepool_controller.go
+++ b/internal/controllers/machinepool/machinepool_controller.go
@@ -257,10 +257,15 @@ func (r *Reconciler) reconcileSetOwnerAndLabels(_ context.Context, s *scope) (ct
 
 // reconcileDelete delete machinePool related resources.
 func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) (ctrl.Result, error) {
-	if ok, err := r.reconcileDeleteExternal(ctx, s.machinePool); !ok || err != nil {
-		// Return early and don't remove the finalizer if we got an error or
-		// the external reconciliation deletion isn't ready.
+	ok, err := r.reconcileDeleteExternal(ctx, s.machinePool)
+	if err != nil {
+		// Return early and don't remove the finalizer if we got an error.
 		return ctrl.Result{}, fmt.Errorf("failed deleting external references: %s", err)
+	}
+
+	if !ok {
+		// Return early and don't remove the finalizer if we still have external references to delete.
+		return ctrl.Result{}, nil
 	}
 
 	// check nodes delete timeout passed.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

reconcileDeleteExternal also returns false, nil pattern when external objects are still exists. In that case, MP Reconciler returns misleading error that means `failed deleting external references: nil`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->