### PR TITLE
✨ feat: add spec.kubeconfig.metadata to allow setting annotations/labels on kubeconfig secrets

### DIFF
--- a/api/core/v1beta1/cluster_types.go
+++ b/api/core/v1beta1/cluster_types.go
@@ -499,6 +499,10 @@ type ClusterSpec struct {
 	// +listMapKey=conditionType
 	// +kubebuilder:validation:MaxItems=32
 	AvailabilityGates []ClusterAvailabilityGate `json:"availabilityGates,omitempty"`
+
+	// kubeconfig specifies the parameters for the kubeconfig secret.
+	// +optional
+	Kubeconfig *KubeconfigSpec `json:"kubeconfig,omitempty"`
 }
 
 // ConditionPolarity defines the polarity for a metav1.Condition.
@@ -585,6 +589,13 @@ type Topology struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=1000
 	Variables []ClusterVariable `json:"variables,omitempty"`
+}
+
+// KubeconfigSpec specifies the parameters for the kubeconfig secret.
+type KubeconfigSpec struct {
+	// metadata is the metadata applied to the kubeconfig secret.
+	// +optional
+	Metadata ObjectMeta `json:"metadata,omitempty"`
 }
 
 // ControlPlaneTopology specifies the parameters for the control plane nodes in the cluster.

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -518,6 +518,10 @@ type ClusterSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=32
 	AvailabilityGates []ClusterAvailabilityGate `json:"availabilityGates,omitempty"`
+
+	// kubeconfig specifies the parameters for the kubeconfig secret.
+	// +optional
+	Kubeconfig *KubeconfigSpec `json:"kubeconfig,omitempty"`
 }
 
 // ConditionPolarity defines the polarity for a metav1.Condition.
@@ -584,6 +588,13 @@ type Topology struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=1000
 	Variables []ClusterVariable `json:"variables,omitempty"`
+}
+
+// KubeconfigSpec specifies the parameters for the kubeconfig secret.
+type KubeconfigSpec struct {
+	// metadata is the metadata applied to the kubeconfig secret.
+	// +optional
+	Metadata ObjectMeta `json:"metadata,omitempty"`
 }
 
 // IsDefined returns true if the Topology is defined.

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -57,12 +57,17 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 	configSecret, err := secret.GetFromNamespacedName(ctx, r.SecretCachingClient, clusterName, secret.Kubeconfig)
 	switch {
 	case apierrors.IsNotFound(err):
+		var metadata *clusterv1.ObjectMeta
+		if controlPlane.Cluster.Spec.Kubeconfig != nil {
+			metadata = &controlPlane.Cluster.Spec.Kubeconfig.Metadata
+		}
 		createErr := kubeconfig.CreateSecretWithOwner(
 			ctx,
 			r.SecretCachingClient,
 			clusterName,
 			endpoint.String(),
 			controllerOwnerRef,
+			metadata,
 			kubeconfig.KeyEncryptionAlgorithm(controlPlane.GetKeyEncryptionAlgorithm()),
 		)
 		if errors.Is(createErr, kubeconfig.ErrDependentCertificateNotFound) {

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -862,7 +862,8 @@ func TestKubeadmControlPlaneReconciler_adoptKubeconfigSecret(t *testing.T) {
 	capiKubeadmConfigSecretNoOwner := kubeconfig.GenerateSecretWithOwner(
 		client.ObjectKey{Name: "test1", Namespace: metav1.NamespaceDefault},
 		[]byte{},
-		metav1.OwnerReference{})
+		metav1.OwnerReference{},
+		nil)
 	capiKubeadmConfigSecretNoOwner.OwnerReferences = []metav1.OwnerReference{}
 
 	// A KubeadmConfig secret created by CAPI controllers with a non-KCP owner reference.
@@ -873,7 +874,8 @@ func TestKubeadmControlPlaneReconciler_adoptKubeconfigSecret(t *testing.T) {
 	userProvidedKubeadmConfigSecretNoOwner := kubeconfig.GenerateSecretWithOwner(
 		client.ObjectKey{Name: "test1", Namespace: metav1.NamespaceDefault},
 		[]byte{},
-		metav1.OwnerReference{})
+		metav1.OwnerReference{},
+		nil)
 	userProvidedKubeadmConfigSecretNoOwner.Type = corev1.SecretTypeOpaque
 
 	// A user provided KubeadmConfig with a non-KCP owner reference.

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -108,16 +108,20 @@ func New(clusterName, endpoint string, caCert *x509.Certificate, caKey crypto.Si
 // CreateSecret creates the Kubeconfig secret for the given cluster.
 func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, options ...KubeConfigOption) error {
 	name := util.ObjectKey(cluster)
+	var metadata *clusterv1.ObjectMeta
+	if cluster.Spec.Kubeconfig != nil {
+		metadata = &cluster.Spec.Kubeconfig.Metadata
+	}
 	return CreateSecretWithOwner(ctx, c, name, cluster.Spec.ControlPlaneEndpoint.String(), metav1.OwnerReference{
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Cluster",
 		Name:       cluster.Name,
 		UID:        cluster.UID,
-	}, options...)
+	}, metadata, options...)
 }
 
 // CreateSecretWithOwner creates the Kubeconfig secret for the given cluster name, namespace, endpoint, and owner reference.
