### PR TITLE
✨ Implement managedFields interning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,11 @@ ARG gcflags
 ARG ldflags
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
+# TODO: Remove fieldsv1string once build tag is switched (https://github.com/kubernetes/kubernetes/issues/137109#issuecomment-4697742098)
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -trimpath -gcflags "${gcflags}" -ldflags "${ldflags} -extldflags '-static'" \
+    go build -tags=fieldsv1string -trimpath -gcflags "${gcflags}" -ldflags "${ldflags} -extldflags '-static'" \
     -o manager ${package}
 
 # Production image

--- a/Tiltfile
+++ b/Tiltfile
@@ -223,7 +223,7 @@ def build_go_binary(context, reload_deps, debug, go_main, binary_name, label):
         arch = os_arch,
     )
 
-    build_cmd = "{build_env} go build {build_options} -gcflags '{gcflags}' -ldflags '{ldflags}' -o .tiltbuild/bin/{binary_name} {go_main}".format(
+    build_cmd = "{build_env} go build -tags=fieldsv1string {build_options} -gcflags '{gcflags}' -ldflags '{ldflags}' -o .tiltbuild/bin/{binary_name} {go_main}".format(
         build_env = build_env,
         build_options = build_options,
         gcflags = gcflags,

--- a/controllers/crdmigrator/crd_migrator.go
+++ b/controllers/crdmigrator/crd_migrator.go
@@ -475,22 +475,13 @@ func (r *CRDMigrator) reconcileCleanupManagedFields(ctx context.Context, crd *ap
 				//       chances that the managedField entry gets cleaned up. In any case having a minimal entry only
 				//       for metadata.name is better than leaving the old entry that uses an apiVersion that is not
 				//       served anymore (see: https://github.com/kubernetes/kubernetes/issues/111937).
-				fieldV1Map := map[string]interface{}{
-					"f:metadata": map[string]interface{}{
-						"f:name": map[string]interface{}{},
-					},
-				}
-				fieldV1, err := json.Marshal(fieldV1Map)
-				if err != nil {
-					return errors.Wrap(err, "failed to create seeding managedField entry")
-				}
 				managedFields = append(managedFields, metav1.ManagedFieldsEntry{
 					Manager:    obj.GetManagedFields()[0].Manager,
 					Operation:  obj.GetManagedFields()[0].Operation,
 					APIVersion: schema.GroupVersion{Group: crd.Spec.Group, Version: storageVersion}.String(),
 					Time:       ptr.To(metav1.Now()),
 					FieldsType: "FieldsV1",
-					FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+					FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:name":{}}}`),
 				})
 			}
 

--- a/controlplane/kubeadm/internal/controllers/helpers_test.go
+++ b/controlplane/kubeadm/internal/controllers/helpers_test.go
@@ -985,7 +985,7 @@ func toManagedFields(managedFields []managedFieldEntry) []metav1.ManagedFieldsEn
 			Operation:   f.Operation,
 			APIVersion:  f.APIVersion,
 			FieldsType:  "FieldsV1",
-			FieldsV1:    &metav1.FieldsV1{Raw: []byte(trimSpaces(f.FieldsV1))},
+			FieldsV1:    metav1.NewFieldsV1(trimSpaces(f.FieldsV1)),
 			Subresource: f.Subresource,
 		})
 	}

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -4177,7 +4177,7 @@ func toManagedFields(managedFields []managedFieldEntry) []metav1.ManagedFieldsEn
 			Operation:   f.Operation,
 			APIVersion:  f.APIVersion,
 			FieldsType:  "FieldsV1",
-			FieldsV1:    &metav1.FieldsV1{Raw: []byte(trimSpaces(f.FieldsV1))},
+			FieldsV1:    metav1.NewFieldsV1(trimSpaces(f.FieldsV1)),
 			Subresource: f.Subresource,
 		})
 	}

--- a/internal/controllers/topology/cluster/structuredmerge/dryrun_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun_test.go
@@ -177,7 +177,7 @@ func (b objectBuilder) WithManagedFieldsEntry(manager, subresource string, opera
 		Manager:     manager,
 		Operation:   operation,
 		Subresource: subresource,
-		FieldsV1:    &metav1.FieldsV1{Raw: fieldsV1},
+		FieldsV1:    metav1.NewFieldsV1(string(fieldsV1)),
 		Time:        time,
 	})
 	b.u.SetManagedFields(managedFields)

