### PR TITLE
🌱 Add Headlamp to Tilt dev environment

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -485,6 +485,15 @@ def deploy_observability():
             objects = ["capi-visualizer:serviceaccount"],
         )
 
+    if "headlamp" in settings.get("deploy_observability", []):
+        k8s_yaml(read_file("./.tiltbuild/yaml/headlamp.observability.yaml"), allow_duplicates = True)
+        k8s_resource(
+            workload = "headlamp",
+            port_forwards = [port_forward(local_port = 4466, container_port = 4466, name = "Headlamp UI")],
+            labels = ["observability"],
+            objects = ["headlamp-kubeconfig:configmap"],
+        )
+
 def deploy_additional_kustomizations():
     for name in settings.get("additional_kustomizations", []):
         yaml = read_file("./.tiltbuild/yaml/{}.kustomization.yaml".format(name))

--- a/docs/book/src/developer/core/tilt.md
+++ b/docs/book/src/developer/core/tilt.md
@@ -302,6 +302,7 @@ Supported values are:
 * `parca`*: For visualizing profiling data.
 * `tempo`: To store traces.
 * `visualizer`*: Visualize Cluster API resources for each cluster, provide quick access to the specs and status of any resource.
+* `headlamp`*: A Kubernetes web UI with the [Cluster API plugin](https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_cluster-api) for browsing and managing CAPI resources.
 
 \*: Note: the UI will be accessible via a link in the tilt console
 

--- a/hack/observability/headlamp/kubeconfig.yaml
+++ b/hack/observability/headlamp/kubeconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: headlamp-kubeconfig
+  namespace: observability
+data:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        server: https://kubernetes.default.svc
+      name: local
+    contexts:
+    - context:
+        cluster: local
+        user: headlamp
+      name: local
+    current-context: local
+    users:
+    - name: headlamp
+      user:
+        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/hack/observability/headlamp/kustomization.yaml
+++ b/hack/observability/headlamp/kustomization.yaml
@@ -1,0 +1,17 @@
+resources:
+  - ../namespace.yaml
+  - kubeconfig.yaml
+
+helmCharts:
+  - name: headlamp
+    repo: https://kubernetes-sigs.github.io/headlamp/
+    releaseName: headlamp
+    namespace: observability
+    valuesFile: values.yaml
+    version: 0.41.0
+
+helmGlobals:
+    # Store chart in ".charts" folder instead of "charts".
+    # Otherwise "go mod tidy" picks up dependencies of go files contained in the Helm Chart.
+    # "go mod tidy" ignores folders that begin with ".": https://pkg.go.dev/cmd/go#hdr-Package_lists_and_patterns.
+    chartHome: .charts

--- a/hack/observability/headlamp/values.yaml
+++ b/hack/observability/headlamp/values.yaml
@@ -1,0 +1,32 @@
+replicaCount: 1
+
+config:
+  inCluster: false
+  watchPlugins: true
+  extraArgs:
+    - "-kubeconfig=/etc/headlamp/kubeconfig"
+
+volumes:
+  - name: headlamp-kubeconfig
+    configMap:
+      name: headlamp-kubeconfig
+
+volumeMounts:
+  - name: headlamp-kubeconfig
+    mountPath: /etc/headlamp
+    readOnly: true
+
+pluginsManager:
+  enabled: true
+  configContent: |
+    plugins:
+      - name: headlamp_cluster-api
+        source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_cluster-api
+        version: 0.1.0-alpha
+
+clusterRoleBinding:
+  create: true
+
+serviceAccount:
+  create: false
+  name: default


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Headlamp as an observability tool option in the Tilt dev environment, following the existing pattern used by Grafana, Loki, Prometheus, and the CAPI Visualizer.

Developers enable it via `tilt-settings.yaml`:
```yaml
deploy_observability:
  - headlamp
```
**Which issue(s) this PR fixes** 
Fixes #13516

/kind feature
/area devtools 

<img width="1800" height="1015" alt="Screenshot 2026-04-02 at 10 02 17 AM" src="https://github.com/user-attachments/assets/1c6e80e7-dc6a-4255-8992-c702f42d171f" />
