### PR TITLE
🐛 Gracefully handle not-found when resolving owner references

### DIFF
--- a/core/reconcilers/machine/machine_controller.go
+++ b/core/reconcilers/machine/machine_controller.go
@@ -296,6 +296,9 @@ func (r *Reconciler) getOwnerMachineSet(ctx context.Context, m *clusterv1.Machin
 	}
 	ms := &clusterv1.MachineSet{}
 	if err := r.Client.Get(ctx, *machineSetKey, ms); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve owner MachineSet for Machine %s: %w", klog.KObj(m), err)
 	}
 	return ms, nil
@@ -313,6 +316,9 @@ func (r *Reconciler) getOwnerMachineDeployment(ctx context.Context, ms *clusterv
 
 	md := &clusterv1.MachineDeployment{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: ms.Namespace, Name: mdName}, md); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve owner MachineDeployment for MachineSet %s: %w", klog.KObj(ms), err)
 	}
 	return md, nil

--- a/core/reconcilers/machine/machine_controller_status.go
+++ b/core/reconcilers/machine/machine_controller_status.go
@@ -669,6 +669,12 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 	//       - Core CAPI is not aware of specific details of every control plane implementation, so it is not possible to
 	//         compute the UpToDateCondition for control plane machines.
 	if ms == nil || md == nil {
+		// If this Machine was part of a MachineSet/MachineDeployment but the owner
+		// is now gone, remove the stale UpToDate condition to align with stand-alone
+		// machines where this condition does not exist.
+		if m.Labels[clusterv1.MachineDeploymentNameLabel] != "" {
+			conditions.Delete(m, clusterv1.MachineUpToDateCondition)
+		}
 		return
 	}
 

