### PR TITLE
🐛 Validate enforced labels on MachineSet and MachineDeployment selectors

### DIFF
--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -192,6 +192,37 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 		)
 	}
 
+	// Validate that labels that the MachineDeployment controller will overwrite on owned MachineSets
+	// cannot be set to a different value via spec.selector.matchLabels or spec.template.metadata.labels.
+	// If they could, the selector would never match the labels the controller writes, causing
+	// the controller to create MachineSets indefinitely (see https://github.com/kubernetes-sigs/cluster-api/issues/12156).
+	enforcedLabels := map[string]string{
+		clusterv1.MachineDeploymentNameLabel: newMD.Name,
+		clusterv1.ClusterNameLabel:           newMD.Spec.ClusterName,
+	}
+	for labelKey, want := range enforcedLabels {
+		if v, ok := newMD.Spec.Selector.MatchLabels[labelKey]; ok && v != want {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					specPath.Child("selector", "matchLabels").Key(labelKey),
+					v,
+					fmt.Sprintf("must be %q (the MachineDeployment controller overwrites this label on owned MachineSets)", want),
+				),
+			)
+		}
+		if v, ok := newMD.Spec.Template.Labels[labelKey]; ok && v != want {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					specPath.Child("template", "metadata", "labels").Key(labelKey),
+					v,
+					fmt.Sprintf("must be %q (the MachineDeployment controller overwrites this label on owned MachineSets)", want),
+				),
+			)
+		}
+	}
+
 	// MachineSet preflight checks that should be skipped could also be set as annotation on the MachineDeployment
 	// since MachineDeployment annotations are synced to the MachineSet.
 	if feature.Gates.Enabled(feature.MachineSetPreflightChecks) {

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -200,14 +200,19 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 		clusterv1.MachineDeploymentNameLabel: newMD.Name,
 		clusterv1.ClusterNameLabel:           newMD.Spec.ClusterName,
 	}
+	enforcedLabelDesc := map[string]string{
+		clusterv1.MachineDeploymentNameLabel: "metadata.name",
+		clusterv1.ClusterNameLabel:           "spec.clusterName",
+	}
 	for labelKey, want := range enforcedLabels {
+		desc := enforcedLabelDesc[labelKey]
 		if v, ok := newMD.Spec.Selector.MatchLabels[labelKey]; ok && v != want {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
 					specPath.Child("selector", "matchLabels").Key(labelKey),
 					v,
-					fmt.Sprintf("must be %q (the MachineDeployment controller overwrites this label on owned MachineSets)", want),
+					fmt.Sprintf("must be %q to match %s", want, desc),
 				),
 			)
 		}
@@ -217,7 +222,7 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 				field.Invalid(
 					specPath.Child("template", "metadata", "labels").Key(labelKey),
 					v,
-					fmt.Sprintf("must be %q (the MachineDeployment controller overwrites this label on owned MachineSets)", want),
+					fmt.Sprintf("must be %q to match %s", want, desc),
 				),
 			)
 		}

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -663,6 +663,89 @@ func TestMachineDeploymentVersionValidation(t *testing.T) {
 	}
 }
 
