### PR TITLE
📖 Remove outdated `make envsubst` references from docs

### DIFF
--- a/docs/book/src/developer/core/tilt.md
+++ b/docs/book/src/developer/core/tilt.md
@@ -11,11 +11,10 @@ workflow that offers easy deployments and rapid iterative builds.
 2. [kind](https://kind.sigs.k8s.io): v0.31.0 or newer
 3. [Tilt](https://docs.tilt.dev/install.html): v0.33.18 or newer
 4. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
-5. [envsubst](https://github.com/drone/envsubst)
-6. [helm](https://github.com/helm/helm): v3.7.1 or newer
-7. Clone the [Cluster API](https://github.com/kubernetes-sigs/cluster-api) repository
+5. [helm](https://github.com/helm/helm): v3.7.1 or newer
+6. Clone the [Cluster API](https://github.com/kubernetes-sigs/cluster-api) repository
    locally
-8. Clone the provider(s) you want to deploy locally as well
+7. Clone the provider(s) you want to deploy locally as well
 
 ## Getting started
 

--- a/docs/book/src/developer/core/tilt.md
+++ b/docs/book/src/developer/core/tilt.md
@@ -11,7 +11,7 @@ workflow that offers easy deployments and rapid iterative builds.
 2. [kind](https://kind.sigs.k8s.io): v0.31.0 or newer
 3. [Tilt](https://docs.tilt.dev/install.html): v0.33.18 or newer
 4. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
-5. [envsubst](https://github.com/drone/envsubst): provided via `make envsubst`
+5. [envsubst](https://github.com/drone/envsubst)
 6. [helm](https://github.com/helm/helm): v3.7.1 or newer
 7. Clone the [Cluster API](https://github.com/kubernetes-sigs/cluster-api) repository
    locally

--- a/docs/book/src/developer/getting-started.md
+++ b/docs/book/src/developer/getting-started.md
@@ -65,18 +65,15 @@ You'll need to [install `kubebuilder`][kubebuilder].
 
 ### Envsubst
 
-You'll need [`envsubst`][envsubst] or similar to handle clusterctl var replacement. Note: drone/envsubst releases v1.0.2 and earlier do not have the binary packaged under cmd/envsubst. It is available in Go pseudo-version `v1.0.3-0.20200709231038-aa43e1c1a629`
+You'll need [`envsubst`][envsubst] to handle variable substitution in manifests. 
 
-We provide a make target to generate the `envsubst` binary if desired. See the [provider contract][provider-contract] for more details about how clusterctl uses variables.
+The GNU `gettext` version of `envsubst` does not support default values, so you must use the `drone/envsubst` version.
 
 ```bash
-make envsubst
+go install github.com/drone/envsubst/v2/cmd/envsubst@latest
 ```
 
-The generated binary can be found at ./hack/tools/bin/envsubst
-
 [envsubst]: https://github.com/drone/envsubst
-[provider-contract]: providers/contracts/clusterctl.md
 
 ### Cert-Manager
 
@@ -115,10 +112,10 @@ make docker-build
 make docker-push
 
 # Apply the manifests
-kustomize build config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
-kustomize build bootstrap/kubeadm/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
-kustomize build controlplane/kubeadm/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
-kustomize build test/infrastructure/docker/config/default | ./hack/tools/bin/envsubst | kubectl apply -f -
+kustomize build config/default | ~/go/bin/envsubst | kubectl apply -f -
+kustomize build bootstrap/kubeadm/config/default | ~/go/bin/envsubst | kubectl apply -f -
+kustomize build controlplane/kubeadm/config/default | ~/go/bin/envsubst | kubectl apply -f -
+kustomize build test/infrastructure/docker/config/default | ~/go/bin/envsubst | kubectl apply -f -
 ```
 
 ## Testing


### PR DESCRIPTION
**What this PR does / why we need it**:

The `make envsubst` target was removed in #11783, but the developer docs still referenced it.
The `envsubst` prerequisite remains to support the development in the old-fashioned way.

Note: the GNU `gettext` version of `envsubst` (commonly installed via `brew install gettext`) does not support `${VAR:=default}` syntax used in CAPI manifests and will silently leave variables unsubstituted. Because of that, I am explicit about the bin location.

/area documentation