--- a/internal/util/ssa/managedfields.go
+++ b/internal/util/ssa/managedfields.go
@@ -187,7 +187,7 @@ func MigrateManagedFields(ctx context.Context, c client.Client, object client.Ob
 		APIVersion: objectGVK.GroupVersion().String(),
 		Time:       ptr.To(metav1.Now()),
 		FieldsType: "FieldsV1",
-		FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+		FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:name":{}}}`),
 	})
 
 	object.SetManagedFields(managedFields)

--- a/internal/util/ssa/managedfields_test.go
+++ b/internal/util/ssa/managedfields_test.go
@@ -591,7 +591,7 @@ func toManagedFields(managedFields []managedFieldEntry) []metav1.ManagedFieldsEn
 			Operation:   f.Operation,
 			APIVersion:  bootstrapv1.GroupVersion.String(),
 			FieldsType:  "FieldsV1",
-			FieldsV1:    &metav1.FieldsV1{Raw: []byte(trimSpaces(f.FieldsV1))},
+			FieldsV1:    metav1.NewFieldsV1(trimSpaces(f.FieldsV1)),
 			Subresource: f.Subresource,
 		})
 	}

--- a/internal/util/ssa/managedfieldsmitigation.go
+++ b/internal/util/ssa/managedfieldsmitigation.go
@@ -118,7 +118,7 @@ func MigrateClusterAndMitigateManagedFieldsIssue(ctx context.Context, c client.C
 			APIVersion: clusterv1.GroupVersion.String(),
 			Time:       ptr.To(metav1.Now()),
 			FieldsType: "FieldsV1",
-			FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+			FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:name":{}}}`),
 		})
 	}
 
@@ -217,7 +217,7 @@ func MitigateManagedFieldsIssue(ctx context.Context, c client.Client, obj client
 			APIVersion: objGVK.GroupVersion().String(),
 			Time:       ptr.To(metav1.Now()),
 			FieldsType: "FieldsV1",
-			FieldsV1:   &metav1.FieldsV1{Raw: fieldsV1},
+			FieldsV1:   metav1.NewFieldsV1(string(fieldsV1)),
 		})
 	}
 

--- a/internal/util/ssa/managedfieldsmitigation_test.go
+++ b/internal/util/ssa/managedfieldsmitigation_test.go
@@ -146,7 +146,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -154,7 +154,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 			expectManagedFieldIssueMitigated: false,
 			// managedFields are not changed
@@ -163,7 +163,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationUpdate,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -171,7 +171,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 		},
 		{
@@ -184,10 +184,10 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationUpdate,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:name":{}
-}}`))},
+}}`)),
 			}},
 			objectApplies: []objectApply{
 				{
@@ -198,16 +198,16 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: clusterv1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1:   &metav1.FieldsV1{Raw: []byte(clusterManagedFieldsAfterApply)},
+						FieldsV1:   metav1.NewFieldsV1(clusterManagedFieldsAfterApply),
 					}, {
 						Manager:    patchManager,
 						Operation:  metav1.ManagedFieldsOperationUpdate,
 						APIVersion: clusterv1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+						FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:name":{}
-}}`))},
+}}`)),
 					}},
 				},
 			},
@@ -221,7 +221,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -229,7 +229,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
@@ -237,7 +237,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationUpdate,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+				FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:name":{}}}`),
 			}},
 		},
 		{
@@ -249,7 +249,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -257,7 +257,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
@@ -265,7 +265,7 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationUpdate,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:name":{}}}`)},
+				FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:name":{}}}`),
 			}},
 		},
 		{
@@ -277,36 +277,36 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))}}},
+}}`))}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 		},
 		{
@@ -318,36 +318,36 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))}}},
+}}`))}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 		},
 		{
@@ -359,49 +359,49 @@ func TestMigrateClusterAndMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    oldClusterSSAManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:finalizers":{
 		".":{},
 		"v:\"test.com/finalizer\"":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))}}},
