### PR TITLE
🌱 Add options to runtimesdk e2e test

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -120,6 +120,12 @@ type ClusterUpgradeWithRuntimeSDKSpecInput struct {
 
 	// DeployClusterClassInSeparateNamespace defines if the ClusterClass should be deployed in a separate namespace.
 	DeployClusterClassInSeparateNamespace bool
+
+	// SkipMachineSetPreflightChecksTest allows to skip validation of MachineSetPreflightChecks during execution.
+	SkipMachineSetPreflightChecksTest bool
+
+	// SkipHooksConsistentlyBlockCheck allows to skip validation of checks about hooks consistently blocking during execution.
+	SkipHooksConsistentlyBlockCheck bool
 }
 
 // ClusterUpgradeWithRuntimeSDKSpec implements a spec that upgrades a cluster and runs the Kubernetes conformance suite.
@@ -251,7 +257,8 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 				beforeClusterCreateTestHandler(ctx,
 					input.BootstrapClusterProxy.GetClient(),
 					cluster,
-					input.ExtensionConfigName)
+					input.ExtensionConfigName,
+					input.SkipHooksConsistentlyBlockCheck)
 			},
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
@@ -344,6 +351,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 					fromVersion,              // Cluster fromVersion
 					toVersion,                // Cluster toVersion
 					firstControlPlaneVersion, // firstControlPlaneVersion in the upgrade plan, used to check the BeforeControlPlaneUpgrade is not called before its time.
+					input.SkipHooksConsistentlyBlockCheck,
 				)
 
 				// Then check the upgrade is progressing step by step according to the upgrade plan
@@ -356,6 +364,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 						controlPlaneVersion, // Control plane fromVersion for this upgrade step.
 						version,             // Control plane toVersion for this upgrade step.
 						workersVersion,      // Current workersVersion, used to check workers do not upgrade before its time.
+						input.SkipHooksConsistentlyBlockCheck,
 					)
 
 					// Wait CP to update to version
@@ -378,6 +387,8 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 						workersVersion,          // Current workersVersion, used to check workers do not upgrade before its time.
 						nextControlPlaneVersion, // nextControlPlaneVersion in the upgrade plan, used to check the BeforeControlPlaneUpgrade is not called before its time (in case workers do not perform this upgrade step).
 						toVersion,               // toVersion of the upgrade, used to check the AfterClusterUpgrade is not called before its time (in case workers do not perform this upgrade step).
+						input.SkipMachineSetPreflightChecksTest,
+						input.SkipHooksConsistentlyBlockCheck,
 					)
 
 					// If worker should not upgrade at this step, continue
@@ -392,6 +403,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 						input.ExtensionConfigName,
 						workersVersion, // Current workersVersion for this upgrade step.
 						version,        // Workers toVersion for this upgrade step.
+						input.SkipHooksConsistentlyBlockCheck,
 					)
 
 					// Wait for workers to update to version
@@ -407,6 +419,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 						workersVersion,          // Current workersVersion for this upgrade step.
 						nextControlPlaneVersion, // nextControlPlaneVersion in the upgrade plan, used to check the BeforeControlPlaneUpgrade is not called before its time (in case workers do not perform this upgrade step).
 						toVersion,               // toVersion of the upgrade, used to check the AfterClusterUpgrade is not called before its time (in case workers do not perform this upgrade step).
+						input.SkipHooksConsistentlyBlockCheck,
 					)
 				}
 			},
@@ -418,6 +431,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 			clusterResources.Cluster,
 			input.ExtensionConfigName,
 			toVersion, // toVersion of the upgrade.
+			input.SkipHooksConsistentlyBlockCheck,
 		)
 
 		By("Waiting until nodes are ready")
@@ -452,7 +466,7 @@ func ClusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() Cl
 		By("Dumping resources and deleting the workload cluster; deletion waits for BeforeClusterDeleteHook to gate the operation")
 		dumpAndDeleteCluster(ctx, input.BootstrapClusterProxy, input.ClusterctlConfigPath, namespace.Name, clusterName, input.ArtifactFolder)
 
-		beforeClusterDeleteHandler(ctx, input.BootstrapClusterProxy.GetClient(), clusterResources.Cluster, input.ExtensionConfigName)
+		beforeClusterDeleteHandler(ctx, input.BootstrapClusterProxy.GetClient(), clusterResources.Cluster, input.ExtensionConfigName, input.SkipHooksConsistentlyBlockCheck)
 
 		Byf("Waiting for cluster to be deleted")
 		framework.WaitForClusterDeleted(ctx, framework.WaitForClusterDeletedInput{
@@ -710,7 +724,7 @@ func getLifecycleHookResponsesFromConfigMap(ctx context.Context, c client.Client
 
 // beforeClusterCreateTestHandler calls runtimeHookTestHandler with a blockedCondition function which returns false if
 // the Cluster has a control plane or an infrastructure reference.
-func beforeClusterCreateTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string) {
+func beforeClusterCreateTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "BeforeClusterCreate"
 
 	// for BeforeClusterCreate, the hook is blocking if Get Cluster keep returning a cluster without infraCluster and controlPlaneRef set.
@@ -724,14 +738,14 @@ func beforeClusterCreateTestHandler(ctx context.Context, c client.Client, cluste
 		}
 		return blocked
 	}
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, nil, isBlockingCreate, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, nil, isBlockingCreate, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("BeforeClusterCreate unblocked")
 }
 
 // beforeClusterUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if
 // any of the control plane, machine deployments or machine pools has been updated from the initial Kubernetes version.
-func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion, firstControlPlaneVersion string) {
+func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion, firstControlPlaneVersion string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "BeforeClusterUpgrade"
 	beforeClusterUpgradeAnnotation := clusterv1.BeforeClusterUpgradeHookAnnotationPrefix + "/upgrade-test"
 
@@ -764,10 +778,10 @@ func beforeClusterUpgradeTestHandler(ctx context.Context, c client.Client, clust
 	}
 
 	// BeforeClusterUpgrade can be blocked via an annotation hook. Check it works
-	annotationHookTestHandler(ctx, c, cluster, hookName, beforeClusterUpgradeAnnotation, isBlockingUpgrade)
+	annotationHookTestHandler(ctx, c, cluster, hookName, beforeClusterUpgradeAnnotation, isBlockingUpgrade, skipHooksConsistentlyBlockCheck)
 
 	// Test the BeforeClusterUpgrade hook.
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("BeforeClusterUpgrade from %s to %s unblocked", fromVersion, toVersion)
 }
@@ -801,7 +815,7 @@ func checkVersions(ctx context.Context, c client.Client, cluster *clusterv1.Clus
 
 // beforeControlPlaneUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if
 // any of the control plane, machine deployments or machine pools has been updated from the initial Kubernetes version.
-func beforeControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion, workersVersion string) {
+func beforeControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion, workersVersion string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "BeforeControlPlaneUpgrade"
 
 	// for BeforeControlPlaneUpgrade, the hook is blocking if both controlPlane and workers remain at the expected version (both controlPlane and workers should be at fromVersion)
@@ -825,14 +839,14 @@ func beforeControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, 
 		return true
 	}
 
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("BeforeControlPlaneUpgrade from %s to %s unblocked", fromVersion, toVersion)
 }
 
 // afterControlPlaneUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if any
 // MachineDeployment in the Cluster has upgraded to the target Kubernetes version.
-func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, controlPlaneVersion, workersVersion, nextControlPlaneVersion, topologyVersion string) {
+func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, controlPlaneVersion, workersVersion, nextControlPlaneVersion, topologyVersion string, skipMachineSetPreflightChecksTest bool, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "AfterControlPlaneUpgrade"
 
 	// for AfterControlPlaneUpgrade, the hook is blocking if both controlPlane and workers remain at the expected version (controlPlaneVersion, workersVersion)
@@ -882,18 +896,20 @@ func afterControlPlaneUpgradeTestHandler(ctx context.Context, c client.Client, c
 	}
 
 	beforeUnblockingUpgrade := func() {
-		machineSetPreflightChecksTest(ctx, c, cluster)
+		if !skipMachineSetPreflightChecksTest {
+			machineSetPreflightChecksTest(ctx, c, cluster)
+		}
 	}
 
 	// Test the AfterControlPlaneUpgrade hook and perform machine set preflight checks before unblocking.
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{controlPlaneVersion}, isBlockingUpgrade, beforeUnblockingUpgrade)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{controlPlaneVersion}, isBlockingUpgrade, beforeUnblockingUpgrade, skipHooksConsistentlyBlockCheck)
 
 	Byf("AfterControlPlaneUpgrade to %s unblocked", controlPlaneVersion)
 }
 
 // beforeWorkersUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if
 // any of the control plane, machine deployments or machine pools has been updated from the initial Kubernetes version.
