### PR TITLE
🐛 machine: remove leftover unschedulable taint on node reused after KCP rolling upgrade

### DIFF
--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -335,6 +335,18 @@ func (r *Reconciler) patchNode(ctx context.Context, remoteClient client.Client, 
 	// Drop the NodeUninitializedTaint taint on the node given that we are reconciling labels.
 	hasTaintChanges := taints.RemoveNodeTaint(newNode, clusterv1.NodeUninitializedTaint)
 
+	// If the node is cordoned (unschedulable) but the Machine is not being deleted, remove the cordon.
+	// This can happen when a rolling upgrade reuses a node name: the previous Machine's drain sets the
+	// unschedulable taint, the old Machine is deleted, and the new Machine joins with the same node name
+	// but inherits the leftover cordon taint.
+	if m.DeletionTimestamp.IsZero() && newNode.Spec.Unschedulable {
+		newNode.Spec.Unschedulable = false
+		hasTaintChanges = taints.RemoveNodeTaint(newNode, corev1.Taint{
+			Key:    "node.kubernetes.io/unschedulable",
+			Effect: corev1.TaintEffectNoSchedule,
+		}) || hasTaintChanges
+	}
+
 	// Propagate taints set on the Machine to the Node.
 	var propagateTaintsChanges bool
 	if feature.Gates.Enabled(feature.MachineTaintPropagation) {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -708,16 +708,17 @@ func TestPatchNode(t *testing.T) {
 	clusterName := "test-cluster"
 
 	testCases := []struct {
-		name                string
-		oldNode             *corev1.Node
-		newLabels           map[string]string
-		newAnnotations      map[string]string
-		expectedLabels      map[string]string
-		expectedAnnotations map[string]string
-		expectedTaints      []corev1.Taint
-		machine             *clusterv1.Machine
-		ms                  *clusterv1.MachineSet
-		md                  *clusterv1.MachineDeployment
+		name                    string
+		oldNode                 *corev1.Node
+		newLabels               map[string]string
+		newAnnotations          map[string]string
+		expectedLabels          map[string]string
+		expectedAnnotations     map[string]string
+		expectedTaints          []corev1.Taint
+		expectedUnschedulable   bool
+		machine                 *clusterv1.Machine
+		ms                      *clusterv1.MachineSet
+		md                      *clusterv1.MachineDeployment
 	}{
 		{
 			name: "Check that patch works even if there are Status.Addresses with the same key",
@@ -1173,6 +1174,69 @@ func TestPatchNode(t *testing.T) {
 				},
 			},
 		},
+		{
+			// When a rolling upgrade reuses a node name, the previous Machine's drain leaves a
+			// node.kubernetes.io/unschedulable taint on the node. The new Machine joins with the
+			// same node name and should have the leftover cordon removed during reconciliation.
+			name: "Removes unschedulable taint and cordon from node when Machine is not being deleted",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node-%s", util.RandomString(6)),
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+					Taints: []corev1.Taint{
+						{Key: "node.kubernetes.io/unschedulable", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{
+				clusterv1.AnnotationsFromMachineAnnotation: "",
+				clusterv1.LabelsFromMachineAnnotation:      "",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "node.kubernetes.io/not-ready", Effect: "NoSchedule"}, // Added by the API server
+			},
+			machine: newFakeMachine(metav1.NamespaceDefault, clusterName),
+			ms:      newFakeMachineSet(metav1.NamespaceDefault, clusterName),
+			md:      newFakeMachineDeployment(metav1.NamespaceDefault, clusterName),
+		},
+		{
+			// When a Machine is being deleted and the node is cordoned (as part of drain), the
+			// unschedulable taint must NOT be removed.
+			name: "Does not remove unschedulable taint from node when Machine is being deleted",
+			oldNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("node-%s", util.RandomString(6)),
+				},
+				Spec: corev1.NodeSpec{
+					Unschedulable: true,
+					Taints: []corev1.Taint{
+						{Key: "node.kubernetes.io/unschedulable", Effect: corev1.TaintEffectNoSchedule},
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{
+				clusterv1.AnnotationsFromMachineAnnotation: "",
+				clusterv1.LabelsFromMachineAnnotation:      "",
+			},
+			expectedTaints: []corev1.Taint{
+				{Key: "node.kubernetes.io/not-ready", Effect: "NoSchedule"},    // Added by the API server
+				{Key: "node.kubernetes.io/unschedulable", Effect: "NoSchedule"}, // Must be preserved during drain
+			},
+			expectedUnschedulable: true,
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              fmt.Sprintf("ma-%s", util.RandomString(6)),
+					Namespace:         metav1.NamespaceDefault,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"test-finalizer"},
+				},
+				Spec: newFakeMachineSpec(clusterName),
+			},
+			ms: newFakeMachineSet(metav1.NamespaceDefault, clusterName),
+			md: newFakeMachineDeployment(metav1.NamespaceDefault, clusterName),
+		},
 	}
 
 	r := Reconciler{
@@ -1209,6 +1273,7 @@ func TestPatchNode(t *testing.T) {
 				g.Expect(gotNode.Labels).To(BeComparableTo(tc.expectedLabels))
 				g.Expect(gotNode.Annotations).To(BeComparableTo(tc.expectedAnnotations))
 				g.Expect(gotNode.Spec.Taints).To(BeComparableTo(tc.expectedTaints))
+				g.Expect(gotNode.Spec.Unschedulable).To(Equal(tc.expectedUnschedulable))
 			}, 10*time.Second).Should(Succeed())
 		})
 	}


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #13530

