### PR TITLE
🌱 Add support for controller restart to in-memory backend

### DIFF
--- a/test/infrastructure/docker/config/rbac/role.yaml
+++ b/test/infrastructure/docker/config/rbac/role.yaml
@@ -8,10 +8,18 @@ rules:
   - ""
   resources:
   - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apiextensions.k8s.io
@@ -73,6 +81,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/test/infrastructure/docker/internal/controllers/backends/cluster.go
+++ b/test/infrastructure/docker/internal/controllers/backends/cluster.go
@@ -32,8 +32,3 @@ type DevClusterBackendReconciler interface {
 	ReconcileDelete(ctx context.Context, cluster *clusterv1.Cluster, devCluster *infrav1.DevCluster) (ctrl.Result, error)
 	PatchDevCluster(ctx context.Context, patchHelper *patch.Helper, devCluster *infrav1.DevCluster) error
 }
-
-// DevClusterBackendHotRestarter defines restart behaviour for a DevCluster backend.
-type DevClusterBackendHotRestarter interface {
-	HotRestart(ctx context.Context) error
-}

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorycluster_backend.go
@@ -19,11 +19,16 @@ package inmemory
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,6 +40,7 @@ import (
 	inmemoryruntime "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/runtime"
 	inmemoryserver "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 // ClusterBackendReconciler reconciles a InMemoryCluster backend.
@@ -44,30 +50,10 @@ type ClusterBackendReconciler struct {
 	APIServerMux    *inmemoryserver.WorkloadClustersMux
 }
 
-// HotRestart tries to setup the APIServerMux according to an existing sets of InMemoryCluster.
-// NOTE: This is done at best effort in order to make iterative development workflow easier.
-func (r *ClusterBackendReconciler) HotRestart(ctx context.Context) error {
-	inMemoryClusterList := &infrav1.DevClusterList{}
-	if err := r.List(ctx, inMemoryClusterList); err != nil {
-		return err
-	}
-
-	listeners := []inmemoryserver.HotRestartListener{}
-	for _, cluster := range inMemoryClusterList.Items {
-		if cluster.Spec.Backend.InMemory != nil {
-			listeners = append(listeners, inmemoryserver.HotRestartListener{
-				Cluster: klog.KRef(cluster.Namespace, cluster.Name).String(),
-				Name:    cluster.Annotations[infrav1.ListenerAnnotationName],
-				Host:    cluster.Spec.ControlPlaneEndpoint.Host,
-				Port:    cluster.Spec.ControlPlaneEndpoint.Port,
-			})
-		}
-	}
-	return r.APIServerMux.HotRestart(listeners)
-}
-
 // ReconcileNormal handle in memory backend for DevCluster not yet deleted.
 func (r *ClusterBackendReconciler) ReconcileNormal(ctx context.Context, cluster *clusterv1.Cluster, inMemoryCluster *infrav1.DevCluster) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
 	if inMemoryCluster.Spec.Backend.InMemory == nil {
 		return ctrl.Result{}, errors.New("InMemoryBackendReconciler can't be called for DevClusters without an InMemory backend")
 	}
@@ -110,9 +96,53 @@ func (r *ClusterBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		}
 	}
 
+	// Detect and handle when the host changed, e.g. after a CAPD restart.
+	if ptr.Deref(inMemoryCluster.Status.Initialization.Provisioned, false) {
+		if inMemoryCluster.Spec.ControlPlaneEndpoint.Host != r.APIServerMux.Host() {
+			// The host is changed, fix it up in the kubeconfig
+			// Note: Check if the kubeconfig secret has the wrong controlPlaneEndpoint, if yes, fix it up
+			kubeconfigSecret := &corev1.Secret{}
+			if err := r.Client.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Name + "-kubeconfig"}, kubeconfigSecret); err != nil {
+				return ctrl.Result{}, errors.Wrap(err, "failed to get kubeconfig Secret for Cluster")
+			}
+			data, ok := kubeconfigSecret.Data[secret.KubeconfigDataName]
+			if !ok {
+				return ctrl.Result{}, errors.Errorf("missing key %q in kubeconfig Secret for Cluster", secret.KubeconfigDataName)
+			}
+			config, err := clientcmd.Load(data)
+			if err != nil {
+				return ctrl.Result{}, errors.Wrap(err, "failed to convert kubeconfig Secret into a clientcmdapi.Config")
+			}
+			kubeconfigCluster, ok := config.Clusters[cluster.Name]
+			if !ok {
+				return ctrl.Result{}, errors.Errorf("missing clusters map entry in kubeconfig Secret for Cluster")
+			}
+			desiredServer := fmt.Sprintf("https://%s", net.JoinHostPort(r.APIServerMux.Host(), strconv.Itoa(int(inMemoryCluster.Spec.ControlPlaneEndpoint.Port))))
+			if kubeconfigCluster.Server != desiredServer {
+				original := kubeconfigSecret.DeepCopy()
+				kubeconfigCluster.Server = desiredServer
+				kubeconfigBytes, err := clientcmd.Write(*config)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				kubeconfigSecret.Data[secret.KubeconfigDataName] = kubeconfigBytes
+				if err := r.Client.Patch(ctx, kubeconfigSecret, client.MergeFrom(original)); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+
+			log.Info(fmt.Sprintf("InMemoryCluster controlPlane endpoint host updated from %s to %s", inMemoryCluster.Spec.ControlPlaneEndpoint.Host, r.APIServerMux.Host()))
+
+			// surface the new host
+			inMemoryCluster.Spec.ControlPlaneEndpoint.Host = r.APIServerMux.Host()
+
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
+	}
+
 	// Initialize a listener for the workload cluster; if the listener has been already initialized
 	// the operation is a no-op.
