### PR TITLE
🌱 Add workaround for generate release notes

### DIFF
--- a/hack/tools/release/notes/list.go
+++ b/hack/tools/release/notes/list.go
@@ -34,15 +34,17 @@ type githubFromToPRLister struct {
 	fromRef, toRef ref
 	// branch is optional. It helps optimize the PR query by restricting
 	// the results to PRs merged in the selected branch and in main
-	branch string
+	branch               string
+	skipConsistencyCheck bool
 }
 
-func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string) *githubFromToPRLister {
+func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string, skipConsistencyCheck bool) *githubFromToPRLister {
 	return &githubFromToPRLister{
-		client:  &githubClient{repo: repo},
-		fromRef: fromRef,
-		toRef:   toRef,
-		branch:  branch,
+		client:               &githubClient{repo: repo},
+		fromRef:              fromRef,
+		toRef:                toRef,
+		branch:               branch,
+		skipConsistencyCheck: skipConsistencyCheck,
 	}
 }
 
@@ -119,6 +121,8 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 		if _, ok := selectedPRNumbers[fmt.Sprintf("%d", p.Number)]; !ok {
 			continue
 		}
+		selectedPRNumbers[fmt.Sprintf("%d", p.Number)] = true
+
 		labels := make([]string, 0, len(p.Labels))
 		for _, l := range p.Labels {
 			labels = append(labels, l.Name)
@@ -131,9 +135,17 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 		})
 	}
 
+	// Report consistency problems
+	for sp, found := range selectedPRNumbers {
+		if found {
+			continue
+		}
+		log.Printf("PR number %s identified from commits, not found in the PR list", sp)
+	}
+
 	log.Printf("%d PRs match the commits from the git diff", len(prs))
 
-	if len(prs) != len(selectedPRNumbers) {
+	if len(prs) != len(selectedPRNumbers) && !l.skipConsistencyCheck {
 		return nil, errors.Errorf("expected %d PRs from commit list but only found %d", len(selectedPRNumbers), len(prs))
 	}
 
@@ -145,18 +157,18 @@ var (
 	tideSquashedCommitMessage = regexp.MustCompile(`(?m)^.+\(#(?P<number>\d+)\)$`)
 )
 
-func buildSetOfPRNumbers(commits []githubCommitNode) map[string]struct{} {
-	prNumbers := make(map[string]struct{})
+func buildSetOfPRNumbers(commits []githubCommitNode) map[string]bool {
+	prNumbers := make(map[string]bool)
 	for _, commit := range commits {
 		match := mergeCommitMessage.FindStringSubmatch(commit.Commit.Message)
 		if len(match) == 2 {
-			prNumbers[match[1]] = struct{}{}
+			prNumbers[match[1]] = false
 			continue
 		}
 
 		match = tideSquashedCommitMessage.FindStringSubmatch(commit.Commit.Message)
 		if len(match) == 2 {
-			prNumbers[match[1]] = struct{}{}
+			prNumbers[match[1]] = false
 		}
 	}
 

--- a/hack/tools/release/notes/list_test.go
+++ b/hack/tools/release/notes/list_test.go
@@ -40,7 +40,7 @@ func Test_buildSetOfPRNumbers(t *testing.T) {
 	tests := []struct {
 		name    string
 		commits []githubCommitNode
-		want    map[string]struct{}
+		want    map[string]bool
 	}{
 		{
 			name: "merge commit",
@@ -51,8 +51,8 @@ func Test_buildSetOfPRNumbers(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]struct{}{
-				"9072": {},
+			want: map[string]bool{
+				"9072": false,
 			},
 		},
 		{
@@ -64,8 +64,8 @@ func Test_buildSetOfPRNumbers(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]struct{}{
-				"9263": {},
+			want: map[string]bool{
+				"9263": false,
 			},
 		},
 	}

--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -66,6 +66,7 @@ type notesCmdConfig struct {
 	previousReleaseVersion      string
 	prefixAreaLabel             bool
 	deprecation                 bool
+	skipConsistencyCheck        bool
 	addKubernetesVersionSupport bool
 }
 
@@ -83,6 +84,7 @@ func readCmdConfig() *notesCmdConfig {
 	flag.BoolVar(&config.prefixAreaLabel, "prefix-area-label", true, "If enabled, will prefix the area label.")
 	flag.BoolVar(&config.deprecation, "deprecation", true, "If enabled, will add a templated deprecation warning header.")
 	flag.BoolVar(&config.addKubernetesVersionSupport, "add-kubernetes-version-support", true, "If enabled, will add the Kubernetes version support header.")
+	flag.BoolVar(&config.skipConsistencyCheck, "skip-consistency-check", false, "If enabled, the tool will skip the check about consistency between PRs and commits from the git diff.")
 
 	flag.Parse()
 
@@ -127,7 +129,7 @@ func (cmd *notesCmd) run() error {
 	printer.printKubernetesSupport = cmd.config.addKubernetesVersionSupport
 
 	generator := newNotesGenerator(
-		newGithubFromToPRLister(cmd.config.repo, from, to, cmd.config.branch),
+		newGithubFromToPRLister(cmd.config.repo, from, to, cmd.config.branch, cmd.config.skipConsistencyCheck),
 		newPREntryProcessor(cmd.config.prefixAreaLabel),
 		printer,
 		newDependenciesProcessor(cmd.config.repo, from.value, to.value),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We saw release note failing a few times.
While we figure out what it is happening, this PR introduce a flag that allows to continue with the release by generating the release notes even if some manual changes are required (info for the manual changes are surfaced)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->