### PR TITLE
✨ Allow retry during EnsureInstalled for cert-manager

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -247,7 +247,7 @@ type fakeCertManagerClient struct {
 
 var _ cluster.CertManagerClient = &fakeCertManagerClient{}
 
-func (p *fakeCertManagerClient) EnsureInstalled(_ context.Context) error {
+func (p *fakeCertManagerClient) EnsureInstalled(_ context.Context, _ bool) error {
 	return nil
 }
 

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -66,7 +66,7 @@ type CertManagerUpgradePlan struct {
 type CertManagerClient interface {
 	// EnsureInstalled makes sure cert-manager is running and its API is available.
 	// This is required to install a new provider.
-	EnsureInstalled(ctx context.Context) error
+	EnsureInstalled(ctx context.Context, waitCertManager bool) error
 
 	// EnsureLatestVersion checks the cert-manager version currently installed, and if it is
 	// older than the version currently suggested by clusterctl, upgrades it.
@@ -149,11 +149,11 @@ func (cm *certManagerClient) certManagerNamespaceExists(ctx context.Context) (bo
 
 // EnsureInstalled makes sure cert-manager is running and its API is available.
 // This is required to install a new provider.
-func (cm *certManagerClient) EnsureInstalled(ctx context.Context) error {
+func (cm *certManagerClient) EnsureInstalled(ctx context.Context, waitCertManager bool) error {
 	log := logf.Log
 
 	// Checking if a version of cert manager supporting cert-manager-test-resources.yaml is already installed and properly working.
-	if err := cm.waitForAPIReady(ctx, false); err == nil {
+	if err := cm.waitForAPIReady(ctx, waitCertManager); err == nil {
 		log.Info("Skipping installing cert-manager as it is already installed")
 		return nil
 	}

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -76,6 +76,9 @@ type InitOptions struct {
 	// WaitProviderTimeout sets the timeout per provider wait installation
 	WaitProviderTimeout time.Duration
 
+	// WaitCertManager instructs the init command to wait for cert-manager to be installed
+	WaitCertManager bool
+
 	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
 	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
 	skipTemplateProcess bool
@@ -142,7 +145,7 @@ func (c *clusterctlClient) Init(ctx context.Context, options InitOptions) ([]Com
 
 	// Before installing the providers, ensure the cert-manager Webhook is in place.
 	certManager := clusterClient.CertManager()
-	if err := certManager.EnsureInstalled(ctx); err != nil {
+	if err := certManager.EnsureInstalled(ctx, options.WaitCertManager); err != nil {
 		return nil, err
 	}
 

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -40,6 +40,7 @@ type initOptions struct {
 	validate                  bool
 	waitProviders             bool
 	waitProviderTimeout       int
+	waitCertManager           bool
 }
 
 var initOpts = &initOptions{}
@@ -115,6 +116,8 @@ func init() {
 		"Wait for providers to be installed.")
 	initCmd.Flags().IntVar(&initOpts.waitProviderTimeout, "wait-provider-timeout", 5*60,
 		"Wait timeout per provider installation in seconds. This value is ignored if --wait-providers is false")
+	initCmd.Flags().BoolVar(&initOpts.waitCertManager, "wait-cert-manager", false,
+		"Wait for cert-manager to be installed before installing providers. Useful if cert-manager is being installed alongside clusterctl by another process.")
 	initCmd.Flags().BoolVar(&initOpts.validate, "validate", true,
 		"If true, clusterctl will validate that the deployments will succeed on the management cluster.")
 
@@ -143,6 +146,7 @@ func runInit() error {
 		LogUsageInstructions:      true,
 		WaitProviders:             initOpts.waitProviders,
 		WaitProviderTimeout:       time.Duration(initOpts.waitProviderTimeout) * time.Second,
+		WaitCertManager:           initOpts.waitCertManager,
 		IgnoreValidationErrors:    !initOpts.validate,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses issue #13485. During `clusterctl init`, cert-manager is verified via `EnsureInstalled()`. However, the initial test resources installation check (`waitForAPIReady(ctx, false)`) does not allow retrying. If cert-manager is being installed simultaneously by another external process (like an automated Helm job), `clusterctl init` will fail immediately instead of waiting.

This PR adds a `--wait-cert-manager` flag to `clusterctl init`. When enabled, it allows `EnsureInstalled()` to retry during the initial check, utilizing the existing `cert-manager.timeout` configuration.

**Which issue(s) this PR fixes**:
Fixes #13485

**Notes**:
The change updates the `EnsureInstalled` interface in `client/cluster/cert_manager.go` to accept the `waitCertManager` boolean flag and passes it down from the `clusterctl init` options.