### PR TITLE
🐛 Remove conflicting rules field from aggregated ClusterRoles

### DIFF
--- a/config/rbac/aggregated_role.yaml
+++ b/config/rbac/aggregated_role.yaml
@@ -6,4 +6,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       cluster.x-k8s.io/aggregate-to-manager: "true"
-rules: []

--- a/controlplane/kubeadm/config/rbac/aggregated_role.yaml
+++ b/controlplane/kubeadm/config/rbac/aggregated_role.yaml
@@ -6,4 +6,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
-rules: []


### PR DESCRIPTION
In an aggregated ClusterRole, the rules field is created and managed by clusterrole-aggregation-controller. It is also defined to be atomic. This means that specifying it as empty is not only redundant, it will cause a conflict when reconciling the resource with SSA.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13489

/area upgrades
