### PR TITLE
📖 Fix unhealthyMachineConditions examples to use valid condition type

### DIFF
--- a/docs/book/src/tasks/automated-machine-management/healthchecking.md
+++ b/docs/book/src/tasks/automated-machine-management/healthchecking.md
@@ -60,7 +60,7 @@ spec:
         status: "False"
         timeoutSeconds: 300
       unhealthyMachineConditions:
-      - type: "InfrastructureReady"
+      - type: "NodeReady"
         status: Unknown
         timeoutSeconds: 1800
       - type: "InfrastructureReady"

--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -195,7 +195,7 @@ spec:
           status: "False"
           timeoutSeconds: 300
         unhealthyMachineConditions:
-        - type: "InfrastructureReady"
+        - type: "NodeReady"
           status: Unknown
           timeoutSeconds: 1800
         - type: "InfrastructureReady"
@@ -219,7 +219,7 @@ spec:
             status: "False"
             timeoutSeconds: 300
           unhealthyMachineConditions:
-          - type: InfrastructureReady
+          - type: NodeReady
             status: Unknown
             timeoutSeconds: 1800
           - type: InfrastructureReady

--- a/docs/book/src/tasks/using-kustomize.md
+++ b/docs/book/src/tasks/using-kustomize.md
@@ -97,7 +97,7 @@ spec:
     status: "False"
     timeout: 300s
   unhealthyMachineConditions:
-  - type: "InfrastructureReady"
+  - type: "NodeReady"
     status: Unknown
     timeout: 1800s
   - type: "InfrastructureReady"


### PR DESCRIPTION
Fixes #13512

**What this PR does / why we need it**:

The documentation examples for `unhealthyMachineConditions` used `Ready` as the condition type, but the CRD validation explicitly blocks it


```go
  // +kubebuilder:validation:XValidation:rule="!(self in  ['Ready','Available','HealthCheckSucceeded','OwnerRemediated','ExternallyRemediated'])"
```

These conditions are managed by the MHC system itself. Ready is a computed summary that includes HealthCheckSucceeded, so watching it would create a circular dependency.

/area machine