### PR TITLE
:seedling: Optimize go build in `make release-binary`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1121,9 +1121,11 @@ release-binary: $(RELEASE_DIR)
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
-		-e GOCACHE=/tmp/ \
+		-e GOCACHE=/go/build-cache/ \
 		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
+		-v "$$(go env GOMODCACHE):/go/pkg/mod" \
+		-v "$$(go env GOCACHE):/go/build-cache" \
 		-w /workspace \
 		golang:$(GO_VERSION) \
 		go build -a -trimpath -gcflags "$(GCFLAGS)" -ldflags "$(LDFLAGS) -extldflags '-static'" \

--- a/Makefile
+++ b/Makefile
@@ -1124,8 +1124,7 @@ release-binary: $(RELEASE_DIR)
 		-e GOCACHE=/go/build-cache/ \
 		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
-		-v "$$(go env GOMODCACHE):/go/pkg/mod" \
-		-v "$$(go env GOCACHE):/go/build-cache" \
+		-v "$$(go env GOMODCACHE):/go/pkg/mod$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:$(GO_VERSION) \
 		go build -a -trimpath -gcflags "$(GCFLAGS)" -ldflags "$(LDFLAGS) -extldflags '-static'" \

--- a/Makefile
+++ b/Makefile
@@ -1121,7 +1121,6 @@ release-binary: $(RELEASE_DIR)
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
-		-e GOCACHE=/go/build-cache/ \
 		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-v "$$(go env GOMODCACHE):/go/pkg/mod$(DOCKER_VOL_OPTS)" \


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Optimize go build in `make release-binary` by mounting the host's `GOMODCACHE` into the container at `/go/pkg/mod` to reuse the downloaded modules.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13408 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release