### PR TITLE
✨ clustercache: use DefaultTransform in core CAPI, CABPK and KCP

### DIFF
--- a/bootstrap/kubeadm/internal/setup/setup.go
+++ b/bootstrap/kubeadm/internal/setup/setup.go
@@ -100,7 +100,9 @@ func ManagerClientOptions() client.Options {
 
 // ClusterCacheCacheOptions provides clustercache.CacheOptions for the ClusterCache.
 func ClusterCacheCacheOptions() clustercache.CacheOptions {
-	return clustercache.CacheOptions{}
+	return clustercache.CacheOptions{
+		DefaultTransform: cache.TransformStripManagedFields(),
+	}
 }
 
 // ClusterCacheClientOptions provides clustercache.ClientOptions for the ClusterCache.

--- a/controlplane/kubeadm/internal/setup/setup.go
+++ b/controlplane/kubeadm/internal/setup/setup.go
@@ -128,6 +128,7 @@ func ClusterCacheCacheOptions() clustercache.CacheOptions {
 	)
 
 	return clustercache.CacheOptions{
+		DefaultTransform: cache.TransformStripManagedFields(),
 		// Only cache kubeadm static pods
 		ByObject: map[client.Object]cache.ByObject{
 			&corev1.Pod{}: {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -93,12 +93,8 @@ func ManagerClientOptions() client.Options {
 // ClusterCacheCacheOptions provides clustercache.CacheOptions for the ClusterCache.
 func ClusterCacheCacheOptions() clustercache.CacheOptions {
 	return clustercache.CacheOptions{
-		Indexes: []clustercache.CacheOptionsIndex{clustercache.NodeProviderIDIndex},
-		ByObject: map[client.Object]cache.ByObject{
-			&corev1.Node{}: {
-				Transform: cache.TransformStripManagedFields(),
-			},
-		},
+		DefaultTransform: cache.TransformStripManagedFields(),
+		Indexes:          []clustercache.CacheOptionsIndex{clustercache.NodeProviderIDIndex},
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

Sets `DefaultTransform: cache.TransformStripManagedFields()` in the `ClusterCacheCacheOptions()` helper for core CAPI, CABPK, and KCP.

This strips `managedFields` from all objects stored in the per-cluster caches, reducing memory consumption across all three providers.

- Types that already have a per-type `ByObject` transform (e.g. `Pod`/`Node` in KCP) are unaffected: the per-type transform takes precedence over `DefaultTransform`.
- For core CAPI, the existing per-type `Node` entry was already `TransformStripManagedFields()` — it is replaced by the global `DefaultTransform`, which is simpler and covers all cached types uniformly.

The `DefaultTransform` field on `CacheOptions` was exposed in #13780.

## Which issue(s) this PR fixes

Part of #13779

## Special notes for your reviewer

This PR was written in part with the assistance of generative AI (Cursor / Claude Sonnet 4.6). All changes have been reviewed, understood, and verified by the author.

This is the follow-up usage PR requested by @sbueringer during review of #13780.

## Checklist

- [x] squash commits and use the conventional-commits style for the PR title