### PR TITLE
⚠️ Fix minor goroutine leak in util/cache after controller shutdown

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -138,7 +138,7 @@ func (r *KubeadmConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 	).WatchesRawSource(r.ClusterCache.GetClusterSource("kubeadmconfig", r.ClusterToKubeadmConfigs))
 
-	if err := b.Complete(r); err != nil {
+	if err := b.Complete(ctx, r); err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 	return nil

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -333,7 +333,7 @@ func SetupWithManager(ctx context.Context, mgr manager.Manager, options Options,
 		For(&clusterv1.Cluster{}).
 		WithOptions(controllerOptions).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), log, options.WatchFilterValue)).
-		Complete(cc)
+		Complete(ctx, cc)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed setting up ClusterCache with a controller manager")
 	}

--- a/controllers/crdmigrator/crd_migrator.go
+++ b/controllers/crdmigrator/crd_migrator.go
@@ -112,7 +112,7 @@ type ByObjectConfig struct {
 }
 
 func (r *CRDMigrator) SetupWithManager(ctx context.Context, mgr ctrl.Manager, controllerOptions controller.Options) error {
-	if err := r.setup(mgr.GetScheme()); err != nil {
+	if err := r.setup(ctx, mgr.GetScheme()); err != nil {
 		return err
 	}
 
@@ -137,7 +137,7 @@ func (r *CRDMigrator) SetupWithManager(ctx context.Context, mgr ctrl.Manager, co
 		).
 		Named("crdmigrator").
 		WithOptions(controllerOptions).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
@@ -145,7 +145,7 @@ func (r *CRDMigrator) SetupWithManager(ctx context.Context, mgr ctrl.Manager, co
 	return nil
 }
 
-func (r *CRDMigrator) setup(scheme *runtime.Scheme) error {
+func (r *CRDMigrator) setup(ctx context.Context, scheme *runtime.Scheme) error {
 	if r.Client == nil || r.APIReader == nil || len(r.Config) == 0 {
 		return errors.New("Client and APIReader must not be nil and Config must not be empty")
 	}
@@ -172,7 +172,7 @@ func (r *CRDMigrator) setup(scheme *runtime.Scheme) error {
 		r.configByCRDName[contract.CalculateCRDName(gvk.Group, gvk.Kind)] = cfg
 	}
 
-	r.storageVersionMigrationCache = cache.New[objectEntry](1 * time.Hour)
+	r.storageVersionMigrationCache = cache.New[objectEntry](ctx, 1*time.Hour)
 	return nil
 }
 

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -226,7 +226,7 @@ func TestGetWorkloadCluster(t *testing.T) {
 				Client:              env.GetClient(),
 				SecretCachingClient: secretCachingClient,
 				ClusterCache:        clusterCache,
-				ClientCertCache:     cache.New[ClientCertEntry](24 * time.Hour),
+				ClientCertCache:     cache.New[ClientCertEntry](ctx, 24*time.Hour),
 			}
 
 			// Ensure the ClusterCache reconciled at least once (and if possible created a clusterAccessor).

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -149,7 +149,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("kubeadmcontrolplane", r.ClusterToKubeadmControlPlane,
 			clustercache.WatchForProbeFailure(r.RemoteConditionsGracePeriod))).
-		Build(r)
+		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
@@ -166,7 +166,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 			EtcdDialTimeout:     r.EtcdDialTimeout,
 			EtcdCallTimeout:     r.EtcdCallTimeout,
 			EtcdLogger:          r.EtcdLogger,
-			ClientCertCache:     cache.New[internal.ClientCertEntry](24 * time.Hour),
+			ClientCertCache:     cache.New[internal.ClientCertEntry](ctx, 24*time.Hour),
 		}
 	}
 

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -392,7 +392,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if feature.Gates.Enabled(feature.InPlaceUpdates) {
 		// This is the creation of the runtimeClient for the controllers, embedding a shared catalog and registry instance.
 		var certWatcher *certwatcher.CertWatcher
-		runtimeClient, certWatcher, err = internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, certWatcher, err = internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			CertFile: runtimeExtensionCertFile,
 			KeyFile:  runtimeExtensionKeyFile,
 			Catalog:  catalog,

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -1713,7 +1713,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 			r := &generator{
 				Client:        fakeClient,
 				RuntimeClient: runtimeClient,
-				hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+				hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 			}
 			version, err := r.computeControlPlaneVersion(ctx, s)
 			if tt.wantErr {
@@ -4031,8 +4031,8 @@ func TestGenerate(t *testing.T) {
 			fakeClient,
 			clusterCache,
 			fakeRuntimeClient,
-			cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
-			cache.New[GenerateUpgradePlanCacheEntry](10*time.Minute),
+			cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
+			cache.New[GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute),
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 

--- a/exp/topology/desiredstate/lifecycle_hooks_test.go
+++ b/exp/topology/desiredstate/lifecycle_hooks_test.go
@@ -1295,7 +1295,7 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			r := &generator{
 				Client:        fakeClient,
 				RuntimeClient: runtimeClient,
-				hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+				hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 			}
 			version, err := r.computeControlPlaneVersion(ctx, s)
 			g.Expect(err).ToNot(HaveOccurred())

--- a/exp/topology/desiredstate/upgrade_plan_test.go
+++ b/exp/topology/desiredstate/upgrade_plan_test.go
@@ -1218,7 +1218,7 @@ func TestGetUpgradePlanFromExtension(t *testing.T) {
 		Build()
 
 	// Call GetUpgradePlanFromExtension
-	generateUpgradePlanCache := cache.New[GenerateUpgradePlanCacheEntry](10 * time.Minute)
+	generateUpgradePlanCache := cache.New[GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute)
 	f := GetUpgradePlanFromExtension(fakeRuntimeClient, generateUpgradePlanCache, cluster, "test-extension")
 	controlPlaneUpgradePlan, workersUpgradePlan, err := f(ctx, "v1.33.0", "v1.31.0", "v1.31.0")
 
@@ -1305,7 +1305,7 @@ func TestGetUpgradePlanFromExtension_Errors(t *testing.T) {
 			fakeRuntimeClient := fakeRuntimeClientBuilder.Build()
 
 			// Call GetUpgradePlanFromExtension
-			f := GetUpgradePlanFromExtension(fakeRuntimeClient, cache.New[GenerateUpgradePlanCacheEntry](10*time.Minute), cluster, "test-extension")
+			f := GetUpgradePlanFromExtension(fakeRuntimeClient, cache.New[GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute), cluster, "test-extension")
 			_, _, err := f(ctx, tt.desiredVersion, tt.currentControlPlaneVersion, tt.currentMinWorkersVersion)
 
 			g.Expect(err).To(HaveOccurred())

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -117,7 +117,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	c, err := b.
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Build(r)
+		Build(ctx, r)
 
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -94,13 +94,13 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(r.extensionConfigToClusterClass),
 		).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Complete(r)
+		Complete(ctx, r)
 
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
-	r.discoverVariablesCache = cache.New[runtimeclient.CallExtensionCacheEntry](cache.DefaultTTL)
+	r.discoverVariablesCache = cache.New[runtimeclient.CallExtensionCacheEntry](ctx, cache.DefaultTTL)
 	return nil
 }
 

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -1178,7 +1178,7 @@ func TestReconciler_reconcileVariables(t *testing.T) {
 
 			r := &Reconciler{
 				RuntimeClient:          fakeRuntimeClient,
-				discoverVariablesCache: cache.New[runtimeclient.CallExtensionCacheEntry](cache.DefaultTTL),
+				discoverVariablesCache: cache.New[runtimeclient.CallExtensionCacheEntry](ctx, cache.DefaultTTL),
 			}
 
 			// Pin the compatibility version used in variable CEL validation to 1.29, so we don't have to continuously refactor

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller.go
@@ -109,7 +109,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		)).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/clusterresourcesetbinding/clusterresourcesetbinding_controller.go
+++ b/internal/controllers/clusterresourcesetbinding/clusterresourcesetbinding_controller.go
@@ -62,7 +62,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/extensionconfig/extensionconfig_controller.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller.go
@@ -105,7 +105,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		))
 	}
 
