### PR TITLE
✨ Tune controller concurrency and cache timeout for scale

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -129,7 +129,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
 		"Number of clusters to process simultaneously")
 
-	fs.IntVar(&kubeadmConfigConcurrency, "kubeadmconfig-concurrency", 10,
+	fs.IntVar(&kubeadmConfigConcurrency, "kubeadmconfig-concurrency", 100,
 		"Number of kubeadm configs to process simultaneously")
 
 	fs.StringSliceVar(&skipCRDMigrationPhases, "skip-crd-migration-phases", []string{},
@@ -227,6 +227,9 @@ func main() {
 	ctrlOptions := ctrl.Options{
 		Controller: config.Controller{
 			UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
+			// Give the manager more time to sync the caches during startup. This is required
+			// in high scale environments when they are more objects in the system (default is 3m).
+			CacheSyncTimeout: 5 * time.Minute,
 		},
 		Scheme:                     scheme,
 		LeaderElection:             enableLeaderElection,

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -156,7 +156,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Grace period after which remote conditions (e.g. `APIServerPodHealthy`) are set to `Unknown`, "+
 			"the grace period starts from the last successful health probe to the workload cluster")
 
-	fs.IntVar(&kubeadmControlPlaneConcurrency, "kubeadmcontrolplane-concurrency", 10,
+	fs.IntVar(&kubeadmControlPlaneConcurrency, "kubeadmcontrolplane-concurrency", 100,
 		"Number of kubeadm control planes to process simultaneously")
 
 	fs.StringSliceVar(&skipCRDMigrationPhases, "skip-crd-migration-phases", []string{},
@@ -279,6 +279,9 @@ func main() {
 	ctrlOptions := ctrl.Options{
 		Controller: config.Controller{
 			UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
+			// Give the manager more time to sync the caches during startup. This is required
+			// in high scale environments when they are more objects in the system (default is 3m).
+			CacheSyncTimeout: 5 * time.Minute,
 		},
 		Scheme:                     scheme,
 		LeaderElection:             enableLeaderElection,

--- a/main.go
+++ b/main.go
@@ -189,13 +189,13 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Grace period after which remote conditions (e.g. `NodeHealthy`) are set to `Unknown`, "+
 			"the grace period starts from the last successful health probe to the workload cluster")
 
-	fs.IntVar(&clusterTopologyConcurrency, "clustertopology-concurrency", 10,
+	fs.IntVar(&clusterTopologyConcurrency, "clustertopology-concurrency", 50,
 		"Number of clusters to process simultaneously")
 
 	fs.IntVar(&clusterClassConcurrency, "clusterclass-concurrency", 10,
 		"Number of ClusterClasses to process simultaneously")
 
-	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
+	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 50,
 		"Number of clusters to process simultaneously")
 
 	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
@@ -204,22 +204,22 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&extensionConfigConcurrency, "extensionconfig-concurrency", 10,
 		"Number of extension configs to process simultaneously")
 
-	fs.IntVar(&machineConcurrency, "machine-concurrency", 10,
+	fs.IntVar(&machineConcurrency, "machine-concurrency", 100,
 		"Number of machines to process simultaneously")
 
-	fs.IntVar(&machineSetConcurrency, "machineset-concurrency", 10,
+	fs.IntVar(&machineSetConcurrency, "machineset-concurrency", 50,
 		"Number of machine sets to process simultaneously")
 
-	fs.IntVar(&machineDeploymentConcurrency, "machinedeployment-concurrency", 10,
+	fs.IntVar(&machineDeploymentConcurrency, "machinedeployment-concurrency", 50,
 		"Number of machine deployments to process simultaneously")
 
-	fs.IntVar(&machinePoolConcurrency, "machinepool-concurrency", 10,
+	fs.IntVar(&machinePoolConcurrency, "machinepool-concurrency", 50,
 		"Number of machine pools to process simultaneously")
 
 	fs.IntVar(&clusterResourceSetConcurrency, "clusterresourceset-concurrency", 10,
 		"Number of cluster resource sets to process simultaneously")
 
-	fs.IntVar(&machineHealthCheckConcurrency, "machinehealthcheck-concurrency", 10,
+	fs.IntVar(&machineHealthCheckConcurrency, "machinehealthcheck-concurrency", 50,
 		"Number of machine health checks to process simultaneously")
 
 	fs.StringSliceVar(&machineSetPreflightChecks, "machineset-preflight-checks", []string{
@@ -368,6 +368,9 @@ func main() {
 	ctrlOptions := ctrl.Options{
 		Controller: config.Controller{
 			UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
+			// Give the manager more time to sync the caches during startup. This is required
+			// in high scale environments when they are more objects in the system (default is 3m).
+			CacheSyncTimeout: 5 * time.Minute,
 		},
 		Scheme:                     scheme,
 		LeaderElection:             enableLeaderElection,

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -146,7 +146,7 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enableContentionProfiling, "contention-profiling", false,
 		"Enable block profiling")
 
-	fs.IntVar(&concurrency, "concurrency", 10,
+	fs.IntVar(&concurrency, "concurrency", 100,
 		"The number of docker machines to process simultaneously")
 
 	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
@@ -259,6 +259,9 @@ func main() {
 	ctrlOptions := ctrl.Options{
 		Controller: config.Controller{
 			UsePriorityQueue: ptr.To[bool](feature.Gates.Enabled(feature.PriorityQueue)),
+			// Give the manager more time to sync the caches during startup. This is required
+			// in high scale environments when they are more objects in the system (default is 3m).
+			CacheSyncTimeout: 5 * time.Minute,
 		},
 		Scheme:                     scheme,
 		LeaderElection:             enableLeaderElection,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->