### PR TITLE
🌱 Fix typos in generated CRD descriptions

### DIFF
--- a/api/core/v1beta1/machinedeployment_types.go
+++ b/api/core/v1beta1/machinedeployment_types.go
@@ -377,7 +377,7 @@ type MachineRollingUpdateDeployment struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 
 	// deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
-	// Valid values are "Random, "Newest", "Oldest"
+	// Valid values are "Random", "Newest", "Oldest"
 	// When no value is supplied, the default DeletePolicy of MachineSet is used
 	// +kubebuilder:validation:Enum=Random;Newest;Oldest
 	// +optional

--- a/api/core/v1beta1/machinepool_types.go
+++ b/api/core/v1beta1/machinepool_types.go
@@ -106,7 +106,7 @@ type MachinePoolSpec struct {
 
 // MachinePoolStatus defines the observed state of MachinePool.
 type MachinePoolStatus struct {
-	// nodeRefs will point to the corresponding Nodes if it they exist.
+	// nodeRefs will point to the corresponding Nodes if they exist.
 	// +optional
 	// +kubebuilder:validation:MaxItems=10000
 	NodeRefs []corev1.ObjectReference `json:"nodeRefs,omitempty"`

--- a/api/core/v1beta1/machineset_types.go
+++ b/api/core/v1beta1/machineset_types.go
@@ -69,7 +69,7 @@ type MachineSetSpec struct {
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
 	// deletePolicy defines the policy used to identify nodes to delete when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
 	// +kubebuilder:validation:Enum=Random;Newest;Oldest
 	// +optional
 	DeletePolicy string `json:"deletePolicy,omitempty"`

--- a/api/core/v1beta2/cluster_types.go
+++ b/api/core/v1beta2/cluster_types.go
@@ -1129,7 +1129,7 @@ type MachineDeploymentTopologyHealthCheckRemediationTriggerIf struct {
 // +kubebuilder:validation:MinProperties=1
 type MachineDeploymentTopologyMachineDeletionSpec struct {
 	// order defines the order in which Machines are deleted when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
 	// +optional
 	Order MachineSetDeletionOrder `json:"order,omitempty"`
 

--- a/api/core/v1beta2/clusterclass_types.go
+++ b/api/core/v1beta2/clusterclass_types.go
@@ -662,7 +662,7 @@ type MachineDeploymentClassHealthCheckRemediationTriggerIf struct {
 // +kubebuilder:validation:MinProperties=1
 type MachineDeploymentClassMachineDeletionSpec struct {
 	// order defines the order in which Machines are deleted when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
 	// +optional
 	Order MachineSetDeletionOrder `json:"order,omitempty"`
 

--- a/api/core/v1beta2/machinedeployment_types.go
+++ b/api/core/v1beta2/machinedeployment_types.go
@@ -414,7 +414,7 @@ type MachineNamingSpec struct {
 // +kubebuilder:validation:MinProperties=1
 type MachineDeploymentDeletionSpec struct {
 	// order defines the order in which Machines are deleted when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
 	// +optional
 	Order MachineSetDeletionOrder `json:"order,omitempty"`
 }

--- a/api/core/v1beta2/machinepool_types.go
+++ b/api/core/v1beta2/machinepool_types.go
@@ -116,7 +116,7 @@ type MachinePoolStatus struct {
 	// +optional
 	Initialization MachinePoolInitializationStatus `json:"initialization,omitempty,omitzero"`
 
-	// nodeRefs will point to the corresponding Nodes if it they exist.
+	// nodeRefs will point to the corresponding Nodes if they exist.
 	// +optional
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=10000

--- a/api/core/v1beta2/machineset_types.go
+++ b/api/core/v1beta2/machineset_types.go
@@ -113,7 +113,7 @@ type MachineSetSpec struct {
 // +kubebuilder:validation:MinProperties=1
 type MachineSetDeletionSpec struct {
 	// order defines the order in which Machines are deleted when downscaling.
-	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
 	// +optional
 	Order MachineSetDeletionOrder `json:"order,omitempty"`
 }

--- a/api/core/v1beta2/zz_generated.openapi.go
+++ b/api/core/v1beta2/zz_generated.openapi.go
@@ -3251,7 +3251,7 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentClassMachineDeletionSp
 				Properties: map[string]spec.Schema{
 					"order": {
 						SchemaProps: spec.SchemaProps{
-							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\". Valid values are \"Random\", \"Newest\", \"Oldest\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3391,7 +3391,7 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentDeletionSpec(ref commo
 				Properties: map[string]spec.Schema{
 					"order": {
 						SchemaProps: spec.SchemaProps{
-							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\". Valid values are \"Random\", \"Newest\", \"Oldest\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4050,7 +4050,7 @@ func schema_cluster_api_api_core_v1beta2_MachineDeploymentTopologyMachineDeletio
 				Properties: map[string]spec.Schema{
 					"order": {
 						SchemaProps: spec.SchemaProps{
-							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\". Valid values are \"Random\", \"Newest\", \"Oldest\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5560,7 +5560,7 @@ func schema_cluster_api_api_core_v1beta2_MachinePoolStatus(ref common.ReferenceC
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "nodeRefs will point to the corresponding Nodes if it they exist.",
+							Description: "nodeRefs will point to the corresponding Nodes if they exist.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5959,7 +5959,7 @@ func schema_cluster_api_api_core_v1beta2_MachineSetDeletionSpec(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"order": {
 						SchemaProps: spec.SchemaProps{
-							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+							Description: "order defines the order in which Machines are deleted when downscaling. Defaults to \"Random\". Valid values are \"Random\", \"Newest\", \"Oldest\"",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/api/ipam/v1alpha1/ipaddress_types.go
+++ b/api/ipam/v1alpha1/ipaddress_types.go
@@ -53,7 +53,7 @@ type IPAddressSpec struct {
 // +kubebuilder:printcolumn:name="Address",type="string",JSONPath=".spec.address",description="Address"
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool the address is from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool the address is from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdress"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddress"
 
 // IPAddress is the Schema for the ipaddress API.
 type IPAddress struct {

--- a/api/ipam/v1alpha1/ipaddressclaim_types.go
+++ b/api/ipam/v1alpha1/ipaddressclaim_types.go
@@ -46,7 +46,7 @@ type IPAddressClaimStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool to allocate an address from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool to allocate an address from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdressClaim"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddressClaim"
 
 // IPAddressClaim is the Schema for the ipaddressclaim API.
 type IPAddressClaim struct {

--- a/api/ipam/v1beta1/ipaddress_types.go
+++ b/api/ipam/v1beta1/ipaddress_types.go
@@ -54,7 +54,7 @@ type IPAddressSpec struct {
 // +kubebuilder:printcolumn:name="Address",type="string",JSONPath=".spec.address",description="Address"
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool the address is from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool the address is from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdress"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddress"
 
 // IPAddress is the Schema for the ipaddress API.
 type IPAddress struct {

--- a/api/ipam/v1beta1/ipaddressclaim_types.go
+++ b/api/ipam/v1beta1/ipaddressclaim_types.go
@@ -68,7 +68,7 @@ type IPAddressClaimV1Beta2Status struct {
 // +kubebuilder:deprecatedversion
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool to allocate an address from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool to allocate an address from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdressClaim"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddressClaim"
 
 // IPAddressClaim is the Schema for the ipaddressclaim API.
 type IPAddressClaim struct {

--- a/api/ipam/v1beta2/ipaddress_types.go
+++ b/api/ipam/v1beta2/ipaddress_types.go
@@ -93,7 +93,7 @@ type IPPoolReference struct {
 // +kubebuilder:printcolumn:name="Address",type="string",JSONPath=".spec.address",description="Address"
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool the address is from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool the address is from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdress"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddress"
 
 // IPAddress is the Schema for the ipaddress API.
 type IPAddress struct {

--- a/api/ipam/v1beta2/ipaddressclaim_types.go
+++ b/api/ipam/v1beta2/ipaddressclaim_types.go
@@ -109,7 +109,7 @@ type IPAddressClaimV1Beta1DeprecatedStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Pool Name",type="string",JSONPath=".spec.poolRef.name",description="Name of the pool to allocate an address from"
 // +kubebuilder:printcolumn:name="Pool Kind",type="string",JSONPath=".spec.poolRef.kind",description="Kind of the pool to allocate an address from"
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAdressClaim"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of IPAddressClaim"
 
 // IPAddressClaim is the Schema for the ipaddressclaim API.
 type IPAddressClaim struct {

--- a/api/runtime/v1alpha1/extensionconfig_types.go
+++ b/api/runtime/v1alpha1/extensionconfig_types.go
@@ -151,7 +151,7 @@ type ExtensionHandler struct {
 	RequestHook GroupVersionHook `json:"requestHook"`
 
 	// timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
-	// Defaults to 10 is not set.
+	// Defaults to 10 seconds if not set.
 	// +optional
 	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -1599,7 +1599,7 @@ spec:
                                 deletePolicy:
                                   description: |-
                                     deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
-                                    Valid values are "Random, "Newest", "Oldest"
+                                    Valid values are "Random", "Newest", "Oldest"
                                     When no value is supplied, the default DeletePolicy of MachineSet is used
                                   enum:
                                   - Random
@@ -4123,7 +4123,7 @@ spec:
                             order:
                               description: |-
                                 order defines the order in which Machines are deleted when downscaling.
-                                Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                                Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
                               enum:
                               - Random
                               - Newest

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1110,7 +1110,7 @@ spec:
                                     deletePolicy:
                                       description: |-
                                         deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
-                                        Valid values are "Random, "Newest", "Oldest"
+                                        Valid values are "Random", "Newest", "Oldest"
                                         When no value is supplied, the default DeletePolicy of MachineSet is used
                                       enum:
                                       - Random
@@ -2623,7 +2623,7 @@ spec:
                                 order:
                                   description: |-
                                     order defines the order in which Machines are deleted when downscaling.
-                                    Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                                    Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
                                   enum:
                                   - Random
                                   - Newest

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -264,7 +264,7 @@ spec:
                       deletePolicy:
                         description: |-
                           deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
-                          Valid values are "Random, "Newest", "Oldest"
+                          Valid values are "Random", "Newest", "Oldest"
                           When no value is supplied, the default DeletePolicy of MachineSet is used
                         enum:
                         - Random
@@ -923,7 +923,7 @@ spec:
                   order:
                     description: |-
                       order defines the order in which Machines are deleted when downscaling.
-                      Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                      Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
                     enum:
                     - Random
                     - Newest

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -504,8 +504,8 @@ spec:
                   provider.
                 type: boolean
               nodeRefs:
-                description: nodeRefs will point to the corresponding Nodes if it
-                  they exist.
+                description: nodeRefs will point to the corresponding Nodes if they
+                  exist.
                 items:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
@@ -1309,8 +1309,8 @@ spec:
                     type: boolean
                 type: object
               nodeRefs:
-                description: nodeRefs will point to the corresponding Nodes if it
-                  they exist.
+                description: nodeRefs will point to the corresponding Nodes if they
+                  exist.
                 items:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -83,7 +83,7 @@ spec:
               deletePolicy:
                 description: |-
                   deletePolicy defines the policy used to identify nodes to delete when downscaling.
-                  Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                  Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
                 enum:
                 - Random
                 - Newest
@@ -807,7 +807,7 @@ spec:
                   order:
                     description: |-
                       order defines the order in which Machines are deleted when downscaling.
-                      Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                      Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
                     enum:
                     - Random
                     - Newest

--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
@@ -25,7 +25,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdressClaim
+    - description: Time duration since creation of IPAddressClaim
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -163,7 +163,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdressClaim
+    - description: Time duration since creation of IPAddressClaim
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -376,7 +376,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdressClaim
+    - description: Time duration since creation of IPAddressClaim
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_ipaddresses.yaml
@@ -29,7 +29,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdress
+    - description: Time duration since creation of IPAddress
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -131,7 +131,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdress
+    - description: Time duration since creation of IPAddress
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -234,7 +234,7 @@ spec:
       jsonPath: .spec.poolRef.kind
       name: Pool Kind
       type: string
-    - description: Time duration since creation of IPAdress
+    - description: Time duration since creation of IPAddress
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -273,7 +273,7 @@ spec:
                     timeoutSeconds:
                       description: |-
                         timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
-                        Defaults to 10 is not set.
+                        Defaults to 10 seconds if not set.
                       format: int32
                       type: integer
                   required:

--- a/docs/book/src/reference/api/crd-api-reference-v1beta1.md
+++ b/docs/book/src/reference/api/crd-api-reference-v1beta1.md
@@ -3006,7 +3006,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `nodeRefs` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectreference-v1-core) array_ | nodeRefs will point to the corresponding Nodes if it they exist. |  | MaxItems: 10000 <br />Optional: \{\} <br /> |
+| `nodeRefs` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectreference-v1-core) array_ | nodeRefs will point to the corresponding Nodes if they exist. |  | MaxItems: 10000 <br />Optional: \{\} <br /> |
 | `replicas` _integer_ | replicas is the most recently observed number of replicas. |  | Optional: \{\} <br /> |
 | `readyReplicas` _integer_ | readyReplicas is the number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready". |  | Optional: \{\} <br /> |
 | `availableReplicas` _integer_ | availableReplicas is the number of available replicas (ready for at least minReadySeconds) for this MachinePool. |  | Optional: \{\} <br /> |
@@ -3177,7 +3177,7 @@ _Appears in:_
 | `clusterName` _string_ | clusterName is the name of the Cluster this object belongs to. |  | MaxLength: 63 <br />MinLength: 1 <br />Required: \{\} <br /> |
 | `replicas` _integer_ | replicas is the number of desired replicas.<br />This is a pointer to distinguish between explicit zero and unspecified.<br />Defaults to:<br />* if the Kubernetes autoscaler min size and max size annotations are set:<br />  - if it's a new MachineSet, use min size<br />  - if the replicas field of the old MachineSet is < min size, use min size<br />  - if the replicas field of the old MachineSet is > max size, use max size<br />  - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS<br />* otherwise use 1<br />Note: Defaulting will be run whenever the replicas field is not set:<br />* A new MachineSet is created with replicas not set.<br />* On an existing MachineSet the replicas field was first set and is now unset.<br />Those cases are especially relevant for the following Kubernetes autoscaler use cases:<br />* A new MachineSet is created and replicas should be managed by the autoscaler<br />* An existing MachineSet which initially wasn't controlled by the autoscaler<br />  should be later controlled by the autoscaler |  | Optional: \{\} <br /> |
 | `minReadySeconds` _integer_ | minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.<br />Defaults to 0 (machine will be considered available as soon as the Node is ready) |  | Optional: \{\} <br /> |
-| `deletePolicy` _string_ | deletePolicy defines the policy used to identify nodes to delete when downscaling.<br />Defaults to "Random".  Valid values are "Random, "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
+| `deletePolicy` _string_ | deletePolicy defines the policy used to identify nodes to delete when downscaling.<br />Defaults to "Random". Valid values are "Random", "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#labelselector-v1-meta)_ | selector is a label query over machines that should match the replica count.<br />Label keys and values that must match in order to be controlled by this MachineSet.<br />It must match the machine template's labels.<br />More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors |  | Required: \{\} <br /> |
 | `template` _[MachineTemplateSpec](#machinetemplatespec)_ | template is the object that describes the machine that will be created if<br />insufficient replicas are detected.<br />Object references to custom resources are treated as templates. |  | Optional: \{\} <br /> |
 | `machineNamingStrategy` _[MachineNamingStrategy](#machinenamingstrategy)_ | machineNamingStrategy allows changing the naming pattern used when creating Machines.<br />Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines. |  | Optional: \{\} <br /> |
@@ -4509,7 +4509,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | name is the unique name of the ExtensionHandler. |  | MaxLength: 512 <br />MinLength: 1 <br />Required: \{\} <br /> |
 | `requestHook` _[GroupVersionHook](#groupversionhook)_ | requestHook defines the versioned runtime hook which this ExtensionHandler serves. |  | Required: \{\} <br /> |
-| `timeoutSeconds` _integer_ | timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.<br />Defaults to 10 is not set. |  | Optional: \{\} <br /> |
+| `timeoutSeconds` _integer_ | timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.<br />Defaults to 10 seconds if not set. |  | Optional: \{\} <br /> |
 | `failurePolicy` _[FailurePolicy](#failurepolicy)_ | failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.<br />Defaults to Fail if not set. |  | Enum: [Ignore Fail] <br />Optional: \{\} <br /> |
 
 

--- a/docs/book/src/reference/api/crd-api-reference.md
+++ b/docs/book/src/reference/api/crd-api-reference.md
@@ -2883,7 +2883,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random".  Valid values are "Random, "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
+| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random". Valid values are "Random", "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
 | `nodeDrainTimeoutSeconds` _integer_ | nodeDrainTimeoutSeconds is the total amount of time that the controller will spend on draining a node.<br />The default value is 0, meaning that the node can be drained without any time limitations.<br />NOTE: nodeDrainTimeoutSeconds is different from `kubectl drain --timeout`<br />NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 | `nodeVolumeDetachTimeoutSeconds` _integer_ | nodeVolumeDetachTimeoutSeconds is the total amount of time that the controller will spend on waiting for all volumes<br />to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.<br />NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 | `nodeDeletionTimeoutSeconds` _integer_ | nodeDeletionTimeoutSeconds defines how long the controller will attempt to delete the Node that the Machine<br />hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.<br />Defaults to 10 seconds.<br />NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass. |  | Minimum: 0 <br />Optional: \{\} <br /> |
@@ -2974,7 +2974,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random".  Valid values are "Random, "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
+| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random". Valid values are "Random", "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
 
 
 #### MachineDeploymentDeprecatedStatus
@@ -3271,7 +3271,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random".  Valid values are "Random, "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
+| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random". Valid values are "Random", "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
 | `nodeDrainTimeoutSeconds` _integer_ | nodeDrainTimeoutSeconds is the total amount of time that the controller will spend on draining a node.<br />The default value is 0, meaning that the node can be drained without any time limitations.<br />NOTE: nodeDrainTimeoutSeconds is different from `kubectl drain --timeout` |  | Minimum: 0 <br />Optional: \{\} <br /> |
 | `nodeVolumeDetachTimeoutSeconds` _integer_ | nodeVolumeDetachTimeoutSeconds is the total amount of time that the controller will spend on waiting for all volumes<br />to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 | `nodeDeletionTimeoutSeconds` _integer_ | nodeDeletionTimeoutSeconds defines how long the controller will attempt to delete the Node that the Machine<br />hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.<br />Defaults to 10 seconds. |  | Minimum: 0 <br />Optional: \{\} <br /> |
@@ -3985,7 +3985,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#condition-v1-meta) array_ | conditions represents the observations of a MachinePool's current state.<br />Known condition types are Available, BootstrapConfigReady, InfrastructureReady, MachinesReady, MachinesUpToDate,<br />ScalingUp, ScalingDown, Remediating, Deleting, Paused. |  | MaxItems: 32 <br />Optional: \{\} <br /> |
 | `initialization` _[MachinePoolInitializationStatus](#machinepoolinitializationstatus)_ | initialization provides observations of the MachinePool initialization process.<br />NOTE: Fields in this struct are part of the Cluster API contract and are used to orchestrate initial MachinePool provisioning. |  | MinProperties: 1 <br />Optional: \{\} <br /> |
-| `nodeRefs` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectreference-v1-core) array_ | nodeRefs will point to the corresponding Nodes if it they exist. |  | MaxItems: 10000 <br />Optional: \{\} <br /> |
+| `nodeRefs` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#objectreference-v1-core) array_ | nodeRefs will point to the corresponding Nodes if they exist. |  | MaxItems: 10000 <br />Optional: \{\} <br /> |
 | `replicas` _integer_ | replicas is the most recently observed number of replicas. |  | Optional: \{\} <br /> |
 | `readyReplicas` _integer_ | readyReplicas is the number of ready replicas for this MachinePool. A machine is considered ready when Machine's Ready condition is true. |  | Optional: \{\} <br /> |
 | `availableReplicas` _integer_ | availableReplicas is the number of available replicas for this MachinePool. A machine is considered available when Machine's Available condition is true. |  | Optional: \{\} <br /> |
@@ -4157,7 +4157,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random".  Valid values are "Random, "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
+| `order` _[MachineSetDeletionOrder](#machinesetdeletionorder)_ | order defines the order in which Machines are deleted when downscaling.<br />Defaults to "Random". Valid values are "Random", "Newest", "Oldest" |  | Enum: [Random Newest Oldest] <br />Optional: \{\} <br /> |
 
 
 #### MachineSetDeprecatedStatus


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes typos and malformed wording in user-facing CRD descriptions and generated OpenAPI descriptions.

This PR updates the source comments / kubebuilder annotations and regenerates the affected CRDs and OpenAPI output. The change is description-only and does not change API fields, validation, served/storage versions, conversion behavior, or controller behavior.

The corrected descriptions include:

- `nodeRefs will point to the corresponding Nodes if they exist.`
- `Defaults to "Random". Valid values are "Random", "Newest", "Oldest"`
- `Time duration since creation of IPAddress`
- `Time duration since creation of IPAddressClaim`
- `Defaults to 10 seconds if not set.`

Validation performed:

- `make generate-manifests-core`
- `make generate-go-openapi`
- `make verify-gen`
- `git diff --check`

Note: `make verify-gen` prints existing `openapi-gen` API rule violation warnings, but it exits successfully and leaves the generated files up to date.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13639

/area api
/area ipam
/area runtime-sdk
/area machinepool
/area machineset
/area machinedeployment
