### PR TITLE
✨ Migrate ClusterClass rollout e2e test from the docker to the in-memory backend

### DIFF
--- a/test/e2e/clusterclass_changes.go
+++ b/test/e2e/clusterclass_changes.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	runtimev1 "sigs.k8s.io/cluster-api/api/runtime/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/test/e2e/internal/log"
@@ -335,6 +336,11 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 		framework.DumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ClusterctlConfigPath, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
 
 		if !input.SkipCleanup {
+			if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+				Eventually(func() error {
+					return input.BootstrapClusterProxy.GetClient().Delete(ctx, &runtimev1.ExtensionConfig{ObjectMeta: metav1.ObjectMeta{Name: input.ExtensionConfigName}})
+				}, 10*time.Second, 1*time.Second).Should(Succeed(), "Deleting ExtensionConfig failed")
+			}
 			Byf("Deleting namespace used for hosting the %q test spec ClusterClass", specName)
 			framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
 				Deleter: input.BootstrapClusterProxy.GetClient(),

--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -80,6 +80,18 @@ type ClusterClassRolloutSpecInput struct {
 	// This can be e.g. used to filter out additional infrastructure provider specific labels that would
 	// otherwise lead to a failed test.
 	FilterMetadataBeforeValidation func(object client.Object) clusterv1.ObjectMeta
+
+	// ExtensionConfigName is the name of the ExtensionConfig. Defaults to "clusterclass-rollout".
+	// This value is provided to clusterctl as "EXTENSION_CONFIG_NAME" variable and can be used to template the
+	// name of the ExtensionConfig into the ClusterClass.
+	ExtensionConfigName string
+
+	// ExtensionServiceNamespace is the namespace where the service for the Runtime SDK is located
+	// and is used to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionServiceNamespace string
+
+	// ExtensionServiceName is the name of the service to configure in the test-namespace scoped ExtensionConfig.
+	ExtensionServiceName string
 }
 
 // ClusterClassRolloutSpec implements a test that verifies the ClusterClass rollout behavior.
@@ -115,6 +127,11 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
 		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.MustGetVariable(KubernetesVersion)))
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			if input.ExtensionConfigName == "" {
+				input.ExtensionConfigName = specName
+			}
+		}
 
 		// Set a default function to ensure that FilterMetadataBeforeValidation has a default behavior for
 		// filtering metadata if it is not specified by infrastructure provider.
@@ -130,11 +147,27 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 	})
 
 	It("Should successfully rollout the managed topology upon changes to the ClusterClass", func() {
+		if input.ExtensionServiceNamespace != "" && input.ExtensionServiceName != "" {
+			By("Deploy Test Extension ExtensionConfig")
+			defaultAllHandlersToBlocking := false
+			extensionConfig := extensionConfig(input.ExtensionConfigName, input.ExtensionServiceNamespace, input.ExtensionServiceName, true, defaultAllHandlersToBlocking, namespace.Name)
+			Expect(client.IgnoreAlreadyExists(input.BootstrapClusterProxy.GetClient().Create(ctx,
+				extensionConfig))).
+				To(Succeed(), "Failed to create the ExtensionConfig")
+		}
+
 		By("Creating a workload cluster")
 		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
 		if input.InfrastructureProvider != nil {
 			infrastructureProvider = *input.InfrastructureProvider
 		}
+
+		variables := map[string]string{}
+		if input.ExtensionConfigName != "" {
+			// This is used to template the name of the ExtensionConfig into the ClusterClass.
+			variables["EXTENSION_CONFIG_NAME"] = input.ExtensionConfigName
+		}
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -148,6 +181,7 @@ func ClusterClassRolloutSpec(ctx context.Context, inputGetter func() ClusterClas
 				KubernetesVersion:        input.E2EConfig.MustGetVariable(KubernetesVersion),
 				ControlPlaneMachineCount: ptr.To[int64](1),
 				WorkerMachineCount:       ptr.To[int64](1),
+				ClusterctlVariables:      variables,
 			},
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
@@ -596,6 +630,8 @@ func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjec
 			},
 			ccInfrastructureClusterTemplateTemplateMetadata.Annotations,
 		),
