### PR TITLE
🐛 Do not include `BootstrapConfigReady` condition for machine `Ready` c…

### DIFF
--- a/core/reconcilers/machine/machine_controller_phases.go
+++ b/core/reconcilers/machine/machine_controller_phases.go
@@ -166,8 +166,14 @@ func (r *Reconciler) reconcileBootstrap(ctx context.Context, s *scope) (ctrl.Res
 				// TODO: we can also relax this and tolerate the absence of the bootstrap ref way before, e.g. after node ref is set
 				return ctrl.Result{}, nil
 			}
+
+			if m.Status.NodeRef.IsDefined() {
+				// If the node ref is already set, it means that the machine has been already provisioned and the bootstrap object
+				// is not needed anymore. Tolerate bootstrap config not found in this case.
+				return ctrl.Result{}, nil
+			}
+
 			log.Info("Could not find bootstrap config object, requeuing", m.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(m.Namespace, m.Spec.Bootstrap.ConfigRef.Name))
-			// TODO: we can make this smarter and requeue only if we are before node ref is set
 			return ctrl.Result{RequeueAfter: externalReadyWait}, nil
 		}
 		return ctrl.Result{}, err

--- a/core/reconcilers/machine/machine_controller_status.go
+++ b/core/reconcilers/machine/machine_controller_status.go
@@ -747,11 +747,16 @@ func setReadyCondition(ctx context.Context, machine *clusterv1.Machine) {
 	defaultReadinessGates := []string{
 		clusterv1.MachineDeletingCondition,
 		clusterv1.MachineUpdatingCondition,
-		clusterv1.MachineBootstrapConfigReadyCondition,
 		clusterv1.MachineInfrastructureReadyCondition,
 		clusterv1.MachineNodeHealthyCondition,
 		clusterv1.MachineHealthCheckSucceededCondition,
 	}
+	// Once Available condition is true in the machine, the Ready condition in the bootstrap config is not relevant for the machine Ready
+	// condition anymore.
+	if !conditions.IsTrue(machine, clusterv1.MachineAvailableCondition) {
+		defaultReadinessGates = append(defaultReadinessGates, clusterv1.MachineBootstrapConfigReadyCondition)
+	}
+
 	forConditionTypes := make(conditions.ForConditionTypes, 0, len(defaultReadinessGates)+len(machine.Spec.ReadinessGates))
 	forConditionTypes = append(forConditionTypes, defaultReadinessGates...)
 	negativePolarityConditionTypes := []string{clusterv1.MachineDeletingCondition, clusterv1.MachineUpdatingCondition}


### PR DESCRIPTION
…alculation if machine is already `Available`

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Once a Machine becomes Available, the bootstrap config is no longer needed for its operation. This change excludes BootstrapConfigReady from the Ready aggregation once the machine is Available, and tolerates a missing bootstrap config when the node ref is already set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->