-	if err := b.Complete(r); err != nil {
+	if err := b.Complete(ctx, r); err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 

--- a/internal/controllers/extensionconfig/extensionconfig_controller_test.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller_test.go
@@ -60,13 +60,13 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
 
 	registry := runtimeregistry.New()
-	runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+	runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 		Catalog:  cat,
 		Registry: registry,
 	})
 	g.Expect(err).ToNot(HaveOccurred())
 	registryReadOnly := runtimeregistry.New()
-	runtimeClientReadOnly, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+	runtimeClientReadOnly, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 		Catalog:  cat,
 		Registry: registryReadOnly,
 	})
@@ -115,7 +115,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 			RuntimeClient: runtimeClient,
 		}
 		g.Expect(warmup.Start(ctx)).To(Succeed())
-		runtimeClientReadOnly, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClientReadOnly, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registryReadOnly,
 		})
@@ -303,7 +303,7 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		defer srv1.Close()
 
-		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registry,
 		})
@@ -344,7 +344,7 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 		// srv1 := fakeSecureExtensionServer(discoveryHandler("first"))
 		// defer srv1.Close()
 
-		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registry,
 		})

--- a/internal/controllers/extensionconfig/warmup_test.go
+++ b/internal/controllers/extensionconfig/warmup_test.go
@@ -78,7 +78,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			})
 		}
 