-func beforeWorkersUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion string) {
+func beforeWorkersUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, fromVersion, toVersion string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "BeforeWorkersUpgrade"
 
 	// for BeforeWorkersUpgrade, the hook is blocking if both controlPlane and workers remain at the expected version (controlPlaneVersion should be already at toVersion, workers should be at fromVersion)
@@ -917,14 +933,14 @@ func beforeWorkersUpgradeTestHandler(ctx context.Context, c client.Client, clust
 		return true
 	}
 
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{fromVersion, toVersion}, isBlockingUpgrade, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("BeforeWorkersUpgrade from %s to %s unblocked", fromVersion, toVersion)
 }
 
 // afterWorkersUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false if any
 // MachineDeployment in the Cluster has upgraded to the target Kubernetes version.
-func afterWorkersUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, controlPlaneVersion, workersVersion, nextControlPlaneVersion, topologyVersion string) {
+func afterWorkersUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, controlPlaneVersion, workersVersion, nextControlPlaneVersion, topologyVersion string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "AfterWorkersUpgrade"
 
 	// for AfterWorkersUpgrade, the hook is blocking if both controlPlane and workers remain at the expected version (controlPlaneVersion, workersVersion)
@@ -967,14 +983,14 @@ func afterWorkersUpgradeTestHandler(ctx context.Context, c client.Client, cluste
 		return true
 	}
 
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{workersVersion}, isBlockingUpgrade, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{workersVersion}, isBlockingUpgrade, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("AfterWorkersUpgrade to %s unblocked", workersVersion)
 }
 
 // afterAfterClusterUpgradeTestHandler calls runtimeHookTestHandler with a blocking function which returns false
 // if it is possible to upgrade to the next K8s version.
-func afterAfterClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, topologyVersion string) {
+func afterAfterClusterUpgradeTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, topologyVersion string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "AfterClusterUpgrade"
 
 	v, err := semver.ParseTolerant(topologyVersion)
@@ -993,14 +1009,14 @@ func afterAfterClusterUpgradeTestHandler(ctx context.Context, c client.Client, c
 		return false
 	}
 
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{topologyVersion}, isBlockingUpgrade, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, []string{topologyVersion}, isBlockingUpgrade, nil, skipHooksConsistentlyBlockCheck)
 
 	Byf("AfterClusterUpgrade to %s unblocked", topologyVersion)
 }
 
 // beforeClusterDeleteHandler calls runtimeHookTestHandler with a blocking function which returns false if the Cluster
 // cannot be found in the API server.
-func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string) {
+func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, skipHooksConsistentlyBlockCheck bool) {
 	hookName := "BeforeClusterDelete"
 	clusterObjectKey := client.ObjectKeyFromObject(cluster)
 
@@ -1020,14 +1036,14 @@ func beforeClusterDeleteHandler(ctx context.Context, c client.Client, cluster *c
 		return blocked
 	}
 
-	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, nil, isBlockingDelete, nil)
+	runtimeHookTestHandler(ctx, c, cluster, extensionConfigName, hookName, nil, isBlockingDelete, nil, skipHooksConsistentlyBlockCheck)
 }
 
 // annotationHookTestHandler runs a series of tests in sequence to check if the annotation hook can block.
 // 1. Check if the annotation hook is blocking and if the TopologyReconciled condition reports if the annotation hook is blocking.
 // 2. Remove the annotation hook.
 // 3. Check if the TopologyReconciled condition stops reporting the annotation hook is blocking.
