### PR TITLE
✨ Migrate ClusterClass changes e2e test from the docker to the in-memory backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test/e2e/data/infrastructure-docker/**/cluster-template*.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-quick-start-runtimesdk.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-quick-start-runtimesdk-v1beta1.yaml
 !test/e2e/data/infrastructure-docker/**/cluster-template-in-memory.yaml
+!test/e2e/data/infrastructure-docker/**/cluster-template-in-memory-topology.yaml
 !test/e2e/data/infrastructure-docker/**/clusterclass-in-memory.yaml
 test/e2e/data/infrastructure-docker/**/clusterclass-*.yaml
 test/e2e/data/infrastructure-inmemory/**/cluster-template*.yaml

--- a/test/e2e/clusterclass_changes.go
+++ b/test/e2e/clusterclass_changes.go
@@ -112,6 +112,18 @@ type ClusterClassChangesSpecInput struct {
 	// Allows to inject a function to be run after test namespace is created.
 	// If not specified, this is a no-op.
 	PostNamespaceCreated func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string)
+
+	// ExtensionConfigName is the name of the ExtensionConfig. Defaults to "clusterclass-changes".
+	// This value is provided to clusterctl as "EXTENSION_CONFIG_NAME" variable and can be used to template the
+	// name of the ExtensionConfig into the ClusterClass.
+	ExtensionConfigName string
+
+	// ExtensionServiceNamespace is the namespace where the service for the Runtime SDK is located
+	// and is used to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionServiceNamespace string
+
+	// ExtensionServiceName is the name of the service to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionServiceName string
 }
 
 // ClusterClassChangesSpec implements a test that verifies that ClusterClass changes are rolled out successfully.
@@ -154,6 +166,11 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
 		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.MustGetVariable(KubernetesVersion)))
 		Expect(input.ModifyControlPlaneFields).ToNot(BeEmpty(), "Invalid argument. input.ModifyControlPlaneFields can't be empty when calling %s spec", specName)
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			if input.ExtensionConfigName == "" {
+				input.ExtensionConfigName = specName
+			}
+		}
 
 		// Set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = framework.SetupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, input.PostNamespaceCreated)
@@ -163,11 +180,27 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 	})
 
 	It("Should successfully rollout the managed topology upon changes to the ClusterClass", func() {
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			By("Deploy Test Extension ExtensionConfig")
+			defaultAllHandlersToBlocking := false
+			extensionConfig := extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, true, defaultAllHandlersToBlocking, namespace.Name, clusterClassNamespace.Name)
+			Expect(client.IgnoreAlreadyExists(input.BootstrapClusterProxy.GetClient().Create(ctx,
+				extensionConfig))).
+				To(Succeed(), "Failed to create the ExtensionConfig")
+		}
+
 		By("Creating a workload cluster")
 		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
 		if input.InfrastructureProvider != nil {
 			infrastructureProvider = *input.InfrastructureProvider
 		}
+
+		variables := map[string]string{}
+		if input.ExtensionConfigName != "" {
+			// This is used to template the name of the ExtensionConfig into the ClusterClass.
+			variables["EXTENSION_CONFIG_NAME"] = input.ExtensionConfigName
+		}
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -181,6 +214,7 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 				KubernetesVersion:        input.E2EConfig.MustGetVariable(KubernetesVersion),
 				ControlPlaneMachineCount: ptr.To[int64](1),
 				WorkerMachineCount:       ptr.To[int64](1),
+				ClusterctlVariables:      variables,
 			},
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -31,7 +31,13 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", Label("Clus
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			Flavor:                "topology",
+			Flavor:                "in-memory-topology",
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
 			// ModifyControlPlaneFields are the ControlPlane fields which will be set on the
 			// ControlPlaneTemplate of the ClusterClass after the initial Cluster creation.
 			// The test verifies that these fields are rolled out to the ControlPlane.
@@ -48,42 +54,9 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", Label("Clus
 			// InfrastructureMachineTemplate of all MachineDeploymentClasses of the ClusterClass after the initial Cluster creation.
 			// The test verifies that these fields are rolled out to the MachineDeployments.
 			ModifyMachineDeploymentInfrastructureMachineTemplateFields: map[string]interface{}{
-				"spec.template.spec.backend.docker.extraMounts": []interface{}{
-					map[string]interface{}{
-						"containerPath": "/var/run/docker.sock",
-						"hostPath":      "/var/run/docker.sock",
-					},
-					map[string]interface{}{
-						// /tmp cannot be used as containerPath as
-						// it already exists.
-						"containerPath": "/test",
-						"hostPath":      "/tmp",
-					},
-				},
+				"spec.template.spec.backend.inMemory.vm.provisioning.startupDuration": "15s",
 			},
