### PR TITLE
🌱 fix: correct typos in comments and error messages

### DIFF
--- a/api/bootstrap/kubeadm/v1beta1/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta1/kubeadm_types.go
@@ -904,7 +904,7 @@ func (bts BootstrapTokenString) String() string {
 // is of the right format.
 func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
-	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
+	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsing works)
 	if len(substrs) != 3 {
 		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}

--- a/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
+++ b/api/bootstrap/kubeadm/v1beta2/kubeadm_types.go
@@ -1022,7 +1022,7 @@ func (bts BootstrapTokenString) String() string {
 // is of the right format.
 func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
-	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
+	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsing works)
 	if len(substrs) != 3 {
 		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}

--- a/bootstrap/kubeadm/types/upstreamv1beta3/bootstraptokenstring.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/bootstraptokenstring.go
@@ -72,7 +72,7 @@ func (bts BootstrapTokenString) String() string {
 // is of the right format.
 func NewBootstrapTokenString(token string) (*BootstrapTokenString, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
-	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsin works)
+	// TODO: Add a constant for the 3 value here, and explain better why it's needed (other than because how the regexp parsing works)
 	if len(substrs) != 3 {
 		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}

--- a/cmd/clusterctl/client/generate_provider.go
+++ b/cmd/clusterctl/client/generate_provider.go
@@ -63,7 +63,7 @@ func (c *clusterctlClient) GenerateProvider(ctx context.Context, provider string
 
 	compatibleContracts := c.getCompatibleContractVersions(c.currentContractVersion)
 	if !compatibleContracts.Has(releaseSeries.Contract) {
-		return nil, errors.Errorf("current version of clusterctl is only compatible with provider implementing %s conctract versions, detected %s for provider %s", strings.Join(compatibleContracts.UnsortedList(), ", "), releaseSeries.Contract, providerName)
+		return nil, errors.Errorf("current version of clusterctl is only compatible with provider implementing %s contract versions, detected %s for provider %s", strings.Join(compatibleContracts.UnsortedList(), ", "), releaseSeries.Contract, providerName)
 	}
 
 	return c.GetProviderComponents(ctx, provider, providerType, options)

--- a/cmd/clusterctl/client/repository/overrides.go
+++ b/cmd/clusterctl/client/repository/overrides.go
@@ -124,7 +124,7 @@ func getLocalOverride(info *newOverrideInput) ([]byte, error) {
 		return nil, err
 	}
 
-	// it the local override exists, use it
+	// if the local override exists, use it
 	_, err = os.Stat(overridePath)
 	if err == nil {
 		content, err := os.ReadFile(overridePath) //nolint:gosec
@@ -134,7 +134,7 @@ func getLocalOverride(info *newOverrideInput) ([]byte, error) {
 		return content, nil
 	}
 
-	// it the local override does not exists, return (so files from the provider's repository could be used)
+	// if the local override does not exist, return (so files from the provider's repository could be used)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -487,10 +487,10 @@ func TestUpdateCoreDNS(t *testing.T) {
 						return errors.Errorf("the coredns ConfigMap has %d data items, expected 2", len(expectedConfigMap.Data))
 					}
 					if val, ok := expectedConfigMap.Data["Corefile"]; !ok || val != "updated-core-file" {
-						return errors.New("the coredns ConfigMap does not have the Corefile entry or this it has an unexpected value")
+						return errors.New("the coredns ConfigMap does not have the Corefile entry or it has an unexpected value")
 					}
 					if val, ok := expectedConfigMap.Data["Corefile-backup"]; !ok || val != expectedCorefile {
-						return errors.New("the coredns ConfigMap does not have the Corefile-backup entry or this it has an unexpected value")
+						return errors.New("the coredns ConfigMap does not have the Corefile-backup entry or it has an unexpected value")
 					}
 					return nil
 				}, "5s").Should(Succeed())

--- a/controlplane/kubeadm/internal/workload_cluster_rbac.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac.go
@@ -45,7 +45,7 @@ const (
 	APIServerKubeletClientCertCommonName = "kube-apiserver-kubelet-client"
 )
 
-// EnsureResource creates a resoutce if the target resource doesn't exist. If the resource exists already, this function will ignore the resource instead.
+// EnsureResource creates a resource if the target resource doesn't exist. If the resource exists already, this function will ignore the resource instead.
 func (w *Workload) EnsureResource(ctx context.Context, obj client.Object) error {
 	testObj := obj.DeepCopyObject().(client.Object)
 	key := client.ObjectKeyFromObject(obj)

--- a/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
@@ -75,7 +75,7 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding it they already exist for K8s <= 1.37 (kubeadm started adding those roles in patch versions)",
+			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s <= 1.37 (kubeadm started adding those roles in patch versions)",
 			objs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
@@ -105,7 +105,7 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding it they already exist for K8s >= 1.38 (kubeadm should add those roles or KCP in a previous update)",
+			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s >= 1.38 (kubeadm should add those roles or KCP in a previous update)",
 			objs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bunch of small typos scattered across comments and one user-facing error message.

The juicy one: `generate_provider.go` has `conctract` in the error string users actually see when running `clusterctl generate provider` with an incompatible provider version. The rest are comment typos (`resoutce`, `parsin`, `it the`, `or this it`, `it they`).

**How to reproduce the error message typo**:

```
clusterctl generate provider --infrastructure aws:v1.0.0
```
If the provider contract doesn't match, you get:
```
current version of clusterctl is only compatible with provider implementing v1beta1 conctract versions, detected v1alpha4 for provider aws
```

**Files changed**:
- `cmd/clusterctl/client/generate_provider.go` - `conctract` -> `contract` (user-visible error)
- `cmd/clusterctl/client/repository/overrides.go` - `it the` -> `if the` (x2 comments)
- `controlplane/kubeadm/internal/workload_cluster_rbac.go` - `resoutce` -> `resource` (godoc)
- `api/bootstrap/kubeadm/v1beta{1,2}/kubeadm_types.go`, `bootstrap/kubeadm/types/upstreamv1beta3/bootstraptokenstring.go` - `parsin` -> `parsing` (TODO comment, 3 files)
- `controlplane/kubeadm/internal/workload_cluster_{coredns,rbac}_test.go` - `or this it` -> `or if it`, `it they` -> `if they`

Pure text changes, no logic touched.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #