### PR TITLE
🌱 Refactor consistency store to allow defer without previous store registration

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -158,9 +158,6 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("kubeadmcontrolplane", r.ClusterToKubeadmControlPlane,
 			clustercache.WatchForProbeFailure(r.RemoteConditionsGracePeriod))).
-		WithConsistencyStore(map[schema.GroupResource]client.Object{
-			machineGR: &clusterv1.Machine{},
-		}).
 		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/certs"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
@@ -298,7 +299,7 @@ func (r *KubeadmControlPlaneReconciler) createMachine(ctx context.Context, kcp *
 	if err := ssa.Patch(ctx, r.Client, kcpManagerName, machine); err != nil {
 		return err
 	}
-	r.controller.DeferNextReconcileUntilCacheUpToDate(kcp, machineGR, machine.ResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(kcp, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
 	// Remove the annotation tracking that a remediation is in progress (the remediation completed when
 	// the replacement machine has been created above).
 	delete(kcp.Annotations, controlplanev1.RemediationInProgressAnnotation)

--- a/controlplane/kubeadm/internal/controllers/inplace_trigger.go
+++ b/controlplane/kubeadm/internal/controllers/inplace_trigger.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/internal/hooks"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 )
 
 func (r *KubeadmControlPlaneReconciler) triggerInPlaceUpdate(ctx context.Context, controlPlane *internal.ControlPlane, machine *clusterv1.Machine, machineUpToDateResult internal.UpToDateResult) error {
@@ -59,7 +60,7 @@ func (r *KubeadmControlPlaneReconciler) triggerInPlaceUpdate(ctx context.Context
 
 		// Wait until the cache observed the Machine with UpdateInProgressAnnotation to ensure subsequent reconciles
 		// will observe it as well and accordingly don't trigger another in-place update concurrently.
-		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, machineGR, machine.ResourceVersion)
+		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
 	}
 
 	// TODO: If this func fails below we are going to reconcile again and call triggerInPlaceUpdate again. If KCP
@@ -130,7 +131,7 @@ func (r *KubeadmControlPlaneReconciler) triggerInPlaceUpdate(ctx context.Context
 	if err := hooks.MarkAsPending(ctx, r.Client, desiredMachine, true, runtimehooksv1.UpdateMachine); err != nil {
 		return errors.Wrapf(err, "failed to complete triggering in-place update for Machine %s", klog.KObj(machine))
 	}
-	r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, machineGR, desiredMachine.ResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), desiredMachine.ResourceVersion)
 
 	log.Info(fmt.Sprintf("Completed triggering in-place update for Machine %s", klog.KObj(machine)))
 	r.recorder.Event(machine, corev1.EventTypeNormal, "SuccessfulStartInPlaceUpdate", "Machine starting in-place update")

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -359,7 +360,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		})
 		return ctrl.Result{}, errors.Wrapf(err, "failed to delete unhealthy machine %s", machineToBeRemediated.Name)
 	} else if deletedMachine != nil {
-		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, machineGR, deletedMachine.GetResourceVersion())
+		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), deletedMachine.GetResourceVersion())
 	}
 
 	// Surface the operation is in progress.

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 )
 
 func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Context, controlPlane *internal.ControlPlane) (ctrl.Result, error) {
@@ -161,7 +162,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 			return ctrl.Result{}, err
 		}
 	} else if deletedMachine != nil {
-		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, machineGR, deletedMachine.GetResourceVersion())
+		r.controller.DeferNextReconcileUntilCacheUpToDate(controlPlane.KCP, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), deletedMachine.GetResourceVersion())
 	}
 
 	// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -30,7 +30,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -1345,7 +1344,7 @@ func (f fakeController) DeferNextReconcile(_ reconcile.Request, _ time.Time) {}
 
 func (f fakeController) DeferNextReconcileForObject(_ metav1.Object, _ time.Time) {}
 
-func (f fakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ schema.GroupResource, _ string) {
+func (f fakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ capicontrollerutil.GroupVersionKindType, _ string) {
 }
 
 func (f fakeController) ClearConsistencyStore(_ client.ObjectKey, _ types.UID) {}

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -118,9 +118,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		WithConsistencyStore(map[schema.GroupResource]client.Object{
-			msGR: &clusterv1.MachineSet{},
-		}).
 		Watches(
 			&clusterv1.Cluster{},
 			handler.EnqueueRequestsFromMapFunc(clusterToMachineDeployments),
@@ -394,7 +391,7 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 				r.recorder.Eventf(p.md, corev1.EventTypeWarning, "FailedCreate", "Failed to create MachineSet %s: %v", klog.KObj(ms), err)
 				return errors.Wrapf(err, "failed to create MachineSet %s", klog.KObj(ms))
 			}
-			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, msGR, ms.ResourceVersion)
+			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachineSet"), ms.ResourceVersion)
 			if len(p.oldMSs) > 0 {
 				log.Info(fmt.Sprintf("MachineSets need rollout: %s", strings.Join(machineSetNames(p.oldMSs), ", ")), "reason", p.createReason)
 			}
@@ -434,7 +431,7 @@ func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(c
 
 		// Defer next reconcile only if ResourceVersion has changed.
 		if diff.OriginalMS.ResourceVersion != ms.ResourceVersion {
-			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, msGR, ms.ResourceVersion)
+			r.controller.DeferNextReconcileUntilCacheUpToDate(p.md, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachineSet"), ms.ResourceVersion)
 		}
 
 		if diff.DesiredReplicas < diff.OriginalReplicas {

--- a/internal/controllers/machinedeployment/machinedeployment_sync.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/mdutil"
 	"sigs.k8s.io/cluster-api/util/collections"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 )
 
 // sync is responsible for reconciling deployments on scaling events or when they
@@ -347,7 +348,7 @@ func (r *Reconciler) cleanupDeployment(ctx context.Context, oldMSs []*clusterv1.
 			// If the deletion was successful and the MachineSet had a finalizer when deletion was triggered
 			// deletedMS will contain the MachineSet object after deletion with the resourceVersion set.
 			// If that is the case, defer the next reconcile until the cache observed the MachineSet deletion.
-			r.controller.DeferNextReconcileUntilCacheUpToDate(deployment, msGR, deletedMS.GetResourceVersion())
+			r.controller.DeferNextReconcileUntilCacheUpToDate(deployment, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachineSet"), deletedMS.GetResourceVersion())
 		}
 
 		// Note: We intentionally log after Delete because we want this log line to show up only after DeletionTimestamp has been set.

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -156,9 +156,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 			predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue),
 		).
 		WatchesRawSource(r.ClusterCache.GetClusterSource("machineset", clusterToMachineSets)).
