### PR TITLE
🌱test: add edge case tests for EnsureKubeadmPermissions

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
@@ -140,6 +140,119 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			targetVersion: semver.MustParse("1.38.0"),
 			wantObjs:      nil,
 		},
+		{
+			name:          "Pre-release version 1.38.0-alpha.0 should be treated as >= 1.38.0 and not create ClusterRoleBindings",
+			objs:          nil,
+			targetVersion: semver.MustParse("1.38.0-alpha.0"),
+			wantObjs:      nil,
+		},
+		{
+			name:          "Pre-release version 1.37.0-alpha.0 should be treated as < 1.38.0 and create ClusterRoleBindings",
+			objs:          nil,
+			targetVersion: semver.MustParse("1.37.0-alpha.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-admin",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.GroupKind,
+							Name: ClusterAdminsGroupAndClusterRoleBinding,
+						},
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     KubeletAPIAdminClusterRoleName,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.UserKind,
+							Name: APIServerKubeletClientCertCommonName,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Only kubeadm:cluster-admins exists for K8s <= 1.37: create only kubeadm:apiserver-kubelet-client",
+			objs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+				},
+			},
+			targetVersion: semver.MustParse("1.37.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     KubeletAPIAdminClusterRoleName,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.UserKind,
+							Name: APIServerKubeletClientCertCommonName,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Only kubeadm:apiserver-kubelet-client exists for K8s <= 1.37: create only kubeadm:cluster-admins",
+			objs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+				},
+			},
+			targetVersion: semver.MustParse("1.37.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-admin",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.GroupKind,
+							Name: ClusterAdminsGroupAndClusterRoleBinding,
+						},
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds edge case test coverage for `EnsureKubeadmPermissions` in `controlplane/kubeadm/internal`.

The existing tests covered the main paths (both CRBs created, both pre-existing, version >= 1.38 no-op). This PR adds 4 new test cases for less obvious scenarios:

- **Pre-release boundary at 1.38.0**: `1.38.0-alpha.0` is treated as `>= 1.38.0` (no CRBs created), confirming `WithoutPreReleases()` behavior at the cutoff
- **Pre-release below 1.38.0**: `1.37.0-alpha.0` is treated as `< 1.38.0` (both CRBs created)
- **Partial existence (first only)**: `kubeadm:cluster-admins` already exists, only `kubeadm:apiserver-kubelet-client` is created
- **Partial existence (second only)**: `kubeadm:apiserver-kubelet-client` already exists, only `kubeadm:cluster-admins` is created

No production code changes — test-only PR.

## Test plan

- [x] `go build ./controlplane/kubeadm/internal/` passes
- [ ] CI test run confirms all 8 test cases pass (envtest requires etcd)

### Disclosure
I used AI tools to help prepare this PR, and I reviewed and verified the changes myself.