### PR TITLE
🌱 Surface Runtime Extension errors in conditions

### DIFF
--- a/docs/book/src/developer/providers/migrations/v1.13-to-v1.14.md
+++ b/docs/book/src/developer/providers/migrations/v1.13-to-v1.14.md
@@ -77,7 +77,10 @@ Any feedback or contributions to improve following documentation is welcome!
 
 ## Runtime hooks Changes
 
--
+- Please note that since [CAPI-13813](https://github.com/kubernetes-sigs/cluster-api/pull/13813) errors returned from
+  Runtime Extensions might be surfaced in conditions. Accordingly, please ensure that the error messages are deterministic 
+  to avoid infinite reconciles. This change was done because we realized that errors reported by Runtime Extensions are a 
+  crucial feedback mechanism to users and its too cumbersome for users to search in controller logs for errors.
 
 ## Cluster API Contract changes
 

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
@@ -283,7 +283,7 @@ well with practices like unit testing and generally makes the entire system more
 
 ### Error messages
 
-RuntimeExtension authors should be aware that error messages are surfaced as conditions in Kubernetes resources
+RuntimeExtension authors should be aware that error messages might be surfaced as conditions in Kubernetes resources
 and recorded in Cluster API controller's logs. As a consequence:
 
 - Error message must not contain any sensitive information.

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -33,7 +33,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -174,7 +173,7 @@ func (c *client) Discover(ctx context.Context, extensionConfig *runtimev1.Extens
 	}
 
 	// Check to see if the response is not a success and handle the failure accordingly.
-	if err := validateResponseStatus(log, response, "discover extension", extensionConfig.Name); err != nil {
+	if err := validateResponseStatus(response, "discover extension", extensionConfig.Name); err != nil {
 		return nil, err
 	}
 
@@ -444,7 +443,7 @@ func (c *client) CallExtension(ctx context.Context, hook runtimecatalog.Hook, fo
 	}
 
 	// If the received response is not a success then return an error.
-	if err := validateResponseStatus(log, response, "call extension handler", name); err != nil {
+	if err := validateResponseStatus(response, "call extension handler", name); err != nil {
 		return err
 	}
 
@@ -812,16 +811,13 @@ func ExtensionNameFromHandlerName(registeredHandlerName string) (string, error) 
 
 // validateResponseStatus checks if the response status is successful and returns an error otherwise.
 // It logs appropriate messages for failure and unknown statuses.
-func validateResponseStatus(log logr.Logger, response runtimehooksv1.ResponseObject, operationName, targetName string) error {
+func validateResponseStatus(response runtimehooksv1.ResponseObject, operationName, targetName string) error {
 	if response.GetStatus() != runtimehooksv1.ResponseStatusSuccess {
 		if response.GetStatus() == runtimehooksv1.ResponseStatusFailure {
-			log.Info(fmt.Sprintf("Failed to %s %q: got failure response with message %v", operationName, targetName, response.GetMessage()))
-			// Don't add the message to the error as it is may be unique causing too many reconciliations. Ref: https://github.com/kubernetes-sigs/cluster-api/issues/6921
-			return errors.Errorf("failed to %s %q: got failure response, please check controller logs for errors", operationName, targetName)
+			return errors.Errorf("failed to %s %q: got failure response with message: %v", operationName, targetName, response.GetMessage())
 		}
 		// Handle unknown status.
-		log.Info(fmt.Sprintf("Failed to %s %q: got unknown response status %q with message %v", operationName, targetName, response.GetStatus(), response.GetMessage()))
-		return errors.Errorf("failed to %s %q: got unknown response status %q, please check controller logs for errors", operationName, targetName, response.GetStatus())
+		return errors.Errorf("failed to %s %q: got unknown response status %q with message: %v", operationName, targetName, response.GetStatus(), response.GetMessage())
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This change surfaces Runtime Extension errors in conditions because we realized that errors reported by Runtime Extensions are a  crucial feedback mechanism to users and its too cumbersome for users to search in controller logs for errors.

Example: BeforeClusterCreate
```
- lastTransitionTime: "2026-06-16T13:15:43Z"
      message: 'failed to call extension handlers for hook "BeforeClusterCreate.hooks.runtime.cluster.x-k8s.io":
        failed to call extension handler "before-cluster-create.test-extension": got
        failure response with message: test error message'
      observedGeneration: 1
      reason: ReconcileFailed
      status: "False"
      type: TopologyReconciled
```

Example: TopologyReconciled
```
   - lastTransitionTime: "2026-06-16T13:15:43Z"
      message: 'error computing the desired state of the Cluster topology: failed
        to apply patches: failed to generate patches for patch "test-patch": failed
        to call extension handler "generate-patches.test-extension": got failure response with
        message: test error message'
      observedGeneration: 1
      reason: ReconcileFailed
      status: "False"
      type: TopologyReconciled
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->