### PR TITLE
🌱 Extend stale controller mitigation in MD controller to MS deletion

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -90,7 +90,8 @@ type Reconciler struct {
 	recorder   record.EventRecorder
 	ssaCache   ssa.Cache
 
-	canUpdateMachineSetCache cache.Cache[CanUpdateMachineSetCacheEntry]
+	canUpdateMachineSetCache   cache.Cache[CanUpdateMachineSetCacheEntry]
+	msClientWithDeleteResponse capicontrollerutil.ClientWithDeleteResponse
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
@@ -130,6 +131,11 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
+	r.msClientWithDeleteResponse, err = capicontrollerutil.NewClientWithDeleteResponse(&clusterv1.MachineSet{}, msGR,
+		mgr.GetScheme(), mgr.GetConfig(), mgr.GetHTTPClient())
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
 	r.canUpdateMachineSetCache = cache.New[CanUpdateMachineSetCacheEntry](ctx, cache.HookCacheDefaultTTL)
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -32,7 +32,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/mdutil"
-	clientutil "sigs.k8s.io/cluster-api/internal/util/client"
 	"sigs.k8s.io/cluster-api/util/collections"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 )
@@ -326,7 +325,6 @@ func (r *Reconciler) cleanupDeployment(ctx context.Context, oldMSs []*clusterv1.
 
 	sort.Sort(mdutil.MachineSetsByCreationTimestamp(cleanableMSes))
 
-	machineSetsDeleted := []*clusterv1.MachineSet{}
 	for i := range cleanableMSCount {
 		ms := cleanableMSes[i]
 		if ms.Spec.Replicas == nil {
@@ -338,18 +336,24 @@ func (r *Reconciler) cleanupDeployment(ctx context.Context, oldMSs []*clusterv1.
 			continue
 		}
 
-		if err := r.Client.Delete(ctx, ms); err != nil && !apierrors.IsNotFound(err) {
-			// Return error instead of aggregating and continuing DELETEs on the theory
-			// that we may be overloading the api server.
-			r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedDelete", "Failed to delete MachineSet %q: %v", ms.Name, err)
-			return errors.Wrapf(err, "failed to delete MachineSet %s (cleanup of old MachineSets)", klog.KObj(ms))
+		if deletedMS, err := r.msClientWithDeleteResponse.Delete(ctx, ms); err != nil {
+			if !apierrors.IsNotFound(err) {
+				// Return error instead of aggregating and continuing DELETEs on the theory
+				// that we may be overloading the api server.
+				r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedDelete", "Failed to delete MachineSet %q: %v", ms.Name, err)
+				return errors.Wrapf(err, "failed to delete MachineSet %s (cleanup of old MachineSets)", klog.KObj(ms))
+			}
+		} else if deletedMS != nil {
+			// If the deletion was successful and the MachineSet had a finalizer when deletion was triggered
+			// deletedMS will contain the MachineSet object after deletion with the resourceVersion set.
+			// If that is the case, defer the next reconcile until the cache observed the MachineSet deletion.
+			r.controller.DeferNextReconcileUntilCacheUpToDate(deployment, msGR, deletedMS)
 		}
-		machineSetsDeleted = append(machineSetsDeleted, ms)
 
 		// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.
 		log.Info(fmt.Sprintf("MachineSet %s deleting (cleanup of old MachineSets)", klog.KObj(ms)), "MachineSet", klog.KObj(ms))
 		r.recorder.Eventf(deployment, corev1.EventTypeNormal, "SuccessfulDelete", "Deleted MachineSet %q", ms.Name)
 	}
 
-	return clientutil.WaitForObjectsToBeDeletedFromTheCache(ctx, r.Client, "MachineSet deletion (cleanup of old MachineSet)", machineSetsDeleted...)
+	return nil
 }

--- a/util/controller/client.go
+++ b/util/controller/client.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// ClientWithDeleteResponse is a client that only implements the Delete method.
+// This Delete method diverges from the controller-runtime Client because it returns
+// the object after deletion when possible.
+type ClientWithDeleteResponse interface {
+	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) (client.Object, error)
+}
+
+// NewClientWithDeleteResponse returns a new ClientWithDeleteResponse.
+func NewClientWithDeleteResponse(obj client.Object, objGR schema.GroupResource, scheme *runtime.Scheme, restConfig *rest.Config, httpClient *http.Client) (ClientWithDeleteResponse, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client: failed to get GVK from object")
+	}
+
+	restClient, err := apiutil.RESTClientForGVK(gvk, false, false, restConfig,
+		serializer.NewCodecFactory(scheme), httpClient)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client: failed to create REST client")
+	}
+
+	return &clientWithDeleteResponse{
+		objGR:      objGR,
+		scheme:     scheme,
+		restClient: restClient,
+	}, nil
+}
+
+type clientWithDeleteResponse struct {
+	objGR      schema.GroupResource
+	scheme     *runtime.Scheme
+	restClient rest.Interface
+}
+
+// Delete deletes an object and returns the object after deletion when possible.
+// If the object had finalizers at the time of deletion the object is returned with deletionTimestamp / RV set.
+// If the object did not have finalizers the object will be gone and the object is not returned.
+func (c *clientWithDeleteResponse) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) (client.Object, error) {
+	deleteOpts := client.DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	// DeepCopy obj to avoid overwriting the object in Into below.
+	// If the object is gone after deletion the apiserver returns metav1.Status
+	// and Into below would zero out the obj.
+	obj = obj.DeepCopyObject().(client.Object)
+
+	err := c.restClient.Delete().
+		NamespaceIfScoped(obj.GetNamespace(), true).
+		Resource(c.objGR.Resource).
+		Name(obj.GetName()).
+		Body(deleteOpts.AsDeleteOptions()).
+		Do(ctx).
+		Into(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the object had finalizers at the time of deletion the object is returned by the kube-apiserver
+	// and obj contains the returned object with deletionTimestamp / RV set.
+	if obj.GetResourceVersion() != "" {
+		return obj, nil
+	}
+
+	return nil, nil
+}

--- a/util/controller/client_test.go
+++ b/util/controller/client_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/test/builder"
+)
+
+func Test_Delete(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	ns, err := env.CreateNamespace(ctx, "test-client")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ms := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ms",
+			Namespace: ns.Name,
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName: "test1",
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test1",
+					Bootstrap: clusterv1.Bootstrap{
+						DataSecretName: ptr.To("data-secret"),
+					},
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						APIGroup: builder.InfrastructureGroupVersion.Group,
+						Kind:     builder.TestInfrastructureMachineTemplateKind,
+						Name:     "inframachinetemplate",
+					},
+				},
+			},
+		},
+	}
+	msWithFinalizer := ms.DeepCopy()
+	msWithFinalizer.Name = "ms-with-finalizer"
+	msWithFinalizer.Finalizers = []string{"finalizer.example.com/test"}
+
+	c, err := NewClientWithDeleteResponse(
+		&clusterv1.MachineSet{}, schema.GroupResource{
+			Group:    clusterv1.GroupVersion.Group,
+			Resource: "machinesets",
+		},
+		env.GetScheme(), env.GetConfig(), env.GetHTTPClient())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(env.CreateAndWait(ctx, ms)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, msWithFinalizer)).To(Succeed())
+
+	msOriginal := ms.DeepCopy()
+	deletedMS, err := c.Delete(ctx, ms)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ms).To(Equal(msOriginal))
+	g.Expect(deletedMS).To(BeNil())
+
+	msOriginal = msWithFinalizer.DeepCopy()
+	deletedMS, err = c.Delete(ctx, msWithFinalizer)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(msWithFinalizer).To(Equal(msOriginal))
+	g.Expect(msWithFinalizer).ToNot(BeNil())
+	g.Expect(deletedMS.GetResourceVersion()).ToNot(BeEmpty())
+}

--- a/util/controller/suite_test.go
+++ b/util/controller/suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"os"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+var (
+	env *envtest.Environment
+	ctx = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13725

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->