+		// Ignore InMemory listener annotation.
+		"inmemorycluster.infrastructure.cluster.x-k8s.io/listener",
 	)
 }
 
@@ -705,6 +741,8 @@ func assertControlPlaneMachines(g Gomega, clusterObjects ClusterObjects, cluster
 				machineMetadata.Annotations,
 			).without(g, controlplanev1.PreTerminateHookCleanupAnnotation),
 			controlPlaneMachineTemplateMetadata.Annotations,
+			// Ignore InMemory specific annotations.
+			"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 		)
 
 		// ControlPlane Machine InfrastructureMachine.metadata
@@ -743,6 +781,8 @@ func assertControlPlaneMachines(g Gomega, clusterObjects ClusterObjects, cluster
 				controlPlaneMachineTemplateMetadata.Annotations,
 				controlPlaneInfrastructureMachineTemplateTemplateMetadata.Annotations,
 			),
+			// Ignore InMemory specific annotations.
+			"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 		)
 
 		// ControlPlane Machine BootstrapConfig.metadata
@@ -1095,6 +1135,8 @@ func assertMachineSetsMachines(g Gomega, clusterObjects ClusterObjects, cluster 
 				)
 				expectMapsToBeEquivalent(g, machineMetadata.Annotations,
 					machineSet.Spec.Template.Annotations,
+					// Ignore InMemory specific annotations.
+					"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 				)
 
 				// MachineDeployment MachineSet Machine InfrastructureMachine.metadata
@@ -1123,6 +1165,8 @@ func assertMachineSetsMachines(g Gomega, clusterObjects ClusterObjects, cluster 
 						machineSet.Spec.Template.Annotations,
 						infrastructureMachineTemplateTemplateMetadata.Annotations,
 					),
+					// Ignore InMemory specific annotations.
+					"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 				)
 
 				// MachineDeployment MachineSet Machine BootstrapConfig.metadata

--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -583,7 +583,7 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 
 		// InfrastructureCluster
 		By("Checking InfrastructureCluster object has the right labels, annotations and selectors")
-		assertInfrastructureCluster(g, clusterClassObjects, clusterObjects, cluster, clusterClass)
+		assertInfrastructureCluster(g, clusterClassObjects, clusterObjects, cluster, clusterClass, filterMetadataBeforeValidation)
 
 		// ControlPlane
 		controlPlaneContractVersion, err := contract.GetContractVersionForVersion(ctx, clusterProxy.GetClient(), clusterObjects.ControlPlane.GroupVersionKind().GroupKind(), clusterObjects.ControlPlane.GroupVersionKind().Version)
@@ -609,11 +609,12 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 	}, 30*time.Second, 1*time.Second).Should(Succeed())
 }
 
