### PR TITLE
✨  Migrate templates to use Dev* instead of Docker*

### DIFF
--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -10,7 +10,7 @@ spec:
       name: quick-start-control-plane
     machineInfrastructure:
       templateRef:
-        kind: DockerMachineTemplate
+        kind: DevMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         name: quick-start-control-plane
     healthCheck:
@@ -32,7 +32,7 @@ spec:
   infrastructure:
     templateRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: DockerClusterTemplate
+      kind: DevClusterTemplate
       name: quick-start-cluster
   workers:
     machineDeployments:
@@ -45,7 +45,7 @@ spec:
       infrastructure:
         templateRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: DockerMachineTemplate
+          kind: DevMachineTemplate
           name: quick-start-default-worker-machinetemplate
       healthCheck:
         checks:
@@ -73,7 +73,7 @@ spec:
       infrastructure:
         templateRef:
           apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: DockerMachinePoolTemplate
+          kind: DevMachinePoolTemplate
           name: quick-start-default-worker-machinepooltemplate
   variables:
   - name: imageRepository
@@ -169,42 +169,42 @@ spec:
           template: |
             imageTag: {{ .coreDNSImageTag }}
   - name: customImage
-    description: "Sets the container image that is used for running dockerMachines for the controlPlane and default-worker machineDeployments."
+    description: "Sets the container image that is used for running devMachines for the controlPlane and default-worker machineDeployments."
     definitions:
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-        kind: DockerMachineTemplate
+        kind: DevMachineTemplate
         matchResources:
           machineDeploymentClass:
             names:
             - default-worker
       jsonPatches:
       - op: add
-        path: "/spec/template/spec/customImage"
+        path: "/spec/template/spec/backend/docker/customImage"
         valueFrom:
           template: |
             kindest/node:{{ .builtin.machineDeployment.version | replace "+" "_" }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-        kind: DockerMachinePoolTemplate
+        kind: DevMachinePoolTemplate
         matchResources:
           machinePoolClass:
             names:
             - default-worker
       jsonPatches:
       - op: add
-        path: "/spec/template/spec/template/customImage"
+        path: "/spec/template/spec/backend/docker/customImage"
         valueFrom:
           template: |
             kindest/node:{{ .builtin.machinePool.version | replace "+" "_" }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-        kind: DockerMachineTemplate
+        kind: DevMachineTemplate
         matchResources:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: "/spec/template/spec/customImage"
+        path: "/spec/template/spec/backend/docker/customImage"
         valueFrom:
           template: |
             kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
@@ -257,29 +257,31 @@ spec:
     enabledIf: "{{ .podSecurityStandard.enabled }}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: DockerClusterTemplate
+kind: DevClusterTemplate
 metadata:
   name: quick-start-cluster
 spec:
   template:
     spec:
-      failureDomains:
-        - name: fd1
-          controlPlane: true
-        - name: fd2
-          controlPlane: true
-        - name: fd3
-          controlPlane: true
-        - name: fd4
-          controlPlane: true
-        - name: fd5
-          controlPlane: true
-        - name: fd6
-          controlPlane: false
-        - name: fd7
-          controlPlane: false
-        - name: fd8
-          controlPlane: false
+      backend:
+        docker:
+          failureDomains:
+            - name: fd1
+              controlPlane: true
+            - name: fd2
+              controlPlane: true
+            - name: fd3
+              controlPlane: true
+            - name: fd4
+              controlPlane: true
+            - name: fd5
+              controlPlane: true
+            - name: fd6
+              controlPlane: false
+            - name: fd7
+              controlPlane: false
+            - name: fd8
+              controlPlane: false
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
@@ -305,35 +307,40 @@ spec:
                 value: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: DockerMachineTemplate
+kind: DevMachineTemplate
 metadata:
   name: quick-start-control-plane
 spec:
   template:
     spec:
-      extraMounts:
-      - containerPath: "/var/run/docker.sock"
-        hostPath: "/var/run/docker.sock"
+      backend:
+        docker:
+          extraMounts:
+          - containerPath: "/var/run/docker.sock"
+            hostPath: "/var/run/docker.sock"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: DockerMachineTemplate
+kind: DevMachineTemplate
 metadata:
   name: quick-start-default-worker-machinetemplate
 spec:
   template:
     spec:
-      extraMounts:
-      - containerPath: "/var/run/docker.sock"
-        hostPath: "/var/run/docker.sock"
+      backend:
+        docker:
+          extraMounts:
+          - containerPath: "/var/run/docker.sock"
+            hostPath: "/var/run/docker.sock"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-kind: DockerMachinePoolTemplate
+kind: DevMachinePoolTemplate
 metadata:
   name: quick-start-default-worker-machinepooltemplate
 spec:
   template:
     spec:
-      template: {}
+      backend:
+        docker: {}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Migrate templates to use Dev* instead of Docker*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Part of https://github.com/kubernetes-sigs/cluster-api/issues/13270

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->