### PR TITLE
✨ Add configuration `ExternallyProvisioned` for clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -153,16 +153,22 @@ func (cm *certManagerClient) certManagerNamespaceExists(ctx context.Context) (bo
 func (cm *certManagerClient) EnsureInstalled(ctx context.Context) error {
 	log := logf.Log
 
-	// Checking if a version of cert manager supporting cert-manager-test-resources.yaml is already installed and properly working.
-	if err := cm.waitForAPIReady(ctx, false); err == nil {
-		log.Info("Skipping installing cert-manager as it is already installed")
-		return nil
-	}
-
 	config, err := cm.configClient.CertManager().Get()
 	if err != nil {
 		return err
 	}
+	externallyProvisioned := config.ExternallyProvisioned()
+	// Checking if a version of cert manager supporting cert-manager-test-resources.yaml is already installed and properly working.
+	err = cm.waitForAPIReady(ctx, externallyProvisioned)
+	if err == nil {
+		log.Info("Skipping installing cert-manager as it is already installed")
+		return nil
+	}
+
+	if externallyProvisioned && err != nil {
+		return err
+	}
+
 	objs, err := cm.getManifestObjs(ctx, config)
 	if err != nil {
 		return err

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -110,7 +110,7 @@ func Test_getManifestObjs(t *testing.T) {
 			name: "successfully gets the cert-manager components for a custom release",
 			fields: fields{
 				configClient: func() config.Client {
-					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "").WithCertManager("", "v1.0.0", "")))
+					configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader().WithImageMeta(config.CertManagerImageComponent, "bar-repository.io", "", "").WithCertManager("", "v1.0.0", "", false)))
 					g.Expect(err).ToNot(HaveOccurred())
 					return configClient
 				}(),
@@ -185,12 +185,12 @@ func Test_GetTimeout(t *testing.T) {
 		},
 		{
 			name:   "a custom value of timeout is set",
-			config: newFakeConfig().WithCertManager("", "", "5m"),
+			config: newFakeConfig().WithCertManager("", "", "5m", false),
 			want:   5 * time.Minute,
 		},
 		{
 			name:   "invalid custom value of timeout is set",
-			config: newFakeConfig().WithCertManager("", "", "foo"),
+			config: newFakeConfig().WithCertManager("", "", "foo", false),
 			want:   10 * time.Minute,
 		},
 	}
@@ -464,7 +464,7 @@ func Test_shouldUpgrade(t *testing.T) {
 			g := NewWithT(t)
 
 			proxy := test.NewFakeProxy()
-			fakeConfigClient := newFakeConfig().WithCertManager("", tt.configVersion, "")
+			fakeConfigClient := newFakeConfig().WithCertManager("", tt.configVersion, "", false)
 			pollImmediateWaiter := func(context.Context, time.Duration, time.Duration, wait.ConditionWithContextFunc) error {
 				return nil
 			}
@@ -886,7 +886,7 @@ func (f *fakeConfigClient) WithProvider(provider config.Provider) *fakeConfigCli
 	return f
 }
 
