### PR TITLE
🌱 Add additional test cases for EnsureKubeadmPermissions

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
@@ -140,6 +140,121 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			targetVersion: semver.MustParse("1.38.0"),
 			wantObjs:      nil,
 		},
+		{
+			name:          "Add both ClusterRoleBindings for K8s < 1.29 (no lower bound, applied even before kubeadm introduced them)",
+			objs:          nil,
+			targetVersion: semver.MustParse("1.28.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-admin",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.GroupKind,
+							Name: ClusterAdminsGroupAndClusterRoleBinding,
+						},
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     KubeletAPIAdminClusterRoleName,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.UserKind,
+							Name: APIServerKubeletClientCertCommonName,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "Do not add kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s 1.38 pre-release (pre-releases are treated as >= 1.38 via WithoutPreReleases)",
+			objs:          nil,
+			targetVersion: semver.MustParse("1.38.0-beta.0"),
+			wantObjs:      nil,
+		},
+		{
+			name: "Add only kubeadm:apiserver-kubelet-client when kubeadm:cluster-admins already exists for K8s <= 1.37",
+			objs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
+				},
+			},
+			targetVersion: semver.MustParse("1.37.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     KubeletAPIAdminClusterRoleName,
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.UserKind,
+							Name: APIServerKubeletClientCertCommonName,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Add only kubeadm:cluster-admins when kubeadm:apiserver-kubelet-client already exists for K8s <= 1.37",
+			objs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
+				},
+			},
+			targetVersion: semver.MustParse("1.37.0"),
+			wantObjs: []client.Object{
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: KubeletAPIAdminClusterRoleBindingName,
+					},
+				},
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterAdminsGroupAndClusterRoleBinding,
+					},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-admin",
+					},
+					Subjects: []rbacv1.Subject{
+						{
+							Kind: rbacv1.GroupKind,
+							Name: ClusterAdminsGroupAndClusterRoleBinding,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds test coverage for `EnsureKubeadmPermissions` by testing previously untested branches. No production code changes are included.

Added cases:

- Target version older than v1.29 (e.g., `v1.28.0`): verifies that both ClusterRoleBindings are still created because the function does not enforce a lower version bound.
- Target version is a v1.38 pre-release (e.g., `v1.38.0-beta.0`): verifies that the version is treated as `>= v1.38.0` via `WithoutPreReleases()`, so no ClusterRoleBindings are created.
- Only `kubeadm:cluster-admins` exists: verifies that only the missing `kubeadm:apiserver-kubelet-client` ClusterRoleBinding is created.
- Only `kubeadm:apiserver-kubelet-client` exists: verifies that only the missing `kubeadm:cluster-admins` ClusterRoleBinding is created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13706 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area control-plane