### PR TITLE
:seedling: Improve support for OwnerReferencesPermissionEnforcement admission controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   verbs:
+  - delete
   - get
   - list
   - patch

--- a/docs/book/src/developer/providers/contracts/bootstrap-config.md
+++ b/docs/book/src/developer/providers/contracts/bootstrap-config.md
@@ -85,8 +85,9 @@ The domain for Cluster API resources is `cluster.x-k8s.io`, and bootstrap provid
 generally use `bootstrap.cluster.x-k8s.io` as API group.
 
 If your provider uses a different API group, you MUST grant full read/write RBAC permissions for resources in your API group
-to the Cluster API core controllers. The canonical way to do so is via a `ClusterRole` resource with the [aggregation label]
-`cluster.x-k8s.io/aggregate-to-manager: "true"`.
+to the Cluster API core controllers. If any resource sets another resource as the owner with `blockOwnerDeletion` set,
+additional RBAC to update finalizers on the **owner resource** is required.
+The canonical way to do so is via a `ClusterRole` resource with the [aggregation label] `cluster.x-k8s.io/aggregate-to-manager: "true"`.
 
 The following is an example ClusterRole for a `FooConfig` resource in the `bootstrap.foo.com` API group:
 

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -101,8 +101,9 @@ The domain for Cluster API resources is `cluster.x-k8s.io`, and control plane pr
 generally use `controlplane.cluster.x-k8s.io` as API group.
 
 If your provider uses a different API group, you MUST grant full read/write RBAC permissions for resources in your API group
-to the Cluster API core controllers. The canonical way to do so is via a `ClusterRole` resource with the [aggregation label]
-`cluster.x-k8s.io/aggregate-to-manager: "true"`.
+to the Cluster API core controllers. If any resource sets another resource as the owner with `blockOwnerDeletion` set,
+additional RBAC to update finalizers on the **owner resource** is required.
+The canonical way to do so is via a `ClusterRole` resource with the [aggregation label] `cluster.x-k8s.io/aggregate-to-manager: "true"`.
 
 The following is an example ClusterRole for a `FooControlPlane` resource in the `controlplane.foo.com` API group:
 

--- a/docs/book/src/developer/providers/contracts/infra-cluster.md
+++ b/docs/book/src/developer/providers/contracts/infra-cluster.md
@@ -83,8 +83,9 @@ The domain for Cluster API resources is `cluster.x-k8s.io`, and infrastructure p
 generally use `infrastructure.cluster.x-k8s.io` as API group.
 
 If your provider uses a different API group, you MUST grant full read/write RBAC permissions for resources in your API group
-to the Cluster API core controllers. The canonical way to do so is via a `ClusterRole` resource with the [aggregation label]
-`cluster.x-k8s.io/aggregate-to-manager: "true"`.
+to the Cluster API core controllers. If any resource sets another resource as the owner with `blockOwnerDeletion` set,
+additional RBAC to update finalizers on the **owner resource** is required.
+The canonical way to do so is via a `ClusterRole` resource with the [aggregation label] `cluster.x-k8s.io/aggregate-to-manager: "true"`.
 
 The following is an example ClusterRole for a `FooCluster` resource in the `infrastructure.foo.com` API group:
 

--- a/docs/book/src/developer/providers/contracts/infra-machine.md
+++ b/docs/book/src/developer/providers/contracts/infra-machine.md
@@ -86,8 +86,9 @@ The domain for Cluster API resources is `cluster.x-k8s.io`, and infrastructure p
 generally use `infrastructure.cluster.x-k8s.io` as API group.
 
 If your provider uses a different API group, you MUST grant full read/write RBAC permissions for resources in your API group
-to the Cluster API core controllers. The canonical way to do so is via a `ClusterRole` resource with the [aggregation label]
-`cluster.x-k8s.io/aggregate-to-manager: "true"`.
+to the Cluster API core controllers. If any resource sets another resource as the owner with `blockOwnerDeletion` set,
+additional RBAC to update finalizers on the **owner resource** is required.
+The canonical way to do so is via a `ClusterRole` resource with the [aggregation label] `cluster.x-k8s.io/aggregate-to-manager: "true"`.
 
 The following is an example ClusterRole for a `FooMachine` resource in the `infrastructure.foo.com` API group:
 

