### PR TITLE
:sparkles: Add cert-manager preinstall timeout to support retrying readiness check

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -153,7 +153,8 @@ func (cm *certManagerClient) EnsureInstalled(ctx context.Context) error {
 	log := logf.Log
 
 	// Checking if a version of cert manager supporting cert-manager-test-resources.yaml is already installed and properly working.
-	if err := cm.waitForAPIReady(ctx, false); err == nil {
+	// If PreInstallTimeout is configured, retry the readiness check for that duration, otherwise do a one-shot check.
+	if err := cm.waitForAPIReady(ctx, cm.getPreinstallTimeout()); err == nil {
 		log.Info("Skipping installing cert-manager as it is already installed")
 		return nil
 	}
@@ -193,7 +194,7 @@ func (cm *certManagerClient) install(ctx context.Context, version string, objs [
 	}
 
 	// Wait for the cert-manager API to be ready to accept requests
-	return cm.waitForAPIReady(ctx, true)
+	return cm.waitForAPIReady(ctx, cm.getWaitTimeout())
 }
 
 // PlanUpgrade returns a CertManagerUpgradePlan with information regarding
@@ -387,16 +388,31 @@ func (cm *certManagerClient) shouldUpgrade(desiredVersion string, objs, installO
 }
 
 func (cm *certManagerClient) getWaitTimeout() time.Duration {
-	log := logf.Log
-
 	certManagerConfig, err := cm.configClient.CertManager().Get()
 	if err != nil {
 		return config.CertManagerDefaultTimeout
 	}
-	timeoutDuration, err := time.ParseDuration(certManagerConfig.Timeout())
+	return getCertManagerTimeout(certManagerConfig.Timeout(), "timeout", config.CertManagerDefaultTimeout)
+}
+
+func (cm *certManagerClient) getPreinstallTimeout() time.Duration {
+	certManagerConfig, err := cm.configClient.CertManager().Get()
 	if err != nil {
-		log.Info("Invalid value set for cert-manager configuration", "timeout", certManagerConfig.Timeout())
-		return config.CertManagerDefaultTimeout
+		return config.CertManagerDefaultPreinstallTimeout
+	}
+	return getCertManagerTimeout(certManagerConfig.PreinstallTimeout(), "preinstallTimeout", config.CertManagerDefaultPreinstallTimeout)
+}
+
+// getCertManagerTimeout parses a duration string from cert-manager configuration.
+// If the value is empty or cannot be parsed, it returns the provided default.
+func getCertManagerTimeout(value, label string, defaultValue time.Duration) time.Duration {
+	if value == "" {
+		return defaultValue
+	}
+	timeoutDuration, err := time.ParseDuration(value)
+	if err != nil {
+		logf.Log.Info("Invalid value set for cert-manager configuration", label, value)
+		return defaultValue
 	}
 	return timeoutDuration
 }
@@ -531,39 +547,36 @@ func (cm *certManagerClient) deleteObj(ctx context.Context, obj unstructured.Uns
 // Issuer and Certificate).
 // This ensures that the Kubernetes apiserver is ready to serve resources within the
 // cert-manager API group.
-// If retry is true, the createObj call will be retried if it fails. Otherwise, the
-// 'create' operations will only be attempted once.
-func (cm *certManagerClient) waitForAPIReady(ctx context.Context, retry bool) error {
-	log := logf.Log
-	// Waits for the cert-manager to be available.
-	if retry {
-		log.Info("Waiting for cert-manager to be available...")
-	}
-
+// If timeout is 0, the createObj call will only be attempted once.
+// If timeout is greater than 0, the createObj call will be retried until the timeout.
+func (cm *certManagerClient) waitForAPIReady(ctx context.Context, timeout time.Duration) error {
 	testObjs, err := getTestResourcesManifestObjs()
 	if err != nil {
 		return err
 	}
 
-	for i := range testObjs {
-		o := testObjs[i]
+	if timeout > 0 {
+		logf.Log.Info("Checking if cert-manager is available...")
+		for i := range testObjs {
+			o := testObjs[i]
 
-		// Create the Kubernetes object.
-		// This is wrapped with a retry as the cert-manager API may not be available
-		// yet, so we need to keep retrying until it is.
-		if err := cm.pollImmediateWaiter(ctx, waitCertManagerInterval, cm.getWaitTimeout(), func(ctx context.Context) (bool, error) {
-			if err := cm.createObj(ctx, o); err != nil {
-				// If retrying is disabled, return the error here.
-				if !retry {
-					return false, err
+			if err := cm.pollImmediateWaiter(ctx, waitCertManagerInterval, timeout, func(ctx context.Context) (bool, error) {
+				if err := cm.createObj(ctx, o); err != nil {
+					return false, nil
 				}
-				return false, nil
+				return true, nil
+			}); err != nil {
+				return err
 			}
-			return true, nil
-		}); err != nil {
-			return err
+		}
+	} else {
+		for i := range testObjs {
+			if err := cm.createObj(ctx, testObjs[i]); err != nil {
+				return err
+			}
 		}
 	}
+
 	deleteCertManagerBackoff := newWriteBackoff()
 	for i := range testObjs {
 		obj := testObjs[i]

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -109,7 +109,7 @@ func Test_getManifestObjs(t *testing.T) {
 			name: "successfully gets the cert-manager components for a custom release",
 			fields: fields{
 				configClient: func() config.Client {
-					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "").WithCertManager("", "v1.0.0", "")))
+					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "").WithCertManager("", "v1.0.0", "", "")))
 					g.Expect(err).ToNot(HaveOccurred())
 					return configClient
 				}(),
@@ -184,12 +184,12 @@ func Test_GetTimeout(t *testing.T) {
 		},
 		{
 			name:   "a custom value of timeout is set",
-			config: newFakeConfig().WithCertManager("", "", "5m"),
+			config: newFakeConfig().WithCertManager("", "", "5m", ""),
 			want:   5 * time.Minute,
 		},
 		{
 			name:   "invalid custom value of timeout is set",
-			config: newFakeConfig().WithCertManager("", "", "foo"),
+			config: newFakeConfig().WithCertManager("", "", "foo", ""),
 			want:   10 * time.Minute,
 		},
 	}
@@ -204,6 +204,140 @@ func Test_GetTimeout(t *testing.T) {
 			g.Expect(tm).To(Equal(tt.want))
 		})
 	}
+}
+
+func Test_GetPreinstallTimeout(t *testing.T) {
+	pollImmediateWaiter := func(context.Context, time.Duration, time.Duration, wait.ConditionWithContextFunc) error {
+		return nil
+	}
+
+	tests := []struct {
+		name   string
+		config *fakeConfigClient
+		want   time.Duration
+	}{
+		{
+			name:   "no custom value set for PreinstallTimeout",
+			config: newFakeConfig(),
+			want:   config.CertManagerDefaultPreinstallTimeout,
+		},
+		{
+			name:   "a custom value of PreinstallTimeout is set",
+			config: newFakeConfig().WithCertManager("", "", "", "5m"),
+			want:   5 * time.Minute,
+		},
+		{
+			name:   "invalid custom value of PreinstallTimeout is set",
+			config: newFakeConfig().WithCertManager("", "", "", "foo"),
+			want:   config.CertManagerDefaultPreinstallTimeout,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			cm := newCertManagerClient(tt.config, nil, nil, pollImmediateWaiter)
+
+			tm := cm.getPreinstallTimeout()
+
+			g.Expect(tm).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_waitForAPIReady(t *testing.T) {
+	tests := []struct {
+		name           string
+		timeout        time.Duration
+		proxy          Proxy
+		conditionCalls int // number of times the condition is invoked before giving up; <0 means waiter is not called (timeout=0 path)
+		wantErr        bool
+	}{
+		{
+			name:           "timeout=0: fails immediately when createObj fails, no retry",
+			timeout:        0,
+			proxy:          &errorProxy{FakeProxy: test.NewFakeProxy(), newClientErr: fmt.Errorf("fake client error")},
+			conditionCalls: -1,
+			wantErr:        true,
+		},
+		{
+			name:           "timeout=0: createObj succeeds, returns without error",
+			timeout:        0,
+			proxy:          test.NewFakeProxy(),
+			conditionCalls: -1,
+			wantErr:        false,
+		},
+		{
+			name:           "timeout>0: retries on createObj failure and eventually times out",
+			timeout:        5 * time.Minute,
+			proxy:          &errorProxy{FakeProxy: test.NewFakeProxy(), newClientErr: fmt.Errorf("fake client error")},
+			conditionCalls: 3,
+			wantErr:        true,
+		},
+		{
+			name:           "timeout>0: createObj succeeds, returns without error",
+			timeout:        5 * time.Minute,
+			proxy:          test.NewFakeProxy(),
+			conditionCalls: 1,
+			wantErr:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx := context.Background()
+
+			var capturedInterval, capturedTimeout time.Duration
+			waiterCalled := false
+
+			cm := &certManagerClient{
+				configClient: newFakeConfig(),
+				proxy:        tt.proxy,
+				pollImmediateWaiter: func(ctx context.Context, interval, timeout time.Duration, condition wait.ConditionWithContextFunc) error {
+					waiterCalled = true
+					capturedInterval = interval
+					capturedTimeout = timeout
+
+					for i := 0; i < tt.conditionCalls; i++ {
+						ok, err := condition(ctx)
+						if err != nil {
+							return err
+						}
+						if ok {
+							return nil
+						}
+					}
+					return wait.ErrorInterrupted(fmt.Errorf("timed out waiting for condition"))
+				},
+			}
+
+			err := cm.waitForAPIReady(ctx, tt.timeout)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+
+			if tt.conditionCalls >= 0 {
+				g.Expect(waiterCalled).To(BeTrue(), "expected poll waiter to be invoked for retry path")
+				g.Expect(capturedInterval).To(Equal(waitCertManagerInterval))
+				g.Expect(capturedTimeout).To(Equal(tt.timeout))
+			} else {
+				g.Expect(waiterCalled).To(BeFalse(), "expected direct createObj path for timeout=0, not poll waiter")
+			}
+		})
+	}
+}
+
+// errorProxy embeds FakeProxy and overrides NewClient to return a fixed error.
+type errorProxy struct {
+	*test.FakeProxy
+	newClientErr error
+}
+
+func (p *errorProxy) NewClient(_ context.Context) (client.Client, error) {
+	return nil, p.newClientErr
 }
 
 func Test_shouldUpgrade(t *testing.T) {
@@ -442,7 +576,7 @@ func Test_shouldUpgrade(t *testing.T) {
 			g := NewWithT(t)
 
 			proxy := test.NewFakeProxy()
-			fakeConfigClient := newFakeConfig().WithCertManager("", tt.configVersion, "")
+			fakeConfigClient := newFakeConfig().WithCertManager("", tt.configVersion, "", "")
 			pollImmediateWaiter := func(context.Context, time.Duration, time.Duration, wait.ConditionWithContextFunc) error {
 				return nil
 			}
@@ -851,7 +985,7 @@ func (f *fakeConfigClient) WithProvider(provider config.Provider) *fakeConfigCli
 	return f
 }
 
-func (f *fakeConfigClient) WithCertManager(url, version, timeout string) *fakeConfigClient {
-	f.fakeReader.WithCertManager(url, version, timeout)
+func (f *fakeConfigClient) WithCertManager(url, version, timeout, preinstallTimeout string) *fakeConfigClient {
+	f.fakeReader.WithCertManager(url, version, timeout, preinstallTimeout)
 	return f
 }

--- a/cmd/clusterctl/client/config/cert_manager.go
+++ b/cmd/clusterctl/client/config/cert_manager.go
@@ -29,13 +29,19 @@ type CertManager interface {
 	// Timeout returns the timeout for cert-manager to start.
 	// If empty, 10m will be used.
 	Timeout() string
+
+	// PreinstallTimeout returns the duration to wait for cert-manager to be detected
+	// as already installed before clusterctl proceeds to install it.
+	// If empty or zero, a one-shot check is performed.
+	PreinstallTimeout() string
 }
 
 // certManager implements CertManager.
 type certManager struct {
-	url     string
-	version string
-	timeout string
+	url               string
+	version           string
+	timeout           string
+	preinstallTimeout string
 }
 
 // ensure certManager implements CertManager.
@@ -53,11 +59,16 @@ func (p *certManager) Timeout() string {
 	return p.timeout
 }
 
+func (p *certManager) PreinstallTimeout() string {
+	return p.preinstallTimeout
+}
+
 // NewCertManager creates a new CertManager with the given configuration.
-func NewCertManager(url, version, timeout string) CertManager {
+func NewCertManager(url, version, timeout, preinstallTimeout string) CertManager {
 	return &certManager{
-		url:     url,
-		version: version,
-		timeout: timeout,
+		url:               url,
+		version:           version,
+		timeout:           timeout,
+		preinstallTimeout: preinstallTimeout,
 	}
 }

--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -38,6 +38,10 @@ const (
 
 	// CertManagerDefaultTimeout defines the default cert-manager timeout to be used by clusterctl.
 	CertManagerDefaultTimeout = 10 * time.Minute
+
+	// CertManagerDefaultPreinstallTimeout defines the default duration clusterctl waits for
+	// cert-manager to be detected as already installed before proceeding with install.
+	CertManagerDefaultPreinstallTimeout = 0 * time.Second
 )
 
 // CertManagerClient has methods to work with cert-manager configurations.
@@ -62,15 +66,17 @@ func newCertManagerClient(reader Reader) *certManagerClient {
 
 // configCertManager mirrors config.CertManager interface and allows serialization of the corresponding info.
 type configCertManager struct {
-	URL     string `json:"url,omitempty"`
-	Version string `json:"version,omitempty"`
-	Timeout string `json:"timeout,omitempty"`
+	URL               string `json:"url,omitempty"`
+	Version           string `json:"version,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	PreinstallTimeout string `json:"preinstallTimeout,omitempty"`
 }
 
 func (p *certManagerClient) Get() (CertManager, error) {
 	url := CertManagerDefaultURL
 	version := CertManagerDefaultVersion
 	timeout := CertManagerDefaultTimeout.String()
+	preinstallTimeout := CertManagerDefaultPreinstallTimeout.String()
 
 	userCertManager := &configCertManager{}
 	if err := p.reader.UnmarshalKey(CertManagerConfigKey, &userCertManager); err != nil {
@@ -91,6 +97,9 @@ func (p *certManagerClient) Get() (CertManager, error) {
 	if userCertManager.Timeout != "" {
 		timeout = userCertManager.Timeout
 	}
+	if userCertManager.PreinstallTimeout != "" {
+		preinstallTimeout = userCertManager.PreinstallTimeout
+	}
 
-	return NewCertManager(url, version, timeout), nil
+	return NewCertManager(url, version, timeout, preinstallTimeout), nil
 }

--- a/cmd/clusterctl/client/config/cert_manager_client_test.go
+++ b/cmd/clusterctl/client/config/cert_manager_client_test.go
@@ -40,34 +40,42 @@ func TestCertManagerGet(t *testing.T) {
 			fields: fields{
 				reader: test.NewFakeReader(),
 			},
-			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, CertManagerDefaultTimeout.String()),
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, CertManagerDefaultTimeout.String(), CertManagerDefaultPreinstallTimeout.String()),
 			wantErr: false,
 		},
 		{
 			name: "return custom url if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("foo-url", "vX.Y.Z", ""),
+				reader: test.NewFakeReader().WithCertManager("foo-url", "vX.Y.Z", "", ""),
 			},
-			want:    NewCertManager("foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String()),
+			want:    NewCertManager("foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String(), CertManagerDefaultPreinstallTimeout.String()),
 			wantErr: false,
 		},
 		{
 			name: "return custom url with evaluated env vars if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("${TEST_REPO_PATH}/foo-url", "vX.Y.Z", ""),
+				reader: test.NewFakeReader().WithCertManager("${TEST_REPO_PATH}/foo-url", "vX.Y.Z", "", ""),
 			},
 			envVars: map[string]string{
 				"TEST_REPO_PATH": "/tmp/test",
 			},
-			want:    NewCertManager("/tmp/test/foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String()),
+			want:    NewCertManager("/tmp/test/foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String(), CertManagerDefaultPreinstallTimeout.String()),
 			wantErr: false,
 		},
 		{
 			name: "return timeout if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("", "", "5m"),
+				reader: test.NewFakeReader().WithCertManager("", "", "5m", ""),
 			},
-			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, "5m"),
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, "5m", CertManagerDefaultPreinstallTimeout.String()),
+			wantErr: false,
+		},
+		{
+			name: "return preinstall timeout if defined",
+			fields: fields{
+				reader: test.NewFakeReader().WithCertManager("", "", "", "3m"),
+			},
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, CertManagerDefaultTimeout.String(), "3m"),
 			wantErr: false,
 		},
 	}

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -45,9 +45,10 @@ type configProvider struct {
 // configCertManager is a mirror of config.CertManager, re-implemented here in order to
 // avoid circular dependencies between pkg/client/config and pkg/internal/test.
 type configCertManager struct {
-	URL     string `json:"url,omitempty"`
-	Version string `json:"version,omitempty"`
-	Timeout string `json:"timeout,omitempty"`
+	URL               string `json:"url,omitempty"`
+	Version           string `json:"version,omitempty"`
+	Timeout           string `json:"timeout,omitempty"`
+	PreinstallTimeout string `json:"preinstallTimeout,omitempty"`
 }
 
 // imageMeta is a mirror of config.imageMeta, re-implemented here in order to
@@ -107,11 +108,12 @@ func (f *FakeReader) WithProvider(name string, ttype clusterctlv1.ProviderType, 
 	return f
 }
 
-func (f *FakeReader) WithCertManager(url, version, timeout string) *FakeReader {
+func (f *FakeReader) WithCertManager(url, version, timeout, preinstallTimeout string) *FakeReader {
 	f.certManager = configCertManager{
-		URL:     url,
-		Version: version,
-		Timeout: timeout,
+		URL:               url,
+		Version:           version,
+		Timeout:           timeout,
+		PreinstallTimeout: preinstallTimeout,
 	}
 
 	yaml, _ := yaml.Marshal(f.certManager)


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterctl init` currently performs a one-shot check for cert-manager availability before deciding to install. If cert-manager is being managed externally and its webhook/cainjector aren't ready yet, `clusterctl` races ahead and installs its own copy, causing conflicts.

This PR adds `preinstallTimeout` field to the cert-manager config section. When set to a non-zero duration, `clusterctl` will retry the readiness check for that duration before proceeding with installation. Default is 0 (one-shot) for backward compatibility.

Example config:

```yaml
cert-manager:
  ...
  preinstallTimeout: 5m
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13485

/area clusterctl