### PR TITLE
🌱 Update RemoveEtcdMember to accept a *etcd.Member instead of a member name

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -48,6 +48,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	runtimeclient "sigs.k8s.io/cluster-api/exp/runtime/client"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/util/inplace"
@@ -1289,12 +1290,12 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 
 	// Loop trough etcd members and identify unexpected members.
 	// Note: A member without a name yet is also considered an unexpected members at this stage.
-	unexpectedMembers := sets.New[string]()
+	unexpectedMembers := sets.New[*etcd.Member]()
 	for _, member := range controlPlane.EtcdMembers {
 		if expectedMembers.Has(member.Name) {
 			continue
 		}
-		unexpectedMembers.Insert(member.Name)
+		unexpectedMembers.Insert(member)
 	}
 
 	// If there are no unexpected members, return.
@@ -1304,11 +1305,11 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 
 	unexpectedMembersMsg := []string{}
 	for _, m := range unexpectedMembers.UnsortedList() {
-		if m == "" {
+		if m.Name == "" {
 			unexpectedMembersMsg = append(unexpectedMembersMsg, "(Name not yet assigned)")
 			continue
 		}
-		unexpectedMembersMsg = append(unexpectedMembersMsg, m)
+		unexpectedMembersMsg = append(unexpectedMembersMsg, m.Name)
 	}
 	sort.Strings(unexpectedMembersMsg)
 
@@ -1335,20 +1336,20 @@ func (r *KubeadmControlPlaneReconciler) reconcileEtcdMembers(ctx context.Context
 	}
 
 	sortedUnexpectedMembers := unexpectedMembers.UnsortedList()
-	sort.Strings(sortedUnexpectedMembers)
+	sort.Sort(etcd.Members(sortedUnexpectedMembers))
 	etcdMemberToBeDeleted := sortedUnexpectedMembers[0]
-	etcdMemberToBeDeletedMsg := etcdMemberToBeDeleted
+	etcdMemberToBeDeletedMsg := etcdMemberToBeDeleted.Name
 	if etcdMemberToBeDeletedMsg == "" {
 		etcdMemberToBeDeletedMsg = "(Name not yet assigned)"
 	}
-	log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, removing member %s", strings.Join(unexpectedMembersMsg, ", "), etcdMemberToBeDeleted))
+	log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, removing member %s", strings.Join(unexpectedMembersMsg, ", "), etcdMemberToBeDeleted.Name))
 
 	// Note: if the etcd member to be deleted doesn't have a name yet, we know it is not started yet/still a learner,
 	// and we also know it won't be promoted because there is no underlying machine where kubeadm is running.
 	// Accordingly, skipping checking targetEtcdClusterHealthy (which will fail with learner nodes).
-	if etcdMemberToBeDeleted != "" {
+	if etcdMemberToBeDeleted.Name != "" {
 		addEtcdMember := false
-		if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted) {
+		if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted.Name) {
 			return ctrl.Result{}, errors.Errorf("etcd member %s does not have a corresponding Machine, it must be removed from the cluster but this operation can lead to quorum loss. Please check the etcd status", etcdMemberToBeDeletedMsg)
 		}
 	}
@@ -1460,14 +1461,14 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 	// Target list of machines will have current machines -1 machine (the deletingMachine).
 	// As a consequence:
 	// - etcd member on the deletingMachine is going to be deleted, no etcd member are going to be added.
-	etcdMemberToBeDeleted := r.tryGetEtcdMemberName(ctx, controlPlane, deletingMachine)
+	etcdMemberNameToBeDeleted := r.tryGetEtcdMemberName(ctx, controlPlane, deletingMachine)
 	addEtcdMember := false
 
 	// If it was not possible to get the name of the etcd member hosted on this machine or if the etcd member doesn't have
 	// a name yet, no other checks can be performed. Continue with deletion.
 	// Note: reconcileEtcMembers acts a safeguard/cleanup procedure if an etcdMember is added/reported after this point
 	// and for etcd member without a name.
-	if etcdMemberToBeDeleted == "" {
+	if etcdMemberNameToBeDeleted == "" {
 		if err := r.removePreTerminateHookAnnotationFromMachine(ctx, deletingMachine); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1476,7 +1477,7 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 		return ctrl.Result{RequeueAfter: deleteRequeueAfter}, nil
 	}
 
-	if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted) {
+	if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberNameToBeDeleted) {
 		log.Info(fmt.Sprintf("Cannot delete control plane Machine %s, the operation can lead to etcd quorum loss. Please check the etcd status", klog.KObj(deletingMachine)))
 		return ctrl.Result{RequeueAfter: deleteRequeueAfter}, nil
 	}
@@ -1501,8 +1502,17 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 	// Note: Removing the etcd member will lead to the etcd and the kube-apiserver Pod on the Machine shutting down.
 	// If ControlPlaneKubeletLocalMode is used, the kubelet is communicating with the local apiserver and thus now
 	// won't be able to see any updates to e.g. Pods anymore.
-	if err := workloadCluster.RemoveEtcdMember(ctx, etcdMemberToBeDeleted, controlPlane.Nodes); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to remove etcd member for deleting Machine %s", klog.KObj(deletingMachine))
+	var etcdMemberToBeDeleted *etcd.Member
+	for _, member := range controlPlane.EtcdMembers {
+		if member.Name == etcdMemberNameToBeDeleted {
+			etcdMemberToBeDeleted = member
+			break
+		}
+	}
+	if etcdMemberToBeDeleted != nil {
+		if err := workloadCluster.RemoveEtcdMember(ctx, etcdMemberToBeDeleted, controlPlane.Nodes); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to remove etcd member for deleting Machine %s", klog.KObj(deletingMachine))
+		}
 	}
 
 	if err := r.removePreTerminateHookAnnotationFromMachine(ctx, deletingMachine); err != nil {

--- a/controlplane/kubeadm/internal/controllers/fakes_test.go
+++ b/controlplane/kubeadm/internal/controllers/fakes_test.go
@@ -27,6 +27,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/util/collections"
 )
 
