### PR TITLE
:seedling: Remove unused functions in internal/contract 

### DIFF
--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -192,32 +192,6 @@ func (c *ControlPlaneContract) Selector() *String {
 	}
 }
 
-// FailureReason provides access to the status.failureReason field in an ControlPlane object. Note that this field is optional.
-//
-// Deprecated: This function is deprecated and is going to be removed. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-func (c *ControlPlaneContract) FailureReason() *String {
-	return &String{
-		path: []string{"status", "failureReason"},
-	}
-}
-
-// FailureMessage provides access to the status.failureMessage field in an ControlPlane object. Note that this field is optional.
-//
-// Deprecated: This function is deprecated and is going to be removed. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
-func (c *ControlPlaneContract) FailureMessage() *String {
-	return &String{
-		path: []string{"status", "failureMessage"},
-	}
-}
-
-// ExternalManagedControlPlane provides access to the status.externalManagedControlPlane field in an ControlPlane object.
-// Note that this field is optional.
-func (c *ControlPlaneContract) ExternalManagedControlPlane() *Bool {
-	return &Bool{
-		path: []string{"status", "externalManagedControlPlane"},
-	}
-}
-
 // IsProvisioning returns true if the control plane is being created for the first time.
 // Returns false, if the control plane was already previously provisioned.
 func (c *ControlPlaneContract) IsProvisioning(obj *unstructured.Unstructured) (bool, error) {

--- a/internal/contract/controlplane_template.go
+++ b/internal/contract/controlplane_template.go
@@ -62,24 +62,3 @@ func (c *ControlPlaneTemplateMachineTemplate) Metadata() *Metadata {
 		path: Path{"spec", "template", "spec", "machineTemplate", "metadata"},
 	}
 }
-
-// NodeDrainTimeout provides access to the nodeDrainTimeout of a MachineTemplate.
-func (c *ControlPlaneTemplateMachineTemplate) NodeDrainTimeout() *Duration {
-	return &Duration{
-		path: Path{"spec", "template", "spec", "machineTemplate", "nodeDrainTimeout"},
-	}
-}
-
-// NodeVolumeDetachTimeout provides access to the nodeVolumeDetachTimeout of a MachineTemplate.
-func (c *ControlPlaneTemplateMachineTemplate) NodeVolumeDetachTimeout() *Duration {
-	return &Duration{
-		path: Path{"spec", "template", "spec", "machineTemplate", "nodeVolumeDetachTimeout"},
-	}
-}
-
-// NodeDeletionTimeout provides access to the nodeDeletionTimeout of a MachineTemplate.
-func (c *ControlPlaneTemplateMachineTemplate) NodeDeletionTimeout() *Duration {
-	return &Duration{
-		path: Path{"spec", "template", "spec", "machineTemplate", "nodeDeletionTimeout"},
-	}
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->
**What this PR does / why we need it**:

This is a first step toward #7599 (lint/remove unused functions). It removes six functions in `internal/contract` that are unreachable from both production code and tests across the repository:

* `ControlPlaneContract.FailureReason`
* `ControlPlaneContract.FailureMessage`
* `ControlPlaneContract.ExternalManagedControlPlane`
* `ControlPlaneTemplateMachineTemplate.NodeDrainTimeout`
* `ControlPlaneTemplateMachineTemplate.NodeVolumeDetachTimeout`
* `ControlPlaneTemplateMachineTemplate.NodeDeletionTimeout`

I identified these functions using `golang.org/x/tools/cmd/deadcode`. The existing `unused` linter (already enabled via `.golangci.yml`) only detects unused unexported symbols and therefore cannot catch exported functions that are unreachable in practice.

A naive `deadcode` run over the entire repository produces many false positives because Cluster API exposes public APIs consumed by downstream providers and because the repository is split across multiple Go modules (`.`, `test`, and `hack/tools`). To focus on actionable results, I scoped the analysis to `internal/**`, where Go's `internal` visibility rules guarantee usage must originate from within the Cluster API codebase. I also ran the analysis under an ephemeral `go.work` spanning all repository modules, enabled the `e2e` build tag, and excluded test-only helpers and fakes.

The command used was:

```bash
deadcode -test -tags=e2e -filter 'sigs.k8s.io/cluster-api/internal/' \
  sigs.k8s.io/cluster-api/... sigs.k8s.io/cluster-api/test/...
```

With this configuration, `deadcode` identified exactly the six functions removed by this PR.

Validation performed:

* `go build ./...`
* `go vet ./...`
* `go test ./internal/contract/...`

All checks pass after the removals.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of #7599

 area/control-plane

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->