-func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {
+func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, filterMetadataBeforeValidation func(object client.Object) clusterv1.ObjectMeta) {
 	ccInfrastructureClusterTemplateTemplateMetadata := mustMetadata(contract.InfrastructureClusterTemplate().Template().Metadata().Get(clusterClassObjects.InfrastructureClusterTemplate))
+	infraClusterMetadata := filterMetadataBeforeValidation(clusterObjects.InfrastructureCluster)
 
 	// InfrastructureCluster.metadata
-	expectMapsToBeEquivalent(g, clusterObjects.InfrastructureCluster.GetLabels(),
+	expectMapsToBeEquivalent(g, infraClusterMetadata.Labels,
 		union(
 			map[string]string{
 				clusterv1.ClusterNameLabel:          cluster.Name,
@@ -622,7 +623,7 @@ func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjec
 			ccInfrastructureClusterTemplateTemplateMetadata.Labels,
 		),
 	)
-	expectMapsToBeEquivalent(g, clusterObjects.InfrastructureCluster.GetAnnotations(),
+	expectMapsToBeEquivalent(g, infraClusterMetadata.Annotations,
 		union(
 			map[string]string{
 				clusterv1.TemplateClonedFromGroupKindAnnotation: clusterClass.Spec.Infrastructure.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -630,8 +631,6 @@ func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjec
 			},
 			ccInfrastructureClusterTemplateTemplateMetadata.Annotations,
 		),
-		// Ignore InMemory listener annotation.
-		"inmemorycluster.infrastructure.cluster.x-k8s.io/listener",
 	)
 }
 
@@ -741,8 +740,6 @@ func assertControlPlaneMachines(g Gomega, clusterObjects ClusterObjects, cluster
 				machineMetadata.Annotations,
 			).without(g, controlplanev1.PreTerminateHookCleanupAnnotation),
 			controlPlaneMachineTemplateMetadata.Annotations,
-			// Ignore InMemory specific annotations.
-			"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 		)
 
 		// ControlPlane Machine InfrastructureMachine.metadata
@@ -781,8 +778,6 @@ func assertControlPlaneMachines(g Gomega, clusterObjects ClusterObjects, cluster
 				controlPlaneMachineTemplateMetadata.Annotations,
 				controlPlaneInfrastructureMachineTemplateTemplateMetadata.Annotations,
 			),
-			// Ignore InMemory specific annotations.
-			"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 		)
 
 		// ControlPlane Machine BootstrapConfig.metadata
@@ -1135,8 +1130,6 @@ func assertMachineSetsMachines(g Gomega, clusterObjects ClusterObjects, cluster 
 				)
 				expectMapsToBeEquivalent(g, machineMetadata.Annotations,
 					machineSet.Spec.Template.Annotations,
-					// Ignore InMemory specific annotations.
-					"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 				)
 
 				// MachineDeployment MachineSet Machine InfrastructureMachine.metadata
@@ -1165,8 +1158,6 @@ func assertMachineSetsMachines(g Gomega, clusterObjects ClusterObjects, cluster 
 						machineSet.Spec.Template.Annotations,
 						infrastructureMachineTemplateTemplateMetadata.Annotations,
 					),
-					// Ignore InMemory specific annotations.
-					"machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped",
 				)
 
 				// MachineDeployment MachineSet Machine BootstrapConfig.metadata

--- a/test/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/clusterclass_rollout_test.go
@@ -21,6 +21,9 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
 var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("ClusterClass"), func() {
@@ -38,6 +41,15 @@ var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("Clu
 			// the actual service.
 			ExtensionServiceNamespace: "test-extension-system",
 			ExtensionServiceName:      "test-extension-webhook-service",
+			FilterMetadataBeforeValidation: func(object client.Object) clusterv1.ObjectMeta {
+				annotations := object.GetAnnotations()
+				delete(annotations, "inmemorycluster.infrastructure.cluster.x-k8s.io/listener")
+				delete(annotations, "machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped")
+				return clusterv1.ObjectMeta{
+					Labels:      object.GetLabels(),
+					Annotations: annotations,
+				}
+			},
 		}
 	})
 })

--- a/test/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/clusterclass_rollout_test.go
@@ -21,36 +21,23 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
-	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 )
 
 var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("ClusterClass"), func() {
 	ClusterClassRolloutSpec(ctx, func() ClusterClassRolloutSpecInput {
 		return ClusterClassRolloutSpecInput{
-			E2EConfig:                      e2eConfig,
-			ClusterctlConfigPath:           clusterctlConfigPath,
-			BootstrapClusterProxy:          bootstrapClusterProxy,
-			ArtifactFolder:                 artifactFolder,
-			SkipCleanup:                    skipCleanup,
-			Flavor:                         "topology-taints",
-			FilterMetadataBeforeValidation: filterMetadataBeforeValidation,
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                "in-memory-topology",
+			// The runtime extension gets deployed to the test-extension-system namespace and is exposed
+			// by the test-extension-webhook-service.
+			// The below values are used when creating the cluster-wide ExtensionConfig to refer
+			// the actual service.
+			ExtensionServiceNamespace: "test-extension-system",
+			ExtensionServiceName:      "test-extension-webhook-service",
 		}
 	})
 })
