### PR TITLE
🌱 Replace deprecated gaurav-nelson/github-action-markdown-link-check with tcort fork

### DIFF
--- a/.github/workflows/pr-md-link-check.yaml
+++ b/.github/workflows/pr-md-link-check.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
-    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # tag=1.0.17
+    - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # tag=v1.1.2
       with:
         use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json

--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
         with:
           ref: ${{ matrix.branch }}
-      - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # tag=1.0.17
+      - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # tag=v1.1.2
         with:
           use-quiet-mode: 'yes'
           config-file: .markdownlinkcheck.json


### PR DESCRIPTION
**What this PR does / why we need it**:


Replace the deprecated and archived `gaurav-nelson/github-action-markdown-link-check@1.0.17` with its maintained fork `tcort/github-action-markdown-link-check@v1.1.2` in both markdown link check workflows.

The original action has been deprecated (see https://github.com/gaurav-nelson/github-action-markdown-link-check) and recommends migrating to the tcort fork. The fork has identical inputs, so no configuration changes are needed.

**Which issue(s) this PR fixes**:
Fixes #12138

/area ci