### PR TITLE
🌱 Update version matrix for GitHub workflows for release 1.13

### DIFF
--- a/.github/workflows/weekly-md-link-check.yaml
+++ b/.github/workflows/weekly-md-link-check.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11 ]
+        branch: [ main, release-1.13, release-1.12, release-1.11 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2

--- a/.github/workflows/weekly-security-scan.yaml
+++ b/.github/workflows/weekly-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11 ]
+        branch: [ main, release-1.13, release-1.12, release-1.11 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/weekly-test-release.yaml
+++ b/.github/workflows/weekly-test-release.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, release-1.12, release-1.11 ]
+        branch: [ main, release-1.13, release-1.12, release-1.11 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2


### PR DESCRIPTION
Updates the GitHub workflow version matrix to incorporate the new release v1.13.
Part of: https://github.com/kubernetes-sigs/cluster-api/issues/13209
/area testing