### PR TITLE
🌱 Fix linter findings in hack/tools

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # tag=v9.2.1
         with:
-          version: v2.12.1
+          version: v2.12.2
           working-directory: ${{matrix.working-directory}}
       - name: Lint API
         run: make lint-api

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -1,4 +1,4 @@
-version: v2.7.0
+version: v2.12.2
 name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:

--- a/hack/tools/internal/tilt-prepare/main.go
+++ b/hack/tools/internal/tilt-prepare/main.go
@@ -529,7 +529,7 @@ func runTask(ctx context.Context, wg *sync.WaitGroup, prefix string, f taskFunct
 // makeTask generates a task for invoking a make target.
 func makeTask(name string) taskFunction {
 	return func(ctx context.Context, prefix string, errCh chan error) {
-		cmd := exec.CommandContext(ctx, "make", name)
+		cmd := exec.CommandContext(ctx, "make", name) //nolint:gosec // No security issue: variable is safe.
 
 		var stderr bytes.Buffer
 		cmd.Dir = rootPath
@@ -681,7 +681,7 @@ func cleanupChartTask(path string) taskFunction {
 // kustomizeTask generates a task for running kustomize build on a path and saving the output on a file.
 func kustomizeTask(path, out string) taskFunction {
 	return func(ctx context.Context, prefix string, errCh chan error) {
-		cmd := exec.CommandContext(ctx,
+		cmd := exec.CommandContext(ctx, //nolint:gosec // No security issue: variable is safe.
 			kustomizePath,
 			"build",
 			path,

--- a/hack/tools/mdbook/embed/embed.go
+++ b/hack/tools/mdbook/embed/embed.go
@@ -71,6 +71,6 @@ func (l Embed) Process(input *plugin.Input) error {
 func main() {
 	cfg := Embed{}
 	if err := plugin.Run(cfg, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(err.Error()) //nolint:gosec // Not worried about log injection here.
 	}
 }

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -96,6 +96,6 @@ func (l ReleaseLink) Process(input *plugin.Input) error {
 func main() {
 	cfg := ReleaseLink{}
 	if err := plugin.Run(cfg, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(err.Error()) //nolint:gosec // Not worried about log injection here.
 	}
 }

--- a/hack/tools/mdbook/tabulate/tabulate.go
+++ b/hack/tools/mdbook/tabulate/tabulate.go
@@ -83,6 +83,6 @@ func (l Tabulate) Process(input *plugin.Input) error {
 func main() {
 	cfg := Tabulate{}
 	if err := plugin.Run(cfg, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(err.Error()) //nolint:gosec // Not worried about log injection here.
 	}
 }

--- a/hack/tools/release/notes/github.go
+++ b/hack/tools/release/notes/github.go
@@ -177,7 +177,7 @@ func (c githubClient) listMergedPRs(after, before time.Time, baseBranches ...str
 }
 
 func (c githubClient) runGHAPICommand(url string, response any) error {
-	cmd := exec.Command("gh", "api", url) //nolint:noctx // No context available in this function.
+	cmd := exec.Command("gh", "api", url) //nolint:noctx,gosec // No context available in this function. No security issue: variable is safe.
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
I've been getting these findings locally since ~ a week. I think there's something wrong with GitHub actions caching so they don't show up in GitHub actions.

```
hack/tools/hack/tools/internal/tilt-prepare/main.go:532:10: G204: Subprocess launched with variable (gosec)
                cmd := exec.CommandContext(ctx, "make", name)
                       ^
hack/tools/hack/tools/internal/tilt-prepare/main.go:684:10: G204: Subprocess launched with variable (gosec)
                cmd := exec.CommandContext(ctx,
                        kustomizePath,
                        "build",
                        path,
                        // enable helm to enable helmChartInflationGenerator.
                        "--enable-helm",
                        // to allow picking up resource files from a different folder.
                        "--load-restrictor=LoadRestrictionsNone",
                )
hack/tools/hack/tools/mdbook/embed/embed.go:74:12: G706: Log injection via taint analysis (gosec)
                log.Fatal(err.Error())
                         ^
hack/tools/hack/tools/mdbook/releaselink/releaselink.go:99:12: G706: Log injection via taint analysis (gosec)
                log.Fatal(err.Error())
                         ^
hack/tools/hack/tools/mdbook/tabulate/tabulate.go:86:12: G706: Log injection via taint analysis (gosec)
                log.Fatal(err.Error())
                         ^
hack/tools/hack/tools/release/notes/github.go:180:9: G204: Subprocess launched with variable (gosec)
        cmd := exec.Command("gh", "api", url) //nolint:noctx // No context available in this function.
               ^
```



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->