--- a/core/reconcilers/machine/machine_controller_status_test.go
+++ b/core/reconcilers/machine/machine_controller_status_test.go
@@ -1487,6 +1487,74 @@ func TestSetUpToDateCondition(t *testing.T) {
 			expectCondition:   nil,
 		},
 		{
+			name:              "stale condition removed when MachineDeployment is gone",
+			machineDeployment: nil,
+			machineSet:        &clusterv1.MachineSet{},
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.MachineDeploymentNameLabel: "deleted-machinedeployment",
+					},
+				},
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               clusterv1.MachineUpToDateCondition,
+							Status:             metav1.ConditionTrue,
+							Reason:             clusterv1.MachineUpToDateReason,
+							LastTransitionTime: metav1.NewTime(reconciliationTime),
+						},
+					},
+				},
+			},
+			expectCondition: nil,
+		},
+		{
+			name:              "stale condition removed when MachineSet is gone",
+			machineDeployment: nil,
+			machineSet:        nil,
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						clusterv1.MachineDeploymentNameLabel: "deleted-machinedeployment",
+					},
+				},
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               clusterv1.MachineUpToDateCondition,
+							Status:             metav1.ConditionFalse,
+							Reason:             clusterv1.MachineNotUpToDateReason,
+							LastTransitionTime: metav1.NewTime(reconciliationTime),
+						},
+					},
+				},
+			},
+			expectCondition: nil,
+		},
+		{
+			name:              "condition not removed for control plane machines",
+			machineDeployment: nil,
+			machineSet:        nil,
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               clusterv1.MachineUpToDateCondition,
+							Status:             metav1.ConditionTrue,
+							Reason:             clusterv1.MachineUpToDateReason,
+							LastTransitionTime: metav1.NewTime(reconciliationTime),
+						},
+					},
+				},
+			},
+			expectCondition: &metav1.Condition{
+				Type:   clusterv1.MachineUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachineUpToDateReason,
+			},
+		},
+		{
 			name: "up-to-date",
 			machineDeployment: &clusterv1.MachineDeployment{
 				Spec: clusterv1.MachineDeploymentSpec{

--- a/core/reconcilers/machineset/machineset_controller.go
+++ b/core/reconcilers/machineset/machineset_controller.go
@@ -1329,6 +1329,9 @@ func (r *Reconciler) getOwnerMachineDeployment(ctx context.Context, machineSet *
 
 	md := &clusterv1.MachineDeployment{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: machineSet.Namespace, Name: mdName}, md); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve owner MachineDeployment for MachineSet %s: %w", klog.KObj(machineSet), err)
 	}
 	return md, nil
@@ -1672,7 +1675,9 @@ func (r *Reconciler) reconcileUnhealthyMachines(ctx context.Context, s *scope) (
 
 	// If the MachineSet is part of a MachineDeployment, only allow remediations if
 	// it's the desired revision.
-	if isDeploymentChild(ms) {
+	// If the owning MachineDeployment is not found, skip revision and MaxInFlight checks
+	// and fall through to the default behavior (all machines can be remediated at once).
+	if isDeploymentChild(ms) && owner != nil {
 		if owner.Annotations[clusterv1.RevisionAnnotation] != ms.Annotations[clusterv1.RevisionAnnotation] {
 			// MachineSet is part of a MachineDeployment but isn't the current revision, no remediations allowed.
 			// Note: While remediation won't delete these Machines deleteMachines or startMoveMachines will delete

--- a/core/reconcilers/machineset/machineset_controller_test.go
+++ b/core/reconcilers/machineset/machineset_controller_test.go
@@ -1850,6 +1850,90 @@ func TestMachineSetReconciler_reconcileUnhealthyMachines(t *testing.T) {
 		g.Expect(conditions.Has(m, clusterv1.MachineOwnerRemediatedCondition)).To(BeFalse())
 	})
 
+	t.Run("should remediate unhealthy machines when owning MachineDeployment is not found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		controlPlaneStable := builder.ControlPlane("default", "cp1").
+			WithVersion("v1.26.2").
+			WithStatusFields(map[string]interface{}{
+				"status.version": "v1.26.2",
+			}).
+			Build()
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: "default",
+			},
+			Spec: clusterv1.ClusterSpec{
+				ControlPlaneRef: contract.ObjToContractVersionedObjectReference(controlPlaneStable),
+			},
+		}
+
+		machineSet := &clusterv1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-machineset",
+				Namespace: "default",
+				Labels: map[string]string{
+					clusterv1.MachineDeploymentNameLabel: "deleted-machinedeployment",
+				},
+			},
+		}
+
+		unhealthyMachine := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "unhealthy-machine",
+				Namespace:  "default",
+				Finalizers: []string{"block-deletion"},
+			},
+			Status: clusterv1.MachineStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:    clusterv1.MachineOwnerRemediatedCondition,
+						Status:  metav1.ConditionFalse,
+						Reason:  clusterv1.MachineOwnerRemediatedWaitingForRemediationReason,
+						Message: "Waiting for remediation",
+					},
+					{
+						Type:    clusterv1.MachineHealthCheckSucceededCondition,
+						Status:  metav1.ConditionFalse,
+						Reason:  clusterv1.MachineHealthCheckHasRemediateAnnotationReason,
+						Message: "Marked for remediation via cluster.x-k8s.io/remediate-machine annotation",
+					},
+				},
+			},
+		}
+
+		machines := []*clusterv1.Machine{unhealthyMachine}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(controlPlaneStable, unhealthyMachine).WithStatusSubresource(&clusterv1.Machine{}).Build()
+		r := &Reconciler{
+			Client: fakeClient,
+		}
+
+		s := &scope{
+			cluster:                 cluster,
+			machineSet:              machineSet,
+			machines:                machines,
+			owningMachineDeployment: nil,
+			getAndAdoptMachinesForMachineSetSucceeded: true,
+		}
+
+		_, err := r.reconcileUnhealthyMachines(ctx, s)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		m := &clusterv1.Machine{}
+		g.Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(unhealthyMachine), m)).To(Succeed())
+		g.Expect(m.DeletionTimestamp.IsZero()).To(BeFalse())
+		c := conditions.Get(m, clusterv1.MachineOwnerRemediatedCondition)
+		g.Expect(c).ToNot(BeNil())
+		g.Expect(*c).To(conditions.MatchCondition(metav1.Condition{
+			Type:    clusterv1.MachineOwnerRemediatedCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  clusterv1.MachineSetMachineRemediationMachineDeletingReason,
+			Message: "Machine is deleting",
+		}, conditions.IgnoreLastTransitionTime(true)))
+	})
+
 	t.Run("should update the unhealthy machine MachineOwnerRemediated condition if preflight checks did not pass", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When a Machine or MachineSet has an owner reference pointing to a MachineSet or MachineDeployment that no longer exists (e.g. got forcefully removed), the controller would return a hard error blocking further reconciliation, e.g. for deleting purposes.

This PR handles the not-found case gracefully:

1. **`getOwnerMachineSet` / `getOwnerMachineDeployment`**: treat a NotFound error the same as having no owner (return nil instead of an error).

2. **`reconcileUnhealthyMachines`**: guard against nil `owningMachineDeployment` when the MachineSet is a deployment child but the MachineDeployment is gone. Without this, accessing `owner.Annotations` or `owner.Spec.Remediation.MaxInFlight` would panic. When the owner is gone, remediation skips the revision and MaxInFlight checks and falls through to the default behavior (all machines can be remediated at once).

3. **`setUpToDateCondition`**: remove the stale `UpToDate` condition when a Machine's owning MachineSet/MachineDeployment is deleted, to align with standalone machines where this condition does not exist. This cleanup is scoped to Machines that have the `MachineDeploymentNameLabel` to avoid interfering with control plane machines, where the `UpToDate` condition is set by KCP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13405

/area machine
/area machineset

cc. @fabriziopandini @sbueringer