-func (f *fakeConfigClient) WithCertManager(url, version, timeout string) *fakeConfigClient {
-	f.fakeReader.WithCertManager(url, version, timeout)
+func (f *fakeConfigClient) WithCertManager(url, version, timeout string, externallyProvisioned bool) *fakeConfigClient {
+	f.fakeReader.WithCertManager(url, version, timeout, externallyProvisioned)
 	return f
 }

--- a/cmd/clusterctl/client/config/cert_manager.go
+++ b/cmd/clusterctl/client/config/cert_manager.go
@@ -29,13 +29,18 @@ type CertManager interface {
 	// Timeout returns the timeout for cert-manager to start.
 	// If empty, 10m will be used.
 	Timeout() string
+
+	// ExternallyProvisioned returns the true/false to be used when clusterctl init is initialized.
+	// This checks to see if cert-manager has been installed outside of clusterctl
+	ExternallyProvisioned() bool
 }
 
 // certManager implements CertManager.
 type certManager struct {
-	url     string
-	version string
-	timeout string
+	url                   string
+	version               string
+	timeout               string
+	externallyProvisioned bool
 }
 
 // ensure certManager implements CertManager.
@@ -53,11 +58,16 @@ func (p *certManager) Timeout() string {
 	return p.timeout
 }
 
+func (p *certManager) ExternallyProvisioned() bool {
+	return p.externallyProvisioned
+}
+
 // NewCertManager creates a new CertManager with the given configuration.
-func NewCertManager(url, version, timeout string) CertManager {
+func NewCertManager(url, version, timeout string, externallyProvisioned bool) CertManager {
 	return &certManager{
-		url:     url,
-		version: version,
-		timeout: timeout,
+		url:                   url,
+		version:               version,
+		timeout:               timeout,
+		externallyProvisioned: externallyProvisioned,
 	}
 }

--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/drone/envsubst/v2"
@@ -62,15 +63,17 @@ func newCertManagerClient(reader Reader) *certManagerClient {
 
 // configCertManager mirrors config.CertManager interface and allows serialization of the corresponding info.
 type configCertManager struct {
-	URL     string `json:"url,omitempty"`
-	Version string `json:"version,omitempty"`
-	Timeout string `json:"timeout,omitempty"`
+	URL                   string `json:"url,omitempty"`
+	Version               string `json:"version,omitempty"`
+	Timeout               string `json:"timeout,omitempty"`
+	ExternallyProvisioned string `json:"externallyProvisioned,omitempty"`
 }
 
 func (p *certManagerClient) Get() (CertManager, error) {
 	url := CertManagerDefaultURL
 	version := CertManagerDefaultVersion
 	timeout := CertManagerDefaultTimeout.String()
+	externallyProvisioned := false
 
 	userCertManager := &configCertManager{}
 	if err := p.reader.UnmarshalKey(CertManagerConfigKey, &userCertManager); err != nil {
@@ -91,6 +94,12 @@ func (p *certManagerClient) Get() (CertManager, error) {
 	if userCertManager.Timeout != "" {
 		timeout = userCertManager.Timeout
 	}
+	if userCertManager.ExternallyProvisioned != "" {
+		externallyProvisioned, err = strconv.ParseBool(userCertManager.ExternallyProvisioned)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	return NewCertManager(url, version, timeout), nil
+	return NewCertManager(url, version, timeout, externallyProvisioned), nil
 }

--- a/cmd/clusterctl/client/config/cert_manager_client_test.go
+++ b/cmd/clusterctl/client/config/cert_manager_client_test.go
@@ -40,34 +40,42 @@ func TestCertManagerGet(t *testing.T) {
 			fields: fields{
 				reader: test.NewFakeReader(),
 			},
-			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, CertManagerDefaultTimeout.String()),
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, CertManagerDefaultTimeout.String(), false),
 			wantErr: false,
 		},
 		{
 			name: "return custom url if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("foo-url", "vX.Y.Z", ""),
+				reader: test.NewFakeReader().WithCertManager("foo-url", "vX.Y.Z", "", false),
 			},
-			want:    NewCertManager("foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String()),
+			want:    NewCertManager("foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String(), false),
 			wantErr: false,
 		},
 		{
 			name: "return custom url with evaluated env vars if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("${TEST_REPO_PATH}/foo-url", "vX.Y.Z", ""),
+				reader: test.NewFakeReader().WithCertManager("${TEST_REPO_PATH}/foo-url", "vX.Y.Z", "", false),
 			},
 			envVars: map[string]string{
 				"TEST_REPO_PATH": "/tmp/test",
 			},
-			want:    NewCertManager("/tmp/test/foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String()),
+			want:    NewCertManager("/tmp/test/foo-url", "vX.Y.Z", CertManagerDefaultTimeout.String(), false),
 			wantErr: false,
 		},
 		{
 			name: "return timeout if defined",
 			fields: fields{
-				reader: test.NewFakeReader().WithCertManager("", "", "5m"),
+				reader: test.NewFakeReader().WithCertManager("", "", "5m", false),
 			},
-			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, "5m"),
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, "5m", false),
+			wantErr: false,
+		},
+		{
+			name: "return externallyProvisioned if defined",
+			fields: fields{
+				reader: test.NewFakeReader().WithCertManager("", "", "5m", true),
+			},
+			want:    NewCertManager(CertManagerDefaultURL, CertManagerDefaultVersion, "5m", true),
 			wantErr: false,
 		},
 	}

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -45,9 +45,10 @@ type configProvider struct {
 // configCertManager is a mirror of config.CertManager, re-implemented here in order to
 // avoid circular dependencies between pkg/client/config and pkg/internal/test.
 type configCertManager struct {
-	URL     string `json:"url,omitempty"`
-	Version string `json:"version,omitempty"`
-	Timeout string `json:"timeout,omitempty"`
+	URL                   string `json:"url,omitempty"`
+	Version               string `json:"version,omitempty"`
+	Timeout               string `json:"timeout,omitempty"`
+	ExternallyProvisioned bool   `json:"externallyProvisioned,omitempty"`
 }
 
 // imageMeta is a mirror of config.imageMeta, re-implemented here in order to
@@ -107,11 +108,12 @@ func (f *FakeReader) WithProvider(name string, ttype clusterctlv1.ProviderType, 
 	return f
 }
 
-func (f *FakeReader) WithCertManager(url, version, timeout string) *FakeReader {
+func (f *FakeReader) WithCertManager(url, version, timeout string, externallyProvisioned bool) *FakeReader {
 	f.certManager = configCertManager{
-		URL:     url,
-		Version: version,
-		Timeout: timeout,
+		URL:                   url,
+		Version:               version,
+		Timeout:               timeout,
+		ExternallyProvisioned: externallyProvisioned,
 	}
 
 	yaml, _ := yaml.Marshal(f.certManager)

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -102,6 +102,18 @@ If no value is specified, or the format is invalid, the default value of 10 minu
 
 Please note that the configuration above will be considered also when doing `clusterctl upgrade plan` or `clusterctl upgrade apply`.
 
+For situations when you are using your own cert-manager installation, you can tell clusterctl init that cert-manager is already installed by adding a field to the clusterctl config file, for example:
+
+```yaml
+cert-manager:
+  ...
+  externallyProvisioned: true
+  timeout: 15m
+  ...
+```
+
+This will use the provided timeout value to wait for the externally installed cert-manager installation and **not** install cert-manager.  If the externally provisioned cert-manager installation fails, clusterctl will fail to initialize the management cluster.
+
 ## Migrating to user-managed cert-manager
 
 You may want to migrate to a user-managed cert-manager further down the line, after initialising cert-manager on the management cluster through `clusterctl`.

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -112,7 +112,7 @@ cert-manager:
   ...
 ```
 
-This will use the provided timeout value to wait for the externally installed cert-manager installation and **not** install cert-manager.  If the externally provisioned cert-manager installation fails, clusterctl will fail to initialize the management cluster.
+If the `externallyProvisioned` flag is set, clusterctl will not install cert-manager but only test if it is proper working. If cert-manager is not working the test will be repeated until `timeout` expires; after that clusterctl int will stop and report an error.
 
 ## Migrating to user-managed cert-manager
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This adds a configuration to allow the user to specify a waiting period (duration) before trying to install cert-manager test resources `clusterctl init`.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #13485 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area clusterctl 