--- a/docs/book/src/developer/providers/contracts/infra-machinepool.md
+++ b/docs/book/src/developer/providers/contracts/infra-machinepool.md
@@ -82,8 +82,9 @@ The domain for Cluster API resources is `cluster.x-k8s.io`, and infrastructure p
 generally use `infrastructure.cluster.x-k8s.io` as API group.
 
 If your provider uses a different API group, you MUST grant full read/write RBAC permissions for resources in your API group
-to the Cluster API core controllers. The canonical way to do so is via a `ClusterRole` resource with the [aggregation label]
-`cluster.x-k8s.io/aggregate-to-manager: "true"`.
+to the Cluster API core controllers. If any resource sets another resource as the owner with `blockOwnerDeletion` set,
+additional RBAC to update finalizers on the **owner resource** is required.
+The canonical way to do so is via a `ClusterRole` resource with the [aggregation label] `cluster.x-k8s.io/aggregate-to-manager: "true"`.
 
 The following is an example ClusterRole for a `FooMachinePool` resource in the `infrastructure.foo.com` API group:
 

--- a/docs/book/src/developer/providers/getting-started/controllers-and-reconciliation.md
+++ b/docs/book/src/developer/providers/getting-started/controllers-and-reconciliation.md
@@ -58,7 +58,13 @@ So we'll add another annotation for that, right below the other lines:
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 ```
 
-Make sure to add this annotation to `MailgunClusterReconciler`.
+If any resource sets another resource as the owner with `blockOwnerDeletion` set, additional RBAC to update finalizers on the **owner resource** is required:
+
+```go
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters/finalizers,verbs=update
+```
+
+Make sure to add this/these annotation to `MailgunClusterReconciler`.
 
 Also, for our `MailgunMachineReconciler`, access to Cluster API `Machine` object is needed, so you must add this annotation in `controllers/mailgunmachine_controller.go`:
 

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller.go
@@ -58,7 +58,7 @@ import (
 var ErrSecretTypeNotSupported = errors.New("unsupported secret type")
 
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;update;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets/status;clusterresourcesets/finalizers,verbs=get;update;patch
 

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -141,12 +141,23 @@ func (k *KindClusterProvider) createKindCluster() {
 		kind.CreateWithKubeconfigPath(k.kubeconfigPath),
 	}
 
+	// We enable the OwnerReferencesPermissionEnforcement admission plugin to detect potential
+	// RBAC issues when applying owner references with blockOwnerDeletion.
+	const ownerReferencesPermissionEnforcementPatch = `kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    enable-admission-plugins: OwnerReferencesPermissionEnforcement
+`
+
 	cfg := &kindv1.Cluster{
 		Nodes: []kindv1.Node{
 			{
 				Role:              kindv1.ControlPlaneRole,
 				ExtraPortMappings: k.extraPortMappings,
 			},
+		},
+		KubeadmConfigPatches: []string{
+			ownerReferencesPermissionEnforcementPatch,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Updates the e2e-test kind configuration to enable the OwnerReferencesPermissionEnforcement admission controller. This admission controller is enabled by default in some clusters, e.g., OpenShift. Enabling this for the e2e-tests setup, which is hopefully also used in provider projects, should make more providers support clusters with this admission controller enabled.

Enabling Kubernetes admission plugins in kind is documented here: https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches.

When adding this admission controller, I had to fix a minor RBAC issue to get the e2e tests to pass. Without the RBAC fix, this was observed in the manager logs:

````
E0613 10:29:46.227046       1 controller.go:494] "Reconciler error" err="configmaps \"cni-quick-start-6yctfr-crs-0\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>" controller="clusterresourceset" controllerGroup="addons.cluster.x-k8s.io" controllerKind="ClusterResourceSet" ClusterResourceSet="quick-start-y3z9ns/quick-start-6yctfr-crs-0" reconcileID="b3cf2583-f137-49bf-a187-a660e992ddd1"
````

Also updated provider contracts and the getting-started guide.

Fixes #13801

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
-->

/area testing
/area e2e-testing
/area documentation