-		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registry,
 		})
@@ -130,7 +130,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			})
 		}
 
-		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registry,
 		})
@@ -141,7 +141,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			RuntimeClient: runtimeClient,
 		}
 
-		runtimeClientReadOnly, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClientReadOnly, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registryReadOnly,
 		})
@@ -209,7 +209,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 			g.Expect(env.CreateAndWait(ctx, extensionConfig)).To(Succeed())
 		}
 
-		runtimeClient, _, err := internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, _, err := internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			Catalog:  cat,
 			Registry: registry,
 		})

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -170,12 +170,12 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			&clusterv1.MachineDeployment{},
 			handler.EnqueueRequestsFromMapFunc(mdToMachines),
 		).
-		Build(r)
+		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
-	r.hookCache = cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)
+	r.hookCache = cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
 	r.externalTracker = external.ObjectTracker{

--- a/internal/controllers/machine/machine_controller_inplace_update_test.go
+++ b/internal/controllers/machine/machine_controller_inplace_update_test.go
@@ -83,7 +83,7 @@ func TestReconcileInPlaceUpdate(t *testing.T) {
 
 				client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(machine, infra, bootstrap).Build()
 
-				return &Reconciler{Client: client, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{
+				return &Reconciler{Client: client, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{
 					machine:         machine,
 					infraMachine:    infra,
 					bootstrapConfig: bootstrap,
@@ -193,7 +193,7 @@ func TestReconcileInPlaceUpdate(t *testing.T) {
 				return &Reconciler{
 						Client:        client,
 						RuntimeClient: runtimeClient,
-						hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+						hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 					}, &scope{
 						machine:      machine,
 						infraMachine: infra,
@@ -259,7 +259,7 @@ func TestReconcileInPlaceUpdate(t *testing.T) {
 				return &Reconciler{
 						Client:        client,
 						RuntimeClient: runtimeClient,
-						hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+						hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 					}, &scope{
 						machine:         machine,
 						infraMachine:    infra,
@@ -357,7 +357,7 @@ func TestCallUpdateMachineHook(t *testing.T) {
 					WithCatalog(catalog).
 					WithGetAllExtensionResponses(map[runtimecatalog.GroupVersionHook][]string{}).
 					Build()
-				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
+				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
 			},
 			wantErr:           true,
 			wantErrSubstrings: []string{"no extensions registered for UpdateMachine hook"},
@@ -372,7 +372,7 @@ func TestCallUpdateMachineHook(t *testing.T) {
 						updateGVH: {"ext-a", "ext-b"},
 					}).
 					Build()
-				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
+				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
 			},
 			wantErr:           true,
 			wantErrSubstrings: []string{"found multiple UpdateMachine hooks (ext-a,ext-b): only one hook is supported"},
@@ -394,7 +394,7 @@ func TestCallUpdateMachineHook(t *testing.T) {
 						},
 					}).
 					Build()
-				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
+				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
 			},
 			wantErr:           true,
 			wantErrSubstrings: []string{"runtime hook", "UpdateMachine", "failed"},
@@ -420,7 +420,7 @@ func TestCallUpdateMachineHook(t *testing.T) {
 						},
 					}).
 					Build()
-				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
+				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
 			},
 			wantResult:  ctrl.Result{RequeueAfter: 45 * time.Second},
 			wantMessage: "processing",
@@ -447,7 +447,7 @@ func TestCallUpdateMachineHook(t *testing.T) {
 						},
 					}).
 					Build()
