### PR TITLE
📖 Correct drain order description to lowest order first

### DIFF
--- a/docs/book/src/tasks/automated-machine-management/machine_deletions.md
+++ b/docs/book/src/tasks/automated-machine-management/machine_deletions.md
@@ -70,7 +70,39 @@ Node drain can be broken down into the following phases:
 
 Per default all Pods are drained at the same time. But with `MachineDrainRules` it's also possible to define a drain order
 for Pods with behavior `Drain` (Pods with `WaitCompleted` have a hard-coded order of 0). The Machine controller will drain
-Pods in batches based on their order (from highest to lowest order).
+Pods in batches based on their order, **lowest order first**. Pods that don't match any rule have a default order of 0, so a
+rule with a negative order will drain its pods before unmatched pods, and a rule with a positive order will drain its pods after.
+
+**Example:** To drain pods in a specific namespace first and Rook Ceph OSDs last:
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDrainRule
+metadata:
+  name: drain-managed-namespaces-first
+spec:
+  pods:
+  - selector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["my-app-namespace"]
+  drain:
+    behavior: Drain
+    order: -100  # Negative order: drain before default (0)
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDrainRule
+metadata:
+  name: drain-rook-ceph-osd-last
+spec:
+  pods:
+  - selector:
+      matchLabels:
+        app: rook-ceph-osd
+  drain:
+    behavior: Drain
+    order: 100  # Positive order: drain after default (0)
+```
 
 For more details about `MachineDrainRules`, please see the corresponding [proposal](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240930-machine-drain-rules.md).
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Fixed the documentation error in the "Node drain" section

- Corrected the drain order description from "highest to lowest" to "lowest order first"
- Added clear explanation that pods without matching rules default to order 0
- Added a practical example showing:
  - A rule with order -100 to drain managed namespace pods first (before default)
  - A rule with order 100 to drain Rook Ceph OSDs last (after default)


**Which issue(s) this PR fixes**:
Fixes #13681

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area documentation