### PR TITLE
:bug: machinedeployment: fix nil pointer panic when paused with no matching MachineSet

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -353,8 +353,13 @@ func (r *Reconciler) reconcile(ctx context.Context, s *scope) error {
 func (r *Reconciler) createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(ctx context.Context, p *rolloutPlanner) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	// Note: newMS goes first so in the logs we will have first create/scale up newMS, then scale down oldMSs
-	allMSs := append([]*clusterv1.MachineSet{p.newMS}, p.oldMSs...)
+	// Note: newMS goes first so in the logs we will have first create/scale up newMS, then scale down oldMSs.
+	// p.newMS may be nil when paused and no MachineSet for the new template exists yet.
+	var allMSs []*clusterv1.MachineSet
+	if p.newMS != nil {
+		allMSs = append(allMSs, p.newMS)
+	}
+	allMSs = append(allMSs, p.oldMSs...)
 
 	// Get all the diff introduced by the rollout planner.
 	// Note: collect all the diff first, so for each change we can add an overview of all the MachineSets

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_planner.go
@@ -372,7 +372,7 @@ func (p *rolloutPlanner) getMachineSetDiff(ms *clusterv1.MachineSet) machineSetD
 	// Determine if this is the current MS or an old one.
 	// Note: using "current" for logging instead of "new" to avoid confusion between new/current and new/last created.
 	diff.Type = "old"
-	if ms.Name == p.newMS.Name {
+	if p.newMS != nil && ms.Name == p.newMS.Name {
 		diff.Type = "current"
 	}
 

--- a/internal/controllers/machinedeployment/machinedeployment_sync_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync_test.go
@@ -548,6 +548,43 @@ func assertCondition(t *testing.T, from v1beta1conditions.Getter, condition *clu
 	}
 }
 
+// TestCreateOrUpdateMachineSetsNilNewMS verifies that createOrUpdateMachineSetsAndSyncMachineDeploymentRevision
+// does not panic when the rolloutPlanner's newMS is nil (paused MachineDeployment with no matching MachineSet yet).
+func TestCreateOrUpdateMachineSetsNilNewMS(t *testing.T) {
+	g := NewWithT(t)
+
+	md := &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-md",
+			Namespace:   metav1.NamespaceDefault,
+			Annotations: map[string]string{},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			Paused: ptr.To(true),
+		},
+	}
+
+	// Simulate the planner state after init() with createNewMSIfNotExist=false and no matching MachineSet:
+	// newMS is nil, oldMSs is empty.
+	planner := &rolloutPlanner{
+		md:           md,
+		newMS:        nil,
+		oldMSs:       nil,
+		scaleIntents: make(map[string]int32),
+		originalMSs:  make(map[string]*clusterv1.MachineSet),
+		notes:        make(map[string][]string),
+	}
+
+	r := &Reconciler{
+		Client:   fake.NewClientBuilder().Build(),
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	// Before the fix this panicked: allMSs contained a nil element and ms.Name dereferenced it.
+	err := r.createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(ctx, planner)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
 func Test_computeNewMachineSetName(t *testing.T) {
 	tests := []struct {
 		base       string


### PR DESCRIPTION
## Problem

When all of the following are true the `machinedeployment` controller recovers
a nil-pointer panic on every reconcile, leaving the `MachineDeployment` stuck:

1. `spec.paused: true`
2. The template was updated (e.g. a new Kubernetes version)
3. No `MachineSet` matching the new template hash exists yet
   (`upToDateReplicas: 0`)

`sync()` calls `planner.init()` with `createNewMSIfNotExist=false`.
Because no `MachineSet` matches the new template, `p.newMS` is left `nil`.
Two callers then dereference it unconditionally:

**Site 1** — `createOrUpdateMachineSetsAndSyncMachineDeploymentRevision`:
```go
// p.newMS is nil → allMSs = [nil, ...oldMSs]
allMSs := append([]*clusterv1.MachineSet{p.newMS}, p.oldMSs...)

for _, ms := range allMSs {
    if scaleIntent, ok := p.scaleIntents[ms.Name]; ok { // panic: ms is nil
```

**Site 2** — `getMachineSetDiff`, called for every old MS in the loop above:
```go
if ms.Name == p.newMS.Name { // panic: p.newMS is nil
```

## Real-world traceback

Observed in production with CAPI v1.13.1 on a `MachineDeployment` with
`spec.paused: true` and a pending version upgrade (`upToDateReplicas: 0`):

```
goroutine 3818 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2a88758, 0xc07b33dc70}, {0x22b83a0, 0x3ef10f0})
	k8s.io/apimachinery@v0.35.4/pkg/util/runtime/runtime.go:132 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:202 +0x10e
panic({0x22b83a0?, 0x3ef10f0?})
	runtime/panic.go:783 +0x132
sigs.k8s.io/cluster-api/internal/controllers/machinedeployment.(*Reconciler).createOrUpdateMachineSetsAndSyncMachineDeploymentRevision(0xc0003bc230, {0x2a886b0, 0xc07b3c19e0}, 0xc015a91518)
	sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/machinedeployment_controller.go:352 +0x214
sigs.k8s.io/cluster-api/internal/controllers/machinedeployment.(*Reconciler).sync(0xc0003bc230, {0x2a886b0, 0xc07b3c19e0}, 0xc07b3d0008, {0xc07b390f00, 0x2, 0xa}, 0xc07b3c1ef0, 0x1)
	sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/machinedeployment_sync.go:53 +0x316
sigs.k8s.io/cluster-api/internal/controllers/machinedeployment.(*Reconciler).reconcile(0xc0003bc230, {0x2a886b0, 0xc07b3c19e0}, 0xc015a91960)
	sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/machinedeployment_controller.go:318 +0x7fc
sigs.k8s.io/cluster-api/internal/controllers/machinedeployment.(*Reconciler).Reconcile(0xc0003bc230, {0x2a88758, 0xc07b33dc70}, {{{0xc06c3c3260?, 0x1a?}, {0xc072bdd980?, 0x8e59089a09b97?}}})
	sigs.k8s.io/cluster-api/internal/controllers/machinedeployment/machinedeployment_controller.go:205 +0x936
sigs.k8s.io/cluster-api/util/controller.(*reconcilerWrapper).Reconcile(0xc0008070c0, {0x2a88758, 0xc07b33dc70}, {{{0xc06c3c3260?, 0x3ef2790?}, {0xc072bdd980?, 0xc015a91c48?}}})
	sigs.k8s.io/cluster-api/util/controller/controller.go:67 +0x371
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc07d850400, {0x2a88758?, 0xc07b33dc70}, {{{0xc06c3c3260, 0x0?}, {0xc072bdd980?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:222 +0x1ab
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x2ab97a0, {0x2a886e8, 0xc0004b50e0}, {{{0xc06c3c3260, 0x8}, {0xc072bdd980, 0x1a}}}, 0x0)
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:479 +0x39c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x2ab97a0, {0x2a886e8, 0xc0004b50e0})
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:438 +0x21b
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:313 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 1031
	sigs.k8s.io/controller-runtime@v0.23.3/pkg/internal/controller/controller.go:309 +0x26b
```

## Fix

Guard both dereferences with a `p.newMS != nil` check:

- `createOrUpdateMachineSetsAndSyncMachineDeploymentRevision`: build `allMSs`
  only appending `p.newMS` when it is non-nil.
- `getMachineSetDiff`: skip the `p.newMS.Name` comparison when `p.newMS` is nil
  (the MachineSet can only be "old" in that case, which is already the default).

## Test

Added `TestCreateOrUpdateMachineSetsNilNewMS` in `machinedeployment_sync_test.go`
that directly sets up the planner state produced by `init()` with
`createNewMSIfNotExist=false` and no matching MachineSet, then calls
`createOrUpdateMachineSetsAndSyncMachineDeploymentRevision` and asserts no panic.

## Related

Relates to #8629 (paused MachineDeployment behavior).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)