### PR TITLE
🌱 KCP cleanup etcd members not started after a machine is remediated

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1259,78 +1259,87 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 		return ctrl.Result{}, nil
 	}
 
-	// Collect all the Node names from control plane Machines.
-	nodeNames := []string{}
+	// Loop trough machines and collect the list of expected etcd members, which can be inferred because etcd members name is equal to the node name.
+	// Also keep track if there are machines still pending for the node name being reported (provisioning machines).
+	provisioningMachines := sets.New[string]()
+	expectedMembers := sets.New[string]()
 	for _, machine := range controlPlane.Machines {
 		if !machine.Status.NodeRef.IsDefined() {
-			// If there are provisioning machines (machines without a Node yet), KCP must wait for the control plane
-			// to become stable before acting on etcd members.
-			return ctrl.Result{}, nil
+			provisioningMachines.Insert(machine.Name)
+			continue
 		}
-		nodeNames = append(nodeNames, machine.Status.NodeRef.Name)
+		expectedMembers.Insert(machine.Status.NodeRef.Name)
 	}
+
+	// Loop trough etcd members and identify unexpected members.
+	// Note: A member without a name yet is also considered an unexpected members at this stage.
+	unexpectedMembers := sets.New[string]()
+	for _, member := range controlPlane.EtcdMembers {
+		if expectedMembers.Has(member.Name) {
+			continue
+		}
+		unexpectedMembers.Insert(member.Name)
+	}
+
+	// If there are no unexpected members, return.
+	if len(unexpectedMembers) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	unexpectedMembersMsg := []string{}
+	for _, m := range unexpectedMembers.UnsortedList() {
+		if m == "" {
+			unexpectedMembersMsg = append(unexpectedMembersMsg, "(Name not yet assigned)")
+			continue
+		}
+		unexpectedMembersMsg = append(unexpectedMembersMsg, m)
+	}
+	sort.Strings(unexpectedMembersMsg)
+
+	// If there are no unexpected members, but there is a machine not yet reporting the node name,
+	// there is chance that the unexpected member is the one hosted on the provisioning machine, so wait.
+	if len(provisioningMachines) > 0 {
+		log.Info(fmt.Sprintf("Etcd members %s without a corresponding Machines, potential match with provisioning machines %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(provisioningMachines.UnsortedList(), ", ")))
+		return ctrl.Result{}, nil
+	}
+
+	// If there are unexpected members, KCP must remove them (it removes one, then re-queue).
+	//
+	// Before deleting any etcd member, KCP should assess the potential effects of this operation.
+	//
+	// Most specifically KCP should determine if this operation is going to leave the Kubernetes control plane components
+	// and the etcd cluster in operational state or not.
+	//
+	// In this case, the Target cluster will have the same list of machines as the current clusters
+	// but we are going to remove the etcd members without a corresponding Node/Machine (no etcd member are going to be added).
 
 	workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "cannot get remote client to workload cluster")
 	}
 
-	// Check if there are etcd member without the corresponding Node/Machines.
-	// If any, delete it with best effort
-	removedMembers := []string{}
-	allErrors := []error{}
+	etcdMemberToBeDeleted := unexpectedMembers.UnsortedList()[0]
+	etcdMemberToBeDeletedMsg := etcdMemberToBeDeleted
+	if etcdMemberToBeDeletedMsg == "" {
+		etcdMemberToBeDeletedMsg = "(Name not yet assigned)"
+	}
+	log.Info(fmt.Sprintf("Etcd members %s without a corresponding Machines, removing member %s", strings.Join(unexpectedMembersMsg, ", "), etcdMemberToBeDeleted))
 
-	for _, member := range controlPlane.EtcdMembers {
-		// If this member is just added, it has a empty name until the etcd pod starts. Ignore this member until a name will show up.
-		if member.Name == "" {
-			continue
-		}
-
-		// If the member have a corresponding Node/Machine, continue.
-		nodeFound := false
-		for _, nodeName := range nodeNames {
-			if member.Name == nodeName {
-				nodeFound = true
-				break
-			}
-		}
-		if nodeFound {
-			continue
-		}
-
-		// If the Node/Machineg corresponding to an etcd member cannot be found, KCP must remove it.
-		//
-		// Before deleting the etcd member, KCP should assess the potential effects of this operation.
-		//
-		// Most specifically KCP should determine if this operation is going to leave the Kubernetes control plane components
-		// and the etcd cluster in operational state or not.
-		//
-		// In this case, the Target cluster will have the same list of machines as the current clusters
-		// but we are going to remove the etcd members without a corresponding Node/Machine (no etcd member are going to be added).
-		etcdMemberToBeDeleted := member.Name
+	if etcdMemberToBeDeleted != "" {
 		addEtcdMember := false
 		if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted) {
-			allErrors = append(allErrors, errors.Errorf("etcd member %s does not have a corresponding Machine, it must be removed from the cluster but this operation can lead to quorum loss. Please check the etcd status", etcdMemberToBeDeleted))
-			break
-		}
-
-		if err := workloadCluster.RemoveEtcdMember(ctx, member.Name, controlPlane.Nodes); err != nil {
-			allErrors = append(allErrors, err)
-			continue
-		}
-		removedMembers = append(removedMembers, member.Name)
-	}
-
-	if len(removedMembers) > 0 {
-		log.Info("Etcd members without a corresponding Machines removed from the cluster", "members", removedMembers)
-
-		// If there are no errors, force a new reconcile after removing an etcd member.
-		if len(allErrors) == 0 {
-			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+			return ctrl.Result{}, errors.Errorf("etcd member %s does not have a corresponding Machine, it must be removed from the cluster but this operation can lead to quorum loss. Please check the etcd status", etcdMemberToBeDeletedMsg)
 		}
 	}
 
