### PR TITLE
🐛 Fix failing TestKubeadmControlPlaneReconciler_reconcileEtcdMembers

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1318,7 +1318,9 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 		return ctrl.Result{}, errors.Wrap(err, "cannot get remote client to workload cluster")
 	}
 
-	etcdMemberToBeDeleted := unexpectedMembers.UnsortedList()[0]
+	sortedUnexpectedMembers := unexpectedMembers.UnsortedList()
+	sort.Strings(sortedUnexpectedMembers)
+	etcdMemberToBeDeleted := sortedUnexpectedMembers[0]
 	etcdMemberToBeDeletedMsg := etcdMemberToBeDeleted
 	if etcdMemberToBeDeletedMsg == "" {
 		etcdMemberToBeDeletedMsg = "(Name not yet assigned)"

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -3458,7 +3458,33 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			wantErr:                    true,
 		},
 		{
-			name: "Consider alarms from external members when computing target etcd cluster status",
+			name: "Consider alarms from members not being removed when computing target etcd cluster status",
+			controlPlane: &internal.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+				EtcdMembersAlarms: []etcd.MemberAlarm{
+					{
+						MemberID: 1,
+						Type:     etcd.AlarmNoSpace,
+					},
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: "foo", ID: 1},
+				{Name: "bar", ID: 2},
+			},
+			wantResult:                 ctrl.Result{},
+			wantRemoveEtcdMemberCalled: 0,
+			wantErr:                    true,
+		},
+		{
+			name: "Ignore alarms from external members being removed when computing target etcd cluster status",
 			controlPlane: &internal.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{},
 				Machines: collections.Machines{
@@ -3471,7 +3497,7 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 				EtcdMembersAlarms: []etcd.MemberAlarm{
 					{
 						MemberID: 2,
-						Type:     etcd.AlarmNoSpace,
+						Type:     etcd.AlarmCorrupt,
 					},
 				},
 			},
@@ -3479,9 +3505,9 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 				{Name: "foo", ID: 1},
 				{Name: "bar", ID: 2},
 			},
-			wantResult:                 ctrl.Result{},
-			wantRemoveEtcdMemberCalled: 0,
-			wantErr:                    true,
+			wantResult:                 ctrl.Result{RequeueAfter: 1 * time.Second},
+			wantRemoveEtcdMemberCalled: 1,
+			wantErr:                    false,
 		},
 	}
 

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -2380,29 +2380,64 @@ func TestTargetEtcdClusterHealthy(t *testing.T) {
 		g.Expect(canSafelyTransitionToTargetState).To(BeFalse())
 	})
 
-	t.Run("Can't safely remove a member from a CP with an etcd member without a machine but with alarms", func(t *testing.T) {
+	t.Run("Consider alarms from members not being removed when computing target etcd cluster status", func(t *testing.T) {
 		g := NewWithT(t)
 
 		m1 := getMachine(metav1.NamespaceDefault, "m1-mhc-unhealthy", withMachineHealthCheckFailed())
+		m2 := getMachine(metav1.NamespaceDefault, "m2-etcd-healthy", withHealthyEtcdMember())
 
 		controlPlane := &internal.ControlPlane{
-			Machines: collections.FromMachines(m1),
+			Machines: collections.FromMachines(m1, m2),
 		}
 		controlPlane.EtcdMembers = []*etcd.Member{
 			{
 				ID:   1,
-				Name: "member-without-machine",
+				Name: m1.Status.NodeRef.Name,
+			},
+			{
+				ID:   2,
+				Name: "foo",
 			},
 		}
 		controlPlane.EtcdMembersAlarms = []etcd.MemberAlarm{
 			{
-				MemberID: 1,
+				MemberID: 2,
 				Type:     etcd.AlarmNoSpace,
 			},
 		}
 
 		canSafelyTransitionToTargetState := r.targetEtcdClusterHealthy(ctx, controlPlane, false, m1.Status.NodeRef.Name)
 		g.Expect(canSafelyTransitionToTargetState).To(BeFalse())
+	})
+
+	t.Run("Ignore alarms from external members being removed when computing target etcd cluster status", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m1 := getMachine(metav1.NamespaceDefault, "m1-mhc-unhealthy", withMachineHealthCheckFailed(), withHealthyEtcdMember())
+		m2 := getMachine(metav1.NamespaceDefault, "m2-etcd-healthy", withHealthyEtcdMember())
+
+		controlPlane := &internal.ControlPlane{
+			Machines: collections.FromMachines(m1, m2),
+		}
+		controlPlane.EtcdMembers = []*etcd.Member{
+			{
+				ID:   1,
+				Name: m1.Status.NodeRef.Name,
+			},
+			{
+				ID:   2,
+				Name: "bar",
+			},
+		}
+		controlPlane.EtcdMembersAlarms = []etcd.MemberAlarm{
+			{
+				MemberID: 2,
+				Type:     etcd.AlarmCorrupt,
+			},
+		}
+
+		canSafelyTransitionToTargetState := r.targetEtcdClusterHealthy(ctx, controlPlane, false, "bar")
+		g.Expect(canSafelyTransitionToTargetState).To(BeTrue())
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
-The bug was introduced in PR #13685. 
-The targetEtcdClusterHealthy function in remediation.go was skipping the etcd member being deleted before checking if it had any alarms. 
-This meant that a member with alarms could be removed without the function detecting the unhealthy state.

-Added alarm checking logic before skipping the member to be deleted
-When a member being deleted has alarms, it's marked as unhealthy with the message "(being deleted, has alarms)"
-This ensures the etcd cluster health check properly accounts for alarms on external members before attempting removal

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13712

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area control-plane