### PR TITLE
:seedling: Fix outdated TestGrid config path in CI signal handbook

### DIFF
--- a/docs/release/role-handbooks/ci-signal/README.md
+++ b/docs/release/role-handbooks/ci-signal/README.md
@@ -37,7 +37,7 @@ While we add test coverage for the new release branch we will also drop the test
     1. Copy the `main` branch entry as `release-1.8` in the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/).
     2. Modify the following at the `release-1.8` branch entry:
             * Change intervals (let's use the same as for `release-1.7`).
-2. Create a new dashboard for the new branch in: `test-infra/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml` (`dashboard_groups` and `dashboards`).
+2. Create a new dashboard for the new branch in: `test-infra/config/testgrids/kubernetes/cluster-api-core/config.yaml` (`dashboard_groups` and `dashboards`).
 3. Do not remove old release branches during this setup phase.
 4. Review the templates and modify/remove any outdated logic in the templates.  For example, when `release-1.7` is dropped from support, it can be removed from [this if statement](https://github.com/kubernetes/test-infra/blob/fa895d9f204e912e2bf0bd42221017a6dedf6065/config/jobs/kubernetes-sigs/cluster-api/templates/cluster-api-periodics-upgrades.yaml.tpl#L42).
 5. Regenerate the prowjob configuration running `make generate-test-infra-prowjobs` command from cluster-api repository. Before running this command, ensure to export the `TEST_INFRA_DIR` variable, specifying the location of the [test-infra](https://github.com/kubernetes/test-infra/) repository in your environment. For further information, refer to this [link](https://github.com/kubernetes-sigs/cluster-api/pull/9937).


### PR DESCRIPTION
Updates the TestGrid config path from sig-cluster-lifecycle to cluster-api-core to reflect current test-infra structure.