-				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
+				return &Reconciler{RuntimeClient: runtimeClient, hookCache: cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)}, &scope{machine: newTestMachine(), infraMachine: newTestUnstructured("GenericInfrastructureMachine", "infrastructure.cluster.x-k8s.io/v1beta2", "infra")}
 			},
 			wantResult:  ctrl.Result{},
 			wantMessage: "done",

--- a/internal/controllers/machinedeployment/machinedeployment_canupdatemachineset_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_canupdatemachineset_test.go
@@ -228,7 +228,7 @@ func Test_canUpdateMachineSetInPlace(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithObjects(objs...).Build()
 
-			canUpdateMachineSetCache := cache.New[CanUpdateMachineSetCacheEntry](cache.HookCacheDefaultTTL)
+			canUpdateMachineSetCache := cache.New[CanUpdateMachineSetCacheEntry](ctx, cache.HookCacheDefaultTTL)
 
 			var canExtensionsUpdateMachineSetCalled bool
 			p := &rolloutPlanner{

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -116,12 +116,12 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			predicates.ClusterPausedTransitions(mgr.GetScheme(), predicateLog),
 			// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-		).Complete(r)
+		).Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
-	r.canUpdateMachineSetCache = cache.New[CanUpdateMachineSetCacheEntry](cache.HookCacheDefaultTTL)
+	r.canUpdateMachineSetCache = cache.New[CanUpdateMachineSetCacheEntry](ctx, cache.HookCacheDefaultTTL)
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")
 	r.ssaCache = ssa.NewCache("machinedeployment")
 	return nil

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -130,7 +130,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		// that this reconciler gets invoked very frequently due to watches on Machines and workload cluster Nodes,
 		// but in most cases observed Machines are ok or remediation must be deferred until timeouts will expire.
 		WithRateLimitInterval(rateLimit).
-		Build(r)
+		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/machinepool/machinepool_controller.go
+++ b/internal/controllers/machinepool/machinepool_controller.go
@@ -111,7 +111,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceHasFilterLabel(mgr.GetScheme(), *r.predicateLog, r.WatchFilterValue),
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("machinepool", clusterToMachinePools)).
-		Build(r)
+		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -149,7 +149,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("machineset", clusterToMachineSets)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -138,7 +138,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Build(r)
+		Build(ctx, r)
 
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
@@ -150,7 +150,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		Scheme:          mgr.GetScheme(),
 		PredicateLogger: &predicateLog,
 	}
-	r.hookCache = cache.New[cache.HookEntry](cache.HookCacheDefaultTTL)
+	r.hookCache = cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL)
 	r.desiredStateGenerator, err = desiredstate.NewGenerator(
 		r.Client,
 		r.ClusterCache,
@@ -158,7 +158,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		r.hookCache,
 		// Note: We are using 10m so that we are able to relatively quickly pick up changes to the
 		// upgrade plan from the extension if necessary.
-		cache.New[desiredstate.GenerateUpgradePlanCacheEntry](10*time.Minute),
+		cache.New[desiredstate.GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed creating desired state generator")

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -655,7 +655,7 @@ func TestClusterReconciler_reconcileDelete(t *testing.T) {
 				Client:        fakeClient,
 				APIReader:     fakeClient,
 				RuntimeClient: fakeRuntimeClient,
-				hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+				hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 			}
 
 			s := scope.New(tt.cluster)
@@ -871,7 +871,7 @@ func TestReconciler_callBeforeClusterCreateHook(t *testing.T) {
 			r := &Reconciler{
 				RuntimeClient: runtimeClient,
 				Client:        fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(s.Current.Cluster).Build(),
-				hookCache:     cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+				hookCache:     cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 			}
 			res, err := r.callBeforeClusterCreateHook(ctx, s)
 			if tt.wantErr {

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -1310,8 +1310,8 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 				fakeClient,
 				clustercache.NewFakeEmptyClusterCache(),
 				fakeRuntimeClient,
-				cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
-				cache.New[desiredstate.GenerateUpgradePlanCacheEntry](10*time.Minute),
+				cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
+				cache.New[desiredstate.GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute),
 			)
 			g.Expect(err).ToNot(HaveOccurred())
 
@@ -1319,7 +1319,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 				Client:                fakeClient,
 				APIReader:             fakeClient,
 				RuntimeClient:         fakeRuntimeClient,
-				hookCache:             cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
+				hookCache:             cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
 				desiredStateGenerator: desiredStateGenerator,
 			}
 

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 			predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 		).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -88,7 +88,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ClusterUnpaused(mgr.GetScheme(), predicateLog),
 			predicates.ClusterHasTopology(mgr.GetScheme(), predicateLog),
 		).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -74,8 +74,8 @@ type Options struct {
 }
 
 // New returns a new Client.
