### PR TITLE
🌱 Declare contents: read permissions for pr-verify action

### DIFF
--- a/.github/workflows/pr-verify.yaml
+++ b/.github/workflows/pr-verify.yaml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# Runs in pull_request_target context. Only reads PR title and checks
+# out base ref; no API writes.
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `pr-verify.yaml`. The workflow runs in `pull_request_target` context (elevated default scope) but only reads `github.event.pull_request.title` and shells out to `./hack/verify-pr-title.sh`. Making the scope explicit is especially useful for `pull_request_target` since it inherits broader org defaults.

The sibling `golangci-lint.yml`, `markdown-link-check.yaml`, etc. already declare their permissions. YAML validated locally.