-func annotationHookTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, hook, annotation string, blockingCondition func() bool) {
+func annotationHookTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, hook, annotation string, blockingCondition func() bool, skipHooksConsistentlyBlockCheck bool) {
 	log.Logf("Blocking with the %s annotation hook for 60 seconds", hook)
 
 	expectedBlockingMessage := fmt.Sprintf("annotation %s is set", annotation)
@@ -1053,19 +1069,21 @@ func annotationHookTestHandler(ctx context.Context, c client.Client, cluster *cl
 		return true
 	}, 20*time.Second, 2*time.Second).Should(BeTrue(), "%s (via annotation %s) did not block", hook, annotation)
 
-	Byf("Validating %s hook (via annotation %s) consistently blocks progress in the upgrade", hook, annotation)
+	if !skipHooksConsistentlyBlockCheck {
+		Byf("Validating %s hook (via annotation %s) consistently blocks progress in the upgrade", hook, annotation)
 
-	// Check if the annotation hook keeps blocking.
-	Consistently(func(_ Gomega) bool {
-		if !topologyConditionCheck() {
-			return false
-		}
-		if !blockingCondition() {
-			return false
-		}
-		return true
-	}, 30*time.Second, 2*time.Second).Should(BeTrue(),
-		fmt.Sprintf("Cluster Topology reconciliation continued unexpectedly: hook %s (via annotation %s) is not blocking", hook, annotation))
+		// Check if the annotation hook keeps blocking.
+		Consistently(func(_ Gomega) bool {
+			if !topologyConditionCheck() {
+				return false
+			}
+			if !blockingCondition() {
+				return false
+			}
+			return true
+		}, 30*time.Second, 2*time.Second).Should(BeTrue(),
+			fmt.Sprintf("Cluster Topology reconciliation continued unexpectedly: hook %s (via annotation %s) is not blocking", hook, annotation))
+	}
 
 	// Patch the Cluster to remove the LifecycleHook annotation hook and unblock.
 	Byf("Removing the %s annotation", annotation)
@@ -1099,7 +1117,7 @@ func annotationHookTestHandler(ctx context.Context, c client.Client, cluster *cl
 //
 // Note: runtimeHookTestHandler assumes that the hook passed to it is currently returning a blocking response.
 // Updating the response to be non-blocking happens inline in the function.
-func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, hook string, attributes []string, blockingCondition func() bool, beforeUnblocking func()) {
+func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, extensionConfigName string, hook string, attributes []string, blockingCondition func() bool, beforeUnblocking func(), skipHooksConsistentlyBlockCheck bool) {
 	hookName := computeHookName(hook, attributes)
 	log.Logf("Blocking with the %s hook for 60 seconds", hookName)
 
@@ -1129,13 +1147,15 @@ func runtimeHookTestHandler(ctx context.Context, c client.Client, cluster *clust
 		return nil
 	}, 30*time.Second, 2*time.Second).Should(Succeed(), "%s has not been called", hookName)
 
-	Byf("Validating %s hook consistently blocks progress in the upgrade", hookName)
+	if !skipHooksConsistentlyBlockCheck {
+		Byf("Validating %s hook consistently blocks progress in the upgrade", hookName)
 
-	// Check if the hook keeps blocking.
-	Consistently(func(_ Gomega) bool {
-		return topologyConditionCheck() && blockingCondition()
-	}, 30*time.Second, 5*time.Second).Should(BeTrue(),
-		fmt.Sprintf("Cluster Topology reconciliation continued unexpectedly: hook %s not blocking", hookName))
+		// Check if the hook keeps blocking.
+		Consistently(func(_ Gomega) bool {
+			return topologyConditionCheck() && blockingCondition()
+		}, 30*time.Second, 5*time.Second).Should(BeTrue(),
+			fmt.Sprintf("Cluster Topology reconciliation continued unexpectedly: hook %s not blocking", hookName))
+	}
 
 	if beforeUnblocking != nil {
 		beforeUnblocking()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
runtimesdk e2e test takes a long time, especially when testing with chained upgrades.

This PR introduces two knobs to skip some steps of this test so the test can be speed up e.g. when running locally for troubleshooting 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->