### PR TITLE
🌱Bump cert-manager to v1.20.0

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -29,7 +29,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.19.4"
+	CertManagerDefaultVersion = "v1.20.0"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -194,7 +194,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.19.4). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.20.0). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/developer/getting-started.md
+++ b/docs/book/src/developer/getting-started.md
@@ -83,7 +83,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.4/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.0/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -258,9 +258,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.19.4"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.19.4"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.19.4"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.20.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.20.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.20.0"
 
   # Pull all images defined in DOCKER_PRELOAD_IMAGES.
   for IMAGE in $(grep DOCKER_PRELOAD_IMAGES: < "$E2E_CONF_FILE" | sed -E 's/.*\[(.*)\].*/\1/' | tr ',' ' '); do

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -21,11 +21,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/test-extension-{ARCH}:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.19.4
+- name: quay.io/jetstack/cert-manager-cainjector:v1.20.0
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.19.4
+- name: quay.io/jetstack/cert-manager-webhook:v1.20.0
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.19.4
+- name: quay.io/jetstack/cert-manager-controller:v1.20.0
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This updates cert-manager to v1.20.0 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
N/A 

[Prior Art](https://github.com/kubernetes-sigs/cluster-api/pull/13376)
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl