### PR TITLE
✨ Stale controller mitigation in reconcile wrapper & MD controller, enable store & fifo informer metrics

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/suite_test.go
+++ b/bootstrap/kubeadm/internal/controllers/suite_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/internal/setup"
@@ -46,8 +48,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupReconcilers:     setupReconcilers,

--- a/bootstrap/kubeadm/internal/setup/setup.go
+++ b/bootstrap/kubeadm/internal/setup/setup.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -30,11 +31,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 // ManagerCacheOptions provides cache.Options for the manager.
-func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.Options {
+func ManagerCacheOptions(scheme *runtime.Scheme, controllerName string, watchNamespace string, syncPeriod time.Duration) cache.Options {
 	var watchNamespaces map[string]cache.Config
 	if watchNamespace != "" {
 		watchNamespaces = map[string]cache.Config{
@@ -78,6 +80,7 @@ func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.
 				},
 			},
 		},
+		NewInformer: capicontrollerutil.NewInformerFunc(scheme, controllerName),
 	}
 }
 

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -241,7 +241,7 @@ func main() {
 		HealthProbeBindAddress:     healthAddr,
 		PprofBindAddress:           profilerAddress,
 		Metrics:                    *metricsOptions,
-		Cache:                      setup.ManagerCacheOptions(watchNamespace, syncPeriod),
+		Cache:                      setup.ManagerCacheOptions(scheme, controllerName, watchNamespace, syncPeriod),
 		Client:                     setup.ManagerClientOptions(),
 		WebhookServer: webhook.NewServer(
 			webhook.Options{

--- a/controllers/clustercache/suite_test.go
+++ b/controllers/clustercache/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -41,14 +42,16 @@ func TestMain(m *testing.M) {
 	clusterSecretCacheSelector := labels.NewSelector().Add(*req)
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
 		M: m,
-		ManagerCacheOptions: cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				// Only cache Secrets with the cluster name label.
-				// This is similar to the real world.
-				&corev1.Secret{}: {
-					Label: clusterSecretCacheSelector,
+		SetupManagerCacheOptions: func(_ *runtime.Scheme) cache.Options {
+			return cache.Options{
+				ByObject: map[client.Object]cache.ByObject{
+					// Only cache Secrets with the cluster name label.
+					// This is similar to the real world.
+					&corev1.Secret{}: {
+						Label: clusterSecretCacheSelector,
+					},
 				},
-			},
+			}
 		},
 		SetupEnv: func(e *envtest.Environment) { env = e },
 	}))

--- a/controllers/crdmigrator/suite_test.go
+++ b/controllers/crdmigrator/suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
@@ -51,14 +52,16 @@ func TestMain(m *testing.M) {
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
 		M: m,
-		ManagerCacheOptions: cache.Options{
-			ByObject: map[client.Object]cache.ByObject{
-				// Only cache Secrets with the cluster name label.
-				// This is similar to the real world.
-				&corev1.Secret{}: {
-					Label: clusterSecretCacheSelector,
+		SetupManagerCacheOptions: func(_ *runtime.Scheme) cache.Options {
+			return cache.Options{
+				ByObject: map[client.Object]cache.ByObject{
+					// Only cache Secrets with the cluster name label.
+					// This is similar to the real world.
+					&corev1.Secret{}: {
+						Label: clusterSecretCacheSelector,
+					},
 				},
-			},
+			}
 		},
 		SetupEnv: func(e *envtest.Environment) { env = e },
 	}))

--- a/controlplane/kubeadm/internal/controllers/suite_test.go
+++ b/controlplane/kubeadm/internal/controllers/suite_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/setup"
@@ -46,8 +48,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupReconcilers:     setupReconcilers,

--- a/controlplane/kubeadm/internal/setup/setup.go
+++ b/controlplane/kubeadm/internal/setup/setup.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -34,11 +35,12 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 // ManagerCacheOptions provides cache.Options for the manager.
-func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.Options {
+func ManagerCacheOptions(scheme *runtime.Scheme, controllerName string, watchNamespace string, syncPeriod time.Duration) cache.Options {
 	var watchNamespaces map[string]cache.Config
 	if watchNamespace != "" {
 		watchNamespaces = map[string]cache.Config{
@@ -90,6 +92,7 @@ func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.
 				Label: controlPlaneMachineSelector,
 			},
 		},
+		NewInformer: capicontrollerutil.NewInformerFunc(scheme, controllerName),
 	}
 }
 

--- a/controlplane/kubeadm/internal/suite_test.go
+++ b/controlplane/kubeadm/internal/suite_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/setup"
@@ -46,8 +48,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupReconcilers:     setupReconcilers,

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -293,7 +293,7 @@ func main() {
 		HealthProbeBindAddress:     healthAddr,
 		PprofBindAddress:           profilerAddress,
 		Metrics:                    *metricsOptions,
-		Cache:                      setup.ManagerCacheOptions(watchNamespace, syncPeriod),
+		Cache:                      setup.ManagerCacheOptions(scheme, controllerName, watchNamespace, syncPeriod),
 		Client:                     setup.ManagerClientOptions(),
 		WebhookServer: webhook.NewServer(
 			webhook.Options{

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fastjson v1.6.10
 	go.etcd.io/etcd/api/v3 v3.6.11
 	go.etcd.io/etcd/client/pkg/v3 v3.6.11
@@ -49,14 +50,13 @@ require (
 	k8s.io/component-base v0.36.1
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a
+	k8s.io/streaming v0.36.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0
 )
-
-require k8s.io/streaming v0.36.1
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/internal/controllers/cluster/suite_test.go
+++ b/internal/controllers/cluster/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -107,8 +108,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(timeout)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/clusterclass/suite_test.go
+++ b/internal/controllers/clusterclass/suite_test.go
@@ -31,6 +31,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -74,8 +75,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(30 * time.Second)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/clusterresourceset/suite_test.go
+++ b/internal/controllers/clusterresourceset/suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -111,8 +112,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/extensionconfig/suite_test.go
+++ b/internal/controllers/extensionconfig/suite_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"sigs.k8s.io/cluster-api/api/core/v1beta2/index"
 	"sigs.k8s.io/cluster-api/internal/setup"
@@ -43,8 +45,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -30,6 +30,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
@@ -1342,6 +1344,11 @@ type fakeController struct{}
 func (f fakeController) DeferNextReconcile(_ reconcile.Request, _ time.Time) {}
 
 func (f fakeController) DeferNextReconcileForObject(_ metav1.Object, _ time.Time) {}
+
+func (f fakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ schema.GroupResource, _ metav1.Object) {
+}
+
+func (f fakeController) ClearConsistencyStore(_ client.ObjectKey, _ types.UID) {}
 
 func (f fakeController) Reconcile(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	panic("implement me")

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -106,8 +107,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(timeout)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -41,7 +42,6 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	runtimeclient "sigs.k8s.io/cluster-api/exp/runtime/client"
 	"sigs.k8s.io/cluster-api/feature"
-	clientutil "sigs.k8s.io/cluster-api/internal/util/client"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/cache"
@@ -58,6 +58,11 @@ import (
 var (
 	// machineDeploymentKind contains the schema.GroupVersionKind for the MachineDeployment type.
 	machineDeploymentKind = clusterv1.GroupVersion.WithKind("MachineDeployment")
+
+	msGR = schema.GroupResource{
+		Group:    clusterv1.GroupVersion.Group,
+		Resource: "machinesets",
+	}
 )
 
 // machineDeploymentManagerName is the manager name used for Server-Side-Apply (SSA) operations
@@ -81,8 +86,9 @@ type Reconciler struct {
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 
-	recorder record.EventRecorder
-	ssaCache ssa.Cache
+	controller capicontrollerutil.Controller
+	recorder   record.EventRecorder
+	ssaCache   ssa.Cache
 
 	canUpdateMachineSetCache cache.Cache[CanUpdateMachineSetCacheEntry]
 }
@@ -101,7 +107,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		return err
 	}
 
-	err = capicontrollerutil.NewControllerManagedBy(mgr, predicateLog).
+	c, err := capicontrollerutil.NewControllerManagedBy(mgr, predicateLog).
 		For(&clusterv1.MachineDeployment{}).
 		Owns(&clusterv1.MachineSet{}).
 		// Watches enqueues MachineDeployment for corresponding MachineSet resources, if no managed controller reference (owner) exists.
@@ -111,17 +117,21 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
+		WithConsistencyStore(map[schema.GroupResource]client.Object{
+			msGR: &clusterv1.MachineSet{},
+		}).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
 			predicates.ClusterPausedTransitions(mgr.GetScheme(), predicateLog),
 			// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
-		).Complete(ctx, r)
+		).Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
 	r.canUpdateMachineSetCache = cache.New[CanUpdateMachineSetCacheEntry](ctx, cache.HookCacheDefaultTTL)
+	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")
 	r.ssaCache = ssa.NewCache("machinedeployment")
 	return nil
@@ -136,6 +146,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (retres ct
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
+			r.controller.ClearConsistencyStore(req.NamespacedName, "")
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -377,6 +388,7 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 				r.recorder.Eventf(p.md, corev1.EventTypeWarning, "FailedCreate", "Failed to create MachineSet %s: %v", klog.KObj(ms), err)
 				return errors.Wrapf(err, "failed to create MachineSet %s", klog.KObj(ms))
 			}
+			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, msGR, ms)
 			if len(p.oldMSs) > 0 {
 				log.Info(fmt.Sprintf("MachineSets need rollout: %s", strings.Join(machineSetNames(p.oldMSs), ", ")), "reason", p.createReason)
 			}
@@ -385,13 +397,6 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 				log.Info(fmt.Sprintf("Scaled up current MachineSet %s from 0 to %d replicas (+%[2]d)", klog.KObj(ms), diff.DesiredReplicas))
 			}
 			r.recorder.Eventf(p.md, corev1.EventTypeNormal, "SuccessfulCreate", "Created MachineSet %s with %d replicas", klog.KObj(ms), diff.DesiredReplicas)
-
-			// Keep trying to get the MachineSet. This will force the cache to update and prevent any future reconciliation of
-			// the MachineDeployment to reconcile with an outdated list of MachineSets which could lead to unwanted creation of
-			// a duplicate MachineSet.
-			if err := clientutil.WaitForObjectsToBeAddedToTheCache(ctx, r.Client, "MachineSet creation", ms); err != nil {
-				return err
-			}
 
 			continue
 		}
@@ -421,6 +426,11 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 			return errors.Wrapf(err, "failed to update MachineSet %s", klog.KObj(ms))
 		}
 
+		// Defer next reconcile only if ResourceVersion has changed.
+		if diff.OriginalMS.ResourceVersion != ms.ResourceVersion {
+			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, msGR, ms)
+		}
+
 		if diff.DesiredReplicas < diff.OriginalReplicas {
 			log.Info(fmt.Sprintf("Scaled down %s MachineSet %s from %d to %d replicas (-%d)", diff.Type, klog.KObj(ms), diff.OriginalReplicas, diff.DesiredReplicas, diff.OriginalReplicas-diff.DesiredReplicas))
 			r.recorder.Eventf(p.md, corev1.EventTypeNormal, "SuccessfulScale", "Scaled down MachineSet %v: %d -> %d", ms.Name, diff.OriginalReplicas, diff.DesiredReplicas)
@@ -431,13 +441,6 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 		}
 		if diff.DesiredReplicas == diff.OriginalReplicas && diff.OtherChanges != "" {
 			log.Info(fmt.Sprintf("Updated %s MachineSet %s", diff.Type, klog.KObj(ms)))
-		}
-
-		// Only wait for cache if the object was changed.
-		if diff.OriginalMS.ResourceVersion != ms.ResourceVersion {
-			if err := clientutil.WaitForCacheToBeUpToDate(ctx, r.Client, "MachineSet update", ms); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -469,6 +472,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, s *scope) error {
 
 	// If all the descendant machinesets are deleted, then remove the machinedeployment's finalizer.
 	if len(s.machineSets) == 0 {
+		r.controller.ClearConsistencyStore(client.ObjectKeyFromObject(s.machineDeployment), s.machineDeployment.UID)
 		controllerutil.RemoveFinalizer(s.machineDeployment, clusterv1.MachineDeploymentFinalizer)
 		return nil
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
@@ -938,8 +939,9 @@ func TestReconciler_reconcileDelete(t *testing.T) {
 
 			c := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
 			r := &Reconciler{
-				Client:   c,
-				recorder: record.NewFakeRecorder(32),
+				Client:     c,
+				controller: capicontrollerutil.NewFakeController(),
+				recorder:   record.NewFakeRecorder(32),
 			}
 
 			s := &scope{

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -114,8 +115,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(timeout)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/machinehealthcheck/suite_test.go
+++ b/internal/controllers/machinehealthcheck/suite_test.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/api/core/v1beta2/index"
@@ -105,8 +107,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(timeout)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/machinepool/suite_test.go
+++ b/internal/controllers/machinepool/suite_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/api/core/v1beta2/index"
@@ -74,8 +76,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/machineset/suite_test.go
+++ b/internal/controllers/machineset/suite_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -111,8 +112,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyTimeout(timeout)
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/controllers/topology/cluster/structuredmerge/suite_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/suite_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/internal/setup"
@@ -48,8 +49,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(30 * time.Second)
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		// We are testing the patch helper against a real API Server, no need of additional indexes/reconcilers.

--- a/internal/controllers/topology/cluster/suite_test.go
+++ b/internal/controllers/topology/cluster/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -100,8 +101,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(30 * time.Second)
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -34,11 +35,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 // ManagerCacheOptions provides cache.Options for the manager.
-func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.Options {
+func ManagerCacheOptions(scheme *runtime.Scheme, controllerName string, watchNamespace string, syncPeriod time.Duration) cache.Options {
 	var watchNamespaces map[string]cache.Config
 	if watchNamespace != "" {
 		watchNamespaces = map[string]cache.Config{
@@ -70,6 +72,7 @@ func ManagerCacheOptions(watchNamespace string, syncPeriod time.Duration) cache.
 				},
 			},
 		},
+		NewInformer: capicontrollerutil.NewInformerFunc(scheme, controllerName),
 	}
 }
 

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -131,7 +131,7 @@ func registerSchemes(s *runtime.Scheme) {
 // RunInput is the input for Run.
 type RunInput struct {
 	M                           *testing.M
-	ManagerCacheOptions         cache.Options
+	SetupManagerCacheOptions    func(scheme *runtime.Scheme) cache.Options
 	ManagerClientOptions        client.Options
 	SetupIndexes                func(ctx context.Context, mgr ctrl.Manager)
 	SetupReconcilers            func(ctx context.Context, mgr ctrl.Manager)
@@ -173,7 +173,11 @@ func Run(ctx context.Context, input RunInput) int {
 	}
 
 	// Bootstrapping test environment
-	env := newEnvironment(ctx, scheme, input.AdditionalCRDDirectoryPaths, input.ManagerCacheOptions, input.ManagerClientOptions)
+	var cacheOptions cache.Options
+	if input.SetupManagerCacheOptions != nil {
+		cacheOptions = input.SetupManagerCacheOptions(scheme)
+	}
+	env := newEnvironment(ctx, scheme, input.AdditionalCRDDirectoryPaths, cacheOptions, input.ManagerClientOptions)
 
 	ctx, cancel := context.WithCancelCause(ctx)
 	env.cancelManager = cancel

--- a/internal/topology/upgrade/suite_test.go
+++ b/internal/topology/upgrade/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -101,8 +102,10 @@ func TestMain(m *testing.M) {
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(30 * time.Second)
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupIndexes:         setupIndexes,

--- a/internal/util/ssa/suite_test.go
+++ b/internal/util/ssa/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/internal/setup"
@@ -45,8 +46,10 @@ func init() {
 
 func TestMain(m *testing.M) {
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 	}))

--- a/internal/webhooks/test/suite_test.go
+++ b/internal/webhooks/test/suite_test.go
@@ -23,8 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/api/core/v1beta2/index"
@@ -59,8 +61,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:                    m,
-		ManagerCacheOptions:  setup.ManagerCacheOptions("", 10*time.Minute),
+		M: m,
+		SetupManagerCacheOptions: func(scheme *runtime.Scheme) cache.Options {
+			return setup.ManagerCacheOptions(scheme, "test-controller-manager", "", 10*time.Minute)
+		},
 		ManagerClientOptions: setup.ManagerClientOptions(),
 		SetupEnv:             func(e *envtest.Environment) { env = e },
 		SetupReconcilers:     setupReconcilers,

--- a/main.go
+++ b/main.go
@@ -370,7 +370,7 @@ func main() {
 		HealthProbeBindAddress:     healthAddr,
 		PprofBindAddress:           profilerAddress,
 		Metrics:                    *metricsOptions,
-		Cache:                      setup.ManagerCacheOptions(watchNamespace, syncPeriod),
+		Cache:                      setup.ManagerCacheOptions(scheme, controllerName, watchNamespace, syncPeriod),
 		Client:                     setup.ManagerClientOptions(),
 		WebhookServer: webhook.NewServer(
 			webhook.Options{

--- a/util/controller/builder.go
+++ b/util/controller/builder.go
@@ -18,17 +18,20 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"math"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -51,13 +54,14 @@ const (
 
 // Builder is a wrapper around controller-runtime's builder.Builder.
 type Builder struct {
-	builder           *builder.Builder
-	mgr               manager.Manager
-	predicateLog      logr.Logger
-	options           controller.TypedOptions[reconcile.Request]
-	forObject         client.Object
-	controllerName    string
-	rateLimitInterval time.Duration
+	builder                   *builder.Builder
+	mgr                       manager.Manager
+	predicateLog              logr.Logger
+	options                   controller.TypedOptions[reconcile.Request]
+	forObject                 client.Object
+	controllerName            string
+	rateLimitInterval         time.Duration
+	consistencyStoreResources map[schema.GroupResource]client.Object
 }
 
 // NewControllerManagedBy returns a new controller builder that will be started by the provided Manager.
@@ -136,6 +140,13 @@ func (blder *Builder) WithEventFilter(p predicate.Predicate) *Builder {
 	return blder
 }
 
+// WithConsistencyStore configures a consistency store for the controller. The passed in resources
+// are the ones for which DeferNextReconcileUntilCacheUpToDate can be called.
+func (blder *Builder) WithConsistencyStore(resources map[schema.GroupResource]client.Object) *Builder {
+	blder.consistencyStoreResources = resources
+	return blder
+}
+
 // Named sets the name of the controller to the given name. The name shows up
 // in metrics, among other things, and thus should be a prometheus compatible name
 // (underscores and alphanumeric characters only).
@@ -151,6 +162,8 @@ type Controller interface {
 	controller.Controller
 	DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time)
 	DeferNextReconcileForObject(obj metav1.Object, reconcileAfter time.Time)
+	DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGroupResource schema.GroupResource, writtenObject metav1.Object)
+	ClearConsistencyStore(reconciledObject client.ObjectKey, reconciledObjectUID types.UID)
 }
 
 // Complete builds the Application Controller.
@@ -235,12 +248,38 @@ func (blder *Builder) Build(ctx context.Context, r reconcile.TypedReconciler[rec
 	// Create reconcileCache.
 	reconcileCache := cache.New[reconcileCacheEntry](ctx, cache.DefaultTTL)
 
+	// Create consistencyStore if configured.
+	var consistencyStore consistencyStore
+	if len(blder.consistencyStoreResources) > 0 {
+		stores := make(map[schema.GroupResource]lastSyncRVGetter, len(blder.consistencyStoreResources))
+
+		for resGR, resObj := range blder.consistencyStoreResources {
+			// Note: This creates the informer, but it doesn't start it (and accordingly also doesn't wait for cache sync).
+			informer, err := blder.mgr.GetCache().GetInformer(ctx, resObj, ctrlcache.BlockUntilSynced(false))
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to create %s informer", resGR.Resource)
+			}
+			sharedIndexInformer, ok := informer.(kcache.SharedIndexInformer)
+			if !ok {
+				// Note: This should never happen as controller-runtime only uses SharedIndexInformer.
+				return nil, errors.Errorf("failed to cast %s informer to SharedIndexInformer", resGR.Resource)
+			}
+			stores[resGR] = sharedIndexInformer.GetStore()
+
+			// Initialize metrics to align to what controller-runtime is doing for its metrics.
+			reconcileStaleCacheSkipsTotal.WithLabelValues(controllerName, resGR.Resource).Add(0)
+		}
+
+		consistencyStore = newConsistencyStore(stores)
+	}
+
 	c, err := blder.builder.Build(&reconcilerWrapper{
 		name:              controllerName,
 		reconciler:        r,
 		reconcileCache:    reconcileCache,
 		rateLimitInterval: rateLimitInterval,
 		queueRateLimiter:  queueRateLimiter,
+		consistencyStore:  consistencyStore,
 	})
 	if err != nil {
 		return nil, err
@@ -255,8 +294,9 @@ func (blder *Builder) Build(ctx context.Context, r reconcile.TypedReconciler[rec
 	reconcileTotal.WithLabelValues(controllerName, labelSuccess).Add(0)
 
 	return &controllerWrapper{
-		TypedController: c,
-		reconcileCache:  reconcileCache,
+		TypedController:  c,
+		reconcileCache:   reconcileCache,
+		consistencyStore: consistencyStore,
 	}, nil
 }
 

--- a/util/controller/consistency.go
+++ b/util/controller/consistency.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
+)
+
+// Note: This util has been initially copied from: https://github.com/kubernetes/kubernetes/blob/v1.36.0/pkg/controller/util/consistency/consistency.go.
+
+type consistencyStore interface {
+	// WroteAt records a written RV for an owned resource.
+	WroteAt(owner types.NamespacedName, ownerUID types.UID, resource schema.GroupResource, rv string)
+	// Clear wipes the owner if the UID matches, if left empty it will wipe no
+	// matter what the UID is.
+	Clear(owner types.NamespacedName, ownerUID types.UID)
+	// EnsureReady queries the consistencyStore to check whether or not the
+	// stores records are up to date, returning an error if they are not.
+	EnsureReady(owner types.NamespacedName) []consistencyError
+}
+
+// consistencyError is an error type returned by EnsureReady with information
+// about the resource versions and GroupKind that caused the error.
+type consistencyError struct {
+	ReadRV        string
+	WroteRV       string
+	GroupResource schema.GroupResource
+}
+
+func (c *consistencyError) Error() string {
+	return fmt.Sprintf("read version: %s is not as new as written version: %s for group resource %s", c.ReadRV, c.WroteRV, c.GroupResource.String())
+}
+
+var _ consistencyStore = &realConsistencyStore{}
+
+type lastSyncRVGetter interface {
+	LastStoreSyncResourceVersion() string
+}
+
+type realConsistencyStore struct {
+	// writesLock guards reads/additions/deletions to the writes map.
+	// individual records are responsible for managing their own thread safety.
+	writesLock sync.RWMutex
+	// writes is a map of owner -> ownerRecord
+	writes map[types.NamespacedName]*ownerRecord
+
+	stores map[schema.GroupResource]lastSyncRVGetter
+}
+
+func newConsistencyStore(stores map[schema.GroupResource]lastSyncRVGetter) *realConsistencyStore {
+	return &realConsistencyStore{
+		writes: map[types.NamespacedName]*ownerRecord{},
+		stores: stores,
+	}
+}
+
+// getWrittenRecord returns the record for the given owner, or nil if no record exists.
+func (c *realConsistencyStore) getWrittenRecord(owner types.NamespacedName) *ownerRecord {
+	c.writesLock.RLock()
+	defer c.writesLock.RUnlock()
+	return c.writes[owner]
+}
+
+// ensureWrittenRecord returns a ownerRecord for the given owner and ownerUID.
+// If there is no current record, one is created.
+// If there is a current record with a different ownerUID, it is replaced with an empty record for the specified ownerUID.
+func (c *realConsistencyStore) ensureWrittenRecord(owner types.NamespacedName, ownerUID types.UID) *ownerRecord {
+	// fast path, already exists
+	if record := c.getWrittenRecord(owner); record != nil && record.ownerUID == ownerUID {
+		return record
+	}
+
+	// slow path, init
+	c.writesLock.Lock()
+	defer c.writesLock.Unlock()
+	// check again after write lock
+	if record := c.writes[owner]; record != nil && record.ownerUID == ownerUID {
+		return record
+	}
+	// initialize to the given uid
+	record := newOwnerRecord(ownerUID)
+	c.writes[owner] = record
+	return record
+}
+
+// WroteAt writes the latest written RV if it is greater than the currently
+// written RV for the owner.
+func (c *realConsistencyStore) WroteAt(owner types.NamespacedName, ownerUID types.UID, resource schema.GroupResource, rv string) {
+	c.ensureWrittenRecord(owner, ownerUID).WroteAt(resource, rv)
+}
+
+// Clear deletes the record for owner if it exists and matches the specified
+// ownerUID (or the specified ownerUID is empty).
+func (c *realConsistencyStore) Clear(owner types.NamespacedName, ownerUID types.UID) {
+	// deleted owners typically have an existing record, not worth checking the fast path for missing records
+	c.writesLock.Lock()
+	defer c.writesLock.Unlock()
+	if record := c.writes[owner]; record != nil && (len(ownerUID) == 0 || record.ownerUID == ownerUID) {
+		delete(c.writes, owner)
+	}
+}
+
+// EnsureReady returns nil if observed resource versions are at least as new as
+// any recorded versions for the given owner, otherwise returning the error of
+// what happened. Must not be called concurrent with WroteAt for the same owner.
+func (c *realConsistencyStore) EnsureReady(owner types.NamespacedName) []consistencyError {
+	record := c.getWrittenRecord(owner)
+	if record == nil {
+		return nil
+	}
+	err := record.EnsureReady(c)
+	if err == nil {
+		c.Clear(owner, record.ownerUID)
+		return nil
+	}
+	return err
+}
+
+type ownerRecord struct {
+	// ownerUID must not be mutated after creation
+	ownerUID types.UID
+
+	versionsLock sync.Mutex
+	versions     map[schema.GroupResource]string
+}
+
+func newOwnerRecord(ownerUID types.UID) *ownerRecord {
+	return &ownerRecord{ownerUID: ownerUID, versions: map[schema.GroupResource]string{}}
+}
+
+// WroteAt increments the written resource version of an ownerRecord if it is
+// the newest seen resource version for that resource.
+func (w *ownerRecord) WroteAt(resource schema.GroupResource, rv string) {
+	w.versionsLock.Lock()
+	defer w.versionsLock.Unlock()
+	if _, ok := w.versions[resource]; !ok {
+		w.versions[resource] = rv
+		return
+	}
+	cmp, err := resourceversion.CompareResourceVersion(w.versions[resource], rv)
+	if err == nil && cmp >= 0 {
+		return
+	}
+	w.versions[resource] = rv
+}
+
+// EnsureReady checks whether or not the ownerRecord is ready compared to the
+// read resource versions in the consistency store.
+func (w *ownerRecord) EnsureReady(c *realConsistencyStore) []consistencyError {
+	w.versionsLock.Lock()
+	defer w.versionsLock.Unlock()
+	var errs []consistencyError
+	for gr, wroteRV := range w.versions {
+		store, exists := c.stores[gr]
+		if !exists || store == nil {
+			continue
+		}
+		readRV := store.LastStoreSyncResourceVersion()
+		if readRV == "" {
+			// Since we wait for the store to be ready, the only time "" is if the
+			// LastStoreSyncResourceVersion() feature is not enabled.
+			continue
+		}
+		i, err := resourceversion.CompareResourceVersion(wroteRV, readRV)
+		if err != nil {
+			// comparison errors indicate there's a data problem with resource versions, continue so we don't block syncing
+			continue
+		}
+		if i > 0 {
+			// read version is not as new as owner version, not ready
+			errs = append(errs, consistencyError{
+				WroteRV:       wroteRV,
+				ReadRV:        readRV,
+				GroupResource: gr,
+			})
+		}
+	}
+	return errs
+}

--- a/util/controller/consistency_test.go
+++ b/util/controller/consistency_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestOwnerRecord_WroteAt(t *testing.T) {
+	uid := types.UID("owner-uid-1")
+	or := newOwnerRecord(uid)
+	assert.Equal(t, uid, or.ownerUID)
+	require.NotNil(t, or.versions)
+
+	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	grDs := schema.GroupResource{Group: "apps", Resource: "daemonsets"}
+
+	// First write
+	or.WroteAt(grPod, "5")
+	assert.Equal(t, "5", or.versions[grPod])
+
+	// Second write (higher)
+	or.WroteAt(grPod, "10")
+	assert.Equal(t, "10", or.versions[grPod])
+
+	// Third write (lower)
+	or.WroteAt(grPod, "8")
+	assert.Equal(t, "10", or.versions[grPod])
+
+	// Write to different resource
+	or.WroteAt(grDs, "1")
+	assert.Equal(t, "1", or.versions[grDs])
+	assert.Equal(t, "10", or.versions[grPod], "Pod version should be unchanged")
+}
+
+func TestOwnerRecord_IsReady(t *testing.T) {
+	uid := types.UID("owner-uid-1")
+	or := newOwnerRecord(uid)
+	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	grDs := schema.GroupResource{Group: "apps", Resource: "daemonsets"}
+	podStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	dsStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	resourceStores := map[schema.GroupResource]lastSyncRVGetter{
+		grPod: podStore,
+		grDs:  dsStore,
+	}
+
+	store := newConsistencyStore(resourceStores)
+
+	// Case 1: No writes. Should be ready.
+	require.Empty(t, or.EnsureReady(store), "Should be ready if no writes are recorded")
+
+	// Add a write
+	or.WroteAt(grPod, "10")
+
+	// Case 2: Write exists, but no reads. Should stay ready.
+	require.Empty(t, or.EnsureReady(store), "Should stay ready if write exists and no read")
+
+	// Add a read, but it's lower
+	podStore.Bookmark("5")
+
+	// Case 3: Write exists, read is lower. Not ready.
+	require.NotEmpty(t, or.EnsureReady(store), "Not ready if read < write")
+
+	// Add a read, equal
+	podStore.Bookmark("10")
+
+	// Case 4: Write exists, read is equal. Ready.
+	require.Empty(t, or.EnsureReady(store), "Ready if read == write")
+
+	// Add a read, higher
+	podStore.Bookmark("15")
+
+	// Case 5: Write exists, read is higher. Ready.
+	require.Empty(t, or.EnsureReady(store), "Ready if read > write")
+
+	// Add a second write and read
+	or.WroteAt(grDs, "100")
+	dsStore.Bookmark("50")
+
+	// Case 6: One resource ready, one not. Not ready.
+	require.NotEmpty(t, or.EnsureReady(store), "Not ready if one of multiple writes is not ready (no read)")
+
+	// Make the second one ready
+	dsStore.Bookmark("100")
+
+	// Case 7: All resources ready. Ready.
+	require.Empty(t, or.EnsureReady(store), "Ready if all writes are ready")
+}
+
+func TestConsistencyStore_New(t *testing.T) {
+	store := newConsistencyStore(nil)
+	require.NotNil(t, store)
+	require.NotNil(t, store.writes)
+	assert.Empty(t, store.writes)
+}
+
+func TestConsistencyStore_EnsureWrittenRecord(t *testing.T) {
+	store := newConsistencyStore(nil)
+	owner := types.NamespacedName{Name: "owner1"}
+	uid1 := types.UID("uid-1")
+	uid2 := types.UID("uid-2")
+
+	// Create new
+	r1 := store.ensureWrittenRecord(owner, uid1)
+	require.NotNil(t, r1)
+	assert.Equal(t, uid1, r1.ownerUID)
+	assert.Same(t, r1, store.writes[owner])
+
+	// Get existing with same UID
+	r2 := store.ensureWrittenRecord(owner, uid1)
+	assert.Same(t, r1, r2, "Should return existing record for same UID")
+
+	// Get existing with different UID (should replace)
+	r3 := store.ensureWrittenRecord(owner, uid2)
+	require.NotNil(t, r3)
+	assert.NotSame(t, r1, r3, "Should be a new record")
+	assert.Equal(t, uid2, r3.ownerUID)
+	assert.Same(t, r3, store.writes[owner], "New record should replace old one in map")
+	assert.Empty(t, r3.versions, "New record should be empty")
+
+	// Check that old record is detached
+	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	r1.WroteAt(grPod, "10") // Write to old record
+	assert.Empty(t, r3.versions, "Write to old record should not affect new record")
+}
+
+func TestConsistencyStore_EnsureWrittenRecord_Concurrent(t *testing.T) {
+	store := newConsistencyStore(nil)
+	owner := types.NamespacedName{Name: "owner1"}
+	uid1 := types.UID("uid-1")
+	uid2 := types.UID("uid-2")
+
+	wg := sync.WaitGroup{}
+	numGoroutines := 50
+
+	// Concurrent creation with same UID
+	var firstRecord *ownerRecord
+	var once sync.Once
+	for range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := store.ensureWrittenRecord(owner, uid1)
+			assert.Equal(t, uid1, r.ownerUID)
+			once.Do(func() {
+				firstRecord = r
+			})
+			assert.Same(t, firstRecord, r)
+		}()
+	}
+	wg.Wait()
+	require.NotNil(t, firstRecord)
+	assert.Len(t, store.writes, 1)
+
+	// Concurrent replacement with new UID
+	var replacementRecord *ownerRecord
+	var replaceOnce sync.Once
+	for range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := store.ensureWrittenRecord(owner, uid2)
+			assert.Equal(t, uid2, r.ownerUID)
+			replaceOnce.Do(func() {
+				replacementRecord = r
+			})
+			assert.Same(t, replacementRecord, r)
+		}()
+	}
+	wg.Wait()
+	require.NotNil(t, replacementRecord)
+	assert.Len(t, store.writes, 1)
+	assert.Same(t, replacementRecord, store.writes[owner])
+	assert.NotSame(t, firstRecord, replacementRecord)
+}
+
+func TestConsistencyStore_WroteAt(t *testing.T) {
+	store := newConsistencyStore(nil)
+	owner := types.NamespacedName{Name: "owner1"}
+	uid1 := types.UID("uid-1")
+	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+
+	store.WroteAt(owner, uid1, grPod, "10")
+
+	record := store.getWrittenRecord(owner)
+	require.NotNil(t, record)
+	assert.Equal(t, uid1, record.ownerUID)
+
+	assert.Equal(t, "10", record.versions[grPod])
+
+	// Write again
+	store.WroteAt(owner, uid1, grPod, "20")
+	assert.Equal(t, "20", record.versions[grPod])
+}
+
+func TestConsistencyStore_Clear(t *testing.T) {
+	store := newConsistencyStore(nil)
+	owner1 := types.NamespacedName{Name: "owner1"}
+	owner2 := types.NamespacedName{Name: "owner2"}
+	uid1 := types.UID("uid-1")
+	uid2 := types.UID("uid-2")
+
+	// Setup
+	r1 := store.ensureWrittenRecord(owner1, uid1)
+	r2 := store.ensureWrittenRecord(owner2, uid2)
+	require.Len(t, store.writes, 2)
+
+	// Clear non-existent
+	store.Clear(types.NamespacedName{Name: "non-existent"}, uid1)
+	assert.Len(t, store.writes, 2)
+
+	// Clear with wrong UID
+	store.Clear(owner1, uid2)
+	assert.Len(t, store.writes, 2, "Should not clear with wrong UID")
+	assert.Same(t, r1, store.writes[owner1])
+
+	// Clear with correct UID
+	store.Clear(owner1, uid1)
+	assert.Len(t, store.writes, 1, "Should clear with correct UID")
+	assert.Nil(t, store.writes[owner1])
+	assert.Same(t, r2, store.writes[owner2], "Other record should remain")
+
+	// Re-add r1
+	store.ensureWrittenRecord(owner1, uid1)
+	require.Len(t, store.writes, 2)
+
+	// Clear with empty UID
+	store.Clear(owner1, "")
+	assert.Len(t, store.writes, 1, "Should clear with empty UID")
+	assert.Nil(t, store.writes[owner1])
+	assert.Same(t, r2, store.writes[owner2])
+}
+
+func TestConsistencyStore_IsReady(t *testing.T) {
+	owner1 := types.NamespacedName{Name: "owner1"}
+	uid1 := types.UID("uid-1")
+	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	podStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	resourceStores := map[schema.GroupResource]lastSyncRVGetter{
+		grPod: podStore,
+	}
+
+	store := newConsistencyStore(resourceStores)
+
+	// Case 1: No record. Ready.
+	require.Empty(t, store.EnsureReady(owner1), "Ready if no record exists")
+
+	// Add a write and initial read rv
+	podStore.Bookmark("5")
+	store.WroteAt(owner1, uid1, grPod, "10")
+
+	// Case 2: Record exists, read < write. Not ready.
+	require.NotEmpty(t, store.EnsureReady(owner1), "Not ready if read < write")
+
+	// Add read, equal
+	podStore.Bookmark("10")
+
+	// Case 3: Record exists, read == write. Ready.
+	require.Empty(t, store.EnsureReady(owner1), "Ready if read == write")
+
+	// Add read, higher
+	podStore.Bookmark("15")
+
+	// Case 4: Record exists, read > write. Ready.
+	require.Empty(t, store.EnsureReady(owner1), "Ready if read > write")
+
+	// Assert that the record no longer exists, we no longer need to track the
+	// reads as long as the read has been higher than the latest write.
+	assert.Nil(t, store.getWrittenRecord(owner1), "Written record should no longer exist")
+}

--- a/util/controller/controller.go
+++ b/util/controller/controller.go
@@ -19,11 +19,16 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,12 +36,17 @@ import (
 	"sigs.k8s.io/cluster-api/util/cache"
 )
 
+const requeueDurationStaleCache = 100 * time.Millisecond
+
+var atMostEvery10Seconds = newAtMostEvery(10 * time.Second)
+
 type reconcilerWrapper struct {
 	name              string
 	reconcileCache    cache.Cache[reconcileCacheEntry]
 	reconciler        reconcile.Reconciler
 	rateLimitInterval time.Duration
 	queueRateLimiter  *typedItemExponentialFailureRateLimiter[reconcile.Request]
+	consistencyStore  consistencyStore
 }
 
 func (r *reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -50,6 +60,26 @@ func (r *reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request
 	if cacheEntry, ok := r.reconcileCache.Has(reconcileCacheEntry{Request: req}.Key()); ok {
 		if requeueAfter, requeue := cacheEntry.ShouldRequeue(reconcileStartTime); requeue {
 			return ctrl.Result{RequeueAfter: requeueAfter}, nil
+		}
+	}
+
+	if r.consistencyStore != nil {
+		if consistencyErrs := r.consistencyStore.EnsureReady(req.NamespacedName); len(consistencyErrs) > 0 {
+			log := ctrl.LoggerFrom(ctx)
+			atMostEvery10Seconds.Do(func() {
+				log.V(2).Info("Cache stale, reconciles are requeued until the cache is up-to-date")
+			})
+			for _, consistencyErr := range consistencyErrs {
+				reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, consistencyErr.GroupResource.Resource).Inc()
+			}
+			if log.V(5).Enabled() {
+				var staleCaches []string
+				for _, consistencyErr := range consistencyErrs {
+					staleCaches = append(staleCaches, fmt.Sprintf("%s, writtenRV: %s, observedRV: %s", consistencyErr.GroupResource.Resource, consistencyErr.WroteRV, consistencyErr.ReadRV))
+				}
+				log.V(5).Info(fmt.Sprintf("Cache stale, requeueing after %s (%s)", requeueDurationStaleCache, strings.Join(staleCaches, ", ")))
+			}
+			return ctrl.Result{RequeueAfter: requeueDurationStaleCache}, nil
 		}
 	}
 
@@ -103,7 +133,8 @@ func (r *reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request
 
 type controllerWrapper struct {
 	controller.TypedController[reconcile.Request]
-	reconcileCache cache.Cache[reconcileCacheEntry]
+	reconcileCache   cache.Cache[reconcileCacheEntry]
+	consistencyStore consistencyStore
 }
 
 func (c *controllerWrapper) DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time) {
@@ -146,4 +177,50 @@ func (r reconcileCacheEntry) ShouldRequeue(now time.Time) (requeueAfter time.Dur
 	}
 
 	return time.Duration(0), false
+}
+
+func (c *controllerWrapper) DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGroupResource schema.GroupResource, writtenObject metav1.Object) {
+	// Note: We are using GroupResource here because we want to avoid making bigger changes to the vendored consistencyStore util.
+	// We could calculate GroupResource from a client.Object but we would have to handle error cases.
+	c.consistencyStore.WroteAt(client.ObjectKey{Namespace: reconciledObject.GetNamespace(), Name: reconciledObject.GetName()},
+		reconciledObject.GetUID(), writtenObjectGroupResource, writtenObject.GetResourceVersion())
+}
+
+func (c *controllerWrapper) ClearConsistencyStore(reconciledObject client.ObjectKey, reconciledObjectUID types.UID) {
+	c.consistencyStore.Clear(reconciledObject, reconciledObjectUID)
+}
+
+// atMostEvery will never run the method more than once every specified duration.
+type atMostEvery struct {
+	delay    time.Duration
+	lastCall time.Time
+	mutex    sync.Mutex
+}
+
+// newAtMostEvery creates a new atMostEvery, that will run the method at most every given duration.
+func newAtMostEvery(delay time.Duration) *atMostEvery {
+	return &atMostEvery{
+		delay: delay,
+	}
+}
+
+// updateLastCall returns true if the lastCall time has been updated, false if it was too early.
+func (s *atMostEvery) updateLastCall() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if time.Since(s.lastCall) < s.delay {
+		return false
+	}
+	s.lastCall = time.Now()
+	return true
+}
+
+// Do will run the method if enough time has passed, and return true.
+// Otherwise, it does nothing and returns false.
+func (s *atMostEvery) Do(fn func()) bool {
+	if !s.updateLastCall() {
+		return false
+	}
+	fn()
+	return true
 }

--- a/util/controller/controller_fake.go
+++ b/util/controller/controller_fake.go
@@ -20,7 +20,9 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -45,3 +47,8 @@ func (f *FakeController) DeferNextReconcileForObject(obj metav1.Object, reconcil
 		NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()},
 	}] = reconcileAfter
 }
+
+func (f *FakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ schema.GroupResource, _ metav1.Object) {
+}
+
+func (f *FakeController) ClearConsistencyStore(_ client.ObjectKey, _ types.UID) {}

--- a/util/controller/controller_test.go
+++ b/util/controller/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -59,6 +60,8 @@ func TestReconcile(t *testing.T) {
 
 		rateLimitInterval := 1 * time.Second
 
+		consistencyStore := &fakeConsistencyStore{}
+
 		var reconcileCounter atomic.Int64
 		r := &reconcilerWrapper{
 			name:           "cluster",
@@ -69,6 +72,7 @@ func TestReconcile(t *testing.T) {
 			}),
 			rateLimitInterval: rateLimitInterval,
 			queueRateLimiter:  newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second),
+			consistencyStore:  consistencyStore,
 		}
 		c := controllerWrapper{
 			reconcileCache: reconcileCache,
@@ -129,6 +133,39 @@ func TestReconcile(t *testing.T) {
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
 
 		time.Sleep(1 * time.Second)
+
+		// Simulate a stale cache
+		consistencyStore.errs = []consistencyError{
+			{
+				GroupResource: schema.GroupResource{
+					Group:    clusterv1.GroupVersion.Group,
+					Resource: "machinedeployments",
+				},
+				ReadRV:  "10",
+				WroteRV: "11",
+			},
+			{
+				GroupResource: schema.GroupResource{
+					Group:    clusterv1.GroupVersion.Group,
+					Resource: "cluster",
+				},
+				ReadRV:  "10",
+				WroteRV: "15",
+			},
+		}
+
+		// Reconcile should requeue because of the stale cache
+		res, err = r.Reconcile(t.Context(), req)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res.RequeueAfter).To(Equal(requeueDurationStaleCache))
+		// Metrics should only show a skipped reconcile
+		g.Expect(reconcileCounter.Load()).To(Equal(int64(1)))
+		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "machinedeployments"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "cluster"))).To(Equal(1))
+
+		// Simulate an up-to-date cache
+		consistencyStore.errs = nil
 
 		// Reconcile will reconcile and defer next reconcile by 1s.
 		res, err = r.Reconcile(t.Context(), req)
@@ -238,6 +275,10 @@ func TestReconcile(t *testing.T) {
 		g.Expect(reconcileCounter.Load()).To(Equal(int64(8)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(4))
 		g.Expect(r.queueRateLimiter.NumRequeues(req)).To(Equal(0))
+
+		// No additional reconciles should have been skipped because of a stale cache.
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "machinedeployments"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "cluster"))).To(Equal(1))
 
 		ctrlCancel()
 	})
@@ -400,4 +441,21 @@ func TestShouldRequeue(t *testing.T) {
 			g.Expect(gotRequeueAfter).To(Equal(tt.wantRequeueAfter))
 		})
 	}
+}
+
+type fakeConsistencyStore struct {
+	errs []consistencyError
+}
+
+var _ consistencyStore = &fakeConsistencyStore{}
+
+func (cs *fakeConsistencyStore) WroteAt(_ types.NamespacedName, _ types.UID, _ schema.GroupResource, _ string) {
+}
+
+func (cs *fakeConsistencyStore) ReadAt(_ schema.GroupResource, _ string) {}
+
+func (cs *fakeConsistencyStore) Clear(_ types.NamespacedName, _ types.UID) {}
+
+func (cs *fakeConsistencyStore) EnsureReady(_ types.NamespacedName) []consistencyError {
+	return cs.errs
 }

