### PR TITLE
🌱 Cleanup of ControlPlaneKubeletLocalMode handling in KCP adoption test

### DIFF
--- a/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
@@ -50,8 +50,6 @@ spec:
         - 127.0.0.1
         - 0.0.0.0
         - host.docker.internal
-    featureGates:
-      ControlPlaneKubeletLocalMode: true
 ---
 # cp0 Machine
 apiVersion: cluster.x-k8s.io/v1beta2

--- a/test/e2e/kcp_adoption.go
+++ b/test/e2e/kcp_adoption.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -25,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +38,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/version"
 )
 
 // KCPAdoptionSpecInput is the input for KCPAdoptionSpec.
@@ -144,13 +141,6 @@ func KCPAdoptionSpec(ctx context.Context, inputGetter func() KCPAdoptionSpecInpu
 			LogFolder: filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
 		})
 		Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
-
-		// Remove ControlPlaneKubeletLocalMode for Kubernetes >= v1.36 because the fg has been removed with v1.36.
-		v, err := semver.ParseTolerant(input.E2EConfig.MustGetVariable(KubernetesVersion))
-		Expect(err).ToNot(HaveOccurred())
-		if version.Compare(v, semver.MustParse("1.36.0"), version.WithoutPreReleases()) >= 0 {
-			workloadClusterTemplate = bytes.Replace(workloadClusterTemplate, []byte("featureGates:\n      ControlPlaneKubeletLocalMode: true"), []byte(""), 1)
-		}
 
 		By("Applying the cluster template yaml to the cluster with the 'initial' selector")
 		selector := labels.NewSelector().Add(must(labels.NewRequirement("kcp-adoption.step1", selection.Exists, nil)))


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to #13177

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13694

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->