-		WithConsistencyStore(map[schema.GroupResource]client.Object{
-			machineGR: &clusterv1.Machine{},
-		}).
 		Build(ctx, r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
@@ -422,7 +419,7 @@ func (r *Reconciler) triggerInPlaceUpdate(ctx context.Context, s *scope) (ctrl.R
 			errs = append(errs, errors.Wrapf(err, "failed to complete triggering in-place update for Machine %s", klog.KObj(machine)))
 			continue
 		}
-		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, machineGR, machine.ResourceVersion)
+		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
 
 		log.Info(fmt.Sprintf("Completed triggering in-place update for Machine %s", machine.Name))
 		r.recorder.Event(machine, corev1.EventTypeNormal, "SuccessfulStartInPlaceUpdate", "Machine starting in-place update")
@@ -877,6 +874,7 @@ func (r *Reconciler) createMachines(ctx context.Context, s *scope, machinesToAdd
 			}
 			machine.Spec.Bootstrap.ConfigRef = bootstrapRef
 			log = log.WithValues(bootstrapRef.Kind, klog.KRef(ms.Namespace, bootstrapRef.Name))
+			r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.Unstructured(bootstrapConfig), bootstrapConfig.GetResourceVersion())
 		}
 
 		// Create the InfraMachine.
@@ -897,6 +895,7 @@ func (r *Reconciler) createMachines(ctx context.Context, s *scope, machinesToAdd
 		}
 		log = log.WithValues(infraRef.Kind, klog.KRef(ms.Namespace, infraRef.Name))
 		machine.Spec.InfrastructureRef = infraRef
+		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.Unstructured(infraMachine), infraMachine.GetResourceVersion())
 
 		// Create the Machine.
 		if err := ssa.Patch(ctx, r.Client, machineSetManagerName, machine); err != nil {
@@ -915,7 +914,7 @@ func (r *Reconciler) createMachines(ctx context.Context, s *scope, machinesToAdd
 				clusterv1.ConditionSeverityError, "%s", err.Error())
 			return ctrl.Result{}, kerrors.NewAggregate(errs)
 		}
-		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, machineGR, machine.ResourceVersion)
+		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
 
 		log.Info(fmt.Sprintf("Machine %s created (scale up, creating %d of %d)", klog.KObj(machine), i+1, machinesToAdd), "Machine", klog.KObj(machine), "desiredReplicas", *(ms.Spec.Replicas), "replicas", len(s.machines))
 		r.recorder.Eventf(ms, corev1.EventTypeNormal, "SuccessfulCreate", "Created Machine %q", machine.Name)
@@ -961,7 +960,7 @@ func (r *Reconciler) deleteMachines(ctx context.Context, s *scope, machinesToDel
 				continue
 			}
 			if deletedMachine != nil {
-				r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, machineGR, deletedMachine.GetResourceVersion())
+				r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), deletedMachine.GetResourceVersion())
 			}
 
 			log.Info(fmt.Sprintf("Machine %s deleting (scale down, deleting %d of %d)", klog.KObj(machine), i+1, machinesToDelete))
@@ -1082,7 +1081,7 @@ func (r *Reconciler) startMoveMachines(ctx context.Context, s *scope, targetMSNa
 			errs = append(errs, errors.Wrapf(err, "failed to trigger in-place update for Machine %s by moving to MachineSet %s", klog.KObj(machine), klog.KObj(targetMS)))
 			continue
 		}
-		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, machineGR, machine.ResourceVersion)
+		r.controller.DeferNextReconcileUntilCacheUpToDate(s.machineSet, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
 	}
 
 	if len(errs) > 0 {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
@@ -75,21 +74,6 @@ import (
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinehealthchecks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;delete
-
-var (
-	clusterGR = schema.GroupResource{
-		Group:    clusterv1.GroupVersion.Group,
-		Resource: "clusters",
-	}
-	machineDeploymentGR = schema.GroupResource{
-		Group:    clusterv1.GroupVersion.Group,
-		Resource: "machinedeployments",
-	}
-	machinePoolGR = schema.GroupResource{
-		Group:    clusterv1.GroupVersion.Group,
-		Resource: "machinepools",
-	}
-)
 
 // Reconciler reconciles a managed topology for a Cluster object.
 type Reconciler struct {
@@ -155,11 +139,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), predicateLog, r.WatchFilterValue)).
-		WithConsistencyStore(map[schema.GroupResource]client.Object{
-			clusterGR:           &clusterv1.Cluster{},
-			machineDeploymentGR: &clusterv1.MachineDeployment{},
-			machinePoolGR:       &clusterv1.MachinePool{},
-		}).
 		Build(ctx, r)
 
 	if err != nil {

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/topology/ownerrefs"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/cache"
+	capicontrollerutil "sigs.k8s.io/cluster-api/util/controller"
 )
 
 const (
@@ -523,7 +524,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, s *scope.Scope) error
 	}
 	r.recorder.Eventf(s.Current.Cluster, corev1.EventTypeNormal, updateEventReason, "Updated Cluster %q", klog.KObj(s.Current.Cluster))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(s.Current.Cluster, clusterGR, modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(s.Current.Cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Cluster"), modifiedResourceVersion)
 	return nil
 }
 
@@ -684,7 +685,7 @@ func (r *Reconciler) createMachineDeployment(ctx context.Context, s *scope.Scope
 	}
 	r.recorder.Eventf(cluster, corev1.EventTypeNormal, createEventReason, "Created MachineDeployment %q", klog.KObj(md.Object))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, machineDeploymentGR, modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachineDeployment"), modifiedResourceVersion)
 
 	// If the MachineDeployment has defined a MachineHealthCheck reconcile it.
 	if md.MachineHealthCheck != nil {
@@ -802,7 +803,7 @@ func (r *Reconciler) updateMachineDeployment(ctx context.Context, s *scope.Scope
 	}
 	r.recorder.Eventf(cluster, corev1.EventTypeNormal, updateEventReason, "Updated MachineDeployment %q%s", klog.KObj(currentMD.Object), logMachineDeploymentVersionChange(currentMD.Object, desiredMD.Object))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, machineDeploymentGR, modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachineDeployment"), modifiedResourceVersion)
 
 	// We want to call both cleanup functions even if one of them fails to clean up as much as possible.
 	return nil
@@ -997,7 +998,7 @@ func (r *Reconciler) createMachinePool(ctx context.Context, s *scope.Scope, mp *
 	}
 	r.recorder.Eventf(cluster, corev1.EventTypeNormal, createEventReason, "Created MachinePool %q", klog.KObj(mp.Object))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, machinePoolGR, modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachinePool"), modifiedResourceVersion)
 
 	return nil
 }
@@ -1056,7 +1057,7 @@ func (r *Reconciler) updateMachinePool(ctx context.Context, s *scope.Scope, mpTo
 	}
 	r.recorder.Eventf(cluster, corev1.EventTypeNormal, updateEventReason, "Updated MachinePool %q%s", klog.KObj(currentMP.Object), logMachinePoolVersionChange(currentMP.Object, desiredMP.Object))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, machinePoolGR, modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "MachinePool"), modifiedResourceVersion)
 
 	// We want to call both cleanup functions even if one of them fails to clean up as much as possible.
 	return nil

