### PR TITLE
🐛 Fix KCP in-place update with InfraMachine webhooks with immutability validation

### DIFF
--- a/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -96,9 +97,12 @@ func (r *KubeadmControlPlaneReconciler) canExtensionsUpdateMachine(ctx context.C
 	log := ctrl.LoggerFrom(ctx)
 
 	// Create the CanUpdateMachine request.
-	req, err := createRequest(ctx, r.Client, machine, machineUpToDateResult)
+	cannotUpdateMachineReason, req, err := createRequest(ctx, r.Client, machine, machineUpToDateResult)
 	if err != nil {
 		return false, nil, errors.Wrapf(err, "failed to generate CanUpdateMachine request")
+	}
+	if cannotUpdateMachineReason != "" {
+		return false, []string{cannotUpdateMachineReason}, nil
 	}
 
 	var reasons []string
@@ -129,7 +133,7 @@ func (r *KubeadmControlPlaneReconciler) canExtensionsUpdateMachine(ctx context.C
 	return false, reasons, nil
 }
 
-func createRequest(ctx context.Context, c client.Client, currentMachine *clusterv1.Machine, machineUpToDateResult internal.UpToDateResult) (*runtimehooksv1.CanUpdateMachineRequest, error) {
+func createRequest(ctx context.Context, c client.Client, currentMachine *clusterv1.Machine, machineUpToDateResult internal.UpToDateResult) (string, *runtimehooksv1.CanUpdateMachineRequest, error) {
 	// DeepCopy objects to avoid mutations.
 	currentMachineForDiff := currentMachine.DeepCopy()
 	currentKubeadmConfigForDiff := machineUpToDateResult.CurrentKubeadmConfig.DeepCopy()
@@ -154,16 +158,30 @@ func createRequest(ctx context.Context, c client.Client, currentMachine *cluster
 	// Note: desiredMachineForDiff needs a dry-run because otherwise we have unintended diffs, e.g. dataSecretName,
 	//       providerID and nodeDeletionTimeout don't exist on the newly computed desired Machine.
 	if err := ssa.Patch(ctx, c, kcpManagerName, desiredMachineForDiff, ssa.WithDryRun{}); err != nil {
-		return nil, errors.Wrap(err, "server side apply dry-run failed for desired Machine")
+		// Note: While we check for specific errors for InfraMachine below we don't do the same here for Machine
+		// as we don't expect validating webhook errors for the Machine. If these errors actually occur
+		// we consider this a bug that should be fixed.
+		return "", nil, errors.Wrap(err, "server side apply dry-run failed for desired Machine")
 	}
 	// InfraMachine
 	// Note: Both currentInfraMachineForDiff and desiredInfraMachineForDiff need a dry-run to ensure changes
 	//       in defaulting logic and fields added by other controllers don't lead to an unintended diff.
 	if err := ssa.Patch(ctx, c, kcpManagerName, currentInfraMachineForDiff, ssa.WithDryRun{}); err != nil {
-		return nil, errors.Wrap(err, "server side apply dry-run failed for current InfraMachine")
+		// Note: If ssa.Patch fails because a validating webhook returns an error we cannot in-place update the InfraMachine
+		// as we would also later not be able to apply the InfraMachine object when triggering the in-place update.
+		// We expect that this only happens for desiredInfraMachineForDiff below but added it here as well as a safeguard.
+		if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) {
+			return fmt.Sprintf("server side apply dry-run for current InfraMachine failed: %s", err), nil, nil
+		}
+		return "", nil, errors.Wrap(err, "server side apply dry-run failed for current InfraMachine")
 	}
 	if err := ssa.Patch(ctx, c, kcpManagerName, desiredInfraMachineForDiff, ssa.WithDryRun{}); err != nil {
-		return nil, errors.Wrap(err, "server side apply dry-run failed for desired InfraMachine")
+		// Note: If ssa.Patch fails because a validating webhook returns an error we cannot in-place update the InfraMachine
+		// as we would also later not be able to apply the InfraMachine object when triggering the in-place update.
+		if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) {
+			return fmt.Sprintf("server side apply dry-run for desired InfraMachine failed: %s", err), nil, nil
+		}
+		return "", nil, errors.Wrap(err, "server side apply dry-run failed for desired InfraMachine")
 	}
 	// KubeadmConfig
 	// Note: Both currentKubeadmConfigForDiff and desiredKubeadmConfigForDiff don't need a dry-run as
@@ -184,22 +202,22 @@ func createRequest(ctx context.Context, c client.Client, currentMachine *cluster
 	var err error
 	req.Current.BootstrapConfig, err = patch.ConvertToRawExtension(cleanupKubeadmConfig(currentKubeadmConfigForDiff))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	req.Desired.BootstrapConfig, err = patch.ConvertToRawExtension(cleanupKubeadmConfig(desiredKubeadmConfigForDiff))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	req.Current.InfrastructureMachine, err = patch.ConvertToRawExtension(cleanupUnstructured(currentInfraMachineForDiff))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	req.Desired.InfrastructureMachine, err = patch.ConvertToRawExtension(cleanupUnstructured(desiredInfraMachineForDiff))
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
-	return req, nil
+	return "", req, nil
 }
 
 func cleanupMachine(machine *clusterv1.Machine) *clusterv1.Machine {

--- a/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_canupdatemachine_test.go
@@ -22,9 +22,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -692,6 +695,66 @@ func Test_createRequest(t *testing.T) {
 	unstructured.RemoveNestedField(desiredInfraMachineCleanedUp.Object, "status") // cleanupUnstructured drops status.
 	desiredInfraMachineWithFieldsSetByMachineControllerCleanedUp := desiredInfraMachineCleanedUp.DeepCopy()
 	g.Expect(unstructured.SetNestedField(desiredInfraMachineWithFieldsSetByMachineControllerCleanedUp.Object, "hello world from the infra machine controller", "spec", "bar")).To(Succeed())
+	desiredInfraMachineInvalid := desiredInfraMachine.DeepCopy()
+	g.Expect(unstructured.SetNestedField(desiredInfraMachineInvalid.Object, "invalid", "spec", "foo")).To(Succeed())
+	// Deploy ValidatingAdmissionPolicy to make desiredInfraMachineInvalid invalid.
+	p := &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "in-place-create-request",
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{ns.Name},
+						},
+					},
+				},
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{builder.InfrastructureGroupVersion.Group},
+								APIVersions: []string{"*"},
+								Resources:   []string{"*"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: "!has(object.spec) || !has(object.spec.foo) || object.spec.foo != 'invalid'",
+					Message:    "Field spec.foo must not be set to 'invalid'",
+				},
+			},
+		},
+	}
+	g.Expect(env.Create(t.Context(), p)).To(Succeed())
+	t.Cleanup(func() {
+		g.Expect(env.DeleteAndWait(context.Background(), p)).To(Succeed())
+	})
+	b := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "in-place-create-request",
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName:        p.Name,
+			ValidationActions: []admissionregistrationv1.ValidationAction{admissionregistrationv1.Deny},
+		},
+	}
+	g.Expect(env.Create(t.Context(), b)).To(Succeed())
+	t.Cleanup(func() {
+		g.Expect(env.DeleteAndWait(context.Background(), b)).To(Succeed())
+	})
+	// Wait until ValidatingAdmissionPolicy is active.
+	g.Eventually(func(g Gomega) {
+		g.Expect(apierrors.IsInvalid(ssa.Patch(ctx, env.Client, kcpManagerName, desiredInfraMachineInvalid.DeepCopy(), ssa.WithDryRun{}))).To(BeTrue())
+	}).WithTimeout(5 * time.Second).Should(Succeed())
 
 	tests := []struct {
 		name                          string
@@ -704,6 +767,7 @@ func Test_createRequest(t *testing.T) {
 		modifyMachineAfterCreate      func(ctx context.Context, c client.Client, machine *clusterv1.Machine) error
 		modifyInfraMachineAfterCreate func(ctx context.Context, c client.Client, infraMachine *unstructured.Unstructured) error
 		modifyUpToDateResult          func(result *internal.UpToDateResult)
+		wantCannotUpdateMachineReason string
 		wantReq                       *runtimehooksv1.CanUpdateMachineRequest
 		wantError                     bool
 		wantErrorMessage              string
@@ -820,6 +884,19 @@ func Test_createRequest(t *testing.T) {
 			},
 		},
 		{
+			name:                 "Should return cannotUpdateMachineReason if desiredInfraMachine is invalid",
+			currentMachine:       currentMachine,
+			currentInfraMachine:  currentInfraMachine,
+			currentKubeadmConfig: currentKubeadmConfig,
+			desiredMachine:       desiredMachine,
+			desiredInfraMachine:  desiredInfraMachineInvalid,
+			desiredKubeadmConfig: desiredKubeadmConfig,
+			wantCannotUpdateMachineReason: "server side apply dry-run for desired InfraMachine failed: " +
+				"failed to apply TestInfrastructureMachine: testinfrastructuremachines.infrastructure.cluster.x-k8s.io \"machine-to-in-place-update\" is forbidden: " +
+				"ValidatingAdmissionPolicy 'in-place-create-request' with binding 'in-place-create-request' denied request: " +
+				"Field spec.foo must not be set to 'invalid'",
+		},
+		{
 			name:                 "Should prepare all objects for diff: currentKubeadmConfig & desiredKubeadmConfig are prepared for diff",
 			currentMachine:       currentMachine,
 			currentInfraMachine:  currentInfraMachine,
@@ -889,13 +966,14 @@ func Test_createRequest(t *testing.T) {
 				tt.modifyUpToDateResult(&upToDateResult)
 			}
 
-			req, err := createRequest(ctx, env.Client, currentMachineForPatch, upToDateResult)
+			cannotUpdateMachineReason, req, err := createRequest(ctx, env.Client, currentMachineForPatch, upToDateResult)
 			if tt.wantError {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tt.wantErrorMessage))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
+			g.Expect(cannotUpdateMachineReason).To(BeComparableTo(tt.wantCannotUpdateMachineReason))
 			g.Expect(req).To(BeComparableTo(tt.wantReq))
 		})
 	}