+func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
+	const mdName = "test-md"
+	const clusterName = "test-cluster"
+
+	tests := []struct {
+		name           string
+		selectorLabels map[string]string
+		templateLabels map[string]string
+		expectErr      bool
+	}{
+		{
+			name:           "no enforced labels set is allowed",
+			selectorLabels: map[string]string{"app": "foo"},
+			templateLabels: map[string]string{"app": "foo"},
+			expectErr:      false,
+		},
+		{
+			name: "MachineDeploymentNameLabel matching metadata.name is allowed",
+			selectorLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: mdName,
+				clusterv1.ClusterNameLabel:           clusterName,
+			},
+			templateLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: mdName,
+				clusterv1.ClusterNameLabel:           clusterName,
+			},
+			expectErr: false,
+		},
+		{
+			name: "MachineDeploymentNameLabel mismatched in selector is rejected",
+			selectorLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: "other-name",
+				clusterv1.ClusterNameLabel:           clusterName,
+			},
+			templateLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: "other-name",
+				clusterv1.ClusterNameLabel:           clusterName,
+			},
+			expectErr: true,
+		},
+		{
+			name: "ClusterNameLabel mismatched in template labels is rejected",
+			selectorLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: mdName,
+				clusterv1.ClusterNameLabel:           clusterName,
+			},
+			templateLabels: map[string]string{
+				clusterv1.MachineDeploymentNameLabel: mdName,
+				clusterv1.ClusterNameLabel:           "other-cluster",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			md := &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: mdName},
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: clusterName,
+					Selector:    metav1.LabelSelector{MatchLabels: tt.selectorLabels},
+					Template: clusterv1.MachineTemplateSpec{
+						ObjectMeta: clusterv1.ObjectMeta{Labels: tt.templateLabels},
+						Spec: clusterv1.MachineSpec{
+							ClusterName: clusterName,
+							Bootstrap:   clusterv1.Bootstrap{DataSecretName: ptr.To("data-secret")},
+						},
+					},
+				},
+			}
+
+			warnings, err := (&MachineDeployment{}).ValidateCreate(ctx, md)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(warnings).To(BeEmpty())
+		})
+	}
+}
+
 func TestMachineDeploymentClusterNameImmutable(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -671,13 +671,12 @@ func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
 		name           string
 		selectorLabels map[string]string
 		templateLabels map[string]string
-		expectErr      bool
+		wantErrSubstr  string
 	}{
 		{
 			name:           "no enforced labels set is allowed",
 			selectorLabels: map[string]string{"app": "foo"},
 			templateLabels: map[string]string{"app": "foo"},
-			expectErr:      false,
 		},
 		{
 			name: "MachineDeploymentNameLabel matching metadata.name is allowed",
@@ -689,7 +688,6 @@ func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
 				clusterv1.MachineDeploymentNameLabel: mdName,
 				clusterv1.ClusterNameLabel:           clusterName,
 			},
-			expectErr: false,
 		},
 		{
 			name: "MachineDeploymentNameLabel mismatched in selector is rejected",
@@ -701,7 +699,7 @@ func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
 				clusterv1.MachineDeploymentNameLabel: "other-name",
 				clusterv1.ClusterNameLabel:           clusterName,
 			},
-			expectErr: true,
+			wantErrSubstr: `must be "test-md" to match metadata.name`,
 		},
 		{
 			name: "ClusterNameLabel mismatched in template labels is rejected",
@@ -713,7 +711,7 @@ func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
 				clusterv1.MachineDeploymentNameLabel: mdName,
 				clusterv1.ClusterNameLabel:           "other-cluster",
 			},
-			expectErr: true,
+			wantErrSubstr: `must be "test-cluster" to match spec.clusterName`,
 		},
 	}
 
@@ -736,8 +734,8 @@ func TestMachineDeploymentEnforcedLabelValidation(t *testing.T) {
 			}
 
 			warnings, err := (&MachineDeployment{}).ValidateCreate(ctx, md)
-			if tt.expectErr {
-				g.Expect(err).To(HaveOccurred())
+			if tt.wantErrSubstr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErrSubstr)))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -168,6 +168,32 @@ func (webhook *MachineSet) validate(oldMS, newMS *clusterv1.MachineSet) error {
 		)
 	}
 