--- a/util/controller/informer.go
+++ b/util/controller/informer.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gobuffalo/flect"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// NewInformerFunc provides a new informer func that can be used for cache.Options that configures the
+// informer with an identifier and an informerMetricsProvider for proper logs and metrics.
+func NewInformerFunc(scheme *runtime.Scheme, controllerName string) func(cache.ListerWatcher, runtime.Object, time.Duration, cache.Indexers) cache.SharedIndexInformer {
+	informerName, err := cache.NewInformerName(controllerName)
+	if err != nil {
+		panic("cache.NewInformerName was called twice with the same name, that should never happen")
+	}
+
+	return func(lw cache.ListerWatcher, exampleObject runtime.Object, defaultEventHandlerResyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+		// controller-runtime is using cache.NewSharedIndexInformer per default. This is duplicating
+		// cache.NewSharedIndexInformer and additionally setting the Identifier and InformerMetricsProvider
+		// options which are used for logging and metrics (e.g. the store_resource_version and fifo metrics).
+		opts := cache.SharedIndexInformerOptions{
+			ResyncPeriod: defaultEventHandlerResyncPeriod,
+			Indexers:     indexers,
+		}
+		if gvk, err := apiutil.GVKForObject(exampleObject, scheme); err == nil {
+			opts.Identifier = informerName.WithResource(schema.GroupVersionResource{
+				Group:   gvk.Group,
+				Version: gvk.Version,
+				// Best effort, want to avoid using a restMapper here to get the correct resource.
+				Resource: flect.Pluralize(strings.ToLower(gvk.Kind)),
+			})
+			opts.InformerMetricsProvider = informerMetricsProvider{}
+		}
+		return cache.NewSharedIndexInformerWithOptions(lw, exampleObject, opts)
+	}
+}
+
+// Note: These metrics have been initially copied from: https://github.com/kubernetes/component-base/blob/v0.36.0/metrics/prometheus/clientgo/fifo/metrics.go.
+
+var (
+	subsystem = "informer"
+
+	fifoQueuedItems = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "queued_items",
+			Help:      "Number of items currently queued in the FIFO.",
+		},
+		[]string{"name", "group", "version", "resource"},
+	)
+	fifoProcessingLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem:                       subsystem,
+			Name:                            "processing_latency_seconds",
+			Help:                            "Time taken to process events after popping from the queue.",
+			Buckets:                         []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+		},
+		[]string{"name", "group", "version", "resource"},
+	)
+	storeResourceVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: "informer",
+			Name:      "store_resource_version",
+			Help:      "The 15 least significant digits of the resource version of the store.",
+		},
+		[]string{"name", "group", "version", "resource"},
+	)
+
+	registerOnce sync.Once
+)
+
+func init() {
+	register()
+}
+
+// Register registers FIFO metrics and sets the metrics provider.
+func register() {
+	registerOnce.Do(func() {
+		metrics.Registry.MustRegister(fifoQueuedItems)
+		metrics.Registry.MustRegister(fifoProcessingLatency)
+		metrics.Registry.MustRegister(storeResourceVersion)
+	})
+}
+
+type informerMetricsProvider struct{}
+
+func (informerMetricsProvider) NewQueuedItemMetric(id cache.InformerNameAndResource) cache.GaugeMetric {
+	return &reservedGaugeMetric{
+		id: id,
+		gauge: fifoQueuedItems.WithLabelValues(
+			id.Name(),
+			id.GroupVersionResource().Group,
+			id.GroupVersionResource().Version,
+			id.GroupVersionResource().Resource,
+		),
+	}
+}
+
+func (informerMetricsProvider) NewProcessingLatencyMetric(id cache.InformerNameAndResource) cache.HistogramMetric {
+	return &reservedHistogramMetric{
+		id: id,
+		histogram: fifoProcessingLatency.WithLabelValues(
+			id.Name(),
+			id.GroupVersionResource().Group,
+			id.GroupVersionResource().Version,
+			id.GroupVersionResource().Resource,
+		),
+	}
+}
+
+func (informerMetricsProvider) NewStoreResourceVersionMetric(id cache.InformerNameAndResource) cache.GaugeMetric {
+	return &reservedGaugeMetric{
+		id: id,
+		gauge: storeResourceVersion.WithLabelValues(
+			id.Name(),
+			id.GroupVersionResource().Group,
+			id.GroupVersionResource().Version,
+			id.GroupVersionResource().Resource,
+		),
+	}
+}
+
+// reservedGaugeMetric wraps a gauge and only updates it if the identifier
+// is still reserved. This supports dynamic informers (e.g., GC, ResourceQuota)
+// that may shut down while the process is still running.
+type reservedGaugeMetric struct {
+	id    cache.InformerNameAndResource
+	gauge cache.GaugeMetric
+}
+
+func (r *reservedGaugeMetric) Set(value float64) {
+	if r.id.Reserved() {
+		r.gauge.Set(value)
+	}
+}
+
+// reservedHistogramMetric wraps a histogram and only updates it if the identifier
+// is still reserved. This supports dynamic informers (e.g., GC, ResourceQuota)
+// that may shut down while the process is still running.
+type reservedHistogramMetric struct {
+	id        cache.InformerNameAndResource
+	histogram cache.HistogramMetric
+}
+
+func (r *reservedHistogramMetric) Observe(value float64) {
+	if r.id.Reserved() {
+		r.histogram.Observe(value)
+	}
+}