-func New(options Options) (runtimeclient.Client, *certwatcher.CertWatcher, error) {
-	httpClientCache := cache.New[httpClientEntry](24 * time.Hour)
+func New(ctx context.Context, options Options) (runtimeclient.Client, *certwatcher.CertWatcher, error) {
+	httpClientCache := cache.New[httpClientEntry](ctx, 24*time.Hour)
 
 	var certWatcher *certwatcher.CertWatcher
 	if options.CertFile != "" && options.KeyFile != "" {

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -799,7 +799,7 @@ func TestClient_CallExtension(t *testing.T) {
 				WithObjects(ns).
 				Build()
 
-			c, _, err := New(Options{
+			c, _, err := New(t.Context(), Options{
 				Catalog:  cat,
 				Registry: registry(tt.registeredExtensionConfigs),
 				Client:   fakeClient,
@@ -822,7 +822,7 @@ func TestClient_CallExtension(t *testing.T) {
 
 			// Call again with caching.
 			serverCallCount = 0
-			cache := cache.New[runtimeclient.CallExtensionCacheEntry](cache.DefaultTTL)
+			cache := cache.New[runtimeclient.CallExtensionCacheEntry](t.Context(), cache.DefaultTTL)
 			err = c.CallExtension(context.Background(), tt.args.hook, obj, tt.args.name, tt.args.request, tt.args.response,
 				runtimeclient.WithCaching{Cache: cache, CacheKeyFunc: cacheKeyFunc})
 			if tt.wantErr {
@@ -929,7 +929,7 @@ func TestClient_CallExtensionWithClientAuthentication(t *testing.T) {
 		WithObjects(ns).
 		Build()
 
-	c, certWatcher, err := New(Options{
+	c, certWatcher, err := New(t.Context(), Options{
 		// Add client authentication credentials to the client
 		CertFile: clientCertFile,
 		KeyFile:  clientKeyFile,
@@ -1066,7 +1066,7 @@ func TestClient_GetHttpClient(t *testing.T) {
 		},
 	}
 
-	c, _, err := New(Options{})
+	c, _, err := New(t.Context(), Options{})
 	g.Expect(err).ToNot(HaveOccurred())
 
 	internalClient := c.(*client)
@@ -1331,7 +1331,7 @@ func TestClient_GetAllExtensions(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(ns, nsDifferent).
 				Build()
-			c, _, err := New(Options{
+			c, _, err := New(t.Context(), Options{
 				Catalog:  cat,
 				Registry: registry(tt.registeredExtensionConfigs),
 				Client:   fakeClient,
@@ -1531,7 +1531,7 @@ func TestClient_CallAllExtensions(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(ns).
 				Build()
-			c, _, err := New(Options{
+			c, _, err := New(t.Context(), Options{
 				Catalog:  cat,
 				Registry: registry(tt.registeredExtensionConfigs),
 				Client:   fakeClient,

--- a/main.go
+++ b/main.go
@@ -484,7 +484,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespace stri
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
 		// This is the creation of the runtimeClient for the controllers, embedding a shared catalog and registry instance.
 		var certWatcher *certwatcher.CertWatcher
-		runtimeClient, certWatcher, err = internalruntimeclient.New(internalruntimeclient.Options{
+		runtimeClient, certWatcher, err = internalruntimeclient.New(ctx, internalruntimeclient.Options{
 			CertFile: runtimeExtensionCertFile,
 			KeyFile:  runtimeExtensionKeyFile,
 			Catalog:  catalog,

--- a/test/extension/handlers/topologymutation/handler_integration_test.go
+++ b/test/extension/handlers/topologymutation/handler_integration_test.go
@@ -121,8 +121,8 @@ func TestHandler(t *testing.T) {
 		clientWithV1Beta2ContractCRD,
 		clustercache.NewFakeEmptyClusterCache(),
 		runtimeClient,
-		cache.New[cache.HookEntry](cache.HookCacheDefaultTTL),
-		cache.New[desiredstate.GenerateUpgradePlanCacheEntry](10*time.Minute),
+		cache.New[cache.HookEntry](ctx, cache.HookCacheDefaultTTL),
+		cache.New[desiredstate.GenerateUpgradePlanCacheEntry](ctx, 10*time.Minute),
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/test/infrastructure/docker/internal/controllers/devcluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devcluster_controller.go
@@ -74,7 +74,7 @@ func (r *DevClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("DevCluster"), mgr.GetClient(), &infrav1.DevCluster{})),
 			predicates.ClusterPausedTransitions(mgr.GetScheme(), predicateLog),
-		).Complete(r)
+		).Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/devmachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devmachine_controller.go
@@ -91,7 +91,7 @@ func (r *DevMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			predicates.ClusterPausedTransitionsOrInfrastructureProvisioned(mgr.GetScheme(), predicateLog),
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("devmachine", clusterToDevMachines)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/devmachinepool_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devmachinepool_controller.go
@@ -93,7 +93,7 @@ func (r *DevMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctr
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToDevMachinePools),
 			predicates.ClusterPausedTransitionsOrInfrastructureProvisioned(mgr.GetScheme(), predicateLog),
-		).Build(r)
+		).Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/devmachinetemplate_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devmachinetemplate_controller.go
@@ -97,7 +97,7 @@ func (r *DevMachineTemplateReconciler) SetupWithManager(ctx context.Context, mgr
 		For(&infrav1.DevMachineTemplate{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -154,7 +154,7 @@ func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("DockerCluster"), mgr.GetClient(), &infrav1.DockerCluster{})),
 			predicates.ClusterPausedTransitions(mgr.GetScheme(), predicateLog),
-		).Complete(r)
+		).Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -206,7 +206,7 @@ func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 			predicates.ClusterPausedTransitionsOrInfrastructureProvisioned(mgr.GetScheme(), predicateLog),
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("dockermachine", clusterToDockerMachines)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachinepool_controller.go
@@ -199,7 +199,7 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr 
 			handler.EnqueueRequestsFromMapFunc(clusterToDockerMachinePools),
 			//nolint:staticcheck // This usage will be removed when adding v1beta2 status and implementing the Paused condition.
 			predicates.ClusterUnpausedAndInfrastructureProvisioned(mgr.GetScheme(), predicateLog),
-		).Build(r)
+		).Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/test/infrastructure/docker/internal/controllers/dockermachinetemplate_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachinetemplate_controller.go
@@ -82,7 +82,7 @@ func (r *DockerMachineTemplateReconciler) SetupWithManager(ctx context.Context, 
 		For(&infrav1.DockerMachineTemplate{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		Complete(r)
+		Complete(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}

--- a/util/cache/cache.go
+++ b/util/cache/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -64,9 +65,9 @@ type Cache[E Entry] interface {
 
 // New creates a new cache.
 // ttl is the duration for which we keep entries in the cache.
-func New[E Entry](ttl time.Duration) Cache[E] {
+func New[E Entry](ctx context.Context, ttl time.Duration) Cache[E] {
 	r := &cache[E]{
-		Store: kcache.NewTTLStore(func(obj interface{}) (string, error) {
+		Store: kcache.NewTTLStore(func(obj any) (string, error) {
 			// We only add objects of type E to the cache, so it's safe to cast to E.
 			return obj.(E).Key(), nil
 		}, ttl),
@@ -78,7 +79,11 @@ func New[E Entry](ttl time.Duration) Cache[E] {
 			// items lazily. If we don't do this the cache grows indefinitely.
 			r.List()
 
-			time.Sleep(expirationInterval)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(expirationInterval):
+			}
 		}
 	}()
 	return r

--- a/util/cache/cache_test.go
+++ b/util/cache/cache_test.go
@@ -31,7 +31,7 @@ import (
 func TestCache(t *testing.T) {
 	g := NewWithT(t)
 
-	c := New[HookEntry](DefaultTTL)
+	c := New[HookEntry](t.Context(), DefaultTTL)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/util/controller/builder.go
+++ b/util/controller/builder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
 	"math"
 	"strings"
@@ -153,13 +154,13 @@ type Controller interface {
 }
 
 // Complete builds the Application Controller.
-func (blder *Builder) Complete(r reconcile.TypedReconciler[reconcile.Request]) error {
-	_, err := blder.Build(r)
+func (blder *Builder) Complete(ctx context.Context, r reconcile.TypedReconciler[reconcile.Request]) error {
+	_, err := blder.Build(ctx, r)
 	return err
 }
 
 // Build builds the Application Controller and returns the Controller it created.
-func (blder *Builder) Build(r reconcile.TypedReconciler[reconcile.Request]) (Controller, error) {
+func (blder *Builder) Build(ctx context.Context, r reconcile.TypedReconciler[reconcile.Request]) (Controller, error) {
 	if feature.Gates.Enabled(feature.ReconcilerRateLimiting) && !feature.Gates.Enabled(feature.PriorityQueue) {
 		return nil, errors.New("if feature gate ReconcilerRateLimiting is enabled, feature gate PriorityQueue must be enabled as well")
 	}
@@ -232,7 +233,7 @@ func (blder *Builder) Build(r reconcile.TypedReconciler[reconcile.Request]) (Con
 	blder.builder.WithOptions(blder.options)
 
 	// Create reconcileCache.
-	reconcileCache := cache.New[reconcileCacheEntry](cache.DefaultTTL)
+	reconcileCache := cache.New[reconcileCacheEntry](ctx, cache.DefaultTTL)
 
 	c, err := blder.builder.Build(&reconcilerWrapper{
 		name:              controllerName,

--- a/util/controller/builder_test.go
+++ b/util/controller/builder_test.go
@@ -73,7 +73,7 @@ func TestBuilder(t *testing.T) {
 		Watches(&clusterv1.MachinePool{}, handler.EnqueueRequestsFromMapFunc(nil)).
 		WithOptions(controller.Options{}).
 		WithEventFilter(predicates.ResourceHasFilterLabel(fakeManager.GetScheme(), predicateLog, "labelValue")).
-		Build(reconciler)
+		Build(t.Context(), reconciler)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c).ToNot(BeNil())
 

--- a/util/controller/controller_test.go
+++ b/util/controller/controller_test.go
@@ -52,7 +52,7 @@ func TestReconcile(t *testing.T) {
 	// Note: synctest.Test below will run with a fake clock, so it will add
 	// entries to the cache with a timestamp ~ 2020. We are using a high expiration
 	// time here so that the cache does not expire our entries during the test run.
-	reconcileCache := cache.New[reconcileCacheEntry](250 * 365 * 24 * time.Hour) // 250 years
+	reconcileCache := cache.New[reconcileCacheEntry](t.Context(), 250*365*24*time.Hour) // 250 years
 
 	synctest.Test(t, func(t *testing.T) {
 		g := NewWithT(t)
@@ -248,7 +248,7 @@ func TestReconcileMetrics(t *testing.T) {
 
 	// reconcileCache has to be created outside synctest.Test, otherwise
 	// the test would fail because of the cleanup go routine in the cache.
-	reconcileCache := cache.New[reconcileCacheEntry](cache.DefaultTTL)
+	reconcileCache := cache.New[reconcileCacheEntry](t.Context(), cache.DefaultTTL)
 
 	synctest.Test(t, func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->