-
-func filterMetadataBeforeValidation(object ctrlclient.Object) clusterv1.ObjectMeta {
-	if object.GetObjectKind().GroupVersionKind() == infrav1.GroupVersion.WithKind("DevMachine") {
-		// CAPDdev adds an extra label devmachine.infrastructure.cluster.x-k8s.io/weight on DevMachine, we need to filter it out to pass the
-		// clusterclass rollout test
-		annotations := object.GetAnnotations()
-		delete(annotations, infrav1.LoadbalancerWeightAnnotation)
-		object.SetAnnotations(annotations)
-		return clusterv1.ObjectMeta{Labels: object.GetLabels(), Annotations: object.GetAnnotations()}
-	}
-
-	// If the object is not a Machine, just return the default labels and annotations of the object
-	return clusterv1.ObjectMeta{Labels: object.GetLabels(), Annotations: object.GetAnnotations()}
-}

--- a/test/e2e/data/infrastructure-docker/main/cluster-template-in-memory-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/main/cluster-template-in-memory-topology.yaml
@@ -28,6 +28,15 @@ spec:
           Cluster.topology.controlPlane.label: Cluster.topology.controlPlane.labelValue
           Cluster.topology.controlPlane.label.node.cluster.x-k8s.io: Cluster.topology.controlPlane.nodeLabelValue
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+      taints:
+      - effect: PreferNoSchedule
+        key: pre-existing-on-initialization-taint
+        propagation: OnInitialization
+        value: on-initialization-value
+      - effect: PreferNoSchedule
+        key: pre-existing-always-taint
+        propagation: Always
+        value: always-value
     version: ${KUBERNETES_VERSION}
     workers:
       machineDeployments:
@@ -45,6 +54,15 @@ spec:
         minReadySeconds: 5
         name: md-0
         replicas: ${WORKER_MACHINE_COUNT}
+        taints:
+        - effect: PreferNoSchedule
+          key: pre-existing-on-initialization-taint
+          propagation: OnInitialization
+          value: on-initialization-value
+        - effect: PreferNoSchedule
+          key: pre-existing-always-taint
+          propagation: Always
+          value: always-value
         rollout:
           strategy:
             rollingUpdate:

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -49,6 +50,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
+	inmemoryproxy "sigs.k8s.io/cluster-api/test/infrastructure/inmemory/pkg/server/proxy"
 	"sigs.k8s.io/cluster-api/util/yaml"
 )
 
@@ -523,6 +525,11 @@ func (p *clusterProxy) GetWorkloadCluster(ctx context.Context, namespace, name s
 		p.fixConfig(ctx, name, config)
 	}
 
+	if p.isInMemoryCluster(ctx, namespace, name) {
+		// Add REST config modifier to use port-forwarding for in-memory clusters
+		options = append(options, p.inMemoryRESTConfigModifier(namespace, name))
+	}
+
 	return newFromAPIConfig(name, config, p.scheme, options...)
 }
 
@@ -689,6 +696,128 @@ func (p *clusterProxy) fixConfig(ctx context.Context, name string, config *api.C
 	}
 	currentCluster := config.Contexts[config.CurrentContext].Cluster
 	config.Clusters[currentCluster].Server = controlPlaneURL.String()
