### PR TITLE
🌱 Do not follow redirects when calling runtime extensions

### DIFF
--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -506,6 +506,15 @@ func createHTTPClient(certFile, keyFile string, caData []byte, hostName string) 
 	httpClient.Transport = utilnet.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
 	})
+
+	// Runtime extensions are called at the URL registered via the ExtensionConfig.
+	// Do not follow redirects so the extension server cannot reroute the call to a
+	// different host (e.g. a link-local metadata endpoint), which would bypass the
+	// pinned TLS server name and turn the response into an SSRF primitive.
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return errors.New("redirects are not allowed when calling a runtime extension")
+	}
+
 	return httpClient, nil
 }
 

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -511,8 +511,10 @@ func createHTTPClient(certFile, keyFile string, caData []byte, hostName string) 
 	// Do not follow redirects so the extension server cannot reroute the call to a
 	// different host (e.g. a link-local metadata endpoint), which would bypass the
 	// pinned TLS server name and turn the response into an SSRF primitive.
+	// Returning ErrUseLastResponse stops at the redirect and hands it back as the
+	// response, so the call fails on the non-200 status instead of being followed.
 	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-		return errors.New("redirects are not allowed when calling a runtime extension")
+		return http.ErrUseLastResponse
 	}
 
 	return httpClient, nil

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -1111,6 +1111,18 @@ func TestClient_GetHttpClient(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 }
 
+func TestCreateHTTPClient_doesNotFollowRedirects(t *testing.T) {
+	g := NewWithT(t)
+
+	httpClient, err := createHTTPClient("", "", testcerts.CACert, "extension.example.com")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(httpClient.CheckRedirect).ToNot(BeNil())
+
+	// A redirect returned by an extension server must not be followed, otherwise
+	// the response could reroute the call to an arbitrary host.
+	g.Expect(httpClient.CheckRedirect(&http.Request{}, nil)).To(HaveOccurred())
+}
+
 func cacheKeyFunc(extensionName, extensionConfigResourceVersion string, request runtimehooksv1.RequestObject) string {
 	// Note: extensionName is identical to the value of the name parameter passed into CallExtension.
 	s := fmt.Sprintf("%s-%s", extensionName, extensionConfigResourceVersion)

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -1119,8 +1119,9 @@ func TestCreateHTTPClient_doesNotFollowRedirects(t *testing.T) {
 	g.Expect(httpClient.CheckRedirect).ToNot(BeNil())
 
 	// A redirect returned by an extension server must not be followed, otherwise
-	// the response could reroute the call to an arbitrary host.
-	g.Expect(httpClient.CheckRedirect(&http.Request{}, nil)).To(HaveOccurred())
+	// the response could reroute the call to an arbitrary host. ErrUseLastResponse
+	// makes the client stop at the redirect rather than following it.
+	g.Expect(httpClient.CheckRedirect(&http.Request{}, nil)).To(MatchError(http.ErrUseLastResponse))
 }
 
 func cacheKeyFunc(extensionName, extensionConfigResourceVersion string, request runtimehooksv1.RequestObject) string {


### PR DESCRIPTION
The runtime extension client in createHTTPClient builds its http.Client without a CheckRedirect policy, so it follows whatever redirect an extension server returns. A 307 to e.g. http://169.254.169.254 makes the controller re-POST the hook body there, bypassing the pinned TLS ServerName entirely. Extensions are registered at a fixed URL, so the client should only ever talk to that endpoint; refuse redirects instead. Verified with an httptest server that 307s to a second listener.