### PR TITLE
🌱 test: improve KCP remediation ack signal diagnostics and reset handling

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -274,6 +274,7 @@ intervals:
   node-drain/wait-machine-deleted: ["2m", "10s"]
   kcp-remediation/wait-machines: ["5m", "10s"]
   kcp-remediation/check-machines-stable: ["30s", "5s"]
+  kcp-remediation/wait-ack-signal: ["3m", "10s"]
   kcp-remediation/wait-machine-provisioned: ["5m", "10s"]
   #  Giving a bit more time during scale tests, we analyze independently if everything works quickly enough.
   scale/wait-cluster: ["10m", "10s"]

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -274,7 +274,6 @@ intervals:
   node-drain/wait-machine-deleted: ["2m", "10s"]
   kcp-remediation/wait-machines: ["5m", "10s"]
   kcp-remediation/check-machines-stable: ["30s", "5s"]
-  kcp-remediation/wait-ack-signal: ["3m", "10s"]
   kcp-remediation/wait-machine-provisioned: ["5m", "10s"]
   #  Giving a bit more time during scale tests, we analyze independently if everything works quickly enough.
   scale/wait-cluster: ["10m", "10s"]

--- a/test/e2e/kcp_remediations.go
+++ b/test/e2e/kcp_remediations.go
@@ -54,6 +54,7 @@ type KCPRemediationSpecInput struct {
 	// - wait-cluster, used when waiting for the cluster infrastructure to be provisioned.
 	// - wait-machines, used when waiting for an old machine to be remediated and a new one provisioned.
 	// - check-machines-stable, used when checking that the current list of machines in stable.
+	// - wait-ack-signal, used when waiting for a bootstrapping machine to acknowledge a bootstrap signal.
 	// - wait-machine-provisioned, used when waiting for a machine to be provisioned after unblocking bootstrap.
 	E2EConfig             *clusterctl.E2EConfig
 	ClusterctlConfigPath  string
@@ -204,10 +205,11 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", firstMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:    input.BootstrapClusterProxy.GetClient(),
-			Namespace: namespace.Name,
-			Machine:   firstMachineReplacementName,
-			Signal:    "pass",
+			Client:                    input.BootstrapClusterProxy.GetClient(),
+			Namespace:                 namespace.Name,
+			Machine:                   firstMachineReplacementName,
+			Signal:                    "pass",
+			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", firstMachineReplacementName)
 		Eventually(func() bool {
@@ -285,10 +287,11 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", secondMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:    input.BootstrapClusterProxy.GetClient(),
-			Namespace: namespace.Name,
-			Machine:   secondMachineReplacementName,
-			Signal:    "pass",
+			Client:                    input.BootstrapClusterProxy.GetClient(),
+			Namespace:                 namespace.Name,
+			Machine:                   secondMachineReplacementName,
+			Signal:                    "pass",
+			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", secondMachineReplacementName)
 		Eventually(func() bool {
@@ -327,10 +330,11 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", thirdMachineName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:    input.BootstrapClusterProxy.GetClient(),
-			Namespace: namespace.Name,
-			Machine:   thirdMachineName,
-			Signal:    "pass",
+			Client:                    input.BootstrapClusterProxy.GetClient(),
+			Namespace:                 namespace.Name,
+			Machine:                   thirdMachineName,
+			Signal:                    "pass",
+			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", thirdMachineName)
 		Eventually(func() bool {
@@ -396,10 +400,11 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", thirdMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:    input.BootstrapClusterProxy.GetClient(),
-			Namespace: namespace.Name,
-			Machine:   thirdMachineReplacementName,
-			Signal:    "pass",
+			Client:                    input.BootstrapClusterProxy.GetClient(),
+			Namespace:                 namespace.Name,
+			Machine:                   thirdMachineReplacementName,
+			Signal:                    "pass",
+			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", thirdMachineReplacementName)
 		Eventually(func() bool {
@@ -517,10 +522,11 @@ func createWorkloadClusterAndWait(ctx context.Context, input createWorkloadClust
 }
 
 type sendSignalToBootstrappingMachineInput struct {
-	Client    client.Client
-	Namespace string
-	Machine   string
-	Signal    string
+	Client                    client.Client
+	Namespace                 string
+	Machine                   string
+	Signal                    string
+	WaitForAckSignalIntervals []interface{}
 }
 
 // sendSignalToBootstrappingMachine sends a signal to a machine stuck during bootstrap.
@@ -548,7 +554,7 @@ func sendSignalToBootstrappingMachine(ctx context.Context, input sendSignalToBoo
 		}
 		g.Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(latestCM), latestCM)).To(Succeed())
 		g.Expect(latestCM.Data).To(HaveKeyWithValue(configMapDataKey, fmt.Sprintf("ack-%s", input.Signal)))
-	}, "1m", "10s").Should(Succeed(), "Failed to get ack signal from machine %s", input.Machine)
+	}, input.WaitForAckSignalIntervals...).Should(Succeed(), "Failed to get ack signal from machine %s", input.Machine)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/kcp_remediations.go
+++ b/test/e2e/kcp_remediations.go
@@ -54,7 +54,6 @@ type KCPRemediationSpecInput struct {
 	// - wait-cluster, used when waiting for the cluster infrastructure to be provisioned.
 	// - wait-machines, used when waiting for an old machine to be remediated and a new one provisioned.
 	// - check-machines-stable, used when checking that the current list of machines in stable.
-	// - wait-ack-signal, used when waiting for a bootstrapping machine to acknowledge a bootstrap signal.
 	// - wait-machine-provisioned, used when waiting for a machine to be provisioned after unblocking bootstrap.
 	E2EConfig             *clusterctl.E2EConfig
 	ClusterctlConfigPath  string
@@ -205,11 +204,10 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", firstMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:                    input.BootstrapClusterProxy.GetClient(),
-			Namespace:                 namespace.Name,
-			Machine:                   firstMachineReplacementName,
-			Signal:                    "pass",
-			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
+			Client:    input.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Machine:   firstMachineReplacementName,
+			Signal:    "pass",
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", firstMachineReplacementName)
 		Eventually(func() bool {
@@ -287,11 +285,10 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", secondMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:                    input.BootstrapClusterProxy.GetClient(),
-			Namespace:                 namespace.Name,
-			Machine:                   secondMachineReplacementName,
-			Signal:                    "pass",
-			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
+			Client:    input.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Machine:   secondMachineReplacementName,
+			Signal:    "pass",
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", secondMachineReplacementName)
 		Eventually(func() bool {
@@ -330,11 +327,10 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", thirdMachineName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:                    input.BootstrapClusterProxy.GetClient(),
-			Namespace:                 namespace.Name,
-			Machine:                   thirdMachineName,
-			Signal:                    "pass",
-			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
+			Client:    input.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Machine:   thirdMachineName,
+			Signal:    "pass",
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", thirdMachineName)
 		Eventually(func() bool {
@@ -400,11 +396,10 @@ func KCPRemediationSpec(ctx context.Context, inputGetter func() KCPRemediationSp
 
 		Byf("Unblock bootstrap for Machine %s and wait for it to be provisioned", thirdMachineReplacementName)
 		sendSignalToBootstrappingMachine(ctx, sendSignalToBootstrappingMachineInput{
-			Client:                    input.BootstrapClusterProxy.GetClient(),
-			Namespace:                 namespace.Name,
-			Machine:                   thirdMachineReplacementName,
-			Signal:                    "pass",
-			WaitForAckSignalIntervals: input.E2EConfig.GetIntervals(specName, "wait-ack-signal"),
+			Client:    input.BootstrapClusterProxy.GetClient(),
+			Namespace: namespace.Name,
+			Machine:   thirdMachineReplacementName,
+			Signal:    "pass",
 		})
 		log.Logf("Waiting for Machine %s to be provisioned", thirdMachineReplacementName)
 		Eventually(func() bool {
@@ -522,11 +517,10 @@ func createWorkloadClusterAndWait(ctx context.Context, input createWorkloadClust
 }
 
 type sendSignalToBootstrappingMachineInput struct {
-	Client                    client.Client
-	Namespace                 string
-	Machine                   string
-	Signal                    string
-	WaitForAckSignalIntervals []interface{}
+	Client    client.Client
+	Namespace string
+	Machine   string
+	Signal    string
 }
 
 // sendSignalToBootstrappingMachine sends a signal to a machine stuck during bootstrap.
@@ -546,15 +540,9 @@ func sendSignalToBootstrappingMachine(ctx context.Context, input sendSignalToBoo
 
 	log.Logf("Waiting for Machine %s to acknowledge signal %s has been received", input.Machine, input.Signal)
 	Eventually(func(g Gomega) {
-		latestCM := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      configMapName,
-				Namespace: input.Namespace,
-			},
-		}
-		g.Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(latestCM), latestCM)).To(Succeed())
-		g.Expect(latestCM.Data).To(HaveKeyWithValue(configMapDataKey, fmt.Sprintf("ack-%s", input.Signal)))
-	}, input.WaitForAckSignalIntervals...).Should(Succeed(), "Failed to get ack signal from machine %s", input.Machine)
+		g.Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(cmWithSignal), cmWithSignal)).To(Succeed())
+		g.Expect(cmWithSignal.Data).To(HaveKeyWithValue(configMapDataKey, fmt.Sprintf("ack-%s", input.Signal)))
+	}, "1m", "10s").Should(Succeed(), "Failed to get ack signal from machine %s", input.Machine)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -565,18 +553,9 @@ func sendSignalToBootstrappingMachine(ctx context.Context, input sendSignalToBoo
 	Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 
 	// Resetting the signal in the config map.
-	// We re-fetch the ConfigMap to get the current state as the base for the merge patch,
-	// ensuring the reset patch correctly computes the diff from the current value to "hold".
-	cmForReset := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: input.Namespace,
-		},
-	}
-	Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(cmForReset), cmForReset)).To(Succeed(), "failed to get mhc-test config map for reset")
-	cmForResetBase := cmForReset.DeepCopy()
-	cmForReset.Data[configMapDataKey] = "hold"
-	Expect(input.Client.Patch(ctx, cmForReset, client.MergeFrom(cmForResetBase))).To(Succeed(), "failed to patch mhc-test config map")
+	cmWithSignalBase := cmWithSignal.DeepCopy()
+	cmWithSignal.Data[configMapDataKey] = "hold"
+	Expect(input.Client.Patch(ctx, cmWithSignal, client.MergeFrom(cmWithSignalBase))).To(Succeed(), "failed to patch mhc-test config map")
 }
 
 type waitForMachinesInput struct {

--- a/test/e2e/kcp_remediations.go
+++ b/test/e2e/kcp_remediations.go
@@ -539,10 +539,16 @@ func sendSignalToBootstrappingMachine(ctx context.Context, input sendSignalToBoo
 	Expect(input.Client.Patch(ctx, cmWithSignal, client.MergeFrom(cm))).To(Succeed(), "failed to patch mhc-test config map")
 
 	log.Logf("Waiting for Machine %s to acknowledge signal %s has been received", input.Machine, input.Signal)
-	Eventually(func() string {
-		_ = input.Client.Get(ctx, client.ObjectKeyFromObject(cmWithSignal), cmWithSignal)
-		return cmWithSignal.Data[configMapDataKey]
-	}, "1m", "10s").Should(Equal(fmt.Sprintf("ack-%s", input.Signal)), "Failed to get ack signal from machine %s", input.Machine)
+	Eventually(func(g Gomega) {
+		latestCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: input.Namespace,
+			},
+		}
+		g.Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(latestCM), latestCM)).To(Succeed())
+		g.Expect(latestCM.Data).To(HaveKeyWithValue(configMapDataKey, fmt.Sprintf("ack-%s", input.Signal)))
+	}, "1m", "10s").Should(Succeed(), "Failed to get ack signal from machine %s", input.Machine)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -552,9 +558,19 @@ func sendSignalToBootstrappingMachine(ctx context.Context, input sendSignalToBoo
 	}
 	Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(machine), machine)).To(Succeed())
 