-	return ctrl.Result{}, kerrors.NewAggregate(allErrors)
+	if err := workloadCluster.RemoveEtcdMember(ctx, etcdMemberToBeDeleted, controlPlane.Nodes); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to remove etcd member %s. Please check the etcd status", etcdMemberToBeDeletedMsg)
+	}
+
+	log.Info("Etcd member without a corresponding Machines removed from the cluster", "member", etcdMemberToBeDeletedMsg)
+
+	// Force a new reconcile after removing an etcd member.
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 }
 
 func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Context, controlPlane *internal.ControlPlane) (ctrl.Result, error) {
@@ -1433,8 +1442,10 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 	etcdMemberToBeDeleted := r.tryGetEtcdMemberName(ctx, controlPlane, deletingMachine)
 	addEtcdMember := false
 
-	// If it was not possible to get the etcd member, no other checks can be performed. Continue with deletion.
-	// Note: reconcileEtcMembers acts a safeguard if an etcdMember is added/reported after this point.
+	// If it was not possible to get the name of the etcd member hosted on this machine or if the etcd member doesn't have
+	// a name yet, no other checks can be performed. Continue with deletion.
+	// Note: reconcileEtcMembers acts a safeguard/cleanup procedure if an etcdMember is added/reported after this point
+	// and for etcd member without a name.
 	if etcdMemberToBeDeleted == "" {
 		if err := r.removePreTerminateHookAnnotationFromMachine(ctx, deletingMachine); err != nil {
 			return ctrl.Result{}, err

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1296,10 +1296,10 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 	}
 	sort.Strings(unexpectedMembersMsg)
 
-	// If there are no unexpected members, but there is a machine not yet reporting the node name,
+	// If there are unexpected members, but there is a machine not yet reporting the node name,
 	// there is chance that the unexpected member is the one hosted on the provisioning machine, so wait.
 	if len(provisioningMachines) > 0 {
-		log.Info(fmt.Sprintf("Etcd members %s without a corresponding Machines, potential match with provisioning machines %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(provisioningMachines.UnsortedList(), ", ")))
+		log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, potential match with provisioning machines %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(provisioningMachines.UnsortedList(), ", ")))
 		return ctrl.Result{}, nil
 	}
 
@@ -1323,8 +1323,11 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 	if etcdMemberToBeDeletedMsg == "" {
 		etcdMemberToBeDeletedMsg = "(Name not yet assigned)"
 	}
-	log.Info(fmt.Sprintf("Etcd members %s without a corresponding Machines, removing member %s", strings.Join(unexpectedMembersMsg, ", "), etcdMemberToBeDeleted))
+	log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, removing member %s", strings.Join(unexpectedMembersMsg, ", "), etcdMemberToBeDeleted))
 
+	// Note: if the etcd member to be deleted doesn't have a name yet, we know it is not started yet/still a learner,
+	// and we also know it won't be promoted because there is no underlying machine where kubeadm is running.
+	// Accordingly, skipping checking targetEtcdClusterHealthy (which will fail with learner nodes).
 	if etcdMemberToBeDeleted != "" {
 		addEtcdMember := false
 		if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted) {
@@ -1336,7 +1339,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 		return ctrl.Result{}, errors.Wrapf(err, "failed to remove etcd member %s. Please check the etcd status", etcdMemberToBeDeletedMsg)
 	}
 
-	log.Info("Etcd member without a corresponding Machines removed from the cluster", "member", etcdMemberToBeDeletedMsg)
+	log.Info("Etcd member without a corresponding Machine removed from the cluster", "member", etcdMemberToBeDeletedMsg)
 
 	// Force a new reconcile after removing an etcd member.
 	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -3390,6 +3390,55 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			wantRemoveEtcdMemberCalled: 1,
 		},
 		{
+			name: "Remove additional etcd members without name when the target etcd cluster is healthy - 3CP",
+			controlPlane: &internal.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+					"m2": func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						m.Name = "m2"
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+					"m3": func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						m.Name = "m3"
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: ""},
+			},
+			wantResult:                 ctrl.Result{RequeueAfter: 1 * time.Second},
+			wantRemoveEtcdMemberCalled: 1,
+		},
+		{
+			name: "Do not remove additional etcd members without name when there are provisioning machines",
+			controlPlane: &internal.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						m.Status.NodeRef.Name = ""
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: ""},
+			},
+			wantResult:                 ctrl.Result{},
+			wantRemoveEtcdMemberCalled: 0,
+		},
+		{
 			name: "Do not remove additional etcd members when the target etcd cluster is not healthy",
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{},

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -3372,6 +3372,24 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			wantRemoveEtcdMemberCalled: 1,
 		},
 		{
+			name: "Remove additional etcd members without name when the target etcd cluster is healthy",
+			controlPlane: &internal.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: ""},
+			},
+			wantResult:                 ctrl.Result{RequeueAfter: 1 * time.Second},
+			wantRemoveEtcdMemberCalled: 1,
+		},
+		{
 			name: "Do not remove additional etcd members when the target etcd cluster is not healthy",
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{},

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -721,16 +721,16 @@ func (r *KubeadmControlPlaneReconciler) targetEtcdClusterHealthy(ctx context.Con
 	}
 
 	for _, etcdMember := range controlPlane.EtcdMembers {
-		// Skip the etcd member to be deleted because it won't be part of the target etcd cluster.
-		if etcdMemberToBeDeleted == etcdMember.Name {
-			continue
-		}
-
 		// Consider members without a name as a learner (they are still starting up).
 		if etcdMember.Name == "" {
 			targetTotalMembers++
 			targetLearnerMembers++
 			unhealthyMembers = append(unhealthyMembers, "1 member starting (worst case)")
+			continue
+		}
+
+		// Skip the etcd member to be deleted because it won't be part of the target etcd cluster.
+		if etcdMemberToBeDeleted == etcdMember.Name {
 			continue
 		}
 

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -618,8 +618,8 @@ func (r *KubeadmControlPlaneReconciler) canSafelyRemediateMachine(ctx context.Co
 	etcdMemberToBeDeleted := r.tryGetEtcdMemberName(ctx, controlPlane, machineToBeRemediated)
 	addEtcdMember := false
 
-	// If it was not possible to get the etcd member, no other checks can be performed.
-	// it is not possible to determine if etcd will never show up due to the issue on the machine being remediated,
+	// If it was not possible to get the name of the etcd member hosted on this machine, no other checks can be performed.
+	// NOTE: it is not possible to determine if an etcd member for this machine will never show up due to the issue on the machine being remediated,
 	// or if it will show up later. In this case KCP continue with remediation, which is considered as user intent
 	// (no matter if expressed as MHC configuration or via the manual remediation annotation).
 	// Note: reconcile reconcilePreTerminateHook will try to perform this check again.
@@ -721,16 +721,16 @@ func (r *KubeadmControlPlaneReconciler) targetEtcdClusterHealthy(ctx context.Con
 	}
 
 	for _, etcdMember := range controlPlane.EtcdMembers {
+		// Skip the etcd member to be deleted because it won't be part of the target etcd cluster.
+		if etcdMemberToBeDeleted == etcdMember.Name {
+			continue
+		}
+
 		// Consider members without a name as a learner (they are still starting up).
 		if etcdMember.Name == "" {
 			targetTotalMembers++
 			targetLearnerMembers++
 			unhealthyMembers = append(unhealthyMembers, "1 member starting (worst case)")
-			continue
-		}
-
-		// Skip the etcd member to be deleted because it won't be part of the target etcd cluster.
-		if etcdMemberToBeDeleted == etcdMember.Name {
 			continue
 		}
 

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -442,6 +442,8 @@ func compareMachinesAndMembers(controlPlane *ControlPlane) (bool, []string) {
 		}
 		if !found {
 			// Surface there is an etcd member without a machine into the EtcdClusterHealthy condition on kcp.
+			// Note: this surface an error, because there is no way to determine if this is happening in the brief time
+			// in between when kubeadm adds a member - when the member actually start, or if this is due to the member not starting.
 			name := member.Name
 			if name == "" {
 				name = fmt.Sprintf("%d (Name not yet assigned)", member.ID)

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -593,6 +593,92 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			expectedEtcdMembers:                       []string{"n1", "n2"},
 			expectedEtcdMembersAndMachinesAreMatching: true,
 		},
+		{
+			name: "etcd members without a name when there are no provisioning machines should be reported",
+			machines: []*clusterv1.Machine{
+				fakeMachine("m1", withNodeRef("n1")),
+				fakeMachine("m2", withNodeRef("n2")),
+			},
+			nodes: []*Node{
+				fakeNode("n1"),
+				fakeNode("n2"),
+			},
+			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
+				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+					var errs []error
+					for _, n := range nodeNames {
+						switch n {
+						case "n1":
+							return &etcd.Client{
+								EtcdClient: &fake2.FakeEtcdClient{
+									EtcdEndpoints: []string{},
+									MemberListResponse: &clientv3.MemberListResponse{
+										Header: &pb.ResponseHeader{
+											ClusterId: uint64(1),
+										},
+										Members: []*pb.Member{
+											{Name: "n1", ID: uint64(1)},
+											{Name: "n2", ID: uint64(2)},
+											{Name: "", ID: uint64(3)},
+										},
+									},
+									AlarmResponse: &clientv3.AlarmResponse{
+										Alarms: []*pb.AlarmMember{},
+									},
+								},
+							}, nil
+						case "n2":
+							return &etcd.Client{
+								EtcdClient: &fake2.FakeEtcdClient{
+									EtcdEndpoints: []string{},
+									MemberListResponse: &clientv3.MemberListResponse{
+										Header: &pb.ResponseHeader{
+											ClusterId: uint64(1),
+										},
+										Members: []*pb.Member{
+											{Name: "n1", ID: uint64(1)},
+											{Name: "n2", ID: uint64(2)},
+											{Name: "", ID: uint64(3)},
+										},
+									},
+									AlarmResponse: &clientv3.AlarmResponse{
+										Alarms: []*pb.AlarmMember{},
+									},
+								},
+							}, nil
+						default:
+							errs = append(errs, errors.New("no client for this node"))
+						}
+					}
+					return nil, errors.Wrapf(kerrors.NewAggregate(errs), "could not establish a connection to etcd members hosted on %s", strings.Join(nodeNames, ","))
+				},
+			},
+			expectedKCPV1Beta1Condition: v1beta1conditions.FalseCondition(controlplanev1.EtcdClusterHealthyV1Beta1Condition, controlplanev1.EtcdClusterUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Etcd member 3 (Name not yet assigned) does not have a corresponding Machine"),
+			expectedMachineV1Beta1Conditions: map[string]clusterv1.Conditions{
+				"m1": {
+					*v1beta1conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyV1Beta1Condition),
+				},
+				"m2": {
+					*v1beta1conditions.TrueCondition(controlplanev1.MachineEtcdMemberHealthyV1Beta1Condition),
+				},
+			},
+			expectedKCPCondition: &metav1.Condition{
+				Type:    controlplanev1.KubeadmControlPlaneEtcdClusterHealthyCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyReason,
+				Message: "* Etcd member 3 (Name not yet assigned) does not have a corresponding Machine",
+			},
+			expectedMachineConditions: map[string][]metav1.Condition{
+				"m1": {
+					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason, Message: ""},
+				},
+				"m2": {
+					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason, Message: ""},
+				},
+			},
+			expectedEtcdMembers:                       []string{"n1", "n2", ""},
+			expectedEtcdMembersAndMachinesAreMatching: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2023,6 +2109,25 @@ func TestCompareMachinesAndMembers(t *testing.T) {
 			},
 			expectMembersAndMachinesAreMatching: true,
 			expectKCPErrors:                     nil,
+		},
+		{
+			name: "true if there is a machine without a member but at least a machine is still provisioning (node without a name)",
+			controlPlane: &ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.FromMachines(
+					fakeMachine("m1", withNodeRef("m1")),
+					fakeMachine("m2", withNodeRef("m2")),
+					fakeMachine("m3"), // m3 is still provisioning
+				),
+				EtcdMembers: []*etcd.Member{
+					{Name: "m1"},
+					{Name: "m2"},
+					{Name: ""},
+				},
+				Nodes: nil,
+			},
+			expectMembersAndMachinesAreMatching: true,
+			expectKCPErrors:                     []string{"Etcd member 0 (Name not yet assigned) does not have a corresponding Machine"}, // Surface an error, this situation should exist only for a brief time.
 		},
 		{
 			name: "true if there is a machine without a member but at least a machine is still provisioning",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
There are cases where kubeadm join fails with the following outcomes:
- etcd member added, but not fully started (no name reported)
- node fully provisioned / not visible to CAPI

Before this PR CAPI was capable to remediate the faulty machines, but due to lack of node name/etcd member name, it was not capable to remove the etcd member, thus leading to failure in the next join.

This PR improves KCP so it can cleanup etcd members not started after a machine is remediated, and thus making it possible for the next join to succeed 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->