--- a/test/infrastructure/docker/config/webhook/manifests.yaml
+++ b/test/infrastructure/docker/config/webhook/manifests.yaml
@@ -268,6 +268,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-dockermachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockermachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockermachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-dockermachinetemplate
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/test/infrastructure/docker/internal/controllers/backends/docker/dockermachinepool_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/docker/dockermachinepool_backend.go
@@ -592,6 +592,9 @@ func computeDesiredDevMachine(name string, cluster *clusterv1.Cluster, machinePo
 	if existingDevMachine != nil {
 		devMachine.SetUID(existingDevMachine.UID)
 		devMachine.SetOwnerReferences(existingDevMachine.OwnerReferences)
+		devMachine.Spec.Backend.Docker.CustomImage = existingDevMachine.Spec.Backend.Docker.CustomImage
+		devMachine.Spec.Backend.Docker.PreLoadImages = existingDevMachine.Spec.Backend.Docker.PreLoadImages
+		devMachine.Spec.Backend.Docker.ExtraMounts = existingDevMachine.Spec.Backend.Docker.ExtraMounts
 	}
 
 	// Note: Since the MachinePool controller has not created its owner Machine yet, we want to set the DevMachinePool as the owner so it's not orphaned.

--- a/test/infrastructure/docker/internal/controllers/dockermachinepool_controller_phases.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachinepool_controller_phases.go
@@ -270,6 +270,9 @@ func computeDesiredDockerMachine(name string, cluster *clusterv1.Cluster, machin
 	if existingDockerMachine != nil {
 		dockerMachine.SetUID(existingDockerMachine.UID)
 		dockerMachine.SetOwnerReferences(existingDockerMachine.OwnerReferences)
+		dockerMachine.Spec.CustomImage = existingDockerMachine.Spec.CustomImage
+		dockerMachine.Spec.PreLoadImages = existingDockerMachine.Spec.PreLoadImages
+		dockerMachine.Spec.ExtraMounts = existingDockerMachine.Spec.ExtraMounts
 	}
 
 	// Note: Since the MachinePool controller has not created its owner Machine yet, we want to set the DockerMachinePool as the owner so it's not orphaned.

--- a/test/infrastructure/docker/internal/webhooks/devmachine.go
+++ b/test/infrastructure/docker/internal/webhooks/devmachine.go
@@ -19,6 +19,8 @@ package webhooks
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -55,8 +57,18 @@ func (webhook *DevMachine) ValidateCreate(_ context.Context, _ *infrav1.DevMachi
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (webhook *DevMachine) ValidateUpdate(_ context.Context, _, _ *infrav1.DevMachine) (admission.Warnings, error) {
-	return nil, nil
+func (webhook *DevMachine) ValidateUpdate(_ context.Context, oldObj, newObj *infrav1.DevMachine) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+
+	if oldObj.Spec.Backend.Docker != nil && newObj.Spec.Backend.Docker != nil &&
+		oldObj.Spec.Backend.Docker.CustomImage != newObj.Spec.Backend.Docker.CustomImage {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "backend", "docker", "customImage"), "cannot be modified"))
+	}
+
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("DevMachine").GroupKind(), newObj.Name, allErrs)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.

