### PR TITLE
✨ Use regular patch instead of SSA to patch Cluster in topology controller

### DIFF
--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -734,6 +734,8 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 func computeCluster(_ context.Context, s *scope.Scope, infrastructureCluster, controlPlane *unstructured.Unstructured) (*clusterv1.Cluster, error) {
 	cluster := s.Current.Cluster.DeepCopy()
 
+	// Note: If additional fields should be modified here we have to adjust reconcileCluster accordingly.
+
 	// Enforce the topology labels.
 	// NOTE: The cluster label is added at creation time so this object could be read by the ClusterTopology
 	// controller immediately after creation, even before other controllers are going to add the label (if missing).
@@ -766,10 +768,7 @@ func computeCluster(_ context.Context, s *scope.Scope, infrastructureCluster, co
 		}
 		cluster.Annotations[clusterv1.ClusterTopologyUpgradeStepAnnotation] = *controlPlaneVersion
 	} else {
-		// Note: Setting the annotation to "" instead of deleting it because we cannot be sure
-		// that we are able to remove the annotation from the Cluster with SSA if we lost ownership of
-		// the annotation in managedFields e.g. because of: https://github.com/kubernetes/kubernetes/issues/136919.
-		cluster.Annotations[clusterv1.ClusterTopologyUpgradeStepAnnotation] = ""
+		delete(cluster.Annotations, clusterv1.ClusterTopologyUpgradeStepAnnotation)
 	}
 
 	return cluster, nil

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -1767,7 +1767,7 @@ func TestComputeCluster(t *testing.T) {
 	g.Expect(obj.Namespace).To(Equal(cluster.Namespace))
 	g.Expect(obj.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, cluster.Name))
 	g.Expect(obj.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterTopologyOwnedLabel, ""))
-	g.Expect(obj.GetAnnotations()).To(HaveKeyWithValue(clusterv1.ClusterTopologyUpgradeStepAnnotation, ""))
+	g.Expect(obj.GetAnnotations()).ToNot(HaveKey(clusterv1.ClusterTopologyUpgradeStepAnnotation))
 
 	// Spec
 	g.Expect(obj.Spec.InfrastructureRef).To(BeComparableTo(contract.ObjToContractVersionedObjectReference(infrastructureCluster)))
