### PR TITLE
:seedling: Enable opt-out of OwnerReferencesPermissionEnforcement admission controller & opt-out in clusterctl upgrade tests

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -288,6 +288,10 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 				Images:    input.E2EConfig.Images,
 				IPFamily:  input.E2EConfig.MustGetVariable(IPFamily),
 				LogFolder: filepath.Join(managementClusterLogFolder, "logs-kind"),
+				// Note: Older releases might not have sufficient RBAC to satisfy the OwnerReferencesPermissionEnforcement admission controller.
+				// So for now, we disable it to avoid failing upgrade tests.
+				// TODO: Remove this option to enable OwnerReferencesPermissionEnforcement admission controller in all e2e-tests.
+				DisableOwnerReferencesPermissionEnforcement: true,
 			})
 			Expect(managementClusterProvider).ToNot(BeNil(), "Failed to create a kind cluster")
 

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -88,6 +88,13 @@ func WithExtraPortMappings(mappings []kindv1.PortMapping) KindClusterOption {
 	})
 }
 
+// WithOwnerReferencesPermissionEnforcementDisabled implements a New Option that disables the OwnerReferencesPermissionEnforcement admission controller.
+func WithOwnerReferencesPermissionEnforcementDisabled() KindClusterOption {
+	return kindClusterOptionAdapter(func(k *KindClusterProvider) {
+		k.disableOwnerReferencesPermissionEnforcement = true
+	})
+}
+
 // LogFolder implements a New Option that instruct the kindClusterProvider to dump bootstrap logs in a folder in case of errors.
 func LogFolder(path string) KindClusterOption {
 	return kindClusterOptionAdapter(func(k *KindClusterProvider) {
@@ -117,6 +124,8 @@ type KindClusterProvider struct {
 	ipFamily          kindv1.ClusterIPFamily
 	logFolder         string
 	extraPortMappings []kindv1.PortMapping
+
+	disableOwnerReferencesPermissionEnforcement bool
 }
 
 // Create a Kubernetes cluster using kind.
@@ -141,13 +150,17 @@ func (k *KindClusterProvider) createKindCluster() {
 		kind.CreateWithKubeconfigPath(k.kubeconfigPath),
 	}
 
-	// We enable the OwnerReferencesPermissionEnforcement admission plugin to detect potential
-	// RBAC issues when applying owner references with blockOwnerDeletion.
-	const ownerReferencesPermissionEnforcementPatch = `kind: ClusterConfiguration
+	var kubeadmConfigPatches []string
+	if !k.disableOwnerReferencesPermissionEnforcement {
+		// We enable the OwnerReferencesPermissionEnforcement admission plugin to detect potential
+		// RBAC issues when applying owner references with blockOwnerDeletion.
+		const ownerReferencesPermissionEnforcementPatch = `kind: ClusterConfiguration
 apiServer:
   extraArgs:
     enable-admission-plugins: OwnerReferencesPermissionEnforcement
 `
+		kubeadmConfigPatches = append(kubeadmConfigPatches, ownerReferencesPermissionEnforcementPatch)
+	}
 
 	cfg := &kindv1.Cluster{
 		Nodes: []kindv1.Node{
@@ -156,9 +169,7 @@ apiServer:
 				ExtraPortMappings: k.extraPortMappings,
 			},
 		},
-		KubeadmConfigPatches: []string{
-			ownerReferencesPermissionEnforcementPatch,
-		},
+		KubeadmConfigPatches: kubeadmConfigPatches,
 	}
 
 	if k.ipFamily == kindv1.IPv6Family {

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -61,6 +61,14 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 
 	// CustomNodeImage is the custom node image used for creating the kind node
 	CustomNodeImage string
+
+	// DisableOwnerReferencesPermissionEnforcement can be set to true to disable
+	// the OwnerReferencesPermissionEnforcement admission controller in the cluster.
+	// Some Kubernetes clusters enable this admission plugin by default (e.g. OpenShift),
+	// and even if this plugin isn't enabled by default in Kubernetes/kind, we would
+	// like to support clusters where its enabled.
+	// See https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+	DisableOwnerReferencesPermissionEnforcement bool
 }
 
 // CreateKindBootstrapClusterAndLoadImages returns a new Kubernetes cluster with pre-loaded images.
@@ -96,6 +104,9 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	}
 	if input.CustomNodeImage != "" {
 		options = append(options, WithNodeImage(input.CustomNodeImage))
+	}
+	if input.DisableOwnerReferencesPermissionEnforcement {
+		options = append(options, WithOwnerReferencesPermissionEnforcementDisabled())
 	}
 	options = append(options, WithExtraPortMappings(input.ExtraPortMappings))
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR adds an option to opt out of the admission plugin added in https://github.com/kubernetes-sigs/cluster-api/pull/13805.

**Which issue(s) this PR fixes**

Relates to https://github.com/kubernetes-sigs/cluster-api/pull/13805

Addresses the test issues summarized in https://github.com/kubernetes-sigs/cluster-api/pull/13815#issuecomment-4731184541.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area e2e-testing