-	// Resetting the signal in the config map
-	cmWithSignal.Data[configMapDataKey] = "hold"
-	Expect(input.Client.Patch(ctx, cmWithSignal, client.MergeFrom(cm))).To(Succeed(), "failed to patch mhc-test config map")
+	// Resetting the signal in the config map.
+	// We re-fetch the ConfigMap to get the current state as the base for the merge patch,
+	// ensuring the reset patch correctly computes the diff from the current value to "hold".
+	cmForReset := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: input.Namespace,
+		},
+	}
+	Expect(input.Client.Get(ctx, client.ObjectKeyFromObject(cmForReset), cmForReset)).To(Succeed(), "failed to get mhc-test config map for reset")
+	cmForResetBase := cmForReset.DeepCopy()
+	cmForReset.Data[configMapDataKey] = "hold"
+	Expect(input.Client.Patch(ctx, cmForReset, client.MergeFrom(cmForResetBase))).To(Succeed(), "failed to patch mhc-test config map")
 }
 
 type waitForMachinesInput struct {


### PR DESCRIPTION
### Changes

- Uses the `func(g Gomega)` form in the `Eventually` block so API errors and value mismatches are visible in the final failure output.
- Uses the ConfigMap state observed during the successful ack poll as the `MergeFrom` base before resetting the signal to `"hold"`.
- This ensures the reset patch is computed as `"ack-pass" -> "hold"` instead of comparing against the ConfigMap state captured at the start of the function.

### Notes

The observed failures in #13686 timed out while waiting for the ack signal. This PR does not prove or claim to fix that timeout root cause. It only improves diagnostics around the ack wait and fixes the correctness of the reset path after an ack is observed.

### Disclosure

I used AI tools to help prepare this PR, and I reviewed and verified the changes myself.