+}}`))}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 		},
 	}
@@ -1328,7 +1328,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: controlplanev1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -1336,7 +1336,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 			expectManagedFieldIssueMitigated: false,
 			// managedFields are not changed
@@ -1345,7 +1345,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -1353,7 +1353,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 		},
 		{
@@ -1366,10 +1366,10 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: clusterv1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:name":{}
-}}`))},
+}}`)),
 			}},
 		},
 		{
@@ -1381,7 +1381,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: controlplanev1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
@@ -1389,7 +1389,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
@@ -1397,7 +1397,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneManagedFieldsAfterMitigation)},
+				FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneManagedFieldsAfterMitigation),
 			}},
 			objectApplies: []objectApply{{
 				object: kubeadmControlPlaneApply.DeepCopy(),
@@ -1406,7 +1406,7 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 					Operation:  metav1.ManagedFieldsOperationApply,
 					APIVersion: controlplanev1.GroupVersion.String(),
 					FieldsType: "FieldsV1",
-					FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneManagedFieldsAfterApply)},
+					FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneManagedFieldsAfterApply),
 				}}},
 			},
 		},
@@ -1419,42 +1419,42 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: controlplanev1beta1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1beta1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))}}},
+}}`))}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1beta1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    testFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1beta1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneV1Beta1ManagedFieldsAfterMitigation)},
+				FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneV1Beta1ManagedFieldsAfterMitigation),
 			}},
 			objectApplies: []objectApply{
 				{ // Apply v1beta1
@@ -1464,18 +1464,18 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1beta1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+						FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 					}, {
 						Manager:    testFieldManager,
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1beta1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneManagedFieldsV1Beta1AfterApply)},
+						FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneManagedFieldsV1Beta1AfterApply),
 					}},
 				},
 				{ // Apply v1beta2
@@ -1485,18 +1485,18 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1beta1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+						FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 					}, {
 						Manager:    testFieldManager,
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneManagedFieldsAfterApply)},
+						FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneManagedFieldsAfterApply),
 					}},
 				},
 				{ // Apply v1beta2 again to verify that we can remove extraArgs
@@ -1506,18 +1506,18 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1beta1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+						FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 					}, {
 						Manager:    testFieldManager,
 						Operation:  metav1.ManagedFieldsOperationApply,
 						APIVersion: controlplanev1.GroupVersion.String(),
 						FieldsType: "FieldsV1",
-						FieldsV1:   &metav1.FieldsV1{Raw: []byte(kubeadmControlPlaneManagedFieldsAfterApplyWithoutSomeExtraArgs)},
+						FieldsV1:   metav1.NewFieldsV1(kubeadmControlPlaneManagedFieldsAfterApplyWithoutSomeExtraArgs),
 					}},
 				},
 			},
@@ -1531,60 +1531,60 @@ func TestMitigateManagedFieldsIssue(t *testing.T) {
 				APIVersion: controlplanev1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:annotations":{
 		"f:annotation-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))}}, {
+}}`))}, {
 				Manager:    testFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				Time:       ptr.To(metav1.Now()),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:finalizers":{
 		".":{},
 		"v:\"test.com/finalizer\"":{}
 	}
-}}`))}}},
+}}`))}},
 			expectManagedFieldIssueMitigated: true,
 			expectedManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager:    otherFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:labels":{
 		"f:label-1":{}
 	}
-}}`))},
+}}`)),
 			}, {
 				Manager:    testFieldManager,
 				Operation:  metav1.ManagedFieldsOperationApply,
 				APIVersion: controlplanev1.GroupVersion.String(),
 				FieldsType: "FieldsV1",
-				FieldsV1: &metav1.FieldsV1{Raw: []byte(trimSpaces(`{
+				FieldsV1: metav1.NewFieldsV1(trimSpaces(`{
 "f:metadata":{
 	"f:finalizers":{
 		".":{},
 		"v:\"test.com/finalizer\"":{}
 	}
-}}`))}}},
+}}`))}},
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR enables managedFields interning in CAPI by:
* stop using FieldsV1.Raw directly
* enabling the `fieldsv1string` build tag

xref: https://github.com/kubernetes/kubernetes/issues/137109#issuecomment-4697742098

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->