### PR TITLE
🌱 Partially revert fix self-hosted test

### DIFF
--- a/test/infrastructure/docker/internal/provisioning/cloudinit/adapter.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/adapter.go
@@ -68,13 +68,6 @@ func RawCloudInitToProvisioningCommands(config []byte, mapping kind.Mapping) ([]
 	}
 
 	commands := []provisioning.Cmd{}
-
-	// Add the bootstrap started sentinel file.
-	// Note: this sentinel file stored inside the machine, and it is used as a gate to prevent bootstrap twice.
-	bootstrapStarted := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started"}, Retry: 5}
-	commands = append(commands, bootstrapStarted)
-
-	// Add other commands.
 	for _, action := range actions {
 		cmds, err := action.Commands()
 		if err != nil {

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/adapter_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/adapter_test.go
@@ -109,7 +109,6 @@ write_files:
 `)
 
 	expectedCmds := []provisioning.Cmd{
-		{Cmd: "/bin/sh", Args: []string{"-c", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started"}, Retry: 5},
 		// ca
 		{Cmd: "mkdir", Args: []string{"-p", "/etc/kubernetes/pki"}, Retry: 5},
 		{Cmd: "/bin/sh", Args: []string{"-c", "cat > /etc/kubernetes/pki/ca.crt /dev/stdin"}, Retry: 5},

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
@@ -57,13 +57,14 @@ func (a *runCmd) Commands() ([]provisioning.Cmd, error) {
 
 // ignorePreflightErrors are preflight errors that fail in CAPD and thus we have to ignore them.
 const ignorePreflightErrors = "SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
+const bootstrapStartedSentinelFileCommand = "echo started > /run/cluster-api/capd.bootstrap.started"
 
 func hackKubeadmIgnoreErrors(c provisioning.Cmd) provisioning.Cmd {
 	// case kubeadm commands are defined as a string
 	if c.Cmd == "/bin/sh" && len(c.Args) >= 2 {
 		if c.Args[0] == "-c" {
-			c.Args[1] = strings.Replace(c.Args[1], "kubeadm init", fmt.Sprintf("kubeadm init --ignore-preflight-errors=%s", ignorePreflightErrors), 1)
-			c.Args[1] = strings.Replace(c.Args[1], "kubeadm join", fmt.Sprintf("kubeadm join --ignore-preflight-errors=%s", ignorePreflightErrors), 1)
+			c.Args[1] = strings.Replace(c.Args[1], "kubeadm init", fmt.Sprintf("%s && kubeadm init --ignore-preflight-errors=%s", bootstrapStartedSentinelFileCommand, ignorePreflightErrors), 1)
+			c.Args[1] = strings.Replace(c.Args[1], "kubeadm join", fmt.Sprintf("%s && kubeadm join --ignore-preflight-errors=%s", bootstrapStartedSentinelFileCommand, ignorePreflightErrors), 1)
 		}
 	}
 
@@ -76,6 +77,8 @@ func hackKubeadmIgnoreErrors(c provisioning.Cmd) provisioning.Cmd {
 				strings.Join(
 					append(
 						[]string{
+							// insert the command for creating the bootstrapStartedSentinelFile
+							fmt.Sprintf("%s &&", bootstrapStartedSentinelFileCommand),
 							// kubeadm init or join
 							"kubeadm",
 							c.Args[0],

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
@@ -71,7 +71,7 @@ func TestRunCmdRun(t *testing.T) {
 				},
 			},
 			expectedCmds: []provisioning.Cmd{
-				{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config /run/kubeadm/kubeadm.yaml"}},
+				{Cmd: "/bin/sh", Args: []string{"-c", "echo started > /run/cluster-api/capd.bootstrap.started && kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config /run/kubeadm/kubeadm.yaml"}},
 			},
 		},
 	}
@@ -101,11 +101,11 @@ runcmd:
 
 	r.Cmds[0] = hackKubeadmIgnoreErrors(r.Cmds[0])
 
-	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm.yaml"}}
+	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "echo started > /run/cluster-api/capd.bootstrap.started && kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm.yaml"}}
 	g.Expect(r.Cmds[0]).To(BeComparableTo(expected0))
 
 	r.Cmds[1] = hackKubeadmIgnoreErrors(r.Cmds[1])
 
-	expected1 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm join --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
+	expected1 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "echo started > /run/cluster-api/capd.bootstrap.started && kubeadm join --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
 	g.Expect(r.Cmds[1]).To(BeComparableTo(expected1))
 }

--- a/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
+++ b/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
@@ -70,11 +70,6 @@ func getActions(userData []byte) ([]provisioning.Cmd, error) {
 		return nil, fmt.Errorf("unmarshalling Ignition JSON: %w", err)
 	}
 
-	// Add the bootstrap started sentinel file.
-	// Note: this sentinel file stored inside the machine, and it is used as a gate to prevent bootstrap twice.
-	bootstrapStarted := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started"}, Retry: 5}
-	commands = append(commands, bootstrapStarted)
-
 	// Generate commands for files.
 	for _, f := range ignition.Storage.Files {
 		raw := strings.TrimSpace(f.Contents.Source)
@@ -130,10 +125,10 @@ func hackKubeadmIgnoreErrors(s string) string {
 
 	for idx, line := range lines {
 		if strings.Contains(line, "kubeadm init") {
-			lines[idx] = strings.ReplaceAll(line, "kubeadm init", "kubeadm init --ignore-preflight-errors=all")
+			lines[idx] = strings.ReplaceAll(line, "kubeadm init", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started && kubeadm init --ignore-preflight-errors=all")
 		}
 		if strings.Contains(line, "kubeadm join") {
-			lines[idx] = strings.ReplaceAll(line, "kubeadm join", "kubeadm join --ignore-preflight-errors=all")
+			lines[idx] = strings.ReplaceAll(line, "kubeadm join", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started && kubeadm join --ignore-preflight-errors=all")
 		}
 	}
 

--- a/test/infrastructure/docker/internal/provisioning/ignition/kindadapter_test.go
+++ b/test/infrastructure/docker/internal/provisioning/ignition/kindadapter_test.go
@@ -62,7 +62,6 @@ func TestRealUseCase(t *testing.T) {
   }`)
 
 	expectedCmds := []provisioning.Cmd{
-		{Cmd: "/bin/sh", Args: []string{"-c", "mkdir -p /run/cluster-api && echo started > /run/cluster-api/capd.bootstrap.started"}, Retry: 5},
 		{Cmd: "mkdir", Args: []string{"-p", "/etc/kubernetes/pki"}, Retry: 5},
 		{Cmd: "/bin/sh", Args: []string{"-c", "cat > /etc/kubernetes/pki/ca.crt /dev/stdin"}, Retry: 5},
 		{Cmd: "chmod", Args: []string{"0640", "/etc/kubernetes/pki/ca.crt"}, Retry: 5},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Looks like that #13778 got read of the problem about run once-safeguards for kubeadm init/join, but it also made the bootstrap process less re-entrant in case of CAPD restarts during a rollout on self-hosted clusters, which surfaces as "Waiting for a Node with spec.providerID docker:////self-hosted-5cr8i9-worker-5pgyem to exist"

This PR should mitigate this problem while we think about how to ensure a clean CAPD shutdown when the sequence of bootstrap commands for a Machine is in progress.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->