### PR TITLE
✨ Improve CAPD wait for multi-user target

### DIFF
--- a/test/infrastructure/docker/api/v1beta2/devmachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/devmachine_types.go
@@ -293,7 +293,7 @@ type DockerMachineBackendSpec struct {
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 
 	// bootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-	// The default value is 3m.
+	// The default value is 5m.
 	// +optional
 	BootstrapTimeout *metav1.Duration `json:"bootstrapTimeout,omitempty"`
 }

--- a/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta2/dockermachine_types.go
@@ -60,7 +60,7 @@ type DockerMachineSpec struct {
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 
 	// BootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-	// The default value is 3m.
+	// The default value is 5m.
 	// +optional
 	BootstrapTimeout *metav1.Duration `json:"bootstrapTimeout,omitempty"`
 }

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachines.yaml
@@ -464,7 +464,7 @@ spec:
                       bootstrapTimeout:
                         description: |-
                           bootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-                          The default value is 3m.
+                          The default value is 5m.
                         type: string
                       bootstrapped:
                         description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_devmachinetemplates.yaml
@@ -325,7 +325,7 @@ spec:
                               bootstrapTimeout:
                                 description: |-
                                   bootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-                                  The default value is 3m.
+                                  The default value is 5m.
                                 type: string
                               bootstrapped:
                                 description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -342,7 +342,7 @@ spec:
               bootstrapTimeout:
                 description: |-
                   BootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-                  The default value is 3m.
+                  The default value is 5m.
                 type: string
               bootstrapped:
                 description: |-

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -210,7 +210,7 @@ spec:
                       bootstrapTimeout:
                         description: |-
                           BootstrapTimeout is the total amount of time to wait for the machine to bootstrap before timing out.
-                          The default value is 3m.
+                          The default value is 5m.
                         type: string
                       bootstrapped:
                         description: |-

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachine_backend.go
@@ -210,13 +210,6 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		}
 	}
 
-	// Preload images into the container
-	if len(dockerMachine.Spec.Backend.Docker.PreLoadImages) > 0 {
-		if err := externalMachine.PreloadLoadImages(ctx, dockerMachine.Spec.Backend.Docker.PreLoadImages); err != nil {
-			return ctrl.Result{}, errors.Wrap(err, "failed to pre-load images into the DockerMachine")
-		}
-	}
-
 	// if the machine is a control plane update the load balancer configuration
 	// we should only do this once, as reconfiguration more or less ensures
 	// node ref setting fails
@@ -263,7 +256,7 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		if dockerMachine.Spec.Backend.Docker.BootstrapTimeout != nil {
 			bootstrapTimeout = *dockerMachine.Spec.Backend.Docker.BootstrapTimeout
 		} else {
-			bootstrapTimeout = metav1.Duration{Duration: 3 * time.Minute}
+			bootstrapTimeout = metav1.Duration{Duration: 5 * time.Minute}
 		}
 		timeoutCtx, cancel := context.WithTimeout(ctx, bootstrapTimeout.Duration)
 		defer cancel()
@@ -311,6 +304,20 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 					Message: fmt.Sprintf("Waiting for multi-user target: %s", err.Error()),
 				})
 				return ctrl.Result{}, errors.Wrap(err, "waiting for multi-user target")
+			}
+
+			// Preload images into the container
+			if len(dockerMachine.Spec.Backend.Docker.PreLoadImages) > 0 {
+				if err := externalMachine.PreloadLoadImages(timeoutCtx, dockerMachine.Spec.Backend.Docker.PreLoadImages); err != nil {
+					v1beta1conditions.MarkFalse(dockerMachine, infrav1.BootstrapExecSucceededV1Beta1Condition, infrav1.BootstrapFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Pre-loading images: %s", err.Error())
+					conditions.Set(dockerMachine, metav1.Condition{
+						Type:    infrav1.DevMachineDockerContainerBootstrapExecSucceededCondition,
+						Status:  metav1.ConditionFalse,
+						Reason:  infrav1.DevMachineDockerContainerBootstrapExecWaitingForMultiUserTargetReason,
+						Message: fmt.Sprintf("Pre-loading images: %s", err.Error()),
+					})
+					return ctrl.Result{}, errors.Wrap(err, "failed to pre-load images into the DockerMachine")
+				}
 			}
 
 			// Run the bootstrap script. Simulates cloud-init/Ignition.

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -268,6 +268,16 @@ func (m *Machine) Create(ctx context.Context, image string, role string, version
 		default:
 			return errors.Errorf("unable to create machine for role %s", role)
 		}
+
+		containerRuntime, err := container.RuntimeFrom(ctx)
+		if err != nil {
+			return errors.Wrap(err, "failed to connect to container runtime")
+		}
+
+		if err := m.WaitForMultiUserTarget(ctx, containerRuntime); err != nil {
+			return errors.Wrap(err, "waiting for multi-user target after container creation")
+		}
+
 		// After creating a node we need to wait a small amount of time until crictl does not return an error.
 		// This fixes an issue where we try to kubeadm init too quickly after creating the container.
 		err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 4*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -437,7 +437,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, controller.Options{
 		MaxConcurrentReconciles: concurrency,
-		ReconciliationTimeout:   5 * time.Minute, // increase reconciliation timeout because the DockerMachineReconciler performs long operations like kubeadm init/join, image copy, etc.
+		ReconciliationTimeout:   6 * time.Minute, // increase reconciliation timeout because the DockerMachineReconciler performs long operations like kubeadm init/join, image copy, etc.
 	}); err != nil {
 		setupLog.Error(err, "Unable to create controller", "controller", "DockerMachine")
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Turns out we didn't wait for crictl ps & preloading images

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->