--- a/test/infrastructure/docker/internal/webhooks/dockermachine.go
+++ b/test/infrastructure/docker/internal/webhooks/dockermachine.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
+)
+
+// DockerMachine implements a custom validation webhook for DockerMachine.
+type DockerMachine struct{}
+
+func (webhook *DockerMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &infrav1.DockerMachine{}).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta2-dockermachine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=dockermachines,versions=v1beta2,name=validation.dockermachine.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
+
+var _ admission.Validator[*infrav1.DockerMachine] = &DockerMachine{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DockerMachine) ValidateCreate(_ context.Context, _ *infrav1.DockerMachine) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DockerMachine) ValidateUpdate(_ context.Context, oldObj, newObj *infrav1.DockerMachine) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+
+	if oldObj.Spec.CustomImage != newObj.Spec.CustomImage {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "customImage"), "cannot be modified"))
+	}
+
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+	return nil, apierrors.NewInvalid(infrav1.GroupVersion.WithKind("DockerMachine").GroupKind(), newObj.Name, allErrs)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *DockerMachine) ValidateDelete(_ context.Context, _ *infrav1.DockerMachine) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -520,6 +520,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
+	if err := (&infrawebhooks.DockerMachine{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "Unable to create webhook", "webhook", "DockerMachine")
+		os.Exit(1)
+	}
+
 	if err := (&infrawebhooks.DockerMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "Unable to create webhook", "webhook", "DockerMachineTemplate")
 		os.Exit(1)