+}
+
+// isInMemoryCluster checks if the cluster is an in-memory cluster (DevCluster with inmemory backend).
+func (p *clusterProxy) isInMemoryCluster(ctx context.Context, namespace, name string) bool {
+	cl := p.GetClient()
+
+	cluster := &clusterv1.Cluster{}
+	key := client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := cl.Get(ctx, key, cluster); err != nil {
+		return false
+	}
+
+	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "DevCluster" {
+		return false
+	}
+
+	// Get the DevCluster to check if it's using inmemory backend
+	devCluster, err := external.GetObjectFromContractVersionedRef(ctx, cl, cluster.Spec.InfrastructureRef, namespace)
+	if err != nil {
+		return false
+	}
+
+	// Check if the DevCluster has an inmemory backend
+	backend, found, err := unstructured.NestedMap(devCluster.Object, "spec", "backend", "inMemory")
+	if err != nil || !found {
+		return false
+	}
+	return backend != nil
+}
+
+// inMemoryRESTConfigModifier returns an Option that modifies the REST config to use port-forwarding
+// for in-memory clusters.
+func (p *clusterProxy) inMemoryRESTConfigModifier(namespace, name string) Option {
+	return WithRESTConfigModifier(func(restConfig *rest.Config) {
+		log.Logf("Configuring port-forwarding for in-memory cluster %s/%s", namespace, name)
+
+		mgmtRESTConfig := p.GetRESTConfig()
+
+		dialer := &inMemoryDialer{
+			managementRESTConfig: mgmtRESTConfig,
+			clusterNamespace:     namespace,
+			clusterName:          name,
+		}
+
+		restConfig.Dial = func(ctx context.Context, _, address string) (net.Conn, error) {
+			log.Logf("Using custom dialer for address: %s", address)
+			return dialer.DialContext(ctx, address)
+		}
+
+		log.Logf("Port-forwarding dialer configured for in-memory cluster %s/%s", namespace, name)
+	})
+}
+
+// inMemoryDialer implements a custom dialer that port-forwards to in-memory API server pods.
+type inMemoryDialer struct {
+	managementRESTConfig *rest.Config
+	clusterNamespace     string
+	clusterName          string
+}
+
+// DialContext creates a connection to the in-memory API server using port-forwarding.
+func (d *inMemoryDialer) DialContext(ctx context.Context, addr string) (net.Conn, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address %s: %w", addr, err)
+	}
+
+	var apiPort int
+	if _, err := fmt.Sscanf(portStr, "%d", &apiPort); err != nil {
+		return nil, fmt.Errorf("failed to parse port %s: %w", portStr, err)
+	}
+
+	log.Logf("In-memory dialer: connecting to cluster %s/%s (original address: %s:%s, port: %d)",
+		d.clusterNamespace, d.clusterName, host, portStr, apiPort)
+
+	mgmtClient, err := client.New(d.managementRESTConfig, client.Options{})
+	if err != nil {
+		log.Logf("ERROR: Failed to create management client: %v", err)
+		return nil, fmt.Errorf("failed to create management client: %w", err)
+	}
+
+	podList := &corev1.PodList{}
+	if err := mgmtClient.List(ctx, podList,
+		client.InNamespace("capd-system"),
+		client.MatchingLabels{
+			"control-plane": "controller-manager",
+		}); err != nil {
+		return nil, fmt.Errorf("failed to list capd controller manager pods: %w", err)
+	}
+
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no capd-controller-manager pod found on the management cluster")
+	}
+
+	// Use the first manager pod
+	capdevPod := podList.Items[0]
+
+	log.Logf("Port-forwarding to CAPDev pod %s in namespace %s on port %d", capdevPod.Name, capdevPod.Namespace, apiPort)
+
+	proxy := inmemoryproxy.Proxy{
+		Kind:         "pods",
+		Namespace:    capdevPod.Namespace,
+		ResourceName: capdevPod.Name,
+		KubeConfig:   d.managementRESTConfig,
+		Port:         apiPort,
+	}
+
+	pfDialer, err := inmemoryproxy.NewDialer(proxy)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create port-forward dialer: %w", err)
+	}
+
+	conn, err := pfDialer.DialContextWithAddr(ctx, capdevPod.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial capdev pod %s: %w", capdevPod.Name, err)
+	}
+
+	log.Logf("Successfully established port-forward connection to CAPDev pod %s", capdevPod.Name)
+	return conn, nil
 }
 
 // Dispose clusterProxy internal resources (the operation does not affects the Kubernetes cluster).

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -707,9 +707,10 @@ func (p *clusterProxy) isInMemoryCluster(ctx context.Context, namespace, name st
 		Name:      name,
 		Namespace: namespace,
 	}
