### PR TITLE
🌱 Fix E2E chained upgrade

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -44,6 +44,9 @@ export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=${SKIP_RESOURCE_CLEANUP:-"false"}
 export USE_EXISTING_CLUSTER=false
 
+# TODO: Remove this as soon as a kind image for v1.36.0 is available
+export BUILD_NODE_IMAGE_TAG="v1.36.0"
+
 # Prepare kindest/node images for all the required Kubernetes version; this implies
 # 1. Kubernetes version labels (e.g. latest) to the corresponding version numbers.
 # 2. Pre-pulling the corresponding kindest/node image if available; if not, building the image locally.

--- a/test/e2e/cluster_upgrade_runtimesdk_test.go
+++ b/test/e2e/cluster_upgrade_runtimesdk_test.go
@@ -129,7 +129,8 @@ var _ = Describe("When performing chained upgrades for workload cluster using Cl
 			// KUBERNETES_VERSION_UPGRADE_TO is not in the kind mapper, e.g. in the `e2e-latestk8s` prowjob.
 			// Note: KUBERNETES_VERSION_UPGRADE_TO has to be set either to one version in kind.GetKubernetesVersions() or
 			// to a version greater than the last in the list by at most one minor version.
-			KubernetesVersions: appendIfNecessary(kind.GetKubernetesVersions(), e2eConfig.MustGetVariable(KubernetesVersionUpgradeTo)),
+			// TODO: remove v1.36.0 as soon as a kind image for v1.36.0 is available
+			KubernetesVersions: appendIfNecessary(appendIfNecessary(kind.GetKubernetesVersions(), "v1.36.0"), e2eConfig.MustGetVariable(KubernetesVersionUpgradeTo)),
 			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
 			// by the test-extension-webhook-service.
 			// The below values are used when creating the cluster-wide ExtensionConfig to refer

--- a/test/extension/handlers/upgradeplan/handlers.go
+++ b/test/extension/handlers/upgradeplan/handlers.go
@@ -58,6 +58,10 @@ func (m *ExtensionHandlers) DoGenerateUpgradePlan(ctx context.Context, request *
 
 	// Get the list of Kubernetes versions from the kind mapper.
 	versions := kind.GetKubernetesVersions()
+	// TODO: remove v1.36.0 as soon as a kind image for v1.36.0 is available
+	if !slices.Contains(versions, "v1.36.0") {
+		versions = append(versions, "v1.36.0")
+	}
 	if !slices.Contains(versions, request.ToKubernetesVersion) {
 		versions = append(versions, request.ToKubernetesVersion)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Kind image for 1.36.0 is not yet available; this is an issue that is managed for most of the tests but with chained upgrade the existing machinery does not work because the upgrade path is computed at runtime
So I'm adding a few temporary workarounds to get test green

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->