-	listener, err := r.APIServerMux.InitWorkloadClusterListener(listenerName)
+	listener, err := r.APIServerMux.InitWorkloadClusterListener(listenerName, inMemoryCluster.Spec.ControlPlaneEndpoint.Port)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to init the listener for the workload cluster")
 	}
@@ -124,6 +154,7 @@ func (r *ClusterBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 	if inMemoryCluster.Spec.ControlPlaneEndpoint.Host == "" {
 		inMemoryCluster.Spec.ControlPlaneEndpoint.Host = listener.Host()
 		inMemoryCluster.Spec.ControlPlaneEndpoint.Port = listener.Port()
+		log.Info(fmt.Sprintf("InMemoryCluster assigned controlPlane endpoint %s:%d", inMemoryCluster.Spec.ControlPlaneEndpoint.Host, inMemoryCluster.Spec.ControlPlaneEndpoint.Port))
 	}
 
 	// Mark the InMemoryCluster ready

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -30,6 +30,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -160,7 +161,30 @@ func (r *MachineBackendReconciler) ReconcileNormal(ctx context.Context, cluster 
 		//  the downside of it is that InMemoryMachines status will change by "big steps" vs incrementally.
 		res = util.LowestNonZeroResult(res, phaseResult)
 	}
-	return res, kerrors.NewAggregate(errs)
+	if len(errs) > 0 {
+		return res, kerrors.NewAggregate(errs)
+	}
+
+	if (util.IsControlPlaneMachine(machine) && conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryAPIServerProvisionedCondition)) ||
+		(!util.IsControlPlaneMachine(machine) && conditions.IsTrue(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition)) {
+		if hasBootstrappedAnnotation(machine) {
+			return res, nil
+		}
+
+		machineObj := &unstructured.Unstructured{}
+		machineObj.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("Machine"))
+		machineObj.SetNamespace(machine.Namespace)
+		machineObj.SetName(machine.Name)
+		original := machineObj.DeepCopy()
+		machineObj.SetAnnotations(map[string]string{
+			MachineBootstrappedAnnotationName: "",
+		})
+		if err := r.Client.Patch(ctx, machineObj, client.MergeFrom(original)); err != nil {
+			return res, err
+		}
+	}
+
+	return res, nil
 }
 
 func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, inMemoryMachine *infrav1.DevMachine) (_ ctrl.Result, retErr error) {
@@ -215,7 +239,7 @@ func (r *MachineBackendReconciler) reconcileNormalCloudMachine(ctx context.Conte
 
 	start := cloudMachine.CreationTimestamp
 	now := time.Now()
-	if now.Before(start.Add(provisioningDuration)) {
+	if !hasBootstrappedAnnotation(machine) && now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.VMProvisionedCondition, infrav1.VMWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryVMProvisionedCondition,
@@ -280,7 +304,7 @@ func (r *MachineBackendReconciler) reconcileNormalNode(ctx context.Context, clus
 
 	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryVMProvisionedCondition).LastTransitionTime
 	now := time.Now()
-	if now.Before(start.Add(provisioningDuration)) {
+	if !hasBootstrappedAnnotation(machine) && now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.NodeProvisionedCondition, infrav1.NodeWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryNodeProvisionedCondition,
@@ -426,7 +450,7 @@ func (r *MachineBackendReconciler) reconcileNormalETCD(ctx context.Context, clus
 
 	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
-	if now.Before(start.Add(provisioningDuration)) {
+	if !hasBootstrappedAnnotation(machine) && now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.EtcdProvisionedCondition, infrav1.EtcdWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryEtcdProvisionedCondition,
@@ -667,7 +691,7 @@ func (r *MachineBackendReconciler) reconcileNormalAPIServer(ctx context.Context,
 
 	start := conditions.Get(inMemoryMachine, infrav1.DevMachineInMemoryNodeProvisionedCondition).LastTransitionTime
 	now := time.Now()
-	if now.Before(start.Add(provisioningDuration)) {
+	if !hasBootstrappedAnnotation(machine) && now.Before(start.Add(provisioningDuration)) {
 		v1beta1conditions.MarkFalse(inMemoryMachine, infrav1.APIServerProvisionedCondition, infrav1.APIServerWaitingForStartupTimeoutReason, clusterv1.ConditionSeverityInfo, "")
 		conditions.Set(inMemoryMachine, metav1.Condition{
 			Type:   infrav1.DevMachineInMemoryAPIServerProvisionedCondition,
@@ -1282,4 +1306,14 @@ func (r *MachineBackendReconciler) PatchDevMachine(ctx context.Context, patchHel
 			infrav1.DevMachineInMemoryAPIServerProvisionedCondition,
 		}},
 	)
+}
+
+const (
+	// MachineBootstrappedAnnotationName is added to the Machine once the machine is entirely bootstrapped.
+	MachineBootstrappedAnnotationName = "machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped"
+)
+
+func hasBootstrappedAnnotation(machine *clusterv1.Machine) bool {
+	_, ok := machine.Annotations[MachineBootstrappedAnnotationName]
+	return ok
 }

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_controller_test.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_controller_test.go
@@ -352,7 +352,7 @@ func TestReconcileNormalEtcd(t *testing.T) {
 			DebugPort: inmemoryserver.DefaultDebugPort + 10,
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
+		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String(), 0)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		r := MachineBackendReconciler{
@@ -438,7 +438,7 @@ func TestReconcileNormalEtcd(t *testing.T) {
 			DebugPort: inmemoryserver.DefaultDebugPort + 20,
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
+		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String(), 0)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		r := MachineBackendReconciler{
@@ -582,7 +582,7 @@ func TestReconcileNormalApiServer(t *testing.T) {
 			DebugPort: inmemoryserver.DefaultDebugPort + 11,
 		})
 		g.Expect(err).ToNot(HaveOccurred())
-		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String())
+		_, err = wcmux.InitWorkloadClusterListener(klog.KObj(cluster).String(), 0)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		r := MachineBackendReconciler{

--- a/test/infrastructure/docker/internal/controllers/devcluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devcluster_controller.go
@@ -19,7 +19,6 @@ package controllers
 
 import (
 	"context"
-	"sync"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,9 +57,6 @@ type DevClusterReconciler struct {
 	ContainerRuntime container.Runtime
 	InMemoryManager  inmemoryruntime.Manager
 	APIServerMux     *inmemoryserver.WorkloadClustersMux
-
-	hotRestartDone bool
-	hotRestartLock sync.RWMutex
 }
 
 // SetupWithManager will add watches for this controller.
@@ -88,6 +84,7 @@ func (r *DevClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=devclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=devclusters/status;devclusters/finalizers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;list;watch;update;patch
 
 func (r *DevClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -150,13 +147,6 @@ func (r *DevClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	backendReconciler := r.backendReconcilerFactory(ctx, devCluster)
 
-	// If the selected backend has to perform specific tasks when restarting, do it!
-	if restarter, ok := backendReconciler.(backends.DevClusterBackendHotRestarter); ok {
-		if err := r.reconcileHotRestart(ctx, restarter); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Always attempt to Patch the DevCluster object and status after each reconciliation.
 	defer func() {
 		if err := backendReconciler.PatchDevCluster(ctx, patchHelper, devCluster); err != nil {
@@ -185,30 +175,4 @@ func (r *DevClusterReconciler) backendReconcilerFactory(_ context.Context, devCl
 		Client:           r.Client,
 		ContainerRuntime: r.ContainerRuntime,
 	}
-}
-
-func (r *DevClusterReconciler) reconcileHotRestart(ctx context.Context, restarter backends.DevClusterBackendHotRestarter) error {
-	r.hotRestartLock.RLock()
-	if r.hotRestartDone {
-		// Return if the hot restart was already done.
-		r.hotRestartLock.RUnlock()
-		return nil
-	}
-	r.hotRestartLock.RUnlock()
-
-	r.hotRestartLock.Lock()
-	defer r.hotRestartLock.Unlock()
-
-	// Check again if another go routine did the hot restart before we got the write lock.
-	if r.hotRestartDone {
-		return nil
-	}
-
-	if err := restarter.HotRestart(ctx); err != nil {
-		return err
-	}
-
-	r.hotRestartDone = true
-
-	return nil
 }

--- a/test/infrastructure/docker/internal/controllers/devmachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/devmachine_controller.go
@@ -101,7 +101,7 @@ func (r *DevMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=devmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=devmachines/status;devmachines/finalizers,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;machinesets;machines,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch;patch;
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // Reconcile handles DevMachine events.

--- a/test/infrastructure/inmemory/pkg/server/api/debug.go
+++ b/test/infrastructure/inmemory/pkg/server/api/debug.go
@@ -63,8 +63,8 @@ func NewDebugHandler(manager inmemoryruntime.Manager, log logr.Logger, infoProvi
 	// Discovery endpoints
 	ws.Route(ws.GET("/").To(debugServer.ping))
 	ws.Route(ws.GET("/listeners").To(debugServer.listenersList))
-	ws.Route(ws.GET("/clusters/{namespace}/{name}").To(debugServer.getCluster))
-	ws.Route(ws.POST("/clusters/{namespace}/{name}/listener").To(debugServer.startOrStopListener))
+	ws.Route(ws.GET("/namespaces/{namespace}/clusters/{name}").To(debugServer.getCluster))
+	ws.Route(ws.POST("/namespaces/{namespace}/clusters/{name}/listener").To(debugServer.startOrStopListener))
 
 	debugServer.container.Add(ws)
 

--- a/test/infrastructure/inmemory/pkg/server/mux.go
+++ b/test/infrastructure/inmemory/pkg/server/mux.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	inmemoryruntime "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/runtime"
 	inmemoryapi "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server/api"
 	inmemoryetcd "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server/etcd"
@@ -169,6 +168,11 @@ func NewWorkloadClustersMux(manager inmemoryruntime.Manager, host string, opts .
 	return m, nil
 }
 
+// Host return the host address for the WorkloadClustersMux.
+func (m *WorkloadClustersMux) Host() string {
+	return m.host
+}
+
 // mixedHandler returns an handler that can serve either API server calls or etcd calls.
 func (m *WorkloadClustersMux) mixedHandler() http.Handler {
 	// Prepare a function that can identify which workloadCluster/resourceGroup a
@@ -256,81 +260,9 @@ func (m *WorkloadClustersMux) getCertificate(info *tls.ClientHelloInfo) (*tls.Ce
 	return wcl.apiServerServingCertificate, nil
 }
 
-// HotRestartListener defines listeners for HotRestart.
-type HotRestartListener struct {
-	Cluster string
-	Name    string
-	Host    string
-	Port    int32
-}
-
-// HotRestart tries to set up the mux according to an existing set of InMemoryClusters.
-// NOTE: This is done at best effort in order to make iterative development workflows easier.
-func (m *WorkloadClustersMux) HotRestart(listeners []HotRestartListener) error {
-	if len(listeners) == 0 {
-		return nil
-	}
-
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if len(m.workloadClusterListeners) > 0 {
-		return errors.New("WorkloadClustersMux cannot be hot restarted when there are already initialized listeners")
-	}
-
-	ports := sets.Set[int32]{}
-	maxPort := m.minPort - 1
-	for _, l := range listeners {
-		if l.Host == "" {
-			continue
-		}
-
-		if l.Host != m.host {
-			return errors.Errorf("unable to restart the WorkloadClustersMux, the host address is changed from %s to %s", l.Host, m.host)
-		}
-
-		if ports.Has(l.Port) {
-			return errors.Errorf("unable to restart the WorkloadClustersMux, there are two or more clusters using port %d", l.Port)
-		}
-
-		if l.Name == "" {
-			return errors.Errorf("unable to restart the WorkloadClustersMux, cluster %s doesn't have the %s annotation", l.Cluster, infrav1.ListenerAnnotationName)
-		}
-
-		m.initWorkloadClusterListenerWithPortLocked(l.Name, l.Port)
-
-		if maxPort < l.Port {
-			maxPort = l.Port
-		}
-	}
-
-	m.portIndex = maxPort + 1
-	return nil
-}
-
 // InitWorkloadClusterListener initialize a WorkloadClusterListener by reserving a port for it.
 // Note: The listener will be started when the first API server will be added.
-func (m *WorkloadClustersMux) InitWorkloadClusterListener(wclName string) (*WorkloadClusterListener, error) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if wcl, ok := m.workloadClusterListeners[wclName]; ok {
-		return wcl, nil
-	}
-
-	port, err := m.getFreePortLocked()
-	if err != nil {
-		return nil, err
-	}
-
-	wcl := m.initWorkloadClusterListenerWithPortLocked(wclName, port)
-
-	return wcl, nil
-}
-
-// InitWorkloadClusterListenerWithPort initialize a WorkloadClusterListener by reserving a port for it.
-// Note: The listener will be started when the first API server will be added.
-func (m *WorkloadClustersMux) InitWorkloadClusterListenerWithPort(wclName string, port int32) (*WorkloadClusterListener, error) {
+func (m *WorkloadClustersMux) InitWorkloadClusterListener(wclName string, port int32) (*WorkloadClusterListener, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -348,14 +280,6 @@ func (m *WorkloadClustersMux) InitWorkloadClusterListenerWithPort(wclName string
 		m.portIndex = max(m.portIndex, port+1)
 	}
 
-	wcl := m.initWorkloadClusterListenerWithPortLocked(wclName, port)
-
-	return wcl, nil
-}
-
-// initWorkloadClusterListenerWithPortLocked initializes a workload cluster listener.
-// Note: m.lock must be locked before calling this method.
-func (m *WorkloadClustersMux) initWorkloadClusterListenerWithPortLocked(wclName string, port int32) *WorkloadClusterListener {
 	wcl := &WorkloadClusterListener{
 		scheme:                  m.manager.GetScheme(),
 		host:                    m.host,
@@ -371,7 +295,8 @@ func (m *WorkloadClustersMux) initWorkloadClusterListenerWithPortLocked(wclName 
 	m.workloadClusterNameByPort[fmt.Sprintf("%d", wcl.Port())] = wclName
 
 	m.log.Info("Workload cluster listener created", "listenerName", wclName, "address", wcl.Address())
-	return wcl
+
+	return wcl, nil
 }
 
 // RegisterResourceGroup registers the resource group that host in memory resources for a WorkloadClusterListener.
@@ -414,7 +339,7 @@ func (m *WorkloadClustersMux) WorkloadClusterByResourceGroup(resouceGroup string
 			return wclName, nil
 		}
 	}
-	return "", errors.Errorf("resouceGroup with name %s not yet registered to a workloadClusterListener", resouceGroup)
+	return "", errors.Errorf("resourceGroup with name %s not yet registered to a workloadClusterListener", resouceGroup)
 }
 
 // AddAPIServer mimics adding an API server instance behind the WorkloadClusterListener.
@@ -707,7 +632,7 @@ func (m *WorkloadClustersMux) ListListeners() map[string]string {
 	for k, l := range m.workloadClusterListeners {
 		ret[k] = l.Address()
 		if l.listener == nil {
-			ret[k] += " (not active)"
+			ret[k] += " (stopped)"
 		}
 	}
 	return ret

--- a/test/infrastructure/inmemory/pkg/server/mux_test.go
+++ b/test/infrastructure/inmemory/pkg/server/mux_test.go
@@ -95,7 +95,7 @@ func TestMux(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	defer func() { _ = wcmux.Shutdown(ctx) }()
 
-	listener, err := wcmux.InitWorkloadClusterListener(wcl)
+	listener, err := wcmux.InitWorkloadClusterListener(wcl, 0)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(listener.Host()).To(Equal(host))
 	g.Expect(listener.Port()).ToNot(BeZero())
@@ -276,7 +276,7 @@ func TestAPI_PortForward(t *testing.T) {
 
 	// InfraCluster controller >> when "creating the load balancer"
 	wcl1 := "workload-cluster1-controlPlaneEndpoint"
-	listener, err := wcmux.InitWorkloadClusterListener(wcl1)
+	listener, err := wcmux.InitWorkloadClusterListener(wcl1, 0)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(listener.Host()).To(Equal(host))
 	g.Expect(listener.Port()).ToNot(BeZero())
@@ -665,7 +665,7 @@ func setupWorkloadClusterListener(g Gomega, ports CustomPorts) (*WorkloadCluster
 	// InfraCluster controller >> when "creating the load balancer"
 	wcl1 := "workload-cluster1-controlPlaneEndpoint"
 
-	listener, err := wcmux.InitWorkloadClusterListener(wcl1)
+	listener, err := wcmux.InitWorkloadClusterListener(wcl1, 0)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(listener.Host()).To(Equal(host))
 	g.Expect(listener.Port()).ToNot(BeZero())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Add best effort support for restart to the in memory provider, which is really valuable when testing at scale and for some reason a controller restart is required

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->