### PR TITLE
✨ clustercache: expose and use DefaultTransform on CacheOptions

### DIFF
--- a/controllers/clustercache/cluster_accessor.go
+++ b/controllers/clustercache/cluster_accessor.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,6 +97,9 @@ type clusterAccessorCacheConfig struct {
 
 	// SyncPeriod is the sync period of the cache.
 	SyncPeriod *time.Duration
+
+	// DefaultTransform is applied to all objects before they are stored in the cache.
+	DefaultTransform toolscache.TransformFunc
 
 	// ByObject restricts the cache's ListWatch to the desired fields per GVK at the specified object.
 	ByObject map[client.Object]cache.ByObject

--- a/controllers/clustercache/cluster_accessor_client.go
+++ b/controllers/clustercache/cluster_accessor_client.go
@@ -237,11 +237,12 @@ func createCachedClient(ctx, cacheCtx context.Context, clusterAccessorConfig *cl
 
 	// Create the cache for the cluster.
 	cacheOptions := cache.Options{
-		HTTPClient: httpClientWith11mTimeout,
-		Scheme:     clusterAccessorConfig.Scheme,
-		Mapper:     mapper,
-		SyncPeriod: clusterAccessorConfig.Cache.SyncPeriod,
-		ByObject:   clusterAccessorConfig.Cache.ByObject,
+		HTTPClient:       httpClientWith11mTimeout,
+		Scheme:           clusterAccessorConfig.Scheme,
+		Mapper:           mapper,
+		SyncPeriod:       clusterAccessorConfig.Cache.SyncPeriod,
+		DefaultTransform: clusterAccessorConfig.Cache.DefaultTransform,
+		ByObject:         clusterAccessorConfig.Cache.ByObject,
 	}
 	remoteCache, err := cache.New(configWith11mTimeout, cacheOptions)
 	if err != nil {

--- a/controllers/clustercache/cluster_accessor_test.go
+++ b/controllers/clustercache/cluster_accessor_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -407,6 +408,66 @@ func TestWatch(t *testing.T) {
 	// Disconnect
 	accessor.Disconnect(ctx)
 	g.Expect(accessor.Connected(ctx)).To(BeFalse())
+}
+
+func TestConnectWithDefaultTransform(t *testing.T) {
+	g := NewWithT(t)
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-transform",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
+			},
+		},
+	}
+	clusterKey := client.ObjectKeyFromObject(testCluster)
+	g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, testCluster)).To(Succeed()) }()
+
+	kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, kubeconfig.FromEnvTestConfig(env.Config, testCluster))
+	g.Expect(env.CreateAndWait(ctx, kubeconfigSecret)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, kubeconfigSecret)).To(Succeed()) }()
+
+	config := buildClusterAccessorConfig(env.GetScheme(), Options{
+		SecretClient: env.GetClient(),
+		Client: ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("test-controller-manager"),
+			Timeout:   10 * time.Second,
+		},
+		Cache: CacheOptions{
+			DefaultTransform: cache.TransformStripManagedFields(),
+		},
+	}, nil)
+	accessor := newClusterAccessor(context.Background(), clusterKey, config)
+	g.Expect(accessor.Connect(ctx)).To(Succeed())
+	defer accessor.Disconnect(ctx)
+
+	// Wait for the per-cluster cache to sync.
+	cacheSyncCtx, cacheSyncCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cacheSyncCtxCancel()
+	g.Expect(accessor.lockedState.connection.cache.WaitForCacheSync(cacheSyncCtx)).To(BeTrue())
+
+	// Get the default Namespace via the uncached client: managedFields should be present
+	// because the uncached client fetches directly from the API server.
+	uncachedClient, err := accessor.GetUncachedClient(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	nsUncached := &corev1.Namespace{}
+	g.Expect(uncachedClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceDefault}, nsUncached)).To(Succeed())
+	g.Expect(nsUncached.ManagedFields).ToNot(BeEmpty())
+
+	// Get the same Namespace via the cached client: managedFields should be empty
+	// because DefaultTransform: cache.TransformStripManagedFields() was set.
+	cachedClient, err := accessor.GetClient(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+	nsCached := &corev1.Namespace{}
+	g.Expect(cachedClient.Get(ctx, client.ObjectKey{Name: metav1.NamespaceDefault}, nsCached)).To(Succeed())
+	g.Expect(nsCached.ManagedFields).To(BeEmpty())
 }
 
 type testWatcher struct {

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -71,6 +72,14 @@ type Options struct {
 type CacheOptions struct {
 	// SyncPeriod is the sync period of the cache.
 	SyncPeriod *time.Duration
+
+	// DefaultTransform is a transform function applied to all objects before they are
+	// stored in the per-cluster cache. It is equivalent to cache.Options.DefaultTransform
+	// from controller-runtime and is a convenient way to strip managedFields (or apply
+	// other mutations) from every cached object without having to enumerate every type
+	// in ByObject. When a type also has a ByObject entry with its own Transform set, that
+	// per-type transform takes precedence.
+	DefaultTransform toolscache.TransformFunc
 
 	// ByObject restricts the cache's ListWatch to the desired fields per GVK at the specified object.
 	ByObject map[client.Object]cache.ByObject
@@ -718,6 +727,7 @@ func buildClusterAccessorConfig(scheme *runtime.Scheme, options Options, control
 		Cache: &clusterAccessorCacheConfig{
 			InitialSyncTimeout: 5 * time.Minute,
 			SyncPeriod:         options.Cache.SyncPeriod,
+			DefaultTransform:   options.Cache.DefaultTransform,
 			ByObject:           options.Cache.ByObject,
 			Indexes:            options.Cache.Indexes,
 		},

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -34,10 +34,12 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest/fake"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -304,6 +306,40 @@ func TestMinDurationOrDefault(t *testing.T) {
 
 			gotDuration := minDurationOrDefault(tt.durations, tt.defaultDuration)
 			g.Expect(gotDuration).To(Equal(tt.wantDuration))
+		})
+	}
+}
+
+func TestBuildClusterAccessorConfigDefaultTransform(t *testing.T) {
+	transform := cache.TransformStripManagedFields()
+	tests := []struct {
+		name      string
+		transform toolscache.TransformFunc
+		wantNil   bool
+	}{
+		{
+			name:      "nil transform is preserved as nil",
+			transform: nil,
+			wantNil:   true,
+		},
+		{
+			name:      "non-nil transform is propagated",
+			transform: transform,
+			wantNil:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := buildClusterAccessorConfig(scheme.Scheme, Options{
+				Cache: CacheOptions{DefaultTransform: tt.transform},
+			}, nil)
+			if tt.wantNil {
+				g.Expect(got.Cache.DefaultTransform).To(BeNil())
+			} else {
+				g.Expect(got.Cache.DefaultTransform).ToNot(BeNil())
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it

Exposes `DefaultTransform toolscache.TransformFunc` on `clustercache.CacheOptions`, allowing callers to supply a transformation function that is applied to every object before it is stored in the per-cluster cache.

This also wires `cache.TransformStripManagedFields()` into the three in-tree providers (core CAPI, CABPK, KCP) so that `managedFields` are stripped from all cached objects, reducing per-cluster memory consumption.

Fixes: #13779

## Which issue(s) this PR fixes

Resolves kubernetes-sigs/cluster-api#13779

## Special notes for your reviewer

This PR was written in part with the assistance of generative AI (Cursor / Claude Sonnet 4.6). All changes have been reviewed, understood, and verified by the author — including running both the unit and integration tests locally.

**The second commit** (`✨ clustercache: use DefaultTransform in core CAPI, CABPK and KCP`) was added in response to Stefan's suggestion during review to use the new field in the three in-tree providers.

## How to verify

Unit test:
```
go test sigs.k8s.io/cluster-api/controllers/clustercache -run TestBuildClusterAccessorConfigDefaultTransform -v
```

Integration test (requires `make setup-envtest` first):
```
KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use --bin-path /tmp/envtest-bins) \
  go test sigs.k8s.io/cluster-api/controllers/clustercache -run TestConnectWithDefaultTransform -v
```

## Checklist

- [x] squash commits and use the conventional-commits style for the PR title
- [x] unit/integration tests added