### PR TITLE
🌱 Add a test case to confirm that kcp can safely remove a member when it doesn't have a corresponding machine but it has no alarm

### DIFF
--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -2484,6 +2484,30 @@ func TestTargetEtcdClusterHealthy(t *testing.T) {
 		g.Expect(canSafelyTransitionToTargetState).To(BeFalse())
 	})
 
+	t.Run("Can safely remove a member when it doesn't have a corresponding machine and it has no alarm", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m1 := getMachine(metav1.NamespaceDefault, "m1-mhc-unhealthy", withMachineHealthCheckFailed())
+		m2 := getMachine(metav1.NamespaceDefault, "m2-etcd-healthy", withHealthyEtcdMember())
+
+		controlPlane := &internal.ControlPlane{
+			Machines: collections.FromMachines(m1, m2),
+		}
+		controlPlane.EtcdMembers = []*etcd.Member{
+			{
+				ID:   1,
+				Name: m1.Status.NodeRef.Name,
+			},
+			{
+				ID:   2,
+				Name: "foo",
+			},
+		}
+
+		canSafelyTransitionToTargetState := r.targetEtcdClusterHealthy(ctx, controlPlane, false, m1.Status.NodeRef.Name)
+		g.Expect(canSafelyTransitionToTargetState).To(BeTrue())
+	})
+
 	t.Run("Ignore alarms from external members being removed when computing target etcd cluster status", func(t *testing.T) {
 		g := NewWithT(t)
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR just adds a unit test case to confirm that kcp can safely remove a member when it doesn't have a corresponding machine but it has no alarm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

N/A

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area testing