--- a/util/controller/metrics.go
+++ b/util/controller/metrics.go
@@ -53,6 +53,13 @@ var (
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{"controller"})
+
+	// reconcileStaleCacheSkipsTotal is a prometheus metric that keeps track of how often
+	// reconcile was skipped because the cache was stale.
+	reconcileStaleCacheSkipsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "capi_reconcile_stale_cache_skips_total",
+		Help: "Total number of reconciles skipped due to a stale watch cache.",
+	}, []string{"controller", "cached_resource"})
 )
 
 const (
@@ -63,5 +70,5 @@ const (
 )
 
 func init() {
-	metrics.Registry.MustRegister(reconcileTotal, reconcileTime)
+	metrics.Registry.MustRegister(reconcileTotal, reconcileTime, reconcileStaleCacheSkipsTotal)
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Right now whenever we depend on the cache being up-to-date after a write operation we call util functions after the write that wait until the cache is up-to-date. This wait times out after 10s to not block the reconciler forever. If the cache doesn't catch up in time the next Reconcile might be using a stale cache.

This PR replaces that logic with "stale controller mitigation" as implemented in k/k. xref:
* [kubernetes.io/blog/2026/04/28/kubernetes-v1-36-staleness-mitigation-for-controllers](https://kubernetes.io/blog/2026/04/28/kubernetes-v1-36-staleness-mitigation-for-controllers/)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13725

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->