--- a/test/infrastructure/docker/webhooks/alias.go
+++ b/test/infrastructure/docker/webhooks/alias.go
@@ -25,7 +25,7 @@ import (
 // DockerCluster implements a validating and defaulting webhook for DockerCluster.
 type DockerCluster struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DockerCluster webhooks.
 func (webhook *DockerCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DockerCluster{}).SetupWebhookWithManager(mgr)
 }
@@ -33,15 +33,23 @@ func (webhook *DockerCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // DockerClusterTemplate implements a validating webhook for DockerClusterTemplate.
 type DockerClusterTemplate struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DockerClusterTemplate webhooks.
 func (webhook *DockerClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DockerClusterTemplate{}).SetupWebhookWithManager(mgr)
+}
+
+// DockerMachine implements a validating and defaulting webhook for DockerMachine.
+type DockerMachine struct{}
+
+// SetupWebhookWithManager sets up DockerMachine webhooks.
+func (webhook *DockerMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.DockerMachine{}).SetupWebhookWithManager(mgr)
 }
 
 // DockerMachineTemplate implements a validating webhook for DockerMachineTemplate.
 type DockerMachineTemplate struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DockerMachineTemplate webhooks.
 func (webhook *DockerMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DockerMachineTemplate{}).SetupWebhookWithManager(mgr)
 }
@@ -49,7 +57,7 @@ func (webhook *DockerMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) 
 // DevCluster implements a validating and defaulting webhook for DevCluster.
 type DevCluster struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DevCluster webhooks.
 func (webhook *DevCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DevCluster{}).SetupWebhookWithManager(mgr)
 }
@@ -57,7 +65,7 @@ func (webhook *DevCluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // DevClusterTemplate implements a validating and defaulting webhook for DevClusterTemplate.
 type DevClusterTemplate struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DevClusterTemplate webhooks.
 func (webhook *DevClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DevClusterTemplate{}).SetupWebhookWithManager(mgr)
 }
@@ -65,7 +73,7 @@ func (webhook *DevClusterTemplate) SetupWebhookWithManager(mgr ctrl.Manager) err
 // DevMachine implements a validating and defaulting webhook for DevMachine.
 type DevMachine struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DevMachine webhooks.
 func (webhook *DevMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DevMachine{}).SetupWebhookWithManager(mgr)
 }
@@ -73,7 +81,7 @@ func (webhook *DevMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // DevMachineTemplate implements a validating webhook for DevMachineTemplate.
 type DevMachineTemplate struct{}
 
-// SetupWebhookWithManager sets up ClusterResourceSet webhooks.
+// SetupWebhookWithManager sets up DevMachineTemplate webhooks.
 func (webhook *DevMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return (&webhooks.DevMachineTemplate{}).SetupWebhookWithManager(mgr)
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This issue only occurs if the in-place update feature gate is enabled and if an in-place update extension is deployed.

If the validating webhook of an InfraMachine checks a field for immutability and if a rollout contains a change for this field the rollout gets stuck because KCP fails in createRequest when preparing the objects for the CanUpdateMachine call, because ssa.Patch on the desiredInfraMachine returns an error.

This PR addresses this issue by using the failed ssa.Patch call as a signal that in-place update is not possible.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->