### PR TITLE
:seedling: dev: upgrade tempo & fix configuration

### DIFF
--- a/hack/observability/grafana/chart/values.yaml
+++ b/hack/observability/grafana/chart/values.yaml
@@ -56,7 +56,7 @@ datasources:
     - name: Tempo
       type: tempo
       uid: tempo
-      url: http://tempo:3100
+      url: http://tempo:3200
       editable: true
       jsonData:
         tracesToLogs:

--- a/hack/observability/tempo/kustomization.yaml
+++ b/hack/observability/tempo/kustomization.yaml
@@ -3,11 +3,11 @@ resources:
 
 helmCharts:
 - name: tempo
-  repo: https://grafana.github.io/helm-charts
+  repo: https://grafana-community.github.io/helm-charts
   releaseName: tempo
   namespace: observability
   valuesFile: values.yaml
-  version: 1.24.1
+  version: 2.1.2
 
 helmGlobals:
   # Store chart in ".charts" folder instead of "charts".

--- a/hack/observability/tempo/values.yaml
+++ b/hack/observability/tempo/values.yaml
@@ -1,37 +1,16 @@
-# Placeholder for tempo chart configuration, see https://github.com/grafana/helm-charts/tree/main/charts/tempo
+# See https://github.com/grafana-community/helm-charts/tree/main/charts/tempo
 tempo:
-  searchEnabled: true
-
-config: |
-  multitenancy_enabled: false
-  compactor:
-    compaction:
-      block_retention: 24h
-  distributor:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-  ingester: {}
-  server:
-    http_listen_port: 3100
-  storage:
-    trace:
-      backend: local
-      local:
-        path: /var/tempo/traces
-      wal:
-        path: /var/tempo/wal
-  querier: {}
-  query_frontend: {}
   overrides:
-    per_tenant_override_config: /conf/overrides.yaml
-    metrics_generator_processors:
-    - 'service-graphs'
-    - 'span-metrics'
-  metrics_generator:
-    storage:
-      path: "/tmp/tempo"
-      remote_write:
-      - url: "http://prometheus-server/api/v1/write"
+    defaults:
+      metrics_generator:
+        processors:
+          - service-graphs
+          - span-metrics
+          - local-blocks
+
+  metricsGenerator:
+    enabled: true
+    remoteWriteUrl: http://prometheus-server/api/v1/write
+    processor:
+      local_blocks:
+        filter_server_spans: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes tempo datasource in grafana to match the updated port. 
Updates tempo to the latest chart version (and switches to grafana-community because it's maintained there).
Updates to use typed configuration instead of overriding the full config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13724

/area devtools