### PR TITLE
:bug: fix: adds observedGeneration to extension config

### DIFF
--- a/internal/controllers/extensionconfig/extensionconfig_controller.go
+++ b/internal/controllers/extensionconfig/extensionconfig_controller.go
@@ -208,6 +208,7 @@ func patchExtensionConfig(ctx context.Context, client client.Client, original, m
 			clusterv1.PausedCondition,
 			runtimev1.ExtensionConfigDiscoveredCondition,
 		}},
+		patch.WithStatusObservedGeneration{},
 	)
 	return patchHelper.Patch(ctx, modified, options...)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

I noticed that we never set `status.ObservedGeneration` on extension config objects, this PR adds them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area runtime-sdk