### PR TITLE
🐛 Fix E2E host port binding lookup

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -157,7 +157,7 @@ func (d *dockerRuntime) GetHostPort(ctx context.Context, containerName, portAndP
 
 	// Loop through the container port bindings and return the first HostPort
 	for port, bindings := range containerInfo.Container.NetworkSettings.Ports {
-		if port.Port() == portAndProtocol {
+		if port.String() == portAndProtocol {
 			for _, binding := range bindings {
 				return binding.HostPort, nil
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fix e2e for macOS or WSL, `port.Port()` returns the port number instead `portNumber/protocol` format needed to compare

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #



<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->