--- a/util/controller/builder.go
+++ b/util/controller/builder.go
@@ -28,10 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	kcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -54,14 +52,13 @@ const (
 
 // Builder is a wrapper around controller-runtime's builder.Builder.
 type Builder struct {
-	builder                   *builder.Builder
-	mgr                       manager.Manager
-	predicateLog              logr.Logger
-	options                   controller.TypedOptions[reconcile.Request]
-	forObject                 client.Object
-	controllerName            string
-	rateLimitInterval         time.Duration
-	consistencyStoreResources map[schema.GroupResource]client.Object
+	builder           *builder.Builder
+	mgr               manager.Manager
+	predicateLog      logr.Logger
+	options           controller.TypedOptions[reconcile.Request]
+	forObject         client.Object
+	controllerName    string
+	rateLimitInterval time.Duration
 }
 
 // NewControllerManagedBy returns a new controller builder that will be started by the provided Manager.
@@ -140,13 +137,6 @@ func (blder *Builder) WithEventFilter(p predicate.Predicate) *Builder {
 	return blder
 }
 
-// WithConsistencyStore configures a consistency store for the controller. The passed in resources
-// are the ones for which DeferNextReconcileUntilCacheUpToDate can be called.
-func (blder *Builder) WithConsistencyStore(resources map[schema.GroupResource]client.Object) *Builder {
-	blder.consistencyStoreResources = resources
-	return blder
-}
-
 // Named sets the name of the controller to the given name. The name shows up
 // in metrics, among other things, and thus should be a prometheus compatible name
 // (underscores and alphanumeric characters only).
@@ -162,7 +152,13 @@ type Controller interface {
 	controller.Controller
 	DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time)
 	DeferNextReconcileForObject(obj metav1.Object, reconcileAfter time.Time)
-	DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGroupResource schema.GroupResource, writtenObjectResourceVersion string)
+
+	// DeferNextReconcileUntilCacheUpToDate defers the next reconcile of the reconciledObject until
+	// the cache observed the writtenObject in the given ResourceVersion.
+	// Note: This func should only be called if we have an informer for the writtenObject anyway.
+	DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGVKT GroupVersionKindType, writtenObjectResourceVersion string)
+
+	// ClearConsistencyStore clears the consistency store for a reconciledObject.
 	ClearConsistencyStore(reconciledObject client.ObjectKey, reconciledObjectUID types.UID)
 }
 
