### PR TITLE
🌱 Fix RBAC of the ClusterResourceSet controller for OwnerReferencesPermissionEnforcement

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,12 @@ rules:
 - apiGroups:
   - addons.cluster.x-k8s.io
   resources:
+  - clusterresourcesets
+  verbs:
+  - delete
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
   - clusterresourcesets/finalizers
   - clusterresourcesets/status
   verbs:

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller.go
@@ -60,6 +60,7 @@ var ErrSecretTypeNotSupported = errors.New("unsupported secret type")
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;update;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets,verbs=delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets/status;clusterresourcesets/finalizers,verbs=get;update;patch
 
 // Reconciler reconciles a ClusterResourceSet object.

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -181,7 +181,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.13=>cu
 			WorkloadKubernetesVersion:   "v1.36.1",
 			MgmtFlavor:                  "topology",
 			WorkloadFlavor:              "topology",
-			UseKindForManagementCluster: true,
+			UseKindForManagementCluster: false, // Using false for one test case to ensure this code path of the test keeps working.
 		}
 	})
 })


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Follow-up to #13805

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->