+	// Validate that labels that the MachineSet controller will overwrite on owned Machines
+	// cannot be set to a different value via spec.selector.matchLabels or spec.template.metadata.labels.
+	// If they could, the selector would never match the labels the controller writes, causing
+	// the controller to create Machines indefinitely (see https://github.com/kubernetes-sigs/cluster-api/issues/12156).
+	enforcedNameLabel := format.MustFormatValue(newMS.Name)
+	if v, ok := newMS.Spec.Selector.MatchLabels[clusterv1.MachineSetNameLabel]; ok && v != enforcedNameLabel {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("selector", "matchLabels").Key(clusterv1.MachineSetNameLabel),
+				v,
+				fmt.Sprintf("must be %q (the MachineSet controller overwrites this label on owned Machines based on metadata.name)", enforcedNameLabel),
+			),
+		)
+	}
+	if v, ok := newMS.Spec.Template.Labels[clusterv1.MachineSetNameLabel]; ok && v != enforcedNameLabel {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("template", "metadata", "labels").Key(clusterv1.MachineSetNameLabel),
+				v,
+				fmt.Sprintf("must be %q (the MachineSet controller overwrites this label on owned Machines based on metadata.name)", enforcedNameLabel),
+			),
+		)
+	}
+
 	if feature.Gates.Enabled(feature.MachineSetPreflightChecks) {
 		if err := validateSkippedMachineSetPreflightChecks(newMS); err != nil {
 			allErrs = append(allErrs, err)

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -179,7 +179,7 @@ func (webhook *MachineSet) validate(oldMS, newMS *clusterv1.MachineSet) error {
 			field.Invalid(
 				specPath.Child("selector", "matchLabels").Key(clusterv1.MachineSetNameLabel),
 				v,
-				fmt.Sprintf("must be %q (the MachineSet controller overwrites this label on owned Machines based on metadata.name)", enforcedNameLabel),
+				fmt.Sprintf("must be %q to match metadata.name", enforcedNameLabel),
 			),
 		)
 	}
@@ -189,7 +189,7 @@ func (webhook *MachineSet) validate(oldMS, newMS *clusterv1.MachineSet) error {
 			field.Invalid(
 				specPath.Child("template", "metadata", "labels").Key(clusterv1.MachineSetNameLabel),
 				v,
-				fmt.Sprintf("must be %q (the MachineSet controller overwrites this label on owned Machines based on metadata.name)", enforcedNameLabel),
+				fmt.Sprintf("must be %q to match metadata.name", enforcedNameLabel),
 			),
 		)
 	}

--- a/internal/webhooks/machineset_test.go
+++ b/internal/webhooks/machineset_test.go
@@ -379,31 +379,29 @@ func TestMachineSetEnforcedNameLabelValidation(t *testing.T) {
 		name           string
 		selectorLabels map[string]string
 		templateLabels map[string]string
-		expectErr      bool
+		wantErrSubstr  string
 	}{
 		{
 			name:           "no MachineSetNameLabel set is allowed",
 			selectorLabels: map[string]string{"app": "foo"},
 			templateLabels: map[string]string{"app": "foo"},
-			expectErr:      false,
 		},
 		{
 			name:           "MachineSetNameLabel matching metadata.name is allowed",
 			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
 			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
-			expectErr:      false,
 		},
 		{
 			name:           "MachineSetNameLabel mismatched in selector is rejected",
 			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
 			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
-			expectErr:      true,
+			wantErrSubstr:  `must be "test-ms" to match metadata.name`,
 		},
 		{
 			name:           "MachineSetNameLabel mismatched in template labels is rejected",
 			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
 			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
-			expectErr:      true,
+			wantErrSubstr:  `must be "test-ms" to match metadata.name`,
 		},
 	}
 
@@ -424,8 +422,8 @@ func TestMachineSetEnforcedNameLabelValidation(t *testing.T) {
 			}
 
 			warnings, err := (&MachineSet{}).ValidateCreate(ctx, ms)
-			if tt.expectErr {
-				g.Expect(err).To(HaveOccurred())
+			if tt.wantErrSubstr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.wantErrSubstr)))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}

--- a/internal/webhooks/machineset_test.go
+++ b/internal/webhooks/machineset_test.go
@@ -371,6 +371,69 @@ func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
 	}
 }
 
