### PR TITLE
🌱 Removing cluster-api-provider-nested as it is read-only

### DIFF
--- a/hack/tools/release/internal/update_providers/provider_issues.go
+++ b/hack/tools/release/internal/update_providers/provider_issues.go
@@ -51,7 +51,6 @@ var (
 		"kubernetes-sigs/cluster-api-provider-kubemark",
 		"kubernetes-sigs/cluster-api-provider-kubevirt",
 		"kubernetes-sigs/cluster-api-provider-ibmcloud",
-		"kubernetes-sigs/cluster-api-provider-nested",
 		"oracle/cluster-api-provider-oci",
 		"kubernetes-sigs/cluster-api-provider-openstack",
 		"kubernetes-sigs/cluster-api-operator",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
[cluster-api-provider-nested](https://github.com/kubernetes-retired/cluster-api-provider-nested) is a read-only repo, now under kubernetes-retired. 
Removing from provider_issues.go so the tool doesn't show a failure with err code 403.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area misc