### PR TITLE
[release-1.12] 🌱 Add GO-2026-5026 to .govuln_exclude

### DIFF
--- a/.govuln_exclude
+++ b/.govuln_exclude
@@ -1,2 +1,4 @@
 # GO-2026-4918: This should not be an issue as KCP only uses the affected code to communicate with the kube-apiserver.
 GO-2026-4918
+# GO-2026-5026: This should not be an issue where idna.ToASCII is used in KCP
+GO-2026-5026


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixing weekly scan - https://github.com/kubernetes-sigs/cluster-api/actions/runs/26402007886/job/77716324748
Bumping go version as `go: golang.org/x/net@v0.55.0 requires go >= 1.25.0; switching to go1.25.10`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area dependency