-func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string, owner metav1.OwnerReference, options ...KubeConfigOption) error {
+func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string, owner metav1.OwnerReference, metadata *clusterv1.ObjectMeta, options ...KubeConfigOption) error {
 	server, err := url.JoinPath("https://", endpoint)
 	if err != nil {
 		return err
@@ -127,23 +131,27 @@ func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName cli
 		return err
 	}
 
-	return c.Create(ctx, GenerateSecretWithOwner(clusterName, out, owner))
+	return c.Create(ctx, GenerateSecretWithOwner(clusterName, out, owner, metadata))
 }
 
 // GenerateSecret returns a Kubernetes secret for the given Cluster and kubeconfig data.
 func GenerateSecret(cluster *clusterv1.Cluster, data []byte) *corev1.Secret {
 	name := util.ObjectKey(cluster)
+	var metadata *clusterv1.ObjectMeta
+	if cluster.Spec.Kubeconfig != nil {
+		metadata = &cluster.Spec.Kubeconfig.Metadata
+	}
 	return GenerateSecretWithOwner(name, data, metav1.OwnerReference{
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Cluster",
 		Name:       cluster.Name,
 		UID:        cluster.UID,
-	})
+	}, metadata)
 }
 
 // GenerateSecretWithOwner returns a Kubernetes secret for the given Cluster name, namespace, kubeconfig data, and ownerReference.
-func GenerateSecretWithOwner(clusterName client.ObjectKey, data []byte, owner metav1.OwnerReference) *corev1.Secret {
-	return &corev1.Secret{
+func GenerateSecretWithOwner(clusterName client.ObjectKey, data []byte, owner metav1.OwnerReference, metadata *clusterv1.ObjectMeta) *corev1.Secret {
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 			Namespace: clusterName.Namespace,
@@ -159,6 +167,28 @@ func GenerateSecretWithOwner(clusterName client.ObjectKey, data []byte, owner me
 		},
 		Type: clusterv1.ClusterSecretType,
 	}
+
+	// Apply custom metadata if provided
+	if metadata != nil {
+		if metadata.Labels != nil {
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			for k, v := range metadata.Labels {
+				secret.Labels[k] = v
+			}
+		}
+		if metadata.Annotations != nil {
+			if secret.Annotations == nil {
+				secret.Annotations = make(map[string]string)
+			}
+			for k, v := range metadata.Annotations {
+				secret.Annotations[k] = v
+			}
+		}
+	}
+
+	return secret
 }
 
 // NeedsClientCertRotation returns whether any of the Kubeconfig secret's client certificates will expire before the given threshold.

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -196,6 +196,47 @@ func TestGenerateSecretWithOwner(t *testing.T) {
 		},
 		[]byte(validKubeConfig),
 		owner,
+		nil,
+	)
+
+	g.Expect(kubeconfigSecret).NotTo(BeNil())
+	g.Expect(kubeconfigSecret).To(BeComparableTo(expectedSecret))
+}
+
+func TestGenerateSecretWithOwnerWithMetadata(t *testing.T) {
+	g := NewWithT(t)
+
+	owner := metav1.OwnerReference{
+		Name:       "test1",
+		Kind:       "Cluster",
+		APIVersion: clusterv1.GroupVersion.String(),
+	}
+
+	metadata := &clusterv1.ObjectMeta{
+		Labels: map[string]string{
+			"custom-label": "custom-value",
+		},
+		Annotations: map[string]string{
+			"custom-annotation": "custom-value",
+		},
+	}
+
+	expectedSecret := validSecret.DeepCopy()
+	expectedSecret.SetOwnerReferences([]metav1.OwnerReference{owner})
+	expectedSecret.Labels["custom-label"] = "custom-value"
+	expectedSecret.Labels[clusterv1.ClusterNameLabel] = "test1" // Ensure cluster name label is preserved
+	expectedSecret.Annotations = map[string]string{
+		"custom-annotation": "custom-value",
+	}
+
+	kubeconfigSecret := GenerateSecretWithOwner(
+		client.ObjectKey{
+			Name:      "test1",
+			Namespace: "test",
+		},
+		[]byte(validKubeConfig),
+		owner,
+		metadata,
 	)
 
 	g.Expect(kubeconfigSecret).NotTo(BeNil())
@@ -266,6 +307,7 @@ func TestCreateSecretWithOwner(t *testing.T) {
 		},
 		"localhost:6443",
 		owner,
+		nil,
 	)
 
 	g.Expect(err).ToNot(HaveOccurred())
@@ -321,6 +363,7 @@ func TestCreateSecretWithOwnerHasEndpointPrefixIsSlush(t *testing.T) {
 		},
 		"/localhost:6443",
 		owner,
+		nil,
 	)
 
 	g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Added optional spec.kubeconfig.metadata field to ClusterSpec in both v1beta1 and v1beta2 APIs,
enabling users to set custom annotations and labels on generated kubeconfig secrets.

This enables integration with annotation-based tools like Reflector that require specific
annotations (e.g., reflector.v1.k8s.emberstack.com/reflection-allowed) on secrets for proper
functioning, eliminating the need for post-creation patching via CronJobs.

Key changes:
- Add KubeconfigSpec type with Metadata field to ClusterSpec
- Update kubeconfig utility functions to apply metadata during secret creation
- Modify controllers to extract and pass metadata from cluster spec
- Preserve metadata during secret regeneration
- Add comprehensive tests for metadata functionality
- Maintain backward compatibility with optional field

Signed-off-by: [PillatiPriyanka]

