### PR TITLE
🐛 Skip update check for clusterctl completion

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -90,6 +90,14 @@ var (
 		Short:   "Output shell completion code for the specified shell (bash, zsh or fish)",
 		Long:    templates.LongDesc(completionLong),
 		Example: completionExample,
+		PostRun: func(cmd *cobra.Command, _ []string) {
+			// Disable PersistentPostRun on the parent command to skip the update check to avoid blocking shell startup.
+			// Setting this to a no-op function makes it work in case the command is registered at a deeper level, as long as
+			// EnableTraverseRunHooks remains false.
+			cmd.Parent().PersistentPostRunE = func(_ *cobra.Command, _ []string) error {
+				return nil
+			}
+		},
 		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("please specify a shell")


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables clusterctl's update check when generating shell completions to avoid blocking shell startup in case of slow network.
Small downside: you no longer get notified about new clusterctl versions when opening a new shell.

**Which issue(s) this PR fixes**:
Fixes #13652

/area clusterctl