@@ -106,7 +107,7 @@ func (f *fakeWorkloadCluster) UpdateEtcdLocalInKubeadmConfigMap(bootstrapv1.Loca
 	return nil
 }
 
-func (f *fakeWorkloadCluster) RemoveEtcdMember(_ context.Context, _ string, _ []*internal.Node) error {
+func (f *fakeWorkloadCluster) RemoveEtcdMember(_ context.Context, _ *etcd.Member, _ []*internal.Node) error {
 	f.removeEtcdMemberCalled++
 	return nil
 }

--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -114,6 +114,13 @@ type Member struct {
 	IsLearner bool
 }
 
+// Members is a slice of Member pointers that implements sort.Interface, ordering by member name.
+type Members []*Member
+
+func (m Members) Len() int           { return len(m) }
+func (m Members) Less(i, j int) bool { return m[i].Name < m[j].Name }
+func (m Members) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
 // pbMemberToMember converts the protobuf representation of a cluster member to a Member struct.
 func pbMemberToMember(m *etcdserverpb.Member) *Member {
 	return &Member{

--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -35,6 +35,16 @@ func MemberForName(members []*etcd.Member, name string) *etcd.Member {
 	return nil
 }
 
+// MemberForID returns the etcd member with the matching ID.
+func MemberForID(members []*etcd.Member, id uint64) *etcd.Member {
+	for _, m := range members {
+		if m.ID == id {
+			return m
+		}
+	}
+	return nil
+}
+
 // MemberNames returns a list of all the etcd member names.
 // Note: this function is specificially designed for MemberEqual and setting condition messages.
 func MemberNames(members []*etcd.Member) []string {

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -44,6 +44,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	kubeadmtypes "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/desiredstate"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/proxy"
 	"sigs.k8s.io/cluster-api/util/certs"
 	containerutil "sigs.k8s.io/cluster-api/util/container"
@@ -79,7 +80,7 @@ type WorkloadCluster interface {
 	UpdateEncryptionAlgorithm(encryptionAlgorithm bootstrapv1.EncryptionAlgorithmType) func(*bootstrapv1.ClusterConfiguration)
 	UpdateKubeProxyImageInfo(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error
 	UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error
-	RemoveEtcdMember(ctx context.Context, name string, nodes []*Node) error
+	RemoveEtcdMember(ctx context.Context, m *etcd.Member, nodes []*Node) error
 	ForwardEtcdLeadership(ctx context.Context, machine *clusterv1.Machine, leaderCandidate *clusterv1.Machine, nodes []*Node) error
 	EnsureKubeadmPermissions(ctx context.Context, version semver.Version) error
 	UpdateClusterConfiguration(ctx context.Context, version semver.Version, mutators ...func(*bootstrapv1.ClusterConfiguration)) error

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -53,12 +53,12 @@ func (w *Workload) UpdateEtcdExternalInKubeadmConfigMap(etcdExternal bootstrapv1
 // RemoveEtcdMember removes the etcd member from the target cluster's etcd cluster.
 // Removing the last remaining member of the cluster is not supported.
 // Note: It is a responsibility of the caller to check if this operation doesn't lead to quorum loss.
-func (w *Workload) RemoveEtcdMember(ctx context.Context, name string, nodes []*Node) error {
+func (w *Workload) RemoveEtcdMember(ctx context.Context, m *etcd.Member, nodes []*Node) error {
 	// Exclude node being removed from etcd client node list
 	// Note: this operation relies on the assumption that node name is equal to the name of the corresponding etcd member.
 	var remainingNodes []string
 	for _, n := range nodes {
-		if n.Name != name {
+		if n.Name != m.Name {
 			remainingNodes = append(remainingNodes, n.Name)
 		}
 	}
@@ -73,7 +73,7 @@ func (w *Workload) RemoveEtcdMember(ctx context.Context, name string, nodes []*N
 	if err != nil {
 		return errors.Wrap(err, "failed to list etcd members using etcd client")
 	}
-	member := etcdutil.MemberForName(members, name)
+	member := etcdutil.MemberForID(members, m.ID)
 
 	// The member has already been removed, return immediately
 	if member == nil {

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -239,19 +239,19 @@ func TestRemoveEtcdMember(t *testing.T) {
 
 	tests := []struct {
 		name                string
-		memberToDelete      string
+		memberToDelete      *etcd.Member
 		etcdClientGenerator etcdClientFor
 		expectErr           bool
 	}{
 		{
 			name:                "returns an error if it fails to create the etcd client",
-			memberToDelete:      "cp1",
+			memberToDelete:      &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{forNodesErr: errors.New("no client")},
 			expectErr:           true,
 		},
 		{
 			name:           "returns an error if the client errors getting etcd members",
-			memberToDelete: "cp1",
+			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
@@ -263,7 +263,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 		},
 		{
 			name:           "no op if the member already does not exist",
-			memberToDelete: "cp2",
+			memberToDelete: &etcd.Member{ID: uint64(2), Name: "cp2"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
@@ -279,7 +279,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 		},
 		{
 			name:           "returns an error if there is only one member",
-			memberToDelete: "cp1",
+			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
@@ -295,7 +295,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 		},
 		{
 			name:           "returns an error if the client errors removing the etcd member",
-			memberToDelete: "cp1",
+			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
@@ -313,7 +313,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 		},
 		{
 			name:           "removes the member from etcd",
-			memberToDelete: "cp1",
+			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
 				forNodesClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{


### PR DESCRIPTION
Resurrect https://github.com/kubernetes-sigs/cluster-api/pull/13773 


When an etcd member isn't started yet, its name is empty. We should use member ID to identify an etcd member instead of the member name. Each etcd member (no matter it gets started or not), it's always guaranteed that it has a valid member ID.

Refer to https://github.com/kubernetes-sigs/cluster-api/pull/13685#discussion_r3343723219

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->