-	if err := cl.Get(ctx, key, cluster); err != nil {
-		return false
-	}
+
+	Eventually(func() error {
+		return cl.Get(ctx, key, cluster)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to get %s", key)
 
 	if !cluster.Spec.InfrastructureRef.IsDefined() || cluster.Spec.InfrastructureRef.Kind != "DevCluster" {
 		return false
@@ -793,7 +794,11 @@ func (d *inMemoryDialer) DialContext(ctx context.Context, addr string) (net.Conn
 		return nil, fmt.Errorf("no capd-controller-manager pod found on the management cluster")
 	}
 
-	// Use the first manager pod
+	// We assume exactly one CAPD controller manager pod.
+	if len(podList.Items) > 1 {
+		return nil, fmt.Errorf("expected exactly 1 capd-controller-manager pod, got %d", len(podList.Items))
+	}
+
 	capdevPod := podList.Items[0]
 
 	log.Logf("Port-forwarding to CAPDev pod %s in namespace %s on port %d", capdevPod.Name, capdevPod.Namespace, apiPort)

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -361,23 +361,69 @@ func (r *MachineBackendReconciler) reconcileNormalNode(ctx context.Context, clus
 			node.Labels = map[string]string{}
 		}
 		node.Labels["node-role.kubernetes.io/control-plane"] = ""
-		node.Spec.Taints = []corev1.Taint{
-			{
-				Key:    "node-role.kubernetes.io/control-plane",
-				Effect: corev1.TaintEffectNoSchedule,
-			},
-		}
+		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+			Key:    "node-role.kubernetes.io/control-plane",
+			Effect: corev1.TaintEffectNoSchedule,
+		})
 	}
 
-	if err := inmemoryClient.Get(ctx, client.ObjectKeyFromObject(node), node); err != nil {
+	existingNode := &corev1.Node{}
+	if err := inmemoryClient.Get(ctx, client.ObjectKeyFromObject(node), existingNode); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to get node")
+		}
+
+		// Node doesn't exist, create it with both "Always" and "OnInitialization" taints
+		for _, machineTaint := range machine.Spec.Taints {
+			if machineTaint.Propagation == clusterv1.MachineTaintPropagationAlways ||
+				machineTaint.Propagation == clusterv1.MachineTaintPropagationOnInitialization {
+				node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+					Key:    machineTaint.Key,
+					Value:  machineTaint.Value,
+					Effect: machineTaint.Effect,
+				})
+			}
 		}
 
 		// NOTE: for the first control plane machine we might create the node before etcd and API server pod are running
 		// but this is not an issue, because it won't be visible to CAPI until the API server start serving requests.
 		if err := inmemoryClient.Create(ctx, node); err != nil && !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to create Node")
+		}
+	} else {
+		// Node exists, update it with only "Always" taints (OnInitialization taints should not be updated)
+		var updatedTaints []corev1.Taint
+
+		// Keep existing OnInitialization taints
+		for _, existingTaint := range existingNode.Spec.Taints {
+			isOnInitTaint := false
+			for _, machineTaint := range machine.Spec.Taints {
+				if machineTaint.Key == existingTaint.Key && machineTaint.Propagation == clusterv1.MachineTaintPropagationOnInitialization {
+					isOnInitTaint = true
+					break
+				}
+			}
+			if isOnInitTaint {
+				updatedTaints = append(updatedTaints, existingTaint)
+			}
+		}
+
+		// Add Always taints and control plane taint
+		updatedTaints = append(updatedTaints, node.Spec.Taints...)
+		for _, machineTaint := range machine.Spec.Taints {
+			if machineTaint.Propagation == clusterv1.MachineTaintPropagationAlways {
+				updatedTaints = append(updatedTaints, corev1.Taint{
+					Key:    machineTaint.Key,
+					Value:  machineTaint.Value,
+					Effect: machineTaint.Effect,
+				})
+			}
+		}
+
+		existingNode.Spec.Taints = updatedTaints
+		existingNode.Labels = node.Labels
+		if err := inmemoryClient.Update(ctx, existingNode); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to update Node")
 		}
 	}
 