-			// ModifyMachinePoolBootstrapConfigTemplateFields are the fields which will be set on the
-			// BootstrapConfigTemplate of all MachinePoolClasses of the ClusterClass after the initial Cluster creation.
-			// The test verifies that these fields are rolled out to the MachinePools.
-			ModifyMachinePoolBootstrapConfigTemplateFields: map[string]interface{}{
-				"spec.template.spec.verbosity": int64(4),
-			},
-			// ModifyMachinePoolInfrastructureMachineTemplateFields are the fields which will be set on the
-			// InfrastructureMachinePoolTemplate of all MachinePoolClasses of the ClusterClass after the initial Cluster creation.
-			// The test verifies that these fields are rolled out to the MachinePools.
-			ModifyMachinePoolInfrastructureMachinePoolTemplateFields: map[string]interface{}{
-				"spec.template.spec.backend.docker.extraMounts": []interface{}{
-					map[string]interface{}{
-						"containerPath": "/var/run/docker.sock",
-						"hostPath":      "/var/run/docker.sock",
-					},
-					map[string]interface{}{
-						// /tmp cannot be used as containerPath as
-						// it already exists.
-						"containerPath": "/test",
-						"hostPath":      "/tmp",
-					},
-				},
-			},
+			// Note: MachinePool changes are not covered as DevMachinePool does not support in-memory backend yet.
 		}
 	})
 })

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -197,6 +197,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-topology-taints.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-ignition.yaml"
     - sourcePath: "../data/infrastructure-docker/main/cluster-template-in-memory.yaml"
+    - sourcePath: "../data/infrastructure-docker/main/cluster-template-in-memory-topology.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-in-memory.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start.yaml"
     - sourcePath: "../data/infrastructure-docker/main/clusterclass-quick-start-kcp-only.yaml"

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-in-memory-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-in-memory-topology.yaml
@@ -1,0 +1,56 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: "${NAMESPACE}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - ${DOCKER_POD_CIDRS}
+    serviceDomain: ${DOCKER_SERVICE_DOMAIN}
+    services:
+      cidrBlocks:
+      - ${DOCKER_SERVICE_CIDRS}
+  topology:
+    classRef:
+      name: in-memory
+      namespace: ${CLUSTER_CLASS_NAMESPACE:-${NAMESPACE}}
+    controlPlane:
+      deletion:
+        nodeDeletionTimeoutSeconds: 0
+        nodeVolumeDetachTimeoutSeconds: 300
+      metadata:
+        annotations:
+          Cluster.topology.controlPlane.annotation: Cluster.topology.controlPlane.annotationValue
+          Cluster.topology.controlPlane.annotation.node.cluster.x-k8s.io: Cluster.topology.controlPlane.nodeAnnotationValue
+        labels:
+          Cluster.topology.controlPlane.label: Cluster.topology.controlPlane.labelValue
+          Cluster.topology.controlPlane.label.node.cluster.x-k8s.io: Cluster.topology.controlPlane.nodeLabelValue
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+      - class: default-worker
+        deletion:
+          nodeDeletionTimeoutSeconds: 0
+          nodeVolumeDetachTimeoutSeconds: 300
+        metadata:
+          annotations:
+            Cluster.topology.machineDeployment.annotation: Cluster.topology.machineDeployment.annotationValue
+            Cluster.topology.md.annotation.node.cluster.x-k8s.io: Cluster.topology.machineDeployment.nodeAnnotationValue
+          labels:
+            Cluster.topology.machineDeployment.label: Cluster.topology.machineDeployment.labelValue
+            Cluster.topology.machineDeployment.label.node.cluster.x-k8s.io: Cluster.topology.machineDeployment.nodeLabelValue
+        minReadySeconds: 5
+        name: md-0
+        replicas: ${WORKER_MACHINE_COUNT}
+        rollout:
+          strategy:
+            rollingUpdate:
+              maxSurge: 20%
+              maxUnavailable: 0
+            type: RollingUpdate
+    variables:
+      - name: imageRepository
+        value: "kindest"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR contains the changes to migrate "When testing ClusterClass change" E2E test from docker back-end to in-memory back-end

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # Part of https://github.com/kubernetes-sigs/cluster-api/issues/13270

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->