@@ -248,30 +244,8 @@ func (blder *Builder) Build(ctx context.Context, r reconcile.TypedReconciler[rec
 	// Create reconcileCache.
 	reconcileCache := cache.New[reconcileCacheEntry](ctx, cache.DefaultTTL)
 
-	// Create consistencyStore if configured.
-	var consistencyStore consistencyStore
-	if len(blder.consistencyStoreResources) > 0 {
-		stores := make(map[schema.GroupResource]lastSyncRVGetter, len(blder.consistencyStoreResources))
-
-		for resGR, resObj := range blder.consistencyStoreResources {
-			// Note: This creates the informer, but it doesn't start it (and accordingly also doesn't wait for cache sync).
-			informer, err := blder.mgr.GetCache().GetInformer(ctx, resObj, ctrlcache.BlockUntilSynced(false))
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to create %s informer", resGR.Resource)
-			}
-			sharedIndexInformer, ok := informer.(kcache.SharedIndexInformer)
-			if !ok {
-				// Note: This should never happen as controller-runtime only uses SharedIndexInformer.
-				return nil, errors.Errorf("failed to cast %s informer to SharedIndexInformer", resGR.Resource)
-			}
-			stores[resGR] = sharedIndexInformer.GetStore()
-
-			// Initialize metrics to align to what controller-runtime is doing for its metrics.
-			reconcileStaleCacheSkipsTotal.WithLabelValues(controllerName, resGR.Resource).Add(0)
-		}
-
-		consistencyStore = newConsistencyStore(stores)
-	}
+	// Create consistencyStore.
+	consistencyStore := newConsistencyStore(blder.mgr.GetScheme(), blder.mgr.GetCache())
 
 	c, err := blder.builder.Build(&reconcilerWrapper{
 		name:              controllerName,

--- a/util/controller/consistency.go
+++ b/util/controller/consistency.go
@@ -17,43 +17,46 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/resourceversion"
+	kcache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Note: This util has been initially copied from: https://github.com/kubernetes/kubernetes/blob/v1.36.0/pkg/controller/util/consistency/consistency.go.
 
 type consistencyStore interface {
 	// WroteAt records a written RV for an owned resource.
-	WroteAt(owner types.NamespacedName, ownerUID types.UID, resource schema.GroupResource, rv string)
+	WroteAt(owner types.NamespacedName, ownerUID types.UID, gvkt GroupVersionKindType, rv string)
 	// Clear wipes the owner if the UID matches, if left empty it will wipe no
 	// matter what the UID is.
 	Clear(owner types.NamespacedName, ownerUID types.UID)
 	// EnsureReady queries the consistencyStore to check whether or not the
 	// stores records are up to date, returning an error if they are not.
-	EnsureReady(owner types.NamespacedName) []consistencyError
+	EnsureReady(ctx context.Context, owner types.NamespacedName) ([]consistencyError, error)
 }
 
 // consistencyError is an error type returned by EnsureReady with information
 // about the resource versions and GroupKind that caused the error.
 type consistencyError struct {
-	ReadRV        string
-	WroteRV       string
-	GroupResource schema.GroupResource
-}
-
-func (c *consistencyError) Error() string {
-	return fmt.Sprintf("read version: %s is not as new as written version: %s for group resource %s", c.ReadRV, c.WroteRV, c.GroupResource.String())
+	ReadRV               string
+	WroteRV              string
+	GroupVersionKindType GroupVersionKindType
 }
 
 var _ consistencyStore = &realConsistencyStore{}
 
-type lastSyncRVGetter interface {
-	LastStoreSyncResourceVersion() string
+type informerGetter interface {
+	GetInformer(ctx context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error)
 }
 
 type realConsistencyStore struct {
@@ -63,13 +66,19 @@ type realConsistencyStore struct {
 	// writes is a map of owner -> ownerRecord
 	writes map[types.NamespacedName]*ownerRecord
 
-	stores map[schema.GroupResource]lastSyncRVGetter
+	storesLock sync.RWMutex
+	stores     map[GroupVersionKindType]kcache.Store
+
+	scheme         *runtime.Scheme
+	informerGetter informerGetter
 }
 
-func newConsistencyStore(stores map[schema.GroupResource]lastSyncRVGetter) *realConsistencyStore {
+func newConsistencyStore(scheme *runtime.Scheme, cache informerGetter) *realConsistencyStore {
 	return &realConsistencyStore{
-		writes: map[types.NamespacedName]*ownerRecord{},
-		stores: stores,
+		writes:         map[types.NamespacedName]*ownerRecord{},
+		stores:         map[GroupVersionKindType]kcache.Store{},
+		scheme:         scheme,
+		informerGetter: cache,
 	}
 }
 
@@ -104,8 +113,8 @@ func (c *realConsistencyStore) ensureWrittenRecord(owner types.NamespacedName, o
 
 // WroteAt writes the latest written RV if it is greater than the currently
 // written RV for the owner.
-func (c *realConsistencyStore) WroteAt(owner types.NamespacedName, ownerUID types.UID, resource schema.GroupResource, rv string) {
-	c.ensureWrittenRecord(owner, ownerUID).WroteAt(resource, rv)
+func (c *realConsistencyStore) WroteAt(owner types.NamespacedName, ownerUID types.UID, gvkt GroupVersionKindType, rv string) {
+	c.ensureWrittenRecord(owner, ownerUID).WroteAt(gvkt, rv)
 }
 
 // Clear deletes the record for owner if it exists and matches the specified
@@ -122,17 +131,21 @@ func (c *realConsistencyStore) Clear(owner types.NamespacedName, ownerUID types.
 // EnsureReady returns nil if observed resource versions are at least as new as
 // any recorded versions for the given owner, otherwise returning the error of
 // what happened. Must not be called concurrent with WroteAt for the same owner.
-func (c *realConsistencyStore) EnsureReady(owner types.NamespacedName) []consistencyError {
+func (c *realConsistencyStore) EnsureReady(ctx context.Context, owner types.NamespacedName) ([]consistencyError, error) {
 	record := c.getWrittenRecord(owner)
 	if record == nil {
-		return nil
+		return nil, nil
 	}
-	err := record.EnsureReady(c)
-	if err == nil {
+	consistencyErrors, err := record.EnsureReady(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(consistencyErrors) == 0 {
 		c.Clear(owner, record.ownerUID)
-		return nil
+		return nil, nil
 	}
-	return err
+	return consistencyErrors, nil
 }
 
 type ownerRecord struct {
@@ -140,44 +153,97 @@ type ownerRecord struct {
 	ownerUID types.UID
 
 	versionsLock sync.Mutex
-	versions     map[schema.GroupResource]string
+	versions     map[GroupVersionKindType]string
+}
+
+// ObjectType is the type of an object.
+type ObjectType string
+
+var (
+	// ObjectTypeUnstructured is the type of an object for Unstructured.
+	ObjectTypeUnstructured ObjectType = "Unstructured"
+
+	// ObjectTypePartialObjectMetadata is the type of an object for PartialObjectMetadata.
+	ObjectTypePartialObjectMetadata ObjectType = "PartialObjectMetadata"
+
+	// ObjectTypeStructured is the type of an object for a regular structured object.
+	ObjectTypeStructured ObjectType = "Structured"
+)
+
+// GroupVersionKindType described the GVK and type of an object.
+type GroupVersionKindType struct {
+	schema.GroupVersionKind
+	Type ObjectType
+}
+
+// StructuredObject is a util that allows to create a GroupVersionKindType for a structured object.
+func StructuredObject(gv schema.GroupVersion, kind string) GroupVersionKindType {
+	return GroupVersionKindType{
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   gv.Group,
+			Version: gv.Version,
+			Kind:    kind,
+		},
+		Type: ObjectTypeStructured,
+	}
+}
+
+// Unstructured is a util that allows to create a GroupVersionKindType for an Unstructured object.
+func Unstructured(u *unstructured.Unstructured) GroupVersionKindType {
+	return GroupVersionKindType{
+		GroupVersionKind: u.GroupVersionKind(),
+		Type:             ObjectTypeUnstructured,
+	}
+}
+
+// PartialObjectMetadata is a util that allows to create a GroupVersionKindType for an PartialObjectMetadata object.
+func PartialObjectMetadata(u *metav1.PartialObjectMetadata) GroupVersionKindType {
+	return GroupVersionKindType{
+		GroupVersionKind: u.GroupVersionKind(),
+		Type:             ObjectTypePartialObjectMetadata,
+	}
 }
 
 func newOwnerRecord(ownerUID types.UID) *ownerRecord {
-	return &ownerRecord{ownerUID: ownerUID, versions: map[schema.GroupResource]string{}}
+	return &ownerRecord{ownerUID: ownerUID, versions: map[GroupVersionKindType]string{}}
 }
 
 // WroteAt increments the written resource version of an ownerRecord if it is
 // the newest seen resource version for that resource.
-func (w *ownerRecord) WroteAt(resource schema.GroupResource, rv string) {
+func (w *ownerRecord) WroteAt(gvkt GroupVersionKindType, rv string) {
 	w.versionsLock.Lock()
 	defer w.versionsLock.Unlock()
-	if _, ok := w.versions[resource]; !ok {
-		w.versions[resource] = rv
+	if _, ok := w.versions[gvkt]; !ok {
+		w.versions[gvkt] = rv
 		return
 	}
-	cmp, err := resourceversion.CompareResourceVersion(w.versions[resource], rv)
+	cmp, err := resourceversion.CompareResourceVersion(w.versions[gvkt], rv)
 	if err == nil && cmp >= 0 {
 		return
 	}
-	w.versions[resource] = rv
+	w.versions[gvkt] = rv
 }
 
 // EnsureReady checks whether or not the ownerRecord is ready compared to the
 // read resource versions in the consistency store.
-func (w *ownerRecord) EnsureReady(c *realConsistencyStore) []consistencyError {
+func (w *ownerRecord) EnsureReady(ctx context.Context, c *realConsistencyStore) ([]consistencyError, error) {
 	w.versionsLock.Lock()
 	defer w.versionsLock.Unlock()
 	var errs []consistencyError
-	for gr, wroteRV := range w.versions {
-		store, exists := c.stores[gr]
-		if !exists || store == nil {
-			continue
+	for gvkt, wroteRV := range w.versions {
+		store, err := getStore(ctx, c, gvkt)
+		if err != nil {
+			return nil, err
 		}
 		readRV := store.LastStoreSyncResourceVersion()
 		if readRV == "" {
-			// Since we wait for the store to be ready, the only time "" is if the
-			// LastStoreSyncResourceVersion() feature is not enabled.
+			// As we are also creating Informers dynamically in Reconcile funcs there might be informers that are
+			// not synced yet. In that case we want to wait for informers to sync and catch up.
+			errs = append(errs, consistencyError{
+				WroteRV:              wroteRV,
+				ReadRV:               readRV,
+				GroupVersionKindType: gvkt,
+			})
 			continue
 		}
 		i, err := resourceversion.CompareResourceVersion(wroteRV, readRV)
@@ -188,11 +254,64 @@ func (w *ownerRecord) EnsureReady(c *realConsistencyStore) []consistencyError {
 		if i > 0 {
 			// read version is not as new as owner version, not ready
 			errs = append(errs, consistencyError{
-				WroteRV:       wroteRV,
-				ReadRV:        readRV,
-				GroupResource: gr,
+				WroteRV:              wroteRV,
+				ReadRV:               readRV,
+				GroupVersionKindType: gvkt,
 			})
 		}
 	}
-	return errs
+	return errs, nil
+}
+
+func getStore(ctx context.Context, c *realConsistencyStore, gvkt GroupVersionKindType) (kcache.Store, error) {
+	c.storesLock.RLock()
+	store, exists := c.stores[gvkt]
+	c.storesLock.RUnlock()
+
+	if exists {
+		return store, nil
+	}
+
+	c.storesLock.Lock()
+	defer c.storesLock.Unlock()
+
+	// Check again now that we have the write lock.
+	store, exists = c.stores[gvkt]
+	if exists {
+		return store, nil
+	}
+
+	var obj client.Object
+	switch gvkt.Type {
+	case ObjectTypeUnstructured:
+		obj = &unstructured.Unstructured{}
+		obj.GetObjectKind().SetGroupVersionKind(gvkt.GroupVersionKind)
+	case ObjectTypePartialObjectMetadata:
+		obj = &metav1.PartialObjectMetadata{}
+		obj.GetObjectKind().SetGroupVersionKind(gvkt.GroupVersionKind)
+	case ObjectTypeStructured:
+		runtimeObj, err := c.scheme.New(gvkt.GroupVersionKind)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create %s object: %w", gvkt.Kind, err)
+		}
+		var ok bool
+		obj, ok = runtimeObj.(client.Object)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast %s object to client.Object: %w", gvkt.Kind, err)
+		}
+	}
+
+	// Note: This creates the informer if it doesn't exist already, but it doesn't  wait for the cache to sync.
+	informer, err := c.informerGetter.GetInformer(ctx, obj, cache.BlockUntilSynced(false))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create %s informer: %w", gvkt.Kind, err)
+	}
+	sharedIndexInformer, ok := informer.(kcache.SharedIndexInformer)
+	if !ok {
+		// Note: This should never happen as controller-runtime only uses SharedIndexInformer.
+		return nil, fmt.Errorf("failed to cast %s informer to SharedIndexInformer", gvkt.Kind)
+	}
+
+	c.stores[gvkt] = sharedIndexInformer.GetStore()
+	return c.stores[gvkt], nil
 }

--- a/util/controller/consistency_test.go
+++ b/util/controller/consistency_test.go
@@ -17,14 +17,22 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
 func TestOwnerRecord_WroteAt(t *testing.T) {
@@ -33,91 +41,110 @@ func TestOwnerRecord_WroteAt(t *testing.T) {
 	assert.Equal(t, uid, or.ownerUID)
 	require.NotNil(t, or.versions)
 
-	grPod := schema.GroupResource{Group: "", Resource: "pods"}
-	grDs := schema.GroupResource{Group: "apps", Resource: "daemonsets"}
+	gvktPod := StructuredObject(schema.GroupVersion{Group: "", Version: "v1"}, "Pod")
+	gvktDS := StructuredObject(schema.GroupVersion{Group: "apps", Version: "v1"}, "DaemonSet")
 
 	// First write
-	or.WroteAt(grPod, "5")
-	assert.Equal(t, "5", or.versions[grPod])
+	or.WroteAt(gvktPod, "5")
+	assert.Equal(t, "5", or.versions[gvktPod])
 
 	// Second write (higher)
-	or.WroteAt(grPod, "10")
-	assert.Equal(t, "10", or.versions[grPod])
+	or.WroteAt(gvktPod, "10")
+	assert.Equal(t, "10", or.versions[gvktPod])
 
 	// Third write (lower)
-	or.WroteAt(grPod, "8")
-	assert.Equal(t, "10", or.versions[grPod])
+	or.WroteAt(gvktPod, "8")
+	assert.Equal(t, "10", or.versions[gvktPod])
 
 	// Write to different resource
-	or.WroteAt(grDs, "1")
-	assert.Equal(t, "1", or.versions[grDs])
-	assert.Equal(t, "10", or.versions[grPod], "Pod version should be unchanged")
+	or.WroteAt(gvktDS, "1")
+	assert.Equal(t, "1", or.versions[gvktDS])
+	assert.Equal(t, "10", or.versions[gvktPod], "Pod version should be unchanged")
 }
 
 func TestOwnerRecord_IsReady(t *testing.T) {
 	uid := types.UID("owner-uid-1")
 	or := newOwnerRecord(uid)
-	grPod := schema.GroupResource{Group: "", Resource: "pods"}
-	grDs := schema.GroupResource{Group: "apps", Resource: "daemonsets"}
+	gvktPod := StructuredObject(schema.GroupVersion{Group: "", Version: "v1"}, "Pod")
+	gvktDS := StructuredObject(schema.GroupVersion{Group: "apps", Version: "v1"}, "DaemonSet")
 	podStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	dsStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	resourceStores := map[schema.GroupResource]lastSyncRVGetter{
-		grPod: podStore,
-		grDs:  dsStore,
+	resourceStores := map[GroupVersionKindType]cache.Store{
+		gvktPod: podStore,
+		gvktDS:  dsStore,
 	}
 
-	store := newConsistencyStore(resourceStores)
+	store := &realConsistencyStore{
+		writes: map[types.NamespacedName]*ownerRecord{},
+		stores: resourceStores,
+	}
 
 	// Case 1: No writes. Should be ready.
-	require.Empty(t, or.EnsureReady(store), "Should be ready if no writes are recorded")
+	consistencyErrors, err := or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Should be ready if no writes are recorded")
 
 	// Add a write
-	or.WroteAt(grPod, "10")
+	or.WroteAt(gvktPod, "10")
 
-	// Case 2: Write exists, but no reads. Should stay ready.
-	require.Empty(t, or.EnsureReady(store), "Should stay ready if write exists and no read")
+	// Case 2: Write exists, but no reads. Not ready.
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.NotEmpty(t, consistencyErrors, "Not ready if read (0) < write")
 
 	// Add a read, but it's lower
 	podStore.Bookmark("5")
 
 	// Case 3: Write exists, read is lower. Not ready.
-	require.NotEmpty(t, or.EnsureReady(store), "Not ready if read < write")
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.NotEmpty(t, consistencyErrors, "Not ready if read < write")
 
 	// Add a read, equal
 	podStore.Bookmark("10")
 
 	// Case 4: Write exists, read is equal. Ready.
-	require.Empty(t, or.EnsureReady(store), "Ready if read == write")
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if read == write")
 
 	// Add a read, higher
 	podStore.Bookmark("15")
 
 	// Case 5: Write exists, read is higher. Ready.
-	require.Empty(t, or.EnsureReady(store), "Ready if read > write")
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if read > write")
 
 	// Add a second write and read
-	or.WroteAt(grDs, "100")
+	or.WroteAt(gvktDS, "100")
 	dsStore.Bookmark("50")
 
 	// Case 6: One resource ready, one not. Not ready.
-	require.NotEmpty(t, or.EnsureReady(store), "Not ready if one of multiple writes is not ready (no read)")
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.NotEmpty(t, consistencyErrors, "Not ready if one of multiple writes is not ready (no read)")
 
 	// Make the second one ready
 	dsStore.Bookmark("100")
 
 	// Case 7: All resources ready. Ready.
-	require.Empty(t, or.EnsureReady(store), "Ready if all writes are ready")
+	consistencyErrors, err = or.EnsureReady(t.Context(), store)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if all writes are ready")
 }
 
 func TestConsistencyStore_New(t *testing.T) {
-	store := newConsistencyStore(nil)
+	store := newConsistencyStore(nil, nil)
 	require.NotNil(t, store)
 	require.NotNil(t, store.writes)
 	assert.Empty(t, store.writes)
+	require.NotNil(t, store.stores)
+	assert.Empty(t, store.stores)
 }
 
 func TestConsistencyStore_EnsureWrittenRecord(t *testing.T) {
-	store := newConsistencyStore(nil)
+	store := newConsistencyStore(nil, nil)
 	owner := types.NamespacedName{Name: "owner1"}
 	uid1 := types.UID("uid-1")
 	uid2 := types.UID("uid-2")
@@ -141,13 +168,13 @@ func TestConsistencyStore_EnsureWrittenRecord(t *testing.T) {
 	assert.Empty(t, r3.versions, "New record should be empty")
 
 	// Check that old record is detached
-	grPod := schema.GroupResource{Group: "", Resource: "pods"}
-	r1.WroteAt(grPod, "10") // Write to old record
+	gvktPod := StructuredObject(schema.GroupVersion{Group: "", Version: "v1"}, "Pod")
+	r1.WroteAt(gvktPod, "10") // Write to old record
 	assert.Empty(t, r3.versions, "Write to old record should not affect new record")
 }
 
 func TestConsistencyStore_EnsureWrittenRecord_Concurrent(t *testing.T) {
-	store := newConsistencyStore(nil)
+	store := newConsistencyStore(nil, nil)
 	owner := types.NamespacedName{Name: "owner1"}
 	uid1 := types.UID("uid-1")
 	uid2 := types.UID("uid-2")
@@ -197,26 +224,26 @@ func TestConsistencyStore_EnsureWrittenRecord_Concurrent(t *testing.T) {
 }
 
 func TestConsistencyStore_WroteAt(t *testing.T) {
-	store := newConsistencyStore(nil)
+	store := newConsistencyStore(nil, nil)
 	owner := types.NamespacedName{Name: "owner1"}
 	uid1 := types.UID("uid-1")
-	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	gvktPod := StructuredObject(schema.GroupVersion{Group: "", Version: "v1"}, "Pod")
 
-	store.WroteAt(owner, uid1, grPod, "10")
+	store.WroteAt(owner, uid1, gvktPod, "10")
 
 	record := store.getWrittenRecord(owner)
 	require.NotNil(t, record)
 	assert.Equal(t, uid1, record.ownerUID)
 
-	assert.Equal(t, "10", record.versions[grPod])
+	assert.Equal(t, "10", record.versions[gvktPod])
 
 	// Write again
-	store.WroteAt(owner, uid1, grPod, "20")
-	assert.Equal(t, "20", record.versions[grPod])
+	store.WroteAt(owner, uid1, gvktPod, "20")
+	assert.Equal(t, "20", record.versions[gvktPod])
 }
 
 func TestConsistencyStore_Clear(t *testing.T) {
-	store := newConsistencyStore(nil)
+	store := newConsistencyStore(nil, nil)
 	owner1 := types.NamespacedName{Name: "owner1"}
 	owner2 := types.NamespacedName{Name: "owner2"}
 	uid1 := types.UID("uid-1")
@@ -256,37 +283,103 @@ func TestConsistencyStore_Clear(t *testing.T) {
 func TestConsistencyStore_IsReady(t *testing.T) {
 	owner1 := types.NamespacedName{Name: "owner1"}
 	uid1 := types.UID("uid-1")
-	grPod := schema.GroupResource{Group: "", Resource: "pods"}
+	gvktPod := StructuredObject(schema.GroupVersion{Group: "", Version: "v1"}, "Pod")
 	podStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
-	resourceStores := map[schema.GroupResource]lastSyncRVGetter{
-		grPod: podStore,
+	resourceStores := map[GroupVersionKindType]cache.Store{
+		gvktPod: podStore,
 	}
 
-	store := newConsistencyStore(resourceStores)
+	store := &realConsistencyStore{
+		writes: map[types.NamespacedName]*ownerRecord{},
+		stores: resourceStores,
+	}
 
 	// Case 1: No record. Ready.
-	require.Empty(t, store.EnsureReady(owner1), "Ready if no record exists")
+	consistencyErrors, err := store.EnsureReady(t.Context(), owner1)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if no record exists")
 
 	// Add a write and initial read rv
 	podStore.Bookmark("5")
-	store.WroteAt(owner1, uid1, grPod, "10")
+	store.WroteAt(owner1, uid1, gvktPod, "10")
 
 	// Case 2: Record exists, read < write. Not ready.
-	require.NotEmpty(t, store.EnsureReady(owner1), "Not ready if read < write")
+	consistencyErrors, err = store.EnsureReady(t.Context(), owner1)
+	require.Nil(t, err)
+	require.NotEmpty(t, consistencyErrors, "Not ready if read < write")
 
 	// Add read, equal
 	podStore.Bookmark("10")
 
 	// Case 3: Record exists, read == write. Ready.
-	require.Empty(t, store.EnsureReady(owner1), "Ready if read == write")
+	consistencyErrors, err = store.EnsureReady(t.Context(), owner1)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if read == write")
 
 	// Add read, higher
 	podStore.Bookmark("15")
 
 	// Case 4: Record exists, read > write. Ready.
-	require.Empty(t, store.EnsureReady(owner1), "Ready if read > write")
+	consistencyErrors, err = store.EnsureReady(t.Context(), owner1)
+	require.Nil(t, err)
+	require.Empty(t, consistencyErrors, "Ready if read > write")
 
 	// Assert that the record no longer exists, we no longer need to track the
 	// reads as long as the read has been higher than the latest write.
 	assert.Nil(t, store.getWrittenRecord(owner1), "Written record should no longer exist")
+}
+
+func TestConsistencyStore_getStore(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.AddToScheme(scheme)
+
+	c := newConsistencyStore(scheme, &fakeInformerGetter{})
+
+	// Get store of *clusterv1.Machine informer.
+	store, err := getStore(t.Context(), c, StructuredObject(clusterv1.GroupVersion, "Machine"))
+	assert.Nil(t, err)
+	_, ok := store.(*fakeStore).obj.(*clusterv1.Machine)
+	assert.True(t, ok)
+
+	// Get store of clusterv1.Machine Unstructured informer.
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("Machine"))
+	store, err = getStore(t.Context(), c, Unstructured(u))
+	assert.Nil(t, err)
+	u, ok = store.(*fakeStore).obj.(*unstructured.Unstructured)
+	assert.True(t, ok)
+	assert.Equal(t, clusterv1.GroupVersion.WithKind("Machine"), u.GroupVersionKind())
+
+	// Get store of clusterv1.Machine PartialObjectMeta informer.
+	p := &metav1.PartialObjectMetadata{}
+	p.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("Machine"))
+	store, err = getStore(t.Context(), c, PartialObjectMetadata(p))
+	assert.Nil(t, err)
+	p, ok = store.(*fakeStore).obj.(*metav1.PartialObjectMetadata)
+	assert.True(t, ok)
+	assert.Equal(t, clusterv1.GroupVersion.WithKind("Machine"), p.GroupVersionKind())
+
+	assert.Len(t, c.stores, 3)
+}
+
+type fakeInformerGetter struct{}
+
+func (f *fakeInformerGetter) GetInformer(_ context.Context, obj client.Object, _ ...ctrlcache.InformerGetOption) (ctrlcache.Informer, error) {
+	return &fakeInformer{obj: obj}, nil
+}
+
+var _ cache.SharedIndexInformer = &fakeInformer{}
+
+type fakeInformer struct {
+	obj client.Object
+	cache.SharedIndexInformer
+}
+
+func (f *fakeInformer) GetStore() cache.Store {
+	return &fakeStore{obj: f.obj}
+}
+
+type fakeStore struct {
+	obj client.Object
+	cache.Store
 }

--- a/util/controller/controller.go
+++ b/util/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,24 +62,26 @@ func (r *reconcilerWrapper) Reconcile(ctx context.Context, req reconcile.Request
 		}
 	}
 
-	if r.consistencyStore != nil {
-		if consistencyErrs := r.consistencyStore.EnsureReady(req.NamespacedName); len(consistencyErrs) > 0 {
-			log := ctrl.LoggerFrom(ctx)
-			atMostEvery10Seconds.Do(func() {
-				log.V(2).Info("Cache stale, reconciles are requeued until the cache is up-to-date")
-			})
-			for _, consistencyErr := range consistencyErrs {
-				reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, consistencyErr.GroupResource.Resource).Inc()
-			}
-			if log.V(5).Enabled() {
-				var staleCaches []string
-				for _, consistencyErr := range consistencyErrs {
-					staleCaches = append(staleCaches, fmt.Sprintf("%s, writtenRV: %s, observedRV: %s", consistencyErr.GroupResource.Resource, consistencyErr.WroteRV, consistencyErr.ReadRV))
-				}
-				log.V(5).Info(fmt.Sprintf("Cache stale, requeueing after %s (%s)", requeueDurationStaleCache, strings.Join(staleCaches, ", ")))
-			}
-			return ctrl.Result{RequeueAfter: requeueDurationStaleCache}, nil
+	consistencyErrs, err := r.consistencyStore.EnsureReady(ctx, req.NamespacedName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(consistencyErrs) > 0 {
+		log := ctrl.LoggerFrom(ctx)
+		atMostEvery10Seconds.Do(func() {
+			log.V(2).Info("Cache stale, reconciles are requeued until the cache is up-to-date")
+		})
+		for _, consistencyErr := range consistencyErrs {
+			reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, consistencyErr.GroupVersionKindType.Kind).Inc()
 		}
+		if log.V(5).Enabled() {
+			var staleCaches []string
+			for _, consistencyErr := range consistencyErrs {
+				staleCaches = append(staleCaches, fmt.Sprintf("%s, writtenRV: %s, observedRV: %s", consistencyErr.GroupVersionKindType.Kind, consistencyErr.WroteRV, consistencyErr.ReadRV))
+			}
+			log.V(5).Info(fmt.Sprintf("Cache stale, requeueing after %s (%s)", requeueDurationStaleCache, strings.Join(staleCaches, ", ")))
+		}
+		return ctrl.Result{RequeueAfter: requeueDurationStaleCache}, nil
 	}
 
 	// Add entry to the reconcileCache so we won't run Reconcile more than once per second.
@@ -179,11 +180,11 @@ func (r reconcileCacheEntry) ShouldRequeue(now time.Time) (requeueAfter time.Dur
 	return time.Duration(0), false
 }
 
-func (c *controllerWrapper) DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGroupResource schema.GroupResource, writtenObjectResourceVersion string) {
+func (c *controllerWrapper) DeferNextReconcileUntilCacheUpToDate(reconciledObject metav1.Object, writtenObjectGVKT GroupVersionKindType, writtenObjectResourceVersion string) {
 	// Note: We are using GroupResource here because we want to avoid making bigger changes to the vendored consistencyStore util.
 	// We could calculate GroupResource from a client.Object but we would have to handle error cases.
 	c.consistencyStore.WroteAt(client.ObjectKey{Namespace: reconciledObject.GetNamespace(), Name: reconciledObject.GetName()},
-		reconciledObject.GetUID(), writtenObjectGroupResource, writtenObjectResourceVersion)
+		reconciledObject.GetUID(), writtenObjectGVKT, writtenObjectResourceVersion)
 }
 
 func (c *controllerWrapper) ClearConsistencyStore(reconciledObject client.ObjectKey, reconciledObjectUID types.UID) {

--- a/util/controller/controller_fake.go
+++ b/util/controller/controller_fake.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -48,7 +47,7 @@ func (f *FakeController) DeferNextReconcileForObject(obj metav1.Object, reconcil
 	}] = reconcileAfter
 }
 
-func (f *FakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ schema.GroupResource, _ string) {
+func (f *FakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ GroupVersionKindType, _ string) {
 }
 
 func (f *FakeController) ClearConsistencyStore(_ client.ObjectKey, _ types.UID) {}

--- a/util/controller/controller_test.go
+++ b/util/controller/controller_test.go
@@ -137,20 +137,14 @@ func TestReconcile(t *testing.T) {
 		// Simulate a stale cache
 		consistencyStore.errs = []consistencyError{
 			{
-				GroupResource: schema.GroupResource{
-					Group:    clusterv1.GroupVersion.Group,
-					Resource: "machinedeployments",
-				},
-				ReadRV:  "10",
-				WroteRV: "11",
+				GroupVersionKindType: StructuredObject(clusterv1.GroupVersion, "MachineDeployment"),
+				ReadRV:               "10",
+				WroteRV:              "11",
 			},
 			{
-				GroupResource: schema.GroupResource{
-					Group:    clusterv1.GroupVersion.Group,
-					Resource: "cluster",
-				},
-				ReadRV:  "10",
-				WroteRV: "15",
+				GroupVersionKindType: StructuredObject(clusterv1.GroupVersion, "Cluster"),
+				ReadRV:               "10",
+				WroteRV:              "15",
 			},
 		}
 
@@ -161,8 +155,8 @@ func TestReconcile(t *testing.T) {
 		// Metrics should only show a skipped reconcile
 		g.Expect(reconcileCounter.Load()).To(Equal(int64(1)))
 		g.Expect(counterMetricValue(reconcileTotal.WithLabelValues(r.name, labelSuccess))).To(Equal(1))
-		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "machinedeployments"))).To(Equal(1))
-		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "cluster"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "MachineDeployment"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "Cluster"))).To(Equal(1))
 
 		// Simulate an up-to-date cache
 		consistencyStore.errs = nil
@@ -277,8 +271,8 @@ func TestReconcile(t *testing.T) {
 		g.Expect(r.queueRateLimiter.NumRequeues(req)).To(Equal(0))
 
 		// No additional reconciles should have been skipped because of a stale cache.
-		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "machinedeployments"))).To(Equal(1))
-		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "cluster"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "MachineDeployment"))).To(Equal(1))
+		g.Expect(counterMetricValue(reconcileStaleCacheSkipsTotal.WithLabelValues(r.name, "Cluster"))).To(Equal(1))
 
 		ctrlCancel()
 	})
@@ -301,6 +295,7 @@ func TestReconcileMetrics(t *testing.T) {
 			reconcileCache:    reconcileCache,
 			rateLimitInterval: rateLimitInterval,
 			queueRateLimiter:  newTypedItemExponentialFailureRateLimiter[reconcile.Request](rateLimitInterval, 5*time.Millisecond, 1000*time.Second),
+			consistencyStore:  &fakeConsistencyStore{},
 		}
 
 		req := reconcile.Request{
@@ -449,13 +444,13 @@ type fakeConsistencyStore struct {
 
 var _ consistencyStore = &fakeConsistencyStore{}
 
-func (cs *fakeConsistencyStore) WroteAt(_ types.NamespacedName, _ types.UID, _ schema.GroupResource, _ string) {
+func (cs *fakeConsistencyStore) WroteAt(_ types.NamespacedName, _ types.UID, _ GroupVersionKindType, _ string) {
 }
 
 func (cs *fakeConsistencyStore) ReadAt(_ schema.GroupResource, _ string) {}
 
 func (cs *fakeConsistencyStore) Clear(_ types.NamespacedName, _ types.UID) {}
 
-func (cs *fakeConsistencyStore) EnsureReady(_ types.NamespacedName) []consistencyError {
-	return cs.errs
+func (cs *fakeConsistencyStore) EnsureReady(_ context.Context, _ types.NamespacedName) ([]consistencyError, error) {
+	return cs.errs, nil
 }

--- a/util/controller/metrics.go
+++ b/util/controller/metrics.go
@@ -59,7 +59,7 @@ var (
 	reconcileStaleCacheSkipsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "capi_reconcile_stale_cache_skips_total",
 		Help: "Total number of reconciles skipped due to a stale watch cache.",
-	}, []string{"controller", "cached_resource"})
+	}, []string{"controller", "cached_kind"})
 )
 
 const (


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/13725

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->