### PR TITLE
🐛 Fix Tilt kube-state-metrics deployment

### DIFF
--- a/hack/observability/kube-state-metrics/crd-sidecar-patch.yaml
+++ b/hack/observability/kube-state-metrics/crd-sidecar-patch.yaml
@@ -21,7 +21,7 @@ spec:
           value: "18080" # Should not conflict with kube-state-metrics port
         # This image continuously collects config maps with the specified label and
         # updates the configuration for kube-state-metrics using a script.
-        image: kiwigrid/k8s-sidecar:latest
+        image: kiwigrid/k8s-sidecar:2.7.3
         name: crd-sidecar
         volumeMounts:
         - mountPath: /etc/config
@@ -40,7 +40,7 @@ spec:
           EOF
         # This container initializes an empty configuration for kube-state-metrics
         # to have a smooth start.
-        image: kiwigrid/k8s-sidecar:latest
+        image: kiwigrid/k8s-sidecar:2.7.3
         name: init-crd-config
         volumeMounts:
         - mountPath: /etc/config


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

See https://github.com/kiwigrid/k8s-sidecar/issues/569

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->