### PR TITLE
🌱 Make the clusterctl upgrade management cluster control plane count configurable

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -136,6 +136,13 @@ type ClusterctlUpgradeSpecInput struct {
 
 	// ControlPlaneMachineCount specifies the number of control plane machines to create in the workload cluster.
 	ControlPlaneMachineCount *int64
+
+	// ManagementClusterControlPlaneMachineCount specifies the number of control plane machines to create for the
+	// self-hosted management cluster (the workload cluster that is pivoted into and used as the new management
+	// cluster). Defaults to 1 if not set. Setting this higher (e.g. 3) makes the management cluster's control
+	// plane highly available, which can reduce flakiness when the management cluster's API server is fronted by a
+	// load balancer. This has no effect when UseKindForManagementCluster is true.
+	ManagementClusterControlPlaneMachineCount *int64
 }
 
 // ClusterctlUpgradeSpecInputUpgrade defines an upgrade.
@@ -238,6 +245,10 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 
 		initKubernetesVersion = input.InitWithKubernetesVersion
 
+		if input.ManagementClusterControlPlaneMachineCount == nil {
+			input.ManagementClusterControlPlaneMachineCount = ptr.To[int64](1)
+		}
+
 		if len(input.Upgrades) == 0 {
 			// Upgrade once to latest contract version if no upgrades are specified.
 			input.Upgrades = []ClusterctlUpgradeSpecInputUpgrade{
@@ -305,7 +316,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 					Namespace:                managementClusterNamespace.Name,
 					ClusterName:              managementClusterName,
 					KubernetesVersion:        initKubernetesVersion,
-					ControlPlaneMachineCount: ptr.To[int64](1),
+					ControlPlaneMachineCount: input.ManagementClusterControlPlaneMachineCount,
 					WorkerMachineCount:       ptr.To[int64](1),
 				},
 				PreWaitForCluster: func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an optional `ManagementClusterControlPlaneMachineCount` field to `ClusterctlUpgradeSpecInput`. It defaults to 1, so existing behavior is unchanged, but lets a provider stand up a highly-available management cluster during the upgrade test.

CAPZ's `apiversion-upgrade` job is chronically flaky because the self-hosted management cluster has a single control-plane node behind a public load balancer; under upgrade load that node briefly goes unreachable and the test fails. Setting this to 3 makes the management cluster HA and fixes the flake. See kubernetes-sigs/cluster-api-provider-azure#6329, which vendors a copy of this spec as a stop-gap and switches back to this one once the field lands here.

**Which issue(s) this PR fixes**:

```release-note
Add ManagementClusterControlPlaneMachineCount to ClusterctlUpgradeSpecInput to allow a highly-available self-hosted management cluster in the clusterctl upgrade test.
```
