### PR TITLE
🌱 Verify etcd serving certificate against the etcd CA

### DIFF
--- a/controlplane/kubeadm/pkg/cluster.go
+++ b/controlplane/kubeadm/pkg/cluster.go
@@ -173,17 +173,42 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, cluster *clusterv1.
 	caPool := x509.NewCertPool()
 	caPool.AppendCertsFromPEM(crtData)
 	tlsConfig := &tls.Config{
-		RootCAs:      caPool,
 		Certificates: []tls.Certificate{clientCert},
 		MinVersion:   tls.VersionTLS12,
+		// etcd members are reached through the API server proxy using their static pod
+		// name, which is not part of the serving certificate SANs, so the default host
+		// name verification can't be used. Skip it but still verify that the served
+		// certificate chains up to the etcd CA via VerifyConnection.
+		InsecureSkipVerify: true, //nolint:gosec // host name verification is replaced by VerifyConnection below.
+		VerifyConnection:   verifyEtcdServerCertificate(caPool),
 	}
-	tlsConfig.InsecureSkipVerify = true
 	return &Workload{
 		restConfig:          restConfig,
 		Client:              c,
 		CoreDNSMigrator:     &CoreDNSMigrator{},
 		etcdClientGenerator: NewEtcdClientGenerator(restConfig, tlsConfig, m.EtcdDialTimeout, m.EtcdCallTimeout, m.EtcdLogger),
 	}, nil
+}
+
+// verifyEtcdServerCertificate returns a tls.Config VerifyConnection callback that verifies the
+// etcd serving certificate chains up to roots without checking the host name. This is used
+// together with InsecureSkipVerify because etcd members are dialed through the API server proxy
+// using their static pod name, which is not present in the serving certificate SANs.
+func verifyEtcdServerCertificate(roots *x509.CertPool) func(tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) == 0 {
+			return pkgerrors.New("etcd server presented no certificates")
+		}
+		intermediates := x509.NewCertPool()
+		for _, cert := range cs.PeerCertificates[1:] {
+			intermediates.AddCert(cert)
+		}
+		_, err := cs.PeerCertificates[0].Verify(x509.VerifyOptions{
+			Roots:         roots,
+			Intermediates: intermediates,
+		})
+		return err
+	}
 }
 
 func (m *Management) getEtcdCAKeyPair(ctx context.Context, clusterKey client.ObjectKey) ([]byte, []byte, error) {

--- a/controlplane/kubeadm/pkg/cluster_test.go
+++ b/controlplane/kubeadm/pkg/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
@@ -391,4 +392,77 @@ func (f *fakeClient) Update(_ context.Context, _ client.Object, _ ...client.Upda
 		return f.updateErr
 	}
 	return nil
+}
+
+func TestVerifyEtcdServerCertificate(t *testing.T) {
+	mkCA := func(cn string) (*x509.Certificate, *rsa.PrivateKey) {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: cn},
+			NotBefore:             time.Now().Add(-time.Hour),
+			NotAfter:              time.Now().Add(time.Hour),
+			IsCA:                  true,
+			KeyUsage:              x509.KeyUsageCertSign,
+			BasicConstraintsValid: true,
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		caCert, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return caCert, key
+	}
+
+	mkServerCert := func(ca *x509.Certificate, caKey *rsa.PrivateKey) *x509.Certificate {
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(2),
+			// Intentionally use a CN/SAN that does not match the dial endpoint to
+			// mirror how etcd serving certificates look when reached via the proxy.
+			Subject:     pkix.Name{CommonName: "etcd-server"},
+			NotBefore:   time.Now().Add(-time.Hour),
+			NotAfter:    time.Now().Add(time.Hour),
+			KeyUsage:    x509.KeyUsageDigitalSignature,
+			ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cert
+	}
+
+	g := NewWithT(t)
+
+	etcdCA, etcdCAKey := mkCA("etcd-ca")
+	otherCA, otherCAKey := mkCA("other-ca")
+
+	roots := x509.NewCertPool()
+	roots.AddCert(etcdCA)
+	verify := verifyEtcdServerCertificate(roots)
+
+	// A certificate signed by the etcd CA is accepted even though its host name is not checked.
+	trusted := mkServerCert(etcdCA, etcdCAKey)
+	g.Expect(verify(tls.ConnectionState{PeerCertificates: []*x509.Certificate{trusted}})).To(Succeed())
+
+	// A certificate signed by a different CA is rejected.
+	impostor := mkServerCert(otherCA, otherCAKey)
+	g.Expect(verify(tls.ConnectionState{PeerCertificates: []*x509.Certificate{impostor}})).ToNot(Succeed())
+
+	// No certificate at all is rejected.
+	g.Expect(verify(tls.ConnectionState{})).ToNot(Succeed())
 }


### PR DESCRIPTION
GetWorkloadCluster loads the etcd CA into RootCAs but then sets InsecureSkipVerify=true, so RootCAs is discarded and the etcd serving certificate is never verified. Default verification was turned off because members are dialed through the API server proxy by their static pod name, which isn't in the serving cert SANs. Keep skipping only the host name and verify the served chain against the etcd CA via VerifyConnection.