--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -361,69 +361,23 @@ func (r *MachineBackendReconciler) reconcileNormalNode(ctx context.Context, clus
 			node.Labels = map[string]string{}
 		}
 		node.Labels["node-role.kubernetes.io/control-plane"] = ""
-		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
-			Key:    "node-role.kubernetes.io/control-plane",
-			Effect: corev1.TaintEffectNoSchedule,
-		})
+		node.Spec.Taints = []corev1.Taint{
+			{
+				Key:    "node-role.kubernetes.io/control-plane",
+				Effect: corev1.TaintEffectNoSchedule,
+			},
+		}
 	}
 
-	existingNode := &corev1.Node{}
-	if err := inmemoryClient.Get(ctx, client.ObjectKeyFromObject(node), existingNode); err != nil {
+	if err := inmemoryClient.Get(ctx, client.ObjectKeyFromObject(node), node); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to get node")
-		}
-
-		// Node doesn't exist, create it with both "Always" and "OnInitialization" taints
-		for _, machineTaint := range machine.Spec.Taints {
-			if machineTaint.Propagation == clusterv1.MachineTaintPropagationAlways ||
-				machineTaint.Propagation == clusterv1.MachineTaintPropagationOnInitialization {
-				node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
-					Key:    machineTaint.Key,
-					Value:  machineTaint.Value,
-					Effect: machineTaint.Effect,
-				})
-			}
 		}
 
 		// NOTE: for the first control plane machine we might create the node before etcd and API server pod are running
 		// but this is not an issue, because it won't be visible to CAPI until the API server start serving requests.
 		if err := inmemoryClient.Create(ctx, node); err != nil && !apierrors.IsAlreadyExists(err) {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to create Node")
-		}
-	} else {
-		// Node exists, update it with only "Always" taints (OnInitialization taints should not be updated)
-		var updatedTaints []corev1.Taint
-
-		// Keep existing OnInitialization taints
-		for _, existingTaint := range existingNode.Spec.Taints {
-			isOnInitTaint := false
-			for _, machineTaint := range machine.Spec.Taints {
-				if machineTaint.Key == existingTaint.Key && machineTaint.Propagation == clusterv1.MachineTaintPropagationOnInitialization {
-					isOnInitTaint = true
-					break
-				}
-			}
-			if isOnInitTaint {
-				updatedTaints = append(updatedTaints, existingTaint)
-			}
-		}
-
-		// Add Always taints and control plane taint
-		updatedTaints = append(updatedTaints, node.Spec.Taints...)
-		for _, machineTaint := range machine.Spec.Taints {
-			if machineTaint.Propagation == clusterv1.MachineTaintPropagationAlways {
-				updatedTaints = append(updatedTaints, corev1.Taint{
-					Key:    machineTaint.Key,
-					Value:  machineTaint.Value,
-					Effect: machineTaint.Effect,
-				})
-			}
-		}
-
-		existingNode.Spec.Taints = updatedTaints
-		existingNode.Labels = node.Labels
-		if err := inmemoryClient.Update(ctx, existingNode); err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to update Node")
 		}
 	}
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Similar work: https://github.com/kubernetes-sigs/cluster-api/pull/13764

1. Creates a Dialer for InMemory cluster access
2. Made changes to propagate taints to InMemory Node

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #Part of https://github.com/kubernetes-sigs/cluster-api/issues/13270

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->