### PR TITLE
🐛 Bypass PDBs during drain when node is unreachable

### DIFF
--- a/internal/controllers/machine/drain/drain.go
+++ b/internal/controllers/machine/drain/drain.go
@@ -61,6 +61,11 @@ type Helper struct {
 	// DeletionTimeStamp > N seconds. This can be used e.g. when a Node is unreachable
 	// and the Pods won't drain because of that.
 	SkipWaitForDeleteTimeoutSeconds int
+
+	// DisableEviction forces the drain to use Pod deletion instead of the Eviction API.
+	// This bypasses PodDisruptionBudgets. This should be used when a Node is unreachable
+	// and Pods are not actually running, so PDB protection is not meaningful.
+	DisableEviction bool
 }
 
 // CordonNode cordons a Node.
@@ -431,11 +436,17 @@ func minDrainOrderOfPodsToDrain(pds []PodDelete) int32 {
 }
 
 // evictPod evicts the given Pod, or return an error if it couldn't.
+// When DisableEviction is set, it uses direct Pod deletion instead of the
+// Eviction API, bypassing PodDisruptionBudgets.
 func (d *Helper) evictPod(ctx context.Context, pod *corev1.Pod) error {
 	delOpts := metav1.DeleteOptions{}
 	if d.GracePeriodSeconds >= 0 {
 		gracePeriodSeconds := int64(d.GracePeriodSeconds)
 		delOpts.GracePeriodSeconds = &gracePeriodSeconds
+	}
+
+	if d.DisableEviction {
+		return d.RemoteClient.Delete(ctx, pod, &client.DeleteOptions{Raw: &delOpts})
 	}
 
 	eviction := &policyv1.Eviction{

--- a/internal/controllers/machine/drain/drain_test.go
+++ b/internal/controllers/machine/drain/drain_test.go
@@ -1719,6 +1719,68 @@ func TestEvictPods(t *testing.T) {
 	}
 }
 
+func TestEvictPodsWithDisableEviction(t *testing.T) {
+	g := NewWithT(t)
+
+	podDeleteList := &PodDeleteList{items: []PodDelete{
+		{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1-pdb-blocked",
+					Namespace: "default",
+				},
+			},
+			Status: PodDeleteStatus{
+				DrainBehavior: clusterv1.MachineDrainRuleDrainBehaviorDrain,
+				DrainOrder:    ptr.To[int32](0),
+				Reason:        PodDeleteStatusTypeOkay,
+			},
+		},
+		{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-2-pdb-blocked",
+					Namespace: "default",
+				},
+			},
+			Status: PodDeleteStatus{
+				DrainBehavior: clusterv1.MachineDrainRuleDrainBehaviorDrain,
+				DrainOrder:    ptr.To[int32](0),
+				Reason:        PodDeleteStatusTypeOkay,
+			},
+		},
+	}}
+
+	// Create pods in the fake client so Delete can find them.
+	fakeClient := fake.NewClientBuilder().WithObjects(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1-pdb-blocked", Namespace: "default"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-2-pdb-blocked", Namespace: "default"}},
+	).Build()
+
+	// Track that SubResourceCreate (eviction) is never called.
+	evictionCalled := false
+	fakeClient = interceptor.NewClient(fakeClient, interceptor.Funcs{
+		SubResourceCreate: func(_ context.Context, _ client.Client, _ string, _ client.Object, _ client.Object, _ ...client.SubResourceCreateOption) error {
+			evictionCalled = true
+			return nil
+		},
+	})
+
+	drainer := &Helper{
+		RemoteClient:    fakeClient,
+		DisableEviction: true,
+	}
+
+	gotEvictionResult := drainer.EvictPods(context.Background(), podDeleteList)
+
+	// Verify eviction API was never called.
+	g.Expect(evictionCalled).To(BeFalse(), "Eviction API should not be called when DisableEviction is true")
+
+	// Both pods should have been successfully deleted.
+	g.Expect(gotEvictionResult.PodsDeletionTimestampSet).To(HaveLen(2))
+	g.Expect(gotEvictionResult.PodsFailedEviction).To(BeEmpty())
+}
+
 func TestEvictionResult_ConditionMessage(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -879,15 +879,19 @@ func (r *Reconciler) drainNode(ctx context.Context, s *scope) (ctrl.Result, erro
 		// Override the grace period of pods to reduce the time needed to skip them.
 		drainer.GracePeriodSeconds = 1
 
-		// Our drain code still respects PDBs when evicting Pods, but that does not mean they are respected
-		// in general by the entire system.
 		// When a Node becomes unreachable the following happens:
 		// * node.kubernetes.io/unreachable:NoExecute taint is set on the Node
 		// * taint manager will evict Pods immediately because of the NoExecute taint (without respecting PDBs)
 		//   * https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#concepts
 		//     "NoExecute": "Pods that do not tolerate the taint are evicted immediately""
-		// * our drain code will now ignore the Pods (as they quickly have a deletionTimestamp older than 2 seconds)
-		log.V(3).Info("Node is unreachable, draining will use 1s GracePeriodSeconds and will ignore all Pods that have a deletionTimestamp > 1s old")
+		//
+		// However, when the underlying instance is stopped/terminated, kubelet is not running and
+		// cannot execute the taint manager's deletions. Pods that tolerate the unreachable taint
+		// or have PDBs blocking eviction will remain indefinitely.
+		// Use direct pod deletion (bypassing PDBs) because on unreachable nodes the pods are not
+		// actually running, so PDB protection is not meaningful.
+		drainer.DisableEviction = true
+		log.V(3).Info("Node is unreachable, draining will use 1s GracePeriodSeconds, disable eviction to bypass PDBs, and will ignore all Pods that have a deletionTimestamp > 1s old")
 	}
 
 	if err := drainer.CordonNode(ctx, node); err != nil {


### PR DESCRIPTION
Fixes kubernetes-sigs/cluster-api#13508

**What this PR does / why we need it**:

When a node becomes unreachable (e.g. the underlying instance is stopped), CAPI's machine drain gets stuck indefinitely. The drain uses the Kubernetes Eviction API which respects PDBs. When pods on the unreachable node have PDBs with minAvailable: 1 and currentHealthy: 0, the Eviction API returns 429 TooManyRequests and drain retries forever.

The existing code correctly detects unreachable nodes but relies on the taint manager to bypass PDBs. When the instance is stopped/terminated, kubelet is not running and cannot execute the taint manager's deletions and pods linger indefinitely.

This adds a DisableEviction option to the drain helper that uses direct pod deletion instead of the Eviction API. This is set when the node is unreachable, since pods are not actually running and PDB protection is not meaningful.

/area machine