### PR TITLE
🌱 clusterctl: print help on argument validation errors

### DIFF
--- a/cmd/clusterctl/cmd/args.go
+++ b/cmd/clusterctl/cmd/args.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	goerrors "errors"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type helpError struct {
+	err error
+}
+
+func (e *helpError) Error() string {
+	return e.err.Error()
+}
+
+func (e *helpError) Unwrap() error {
+	return e.err
+}
+
+func wrapHelpError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &helpError{err: err}
+}
+
+func isHelpError(err error) bool {
+	var target *helpError
+	return goerrors.As(err, &target)
+}
+
+func helpOnErrorArgs(args cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, arg []string) error {
+		return wrapHelpError(args(cmd, arg))
+	}
+}
+
+func exactArgsWithMessage(expected int, message string) cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		if len(args) != expected {
+			return wrapHelpError(errors.New(message))
+		}
+		return nil
+	}
+}

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -98,12 +97,7 @@ var (
 				return nil
 			}
 		},
-		Args: func(_ *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("please specify a shell")
-			}
-			return nil
-		},
+		Args: exactArgsWithMessage(1, "please specify a shell"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletion(os.Stdout, cmd, args[0])
 		},

--- a/cmd/clusterctl/cmd/config_repositories.go
+++ b/cmd/clusterctl/cmd/config_repositories.go
@@ -52,7 +52,7 @@ var cro = &configRepositoriesOptions{}
 
 var configRepositoryCmd = &cobra.Command{
 	Use:   "repositories",
-	Args:  cobra.NoArgs,
+	Args:  helpOnErrorArgs(cobra.NoArgs),
 	Short: "Display the list of providers and their repository configurations",
 	Long: templates.LongDesc(`
 		Display the list of providers and their repository configurations.

--- a/cmd/clusterctl/cmd/convert.go
+++ b/cmd/clusterctl/cmd/convert.go
@@ -62,7 +62,7 @@ Examples:
   # Explicitly specify target <VERSION>
   clusterctl convert cluster.yaml --to-version <VERSION> --output converted-cluster.yaml`,
 
-	Args: cobra.MaximumNArgs(1),
+	Args: helpOnErrorArgs(cobra.MaximumNArgs(1)),
 	RunE: func(_ *cobra.Command, args []string) error {
 		return runConvert(args)
 	},

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -84,7 +84,7 @@ var deleteCmd = &cobra.Command{
 		# Important! As a consequence of this operation all the corresponding resources on target clouds
 		# are "orphaned" and thus there may be ongoing costs incurred as a result of this.
 		clusterctl delete --all --include-crd  --include-namespace`),
-	Args: cobra.NoArgs,
+	Args: helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runDelete()
 	},

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -74,12 +74,7 @@ var describeClusterClusterCmd = &cobra.Command{
 		# also when their status is the same as the status of the corresponding machine object.
 		clusterctl describe cluster test-1 --echo`),
 
-	Args: func(_ *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("please specify a cluster name")
-		}
-		return nil
-	},
+	Args: exactArgsWithMessage(1, "please specify a cluster name"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDescribeCluster(cmd, args[0])
 	},

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
@@ -93,12 +92,7 @@ var generateClusterClusterCmd = &cobra.Command{
 		# Prints the list of variables required by the yaml file for creating workload cluster.
 		clusterctl generate cluster my-cluster --list-variables`),
 
-	Args: func(_ *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("please specify a cluster name")
-		}
-		return nil
-	},
+	Args: exactArgsWithMessage(1, "please specify a cluster name"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGenerateClusterTemplate(cmd, args[0])
 	},

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -45,7 +45,7 @@ var gpo = &generateProvidersOptions{}
 
 var generateProviderCmd = &cobra.Command{
 	Use:   "provider",
-	Args:  cobra.NoArgs,
+	Args:  helpOnErrorArgs(cobra.NoArgs),
 	Short: "Generate templates for provider components",
 	Long: templates.LongDesc(`
 		Generate templates for provider components.

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -49,12 +48,7 @@ var getKubeconfigCmd = &cobra.Command{
 		# Get the workload cluster's kubeconfig in a particular namespace.
 		clusterctl get kubeconfig <name of workload cluster> --namespace foo`),
 
-	Args: func(_ *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("please specify a workload cluster name")
-		}
-		return nil
-	},
+	Args: exactArgsWithMessage(1, "please specify a workload cluster name"),
 	RunE: func(_ *cobra.Command, args []string) error {
 		return runGetKubeconfig(args[0])
 	},

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -84,7 +84,7 @@ var initCmd = &cobra.Command{
 
 		# Initialize a management cluster with a custom target namespace for the provider resources.
 		clusterctl init --infrastructure aws --target-namespace foo`),
-	Args: cobra.NoArgs,
+	Args: helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runInit()
 	},

--- a/cmd/clusterctl/cmd/init_list_images.go
+++ b/cmd/clusterctl/cmd/init_list_images.go
@@ -43,7 +43,7 @@ var initListImagesCmd = &cobra.Command{
 		# List infrastructure, bootstrap, control-plane and core images
 		clusterctl init list-images --infrastructure vcd --bootstrap kubeadm --control-plane nested --core cluster-api:v1.2.0
 	`),
-	Args: cobra.NoArgs,
+	Args: helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runInitListImages()
 	},

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -65,7 +65,7 @@ var moveCmd = &cobra.Command{
 		Read Cluster API objects and all dependencies from a directory into a management cluster.
 		clusterctl move --from-directory /tmp/backup-directory
 	`),
-	Args: cobra.NoArgs,
+	Args: helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runMove()
 	},

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -110,7 +110,7 @@ var RootCmd = &cobra.Command{
 func Execute() {
 	handlePlugins()
 
-	if err := RootCmd.Execute(); err != nil {
+	if err := executeRoot(RootCmd); err != nil {
 		if verbosity != nil && *verbosity >= 5 {
 			if err, ok := err.(stackTracer); ok {
 				for _, f := range err.StackTrace() {
@@ -118,9 +118,17 @@ func Execute() {
 				}
 			}
 		}
-		// TODO: print cmd help if validation error
 		os.Exit(1)
 	}
+}
+
+func executeRoot(rootCmd *cobra.Command) error {
+	cmd, err := rootCmd.ExecuteC()
+	if err != nil && cmd != nil && isHelpError(err) {
+		_, _ = cmd.ErrOrStderr().Write([]byte("\n"))
+		_ = cmd.Help()
+	}
+	return err
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/root_test.go
+++ b/cmd/clusterctl/cmd/root_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExecuteRoot_PrintsHelpForArgumentValidationErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	output := bytes.NewBuffer(nil)
+	RootCmd.SetOut(output)
+	RootCmd.SetErr(output)
+	RootCmd.SetArgs([]string{"describe", "cluster"})
+	t.Cleanup(func() {
+		RootCmd.SetArgs(nil)
+		RootCmd.SetOut(nil)
+		RootCmd.SetErr(nil)
+	})
+
+	err := executeRoot(RootCmd)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(output.String()).To(ContainSubstring("Error: please specify a cluster name\n\n"))
+	g.Expect(output.String()).To(ContainSubstring("Usage:"))
+	g.Expect(output.String()).To(ContainSubstring("clusterctl describe cluster NAME [flags]"))
+}
+
+func TestExecuteRoot_DoesNotPrintHelpForRuntimeErrors(t *testing.T) {
+	g := NewWithT(t)
+
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
+	RootCmd.SetOut(stdout)
+	RootCmd.SetErr(stderr)
+	RootCmd.SetArgs([]string{"convert", "/tmp/clusterctl-does-not-exist.yaml"})
+	t.Cleanup(func() {
+		RootCmd.SetArgs(nil)
+		RootCmd.SetOut(nil)
+		RootCmd.SetErr(nil)
+	})
+
+	err := executeRoot(RootCmd)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(stderr.String()).To(ContainSubstring("failed to read input file"))
+	g.Expect(stdout.String()).To(BeEmpty())
+}

--- a/cmd/clusterctl/cmd/upgrade.go
+++ b/cmd/clusterctl/cmd/upgrade.go
@@ -28,7 +28,7 @@ var upgradeCmd = &cobra.Command{
 	Use:     "upgrade",
 	GroupID: groupManagement,
 	Short:   "Upgrade core and provider components in a management cluster",
-	Args:    cobra.NoArgs,
+	Args:    helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return cmd.Help()
 	},

--- a/cmd/clusterctl/cmd/upgrade_apply.go
+++ b/cmd/clusterctl/cmd/upgrade_apply.go
@@ -61,7 +61,7 @@ var upgradeApplyCmd = &cobra.Command{
 
 		# Upgrades only the aws provider to the v2.0.1 version.
 		clusterctl upgrade apply --infrastructure aws:v2.0.1`),
-	Args: cobra.NoArgs,
+	Args: helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runUpgradeApply()
 	},

--- a/cmd/clusterctl/cmd/version.go
+++ b/cmd/clusterctl/cmd/version.go
@@ -42,7 +42,7 @@ var versionCmd = &cobra.Command{
 	Use:     "version",
 	GroupID: groupOther,
 	Short:   "Print clusterctl version",
-	Args:    cobra.NoArgs,
+	Args:    helpOnErrorArgs(cobra.NoArgs),
 	RunE: func(*cobra.Command, []string) error {
 		return runVersion()
 	},


### PR DESCRIPTION
What this PR does / why we need it:

`clusterctl` only printed the raw error when positional arg validation failed. So commands like `clusterctl describe cluster` or `clusterctl version extra` gave no matching usage/examples, which is a bit rough.

This prints command help for arg validation errors, and keeps runtime errors as-is. Added tests for both paths too.

Which issue(s) this PR fixes:

Related to #6867

How to reproduce:

1. Run `go run ./cmd/clusterctl describe cluster`
2. Run `go run ./cmd/clusterctl version extra`

Before this change you only get the error line.
After this change you get the same error, plus the help for the failing command. Much nicer, less guesswork.