@@ -1789,7 +1789,7 @@ func TestComputeCluster(t *testing.T) {
 	g.Expect(obj).ToNot(BeNil())
 	g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(obj.GetAnnotations()).To(HaveKeyWithValue(clusterv1.ClusterTopologyUpgradeStepAnnotation, ""))
+	g.Expect(obj.GetAnnotations()).ToNot(HaveKey(clusterv1.ClusterTopologyUpgradeStepAnnotation))
 
 	// Surfaces the ClusterTopologyUpgradeStepAnnotation annotation during upgrades when runtime SDK feature flag is on.
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)
@@ -1815,7 +1815,7 @@ func TestComputeCluster(t *testing.T) {
 	g.Expect(obj).ToNot(BeNil())
 	g.Expect(err).ToNot(HaveOccurred())
 
-	g.Expect(obj.GetAnnotations()).To(HaveKeyWithValue(clusterv1.ClusterTopologyUpgradeStepAnnotation, ""))
+	g.Expect(obj.GetAnnotations()).ToNot(HaveKey(clusterv1.ClusterTopologyUpgradeStepAnnotation))
 }
 
 func TestComputeMachineDeployment(t *testing.T) {

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -390,7 +390,7 @@ func (r *Reconciler) reconcile(ctx context.Context, s *scope.Scope) (ctrl.Result
 		return ctrl.Result{}, errors.Wrap(err, "error creating dynamic watch")
 	}
 
-	anyManagedFieldIssueMitigated, err := r.mitigateManagedFieldsIssue(ctx, s)
+	anyManagedFieldIssueMitigated, err := r.migrateClusterAndMitigateManagedFieldsIssue(ctx, s)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/topology/cluster/managedfieldsmitigation.go
+++ b/internal/controllers/topology/cluster/managedfieldsmitigation.go
@@ -24,12 +24,12 @@ import (
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 )
 
-func (r *Reconciler) mitigateManagedFieldsIssue(ctx context.Context, s *scope.Scope) (bool, error) {
+func (r *Reconciler) migrateClusterAndMitigateManagedFieldsIssue(ctx context.Context, s *scope.Scope) (bool, error) {
 	if s.Current == nil {
 		return false, nil
 	}
 
-	anyManagedFieldIssueMitigated, err := ssa.MitigateManagedFieldsIssue(ctx, r.Client, s.Current.Cluster, structuredmerge.TopologyManagerName)
+	anyManagedFieldIssueMitigated, err := ssa.MigrateClusterAndMitigateManagedFieldsIssue(ctx, r.Client, s.Current.Cluster)
 	if err != nil {
 		return false, err
 	}

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -501,30 +503,31 @@ func (r *Reconciler) reconcileMachineHealthCheck(ctx context.Context, current, d
 func (r *Reconciler) reconcileCluster(ctx context.Context, s *scope.Scope) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	// Check differences between current and desired state, and eventually patch the current object.
-	patchHelper, err := structuredmerge.NewServerSidePatchHelper(ctx, s.Current.Cluster, s.Desired.Cluster, r.Client, r.ssaCache)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create patch helper for Cluster %s", klog.KObj(s.Current.Cluster))
-	}
-	if !patchHelper.HasChanges() {
+	currentCluster := s.Current.Cluster
+	desiredCluster := s.Desired.Cluster
+
+	if maps.Equal(currentCluster.Labels, desiredCluster.Labels) &&
+		maps.Equal(currentCluster.Annotations, desiredCluster.Annotations) &&
+		currentCluster.Spec.InfrastructureRef == desiredCluster.Spec.InfrastructureRef &&
+		currentCluster.Spec.ControlPlaneRef == desiredCluster.Spec.ControlPlaneRef {
 		log.V(3).Info("No changes for Cluster")
 		return nil
 	}
 
-	diff := patchHelper.Diff()
-	patchData := patchHelper.PatchData()
-	if diff == "" && patchData == "" {
-		log.Info("Patching Cluster")
-	} else {
-		log.Info("Patching Cluster", "diff", diff, "patch", patchData)
-	}
-	modifiedResourceVersion, err := patchHelper.Patch(ctx)
+	// Note: Using DeepCopy here to avoid modifying s.Current.Cluster (we might be using it later in the same Reconcile).
+	desiredCluster = desiredCluster.DeepCopy()
+
+	patchData, err := client.MergeFrom(currentCluster).Data(desiredCluster)
 	if err != nil {
+		return errors.Wrapf(err, "failed to patch Cluster %s: failed to calculate patch", klog.KObj(s.Current.Cluster))
+	}
+	log.Info("Patching Cluster", "patch", patchData)
+	if err := r.Client.Patch(ctx, desiredCluster, client.RawPatch(types.MergePatchType, patchData)); err != nil {
 		return errors.Wrapf(err, "failed to patch Cluster %s", klog.KObj(s.Current.Cluster))
 	}
 	r.recorder.Eventf(s.Current.Cluster, corev1.EventTypeNormal, updateEventReason, "Updated Cluster %q", klog.KObj(s.Current.Cluster))
 
-	r.controller.DeferNextReconcileUntilCacheUpToDate(s.Current.Cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Cluster"), modifiedResourceVersion)
+	r.controller.DeferNextReconcileUntilCacheUpToDate(s.Current.Cluster, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Cluster"), desiredCluster.ResourceVersion)
 	return nil
 }
 

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -1376,14 +1376,27 @@ func TestReconcileCluster(t *testing.T) {
 		Build()
 	// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
 	cluster1.Spec.Paused = ptr.To(true)
-	cluster1WithReferences := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+	cluster1WithReferencesLabelsAnnotations := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+		WithLabels(map[string]string{
+			clusterv1.ClusterNameLabel:          "cluster1",
+			clusterv1.ClusterTopologyOwnedLabel: "",
+		}).
+		WithAnnotations(map[string]string{
+			clusterv1.ClusterTopologyUpgradeStepAnnotation: "v1.29.0",
+		}).
+		WithTopology(&clusterv1.Topology{
+			ClassRef: clusterv1.ClusterClassRef{
+				Name: "class1",
+			},
+			Version: "v1.30.0",
+		}).
 		WithInfrastructureCluster(builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").
 			Build()).
 		WithControlPlane(builder.TestControlPlane(metav1.NamespaceDefault, "control-plane1").Build()).
 		Build()
-	cluster2WithReferences := cluster1WithReferences.DeepCopy()
-	cluster2WithReferences.SetGroupVersionKind(cluster1WithReferences.GroupVersionKind())
-	cluster2WithReferences.Name = "cluster2"
+	cluster2ReferencesLabelsAnnotations := cluster1WithReferencesLabelsAnnotations.DeepCopy()
+	cluster2ReferencesLabelsAnnotations.SetGroupVersionKind(cluster1WithReferencesLabelsAnnotations.GroupVersionKind())
+	cluster2ReferencesLabelsAnnotations.Name = "cluster2"
 
 	tests := []struct {
 		name    string
@@ -1393,17 +1406,17 @@ func TestReconcileCluster(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Should update the cluster if infrastructure and control plane references are not set",
+			name:    "Should update the cluster if infrastructure and control plane references, labels and annotations are not set",
 			current: cluster1,
-			desired: cluster1WithReferences,
-			want:    cluster1WithReferences,
+			desired: cluster1WithReferencesLabelsAnnotations,
+			want:    cluster1WithReferencesLabelsAnnotations,
 			wantErr: false,
 		},
 		{
-			name:    "Should be a no op if infrastructure and control plane references are already set",
-			current: cluster2WithReferences,
-			desired: cluster2WithReferences,
-			want:    cluster2WithReferences,
+			name:    "Should be a no op if infrastructure and control plane references, labels and annotations are already set",
+			current: cluster2ReferencesLabelsAnnotations,
+			desired: cluster2ReferencesLabelsAnnotations,
+			want:    cluster2ReferencesLabelsAnnotations,
 			wantErr: false,
 		},
 	}
@@ -1434,10 +1447,9 @@ func TestReconcileCluster(t *testing.T) {
 			g.Expect(env.CreateAndWait(ctx, cpt)).To(Succeed())
 			g.Expect(env.CreateAndWait(ctx, clusterClass)).To(Succeed())
 
-			if tt.current != nil {
-				// NOTE: it is ok to use create given that the Cluster are created by user.
-				g.Expect(env.CreateAndWait(ctx, tt.current)).To(Succeed())
-			}
+			// NOTE: it is ok to use create given that the Cluster are created by user.
+			g.Expect(env.CreateAndWait(ctx, tt.current)).To(Succeed())
+			tt.desired.ResourceVersion = tt.current.ResourceVersion // Set resourceVersion so patch works.
 
 			s := scope.New(tt.current)
 
@@ -3809,6 +3821,12 @@ func TestReconcileState(t *testing.T) {
 		infrastructureCluster := builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Build()
 		controlPlane := builder.TestControlPlane(metav1.NamespaceDefault, "controlplane-cluster1").Build()
 		desiredCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
+				},
+				Version: "v1.30.0",
+			}).
 			WithInfrastructureCluster(infrastructureCluster).
 			WithControlPlane(controlPlane).
 			Build()
@@ -3824,6 +3842,7 @@ func TestReconcileState(t *testing.T) {
 
 		// NOTE: it is ok to use create given that the Cluster are created by user.
 		g.Expect(env.CreateAndWait(ctx, currentCluster)).To(Succeed())
+		desiredCluster.ResourceVersion = currentCluster.ResourceVersion // Set resourceVersion so patch works.
 
 		s := scope.New(currentCluster)
 		s.Blueprint = &scope.ClusterBlueprint{ClusterClass: &clusterv1.ClusterClass{}}
@@ -3874,6 +3893,12 @@ func TestReconcileState(t *testing.T) {
 		infrastructureCluster := builder.TestInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Build()
 		controlPlane := builder.TestControlPlane(metav1.NamespaceDefault, "controlplane-cluster1").Build()
 		desiredCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
+				},
+				Version: "v1.30.0",
+			}).
 			WithInfrastructureCluster(infrastructureCluster).
 			WithControlPlane(controlPlane).
 			Build()
@@ -3889,6 +3914,7 @@ func TestReconcileState(t *testing.T) {
 
 		// NOTE: it is ok to use create given that the Cluster are created by user.
 		g.Expect(env.CreateAndWait(ctx, currentCluster)).To(Succeed())
+		desiredCluster.ResourceVersion = currentCluster.ResourceVersion // Set resourceVersion so patch works.
 
 		s := scope.New(currentCluster)
 		s.Blueprint = &scope.ClusterBlueprint{ClusterClass: &clusterv1.ClusterClass{}}
@@ -3926,12 +3952,24 @@ func TestReconcileState(t *testing.T) {
 		controlPlane := builder.TestControlPlane(metav1.NamespaceDefault, "controlplane-cluster1").Build()
 
 		currentCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
+				},
+				Version: "v1.30.0",
+			}).
 			WithInfrastructureCluster(infrastructureCluster).
 			Build()
 		// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
 		currentCluster.Spec.Paused = ptr.To(true)
 
 		desiredCluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+			WithTopology(&clusterv1.Topology{
+				ClassRef: clusterv1.ClusterClassRef{
+					Name: "class1",
+				},
+				Version: "v1.30.0",
+			}).
 			WithInfrastructureCluster(infrastructureCluster).
 			WithControlPlane(controlPlane).
 			Build()
@@ -3943,6 +3981,7 @@ func TestReconcileState(t *testing.T) {
 
 		// NOTE: it is ok to use create given that the Cluster are created by user.
 		g.Expect(env.CreateAndWait(ctx, currentCluster)).To(Succeed())
+		desiredCluster.ResourceVersion = currentCluster.ResourceVersion // Set resourceVersion so patch works.
 
 		s := scope.New(currentCluster)
 		s.Blueprint = &scope.ClusterBlueprint{ClusterClass: &clusterv1.ClusterClass{}}

--- a/internal/controllers/topology/cluster/structuredmerge/options.go
+++ b/internal/controllers/topology/cluster/structuredmerge/options.go
@@ -17,9 +17,6 @@ limitations under the License.
 package structuredmerge
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 )
@@ -40,28 +37,6 @@ var (
 		{"metadata", "ownerReferences"},
 		{"spec"},
 	}
-
-	// allowedPathsCluster are the allowed paths specific for Clusters.
-	// The cluster object is not created by the topology controller and already contains fields which are
-	// not supposed for the topology controller to have an opinion on / take (co-)ownership of.
-	// Because of that the allowedPaths are different to other objects.
-	// NOTE: This is mostly the same as defaultAllowedPaths but having more restrictions.
-	allowedPathsCluster = []contract.Path{
-		// apiVersion, kind, name and namespace are required field for a server side apply intent.
-		{"apiVersion"},
-		{"kind"},
-		{"metadata", "name"},
-		{"metadata", "namespace"},
-		{"metadata", "annotations", clusterv1.ClusterTopologyUpgradeStepAnnotation},
-		// uid is optional for a server side apply intent but sets the expectation of an object getting created or a specific one updated.
-		{"metadata", "uid"},
-		// the topology controller controls/has an opinion for the labels ClusterNameLabel
-		// and ClusterTopologyOwnedLabel as well as infrastructureRef and controlPlaneRef in spec.
-		{"metadata", "labels", clusterv1.ClusterNameLabel},
-		{"metadata", "labels", clusterv1.ClusterTopologyOwnedLabel},
-		{"spec", "infrastructureRef"},
-		{"spec", "controlPlaneRef"},
-	}
 )
 
 // HelperOption is some configuration that modifies options for Helper.
@@ -76,17 +51,12 @@ type HelperOptions struct {
 }
 
 // newHelperOptions returns initialized HelperOptions.
-func newHelperOptions(target client.Object, opts ...HelperOption) *HelperOptions {
+func newHelperOptions(opts ...HelperOption) *HelperOptions {
 	helperOptions := &HelperOptions{
 		FilterObjectInput: ssa.FilterObjectInput{
 			AllowedPaths: defaultAllowedPaths,
 			IgnorePaths:  []contract.Path{},
 		},
-	}
-	// Overwrite the allowedPaths for Cluster objects to prevent the topology controller
-	// to take ownership of fields it is not supposed to.
-	if _, ok := target.(*clusterv1.Cluster); ok {
-		helperOptions.AllowedPaths = allowedPathsCluster
 	}
 	helperOptions = helperOptions.ApplyOptions(opts)
 	return helperOptions

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -43,7 +43,7 @@ type serverSidePatchHelper struct {
 // NewServerSidePatchHelper returns a new PatchHelper using server side apply.
 func NewServerSidePatchHelper(ctx context.Context, original, modified client.Object, c client.Client, ssaCache ssa.Cache, opts ...HelperOption) (PatchHelper, error) {
 	// Create helperOptions for filtering the original and modified objects to the desired intent.
-	helperOptions := newHelperOptions(modified, opts...)
+	helperOptions := newHelperOptions(opts...)
 
 	// If required, convert the original and modified objects to unstructured and filter out all the information
 	// not relevant for the topology controller.

--- a/internal/util/ssa/managedfieldsmitigation.go
+++ b/internal/util/ssa/managedfieldsmitigation.go
@@ -36,16 +36,117 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1beta1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 )
 
-const beforeFirstApplyManager = "before-first-apply"
+const (
+	beforeFirstApplyManager = "before-first-apply"
+
+	oldClusterSSAManager = "capi-topology"
+
+	patchManager = "manager"
+)
 
 var kcpScheme = runtime.NewScheme()
 
 func init() {
 	_ = controlplanev1.AddToScheme(kcpScheme)
 	_ = controlplanev1beta1.AddToScheme(kcpScheme)
+}
+
+// MigrateClusterAndMitigateManagedFieldsIssue migrates the Cluster object to regular patch
+// and mitigates the managedField apiserver issue,
+// where apiserver drops managedFields of an object under certain circumstances:
+// https://github.com/kubernetes/kubernetes/issues/136919
+//
+// It removes before-first-apply and capi-topology entries (if they exist)
+// and ensures that there is always a (minimal) entry for manager:Update to avoid
+// that the apiserver adds a new before-first-apply entry during the next SSA call.
+//
+// This addresses the issue in most scenarios, but it also means that an SSA call (by a user) directly after
+// we cleaned up managedFields won't be able to unset fields that the same user previously set.
+//
+// The following cases have to be handled:
+// Case 0: no-op
+//   - [manager:Update]                                                     => [manager:Update]
+//
+// Case 1: no managedFields
+//   - []                                                                   => [manager:Update]
+//
+// Case 2: before-first-apply & capi-topology entries
+//   - a: [before-first-apply:Apply]                                        => [manager:Update]
+//   - b: [capi-topology:Apply]                                             => [manager:Update]
+//   - c: [before-first-apply:Apply,other managers ...]                     => [other managers ...]
+//   - d: [capi-topology:Apply,other managers ...]                          => [other managers ...]
+//   - e: [before-first-apply:Apply,capi-topology:Apply,other managers ...] => [other managers ...]
+//
+// Note: Once the migration period from capi-topology:Apply => manager:Update is over we should remove the migration
+// code. Then we should discuss if we still want to keep the managedField mitigation for other clients that use SSA
+// with the Cluster object until the issue has been fixed in apiserver and our minimal supported Kubernetes version has the fix.
+// Note: Eventually we would like to remove this so we can stop caching managedFields for Cluster objects.
+func MigrateClusterAndMitigateManagedFieldsIssue(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (bool, error) {
+	if util.IsNil(cluster) {
+		// Return if object is nil.
+		return false, nil
+	}
+
+	managedFields := cluster.GetManagedFields()
+
+	if len(managedFields) > 0 && !slices.ContainsFunc(managedFields, isManager(beforeFirstApplyManager, oldClusterSSAManager)) {
+		// Return if object has managedFields and no before-first-apply or capi-topology entry.
+		return false, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	// Remove before-first-apply and capi-topology entries if they exist.
+	managedFields = slices.DeleteFunc(managedFields, isManager(beforeFirstApplyManager, oldClusterSSAManager))
+
+	// Add manager:Update entry managedFields are empty.
+	// Add a seeding managedField entry to prevent SSA to create/infer a default managedField entry when the
+	// first SSA is applied.
+	// If an existing object doesn't have managedFields when applying the first SSA the API server
+	// creates an entry with operation=Update (guessing where the object comes from), but this entry ends up
+	// acting as a co-ownership and we want to prevent this.
+	// NOTE: fieldV1Map cannot be empty, so we add metadata.name which will be cleaned up at the next call with
+	//       the same manager.
+	if len(managedFields) == 0 {
+		managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+			Manager:    patchManager,
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: clusterv1.GroupVersion.String(),
+			Time:       ptr.To(metav1.Now()),
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+		})
+	}
+
+	// Create a patch to update only managedFields.
+	// Include resourceVersion to avoid race conditions.
+	jsonPatch := []map[string]interface{}{
+		{
+			"op":    "replace",
+			"path":  "/metadata/managedFields",
+			"value": managedFields,
+		},
+		{
+			"op":    "replace",
+			"path":  "/metadata/resourceVersion",
+			"value": cluster.GetResourceVersion(),
+		},
+	}
+	patch, err := json.Marshal(jsonPatch)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to migrate Cluster to regular patch and mitigate managedFields issue: failed to marshal patch for managedFields entry")
+	}
+
+	log.Info("Migrating Cluster or fixing up managedFields to mitigate kube-apiserver managedFields issue", "Cluster", klog.KObj(cluster))
+	if err := c.Patch(ctx, cluster, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+		return false, errors.Wrapf(err, "failed to migrate Cluster to regular patch and mitigate managedFields issue: failed to patch %s %s", "Cluster", klog.KObj(cluster))
+	}
+
+	return true, nil
 }
 
 // MitigateManagedFieldsIssue mitigates the managedField apiserver issue,
@@ -88,7 +189,9 @@ func MitigateManagedFieldsIssue(ctx context.Context, c client.Client, obj client
 		return false, nil
 	}
 
-	if len(obj.GetManagedFields()) > 0 && !slices.ContainsFunc(obj.GetManagedFields(), isManager(beforeFirstApplyManager)) {
+	managedFields := obj.GetManagedFields()
+
+	if len(managedFields) > 0 && !slices.ContainsFunc(managedFields, isManager(beforeFirstApplyManager)) {
 		// Return if object has managedFields and no before-first-apply entry.
 		return false, nil
 	}
@@ -100,10 +203,10 @@ func MitigateManagedFieldsIssue(ctx context.Context, c client.Client, obj client
 	}
 
 	// Remove before-first-apply entry if it exists.
-	managedFields := slices.DeleteFunc(obj.GetManagedFields(), isManager(beforeFirstApplyManager))
+	managedFields = slices.DeleteFunc(managedFields, isManager(beforeFirstApplyManager))
 
 	// Add fieldManager entry if it does not exist.
-	if !slices.ContainsFunc(obj.GetManagedFields(), isManager(fieldManager)) {
+	if !slices.ContainsFunc(managedFields, isManager(fieldManager)) {
 		fieldsV1, err := computeManagedFields(obj, objGVK)
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to mitigate managedFields issue: failed to compute managedFields entry")
@@ -216,9 +319,14 @@ func computeManagedFields(obj client.Object, objGVK schema.GroupVersionKind) ([]
 	return fieldsV1, nil
 }
 
-func isManager(manager string) func(entry metav1.ManagedFieldsEntry) bool {
+func isManager(managers ...string) func(entry metav1.ManagedFieldsEntry) bool {
 	return func(entry metav1.ManagedFieldsEntry) bool {
-		return entry.Manager == manager
+		for _, manager := range managers {
+			if entry.Manager == manager {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/util/ssa/managedfieldsmitigation_test.go
+++ b/internal/util/ssa/managedfieldsmitigation_test.go
@@ -38,6 +38,436 @@ import (
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
+func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
+	testFieldManager := "ssa-manager"
+	otherFieldManager := "other-manager"
+
+	cluster := &clusterv1.Cluster{
+		// Have to set TypeMeta explicitly when using SSA with typed objects.
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"label-1": "value-1",
+			},
+			Annotations: map[string]string{
+				"annotation-1": "value-1",
+			},
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
+			},
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.InfrastructureGroupVersion.Group,
+				Kind:     builder.GenericInfrastructureClusterKind,
+				Name:     "infra1",
+			},
+		},
+	}
+	clusterApply := &clusterv1.Cluster{
+		// Have to set TypeMeta explicitly when using SSA with typed objects.
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				"label-ssa": "value-1",
+			},
+			Annotations: map[string]string{
+				"annotation-ssa": "value-1",
+			},
+		},
+		Spec: clusterv1.ClusterSpec{
+			ClusterNetwork: clusterv1.ClusterNetwork{
+				Services: clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"10.128.0.0/12"},
+				},
+				Pods: clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"192.168.0.0/16"},
+				},
+			},
+		},
+	}
+	// Cluster after apply is the combination of cluster and clusterApply.
+	clusterAfterApply := clusterApply.DeepCopy()
+	clusterAfterApply.Annotations["annotation-1"] = "value-1"
+	clusterAfterApply.Labels["label-1"] = "value-1"
+	clusterAfterApply.Spec.ControlPlaneRef = cluster.Spec.ControlPlaneRef
+	clusterAfterApply.Spec.InfrastructureRef = cluster.Spec.InfrastructureRef
+	clusterManagedFieldsAfterApply := trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-ssa":{}
+	},
+	"f:labels":{
+		"f:label-ssa":{}
+	}
+},
+"f:spec":{
+	"f:clusterNetwork":{
+		"f:pods":{
+			"f:cidrBlocks":{}
+		},
+		"f:services":{
+			"f:cidrBlocks":{}
+		}
+	}
+}}`)
+
+	type objectApply struct {
+		object                client.Object
+		expectedObject        client.Object
+		expectedManagedFields []metav1.ManagedFieldsEntry
+	}
+	tests := []struct {
+		name                             string
+		object                           *clusterv1.Cluster
+		managedFields                    []metav1.ManagedFieldsEntry
+		expectManagedFieldIssueMitigated bool
+		expectedManagedFields            []metav1.ManagedFieldsEntry
+		objectApplies                    []objectApply
+	}{
+		{
+			name:   "Case 0: [manager:Update] => [manager:Update]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    patchManager,
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	},
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+			expectManagedFieldIssueMitigated: false,
+			// managedFields are not changed
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    patchManager,
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	},
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+		},
+		{
+			name:                             "Case 1: [] => [manager:Update] (+ SSA call afterwards)",
+			object:                           cluster.DeepCopy(),
+			managedFields:                    []metav1.ManagedFieldsEntry{{}}, // One empty entry sets managedFields on the object to empty
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    patchManager,
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:name":{}
+}}`))},
+			}},
+			objectApplies: []objectApply{
+				{
+					object:         clusterApply,
+					expectedObject: clusterAfterApply,
+					expectedManagedFields: []metav1.ManagedFieldsEntry{{
+						Manager:    testFieldManager,
+						Operation:  metav1.ManagedFieldsOperationApply,
+						APIVersion: clusterv1.GroupVersion.String(),
+						FieldsType: "FieldsV1",
+						FieldsV1:   &metav1.FieldsV1{Raw: []byte(clusterManagedFieldsAfterApply)},
+					}, {
+						Manager:    patchManager,
+						Operation:  metav1.ManagedFieldsOperationUpdate,
+						APIVersion: clusterv1.GroupVersion.String(),
+						FieldsType: "FieldsV1",
+						FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:name":{}
+}}`))},
+					}},
+				},
+			},
+		},
+		{
+			name:   "Case 2a: [before-first-apply:Apply] => [manager:Update]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    beforeFirstApplyManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	},
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    patchManager,
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+			}},
+		},
+		{
+			name:   "Case 2b: [capi-topology:Apply] => [manager:Update]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    oldClusterSSAManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	},
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    patchManager,
+				Operation:  metav1.ManagedFieldsOperationUpdate,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+			}},
+		},
+		{
+			name:   "Case 2c: [before-first-apply:Apply,other managers ...] => [other managers ...]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    beforeFirstApplyManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	}
+}}`))},
+			}, {
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))}}},
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+		},
+		{
+			name:   "Case 2d: [capi-topology:Apply,other managers ...] => [other managers ...]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    oldClusterSSAManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	}
+}}`))},
+			}, {
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))}}},
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+		},
+		{
+			name:   "Case 2e: [before-first-apply:Apply,capi-topology:Apply,other managers ...] => [other managers ...]",
+			object: cluster.DeepCopy(),
+			managedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    beforeFirstApplyManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:annotations":{
+		"f:annotation-1":{}
+	}
+}}`))},
+			}, {
+				Manager:    oldClusterSSAManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:finalizers":{
+		".":{},
+		"v:\"test.com/finalizer\"":{}
+	}
+}}`))},
+			}, {
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				Time:       ptr.To(metav1.Now()),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))}}},
+			expectManagedFieldIssueMitigated: true,
+			expectedManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:    otherFieldManager,
+				Operation:  metav1.ManagedFieldsOperationApply,
+				APIVersion: clusterv1.GroupVersion.String(),
+				FieldsType: "FieldsV1",
+				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+"f:metadata":{
+	"f:labels":{
+		"f:label-1":{}
+	}
+}}`))},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			g := NewWithT(t)
+
+			g.Expect(env.Client.Create(ctx, tt.object)).To(Succeed())
+			t.Cleanup(func() {
+				ctx := context.Background()
+				g.Expect(env.CleanupAndWait(ctx, tt.object)).To(Succeed())
+			})
+
+			// Overwrite managedFields on the object with tt.managedFields.
+			jsonPatch := []map[string]interface{}{
+				{
+					"op":    "replace",
+					"path":  "/metadata/managedFields",
+					"value": tt.managedFields,
+				},
+				{
+					"op":    "replace",
+					"path":  "/metadata/resourceVersion",
+					"value": tt.object.GetResourceVersion(),
+				},
+			}
+			patch, err := json.Marshal(jsonPatch)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(env.Client.Patch(ctx, tt.object, client.RawPatch(types.JSONPatchType, patch))).To(Succeed())
+			// Verify managedField patch above worked.
+			if reflect.DeepEqual(tt.managedFields, []metav1.ManagedFieldsEntry{{}}) {
+				g.Expect(tt.object.GetManagedFields()).To(BeEmpty())
+			} else {
+				g.Expect(cleanupTime(tt.object.GetManagedFields())).To(BeComparableTo(cleanupTime(tt.managedFields)))
+			}
+
+			// Run mitigation code and verify managedFields are as expected afterward.
+			managedFieldIssueMitigated, err := MigrateClusterAndMitigateManagedFieldsIssue(ctx, env.GetClient(), tt.object)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(managedFieldIssueMitigated).To(Equal(tt.expectManagedFieldIssueMitigated))
+			g.Expect(cleanupTime(tt.object.GetManagedFields())).To(BeComparableTo(tt.expectedManagedFields))
+
+			for _, apply := range tt.objectApplies {
+				// Apply object and verify managedFields are as expected afterward.
+				g.Expect(Patch(ctx, env.GetClient(), testFieldManager, apply.object)).To(Succeed())
+				g.Expect(cleanupTime(apply.object.GetManagedFields())).To(BeComparableTo(apply.expectedManagedFields))
+
+				// Verify spec is as expected
+				expectedJSON, err := json.Marshal(apply.expectedObject)
+				g.Expect(err).ToNot(HaveOccurred())
+				expectedJSONMap := map[string]any{}
+				g.Expect(json.Unmarshal(expectedJSON, &expectedJSONMap)).To(Succeed())
+				modifiedJSON, err := json.Marshal(apply.object)
+				g.Expect(err).ToNot(HaveOccurred())
+				modifiedJSONMap := map[string]any{}
+				g.Expect(json.Unmarshal(modifiedJSON, &modifiedJSONMap)).To(Succeed())
+				g.Expect(modifiedJSONMap["metadata"].(map[string]any)["annotations"]).To(BeComparableTo(expectedJSONMap["metadata"].(map[string]any)["annotations"]))
+				g.Expect(modifiedJSONMap["metadata"].(map[string]any)["labels"]).To(BeComparableTo(expectedJSONMap["metadata"].(map[string]any)["labels"]))
+				g.Expect(modifiedJSONMap["spec"]).To(BeComparableTo(expectedJSONMap["spec"]))
+			}
+		})
+	}
+}
+
 func TestMitigateManagedFieldsIssue(t *testing.T) {
 	testFieldManager := "ssa-manager"
 	otherFieldManager := "other-manager"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
After we hit several issues with SSA in the past we would like to reduce SSA usage wherever possible.
As we don't actually need SSA to patch a few fields on the Cluster object this PR refactors the Cluster topology
controller to use a regular patch instead of SSA

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->