### PR TITLE
[release-1.13] :bug: Grant RBAC to support OwnerReferencesPermissionEnforcement admission controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   verbs:
+  - delete
   - get
   - list
   - patch

--- a/internal/controllers/clusterresourceset/clusterresourceset_controller.go
+++ b/internal/controllers/clusterresourceset/clusterresourceset_controller.go
@@ -58,7 +58,7 @@ import (
 var ErrSecretTypeNotSupported = errors.New("unsupported secret type")
 
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;patch;update;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesets/status;clusterresourcesets/finalizers,verbs=get;update;patch
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

After merging a PR adding the OwnerReferencesPermissionEnforcement admission controller to the end-to-end test, we observed some upgrade tests failing. This happens because the upgrade tests install a previous release to verify that the upgrade works.

In hindsight, we should have split the change in https://github.com/kubernetes-sigs/cluster-api/pull/13805 into two PRs: one for the RBAC fix and another one to enable the admission controller and update the docs.

This PR is a substitute for an imagined cherry-pick of the RBAC fix in https://github.com/kubernetes-sigs/cluster-api/pull/13805. The approach is summarized in https://github.com/kubernetes-sigs/cluster-api/pull/13815#issuecomment-4731184541.


**Which issue(s) this PR fixes**

Relates to https://github.com/kubernetes-sigs/cluster-api/issues/13801

/area security