+func TestMachineSetEnforcedNameLabelValidation(t *testing.T) {
+	const msName = "test-ms"
+	enforced := "test-ms"
+
+	tests := []struct {
+		name           string
+		selectorLabels map[string]string
+		templateLabels map[string]string
+		expectErr      bool
+	}{
+		{
+			name:           "no MachineSetNameLabel set is allowed",
+			selectorLabels: map[string]string{"app": "foo"},
+			templateLabels: map[string]string{"app": "foo"},
+			expectErr:      false,
+		},
+		{
+			name:           "MachineSetNameLabel matching metadata.name is allowed",
+			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
+			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
+			expectErr:      false,
+		},
+		{
+			name:           "MachineSetNameLabel mismatched in selector is rejected",
+			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
+			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
+			expectErr:      true,
+		},
+		{
+			name:           "MachineSetNameLabel mismatched in template labels is rejected",
+			selectorLabels: map[string]string{clusterv1.MachineSetNameLabel: enforced},
+			templateLabels: map[string]string{clusterv1.MachineSetNameLabel: "other-name"},
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ms := &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{Name: msName},
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{MatchLabels: tt.selectorLabels},
+					Template: clusterv1.MachineTemplateSpec{
+						ObjectMeta: clusterv1.ObjectMeta{Labels: tt.templateLabels},
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{DataSecretName: ptr.To("data-secret")},
+						},
+					},
+				},
+			}
+
+			warnings, err := (&MachineSet{}).ValidateCreate(ctx, ms)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(warnings).To(BeEmpty())
+		})
+	}
+}
+
 func TestMachineSetClusterNameImmutable(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
**What this PR does / why we need it**:

Today a MachineSet (or MachineDeployment) created with a \`spec.selector.matchLabels\` or \`spec.template.metadata.labels\` entry for a label key that the controller will overwrite on owned objects is silently accepted as long as the selector still matches the template labels. The controller then writes its own value to owned Machines / MachineSets, the selector stops matching them, and the controller keeps creating new replicas in an infinite loop. This was the scenario originally reported in #12156:

- A user creates a MachineSet whose \`spec.selector.matchLabels[cluster.x-k8s.io/set-name]\` value differs from \`metadata.name\`.
- The MachineSet controller writes \`metadata.name\` into \`cluster.x-k8s.io/set-name\` on every Machine it creates.
- Owned Machines therefore never match the selector, so \`spec.replicas - matchingMachines\` stays positive forever, and the controller keeps creating Machines.

@JoelSpeed and @chrischdi pointed out in the issue that the right fix is to reject these inputs at admission time, restricted to the labels the controller actually enforces, and to do the same for MachineDeployment.

**Changes**:

- \`internal/webhooks/machineset.go\`: reject \`spec.selector.matchLabels[cluster.x-k8s.io/set-name]\` and \`spec.template.metadata.labels[cluster.x-k8s.io/set-name]\` whenever they are set to a value other than \`format.MustFormatValue(metadata.name)\` (the same hashed value the defaulter writes when the selector is empty, so names longer than 63 chars keep working).
- \`internal/webhooks/machinedeployment.go\`: same shape for \`cluster.x-k8s.io/deployment-name\` (must equal \`metadata.name\`) and \`cluster.x-k8s.io/cluster-name\` (must equal \`spec.clusterName\`).
- Empty selectors / templates remain handled by the existing defaulters; only user-supplied conflicting values are rejected.
- New unit tests in \`machineset_test.go\` (\`TestMachineSetEnforcedNameLabelValidation\`) and \`machinedeployment_test.go\` (\`TestMachineDeploymentEnforcedLabelValidation\`) cover allowed, matching, and mismatched cases for each enforced label.

**Verification**:

- \`go build ./...\`, \`go vet ./...\` clean.
- \`go test ./internal/webhooks/ -count=1\` passes (\`ok ... 16.8s\`).
- All existing \`TestMachineSetLabelSelectorMatchValidation\`, \`TestMachineDeploymentValidation\`, \`TestMachineSetDefault\`, and \`TestMachineDeploymentDefault\` cases still pass; the new tests add 4 + 4 subtests for the enforced-label paths.

**Which issue(s) this PR fixes**:

Fixes #12156

**Special notes for your reviewer**:

- Scoped intentionally to the validation discussed by @JoelSpeed, @chrischdi, and @sbueringer. The further suggestion to enforce \`.metadata.labels\` on owned Machines / MachineSets is a separate follow-up; happy to take it on next.
- I considered hiding the selector field entirely (Fabrizio's idea) but kept the change additive so it can land without an API break.

/area machineset
/area machine

**Checklist**:
- [x] squashed commits
- [x] includes documentation (release note below)
- [x] adds unit tests

**Release note**:
\`\`\`release-note
The MachineSet and MachineDeployment validating webhooks now reject \`spec.selector.matchLabels\` and \`spec.template.metadata.labels\` entries whose value conflicts with labels the controller enforces on owned objects (\`cluster.x-k8s.io/set-name\` for MachineSet; \`cluster.x-k8s.io/deployment-name\` and \`cluster.x-k8s.io/cluster-name\` for MachineDeployment). This catches the misconfiguration described in #12156 at admission time instead of allowing the controller to create owned replicas indefinitely.
\`\`\`