When `KubeadmControlPlane` performs a rolling upgrade, the new Machine can
join with the same node name as the deleted Machine (e.g. infrastructure
provider reuses VM hostnames). The deleted Machine's drain left a
`node.kubernetes.io/unschedulable` taint on the node, which the new Machine
inherits. `patchNode` removes `NodeUninitializedTaint` on every reconcile
but had no logic to remove the leftover unschedulable taint, leaving the
node permanently in `SchedulingDisabled` state even after the upgrade
completes (`UP-TO-DATE == DESIRED`).

## Root Cause

### Before this fix (bug)

[Old Machine: cdshs] → DeletionTimestamp set
→ reconcileDelete
→ drainNode → CordonNode
→ node "node-0002": Spec.Unschedulable=true
taint: node.kubernetes.io/unschedulable added
→ drain completes → old Machine deleted

[New Machine: 9ssrc] → joins with same node name "node-0002"
→ reconcileNode → patchNode
→ NodeUninitializedTaint removed
→ ❌ node.kubernetes.io/unschedulable NOT removed
→ node-0002 stays SchedulingDisabled permanently



### After this fix

[Old Machine: cdshs] → DeletionTimestamp set
→ reconcileDelete
→ drainNode → CordonNode
→ node "node-0002": Spec.Unschedulable=true
taint: node.kubernetes.io/unschedulable added
→ drain completes → old Machine deleted

[New Machine: 9ssrc] → joins with same node name "node-0002"
→ reconcileNode → patchNode
→ NodeUninitializedTaint removed
→ m.DeletionTimestamp.IsZero() == true  ← new Machine is not being deleted
&& node.Spec.Unschedulable == true    ← leftover cordon detected
→ ✅ node.Spec.Unschedulable = false
→ ✅ node.kubernetes.io/unschedulable taint removed
→ node-0002: Ready ✓



### Why the `DeletionTimestamp` guard is necessary

`reconcileNode` and `reconcileDelete` run in the **same reconcile loop**
(`alwaysReconcile`). Without the guard, a Machine being actively drained
would have its cordon immediately removed by `patchNode` in the same pass:

[Machine being deleted]
→ reconcileDelete → drainNode → CordonNode  (cordon set)
→ reconcileNode   → patchNode               (cordon removed immediately) ❌

[Machine being deleted] with DeletionTimestamp guard
→ reconcileDelete → drainNode → CordonNode  (cordon set)
→ reconcileNode   → patchNode
→ m.DeletionTimestamp.IsZero() == false   ← skip cordon removal
→ cordon preserved ✓                      ← drain proceeds normally



## Affected scenarios

| Scenario | Before | After |
|---|---|---|
| New Machine joins, node name reused from deleted Machine | Node stays `SchedulingDisabled` permanently | Cordon removed on first reconcile |
| Machine being deleted (drain in progress) | Cordon preserved ✓ | Cordon preserved ✓ |

## Testing

Added two test cases to `TestPatchNode`:
- `Removes unschedulable taint and cordon from node when Machine is not being deleted`
- `Does not remove unschedulable taint from node when Machine is being deleted`