### PR TITLE
[WIP] :sparkles: Add make verify-deadcode to detect dead functions under internal/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,11 @@ GO_APIDIFF_BIN := go-apidiff
 GO_APIDIFF := $(abspath $(TOOLS_BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER))
 GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
+DEADCODE_VER := v0.45.0
+DEADCODE_BIN := deadcode
+DEADCODE := $(abspath $(TOOLS_BIN_DIR)/$(DEADCODE_BIN)-$(DEADCODE_VER))
+DEADCODE_PKG := golang.org/x/tools/cmd/deadcode
+
 HADOLINT_VER := v2.12.0
 HADOLINT_FAILURE_THRESHOLD = warning
 
@@ -680,7 +685,7 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 apidiff: $(GO_APIDIFF) ## Check for API differences
 	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
-ALL_VERIFY_CHECKS = licenses boilerplate shellcheck tiltfile modules gen crd-docs conversions doctoc capi-book-summary diagrams go-directive
+ALL_VERIFY_CHECKS = licenses boilerplate shellcheck tiltfile modules gen crd-docs conversions doctoc capi-book-summary diagrams go-directive deadcode
 
 .PHONY: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) lint-dockerfiles ## Run all verify-* targets
@@ -749,6 +754,10 @@ verify-container-images: ## Verify container images
 .PHONY: verify-licenses
 verify-licenses: ## Verify licenses
 	TRACE=$(TRACE) ./hack/scripts/verify/verify-licenses.sh $(TRIVY_VER)
+
+.PHONY: verify-deadcode
+verify-deadcode: $(DEADCODE) ## Verify there are no dead (unreachable) functions under internal/
+	TRACE=$(TRACE) ./hack/scripts/verify/verify-deadcode.sh $(DEADCODE)
 
 .PHONY: verify-govulncheck
 verify-govulncheck: $(GOVULNCHECK) ## Verify code for vulnerabilities
@@ -1440,6 +1449,9 @@ $(GOLANGCI_LINT_BIN): $(GOLANGCI_LINT) ## Build a local copy of golangci-lint.
 .PHONY: $(GOVULNCHECK_BIN)
 $(GOVULNCHECK_BIN): $(GOVULNCHECK) ## Build a local copy of govulncheck.
 
+.PHONY: $(DEADCODE_BIN)
+$(DEADCODE_BIN): $(DEADCODE) ## Build a local copy of deadcode.
+
 .PHONY: $(CRANE_BIN)
 $(CRANE_BIN): $(CRANE) ## Build a local copy of crane.
 
@@ -1476,6 +1488,9 @@ $(GOTESTSUM): # Build gotestsum from tools folder.
 
 $(GO_APIDIFF): # Build go-apidiff from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GO_APIDIFF_PKG) $(GO_APIDIFF_BIN) $(GO_APIDIFF_VER)
+
+$(DEADCODE): # Build deadcode from tools folder.
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(DEADCODE_PKG) $(DEADCODE_BIN) $(DEADCODE_VER)
 
 $(KUSTOMIZE): # Build kustomize from tools folder.
 	CGO_ENABLED=0 GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(KUSTOMIZE_PKG) $(KUSTOMIZE_BIN) $(KUSTOMIZE_VER)

--- a/hack/scripts/verify/verify-deadcode.sh
+++ b/hack/scripts/verify/verify-deadcode.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reports functions under internal/** that no entry point (manager binary or any
+# test) can reach. Only internal/** is gated as it cannot be imported outside the
+# module tree, so unreachable there means dead.
+#
+# Notes: an ephemeral go.work (temp GOWORK, never touches the tree) spans all
+# modules so cross-module usage is seen; -tags=e2e builds the e2e test binary
+# whose entry point is build-tagged; *_test.go and */fake/ are excluded as
+# intentional test support.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+DEADCODE="${1:-deadcode}"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+
+# Build an ephemeral workspace spanning all modules in a temp GOWORK file so the
+# working tree is never modified (go.work is git-ignored on purpose).
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+export GOWORK="${WORK_DIR}/go.work"
+go work init
+go work use "${REPO_ROOT}" "${REPO_ROOT}/test" "${REPO_ROOT}/hack/tools"
+
+echo "Running deadcode on internal/** across all modules..."
+findings="$(
+  "${DEADCODE}" -test -tags=e2e \
+    -filter 'sigs.k8s.io/cluster-api/internal/' \
+    sigs.k8s.io/cluster-api/... \
+    sigs.k8s.io/cluster-api/test/... |
+    grep -v '_test\.go:' |
+    grep -v '/fake/' ||
+    true
+)"
+
+if [[ -n "${findings}" ]]; then
+  echo >&2 "FAIL: unreachable (dead) functions found under internal/:"
+  echo >&2 ""
+  echo >&2 "${findings}"
+  echo >&2 ""
+  echo >&2 "These functions are reachable from neither the manager binary nor any test."
+  echo >&2 "Delete them, or wire them up. If a finding is a false positive (e.g. a build"
+  echo >&2 "tag other than e2e hides its only caller), adjust hack/verify-deadcode.sh."
+  exit 1
+fi
+
+echo "PASS: no dead functions found under internal/."


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

  **What this PR does / why we need it**:

  Adds `make verify-deadcode`, which uses `golang.org/x/tools/cmd/deadcode` to
  report functions under `internal/**` that are unreachable from any entry point
  (the manager binary plus all tests) across every module in the repo.


  How it works:
  - Only `internal/**` is gated. Go forbids importing `internal/` from outside the
      module tree, so "unreachable within our own modules" genuinely means dead.
      Exported packages (`api/`, `util/`, `exp/`, etc.) can be imported by other modules, 
      including downstream provider repositories, whose callers are not visible to whole-program 
      analysis here, so they cannot be gated this way. This detects case 1 from the issue (funcs used by no one). 
      Case 2 from the issue (funcs used only by test code) is out of scope: `deadcode -test`
      treats tests as entry points, so anything a test reaches counts as live. Detecting it
      would mean dropping `-test`, which flags legitimate test-only helpers as dead - too
      many false positives to gate on. This is my first pass at the approach, and I'm open to suggestions 
      if there's a better way to handle the test-only case.
  - An ephemeral `go.work` (written to a temp `GOWORK`, never touching the working
    tree) spans `.`, `test`, and `hack/tools` so cross-module usage is seen.
  - `-tags=e2e` is required so the build-tagged `test/e2e` entry point is analyzed.

  **Which issue(s) this PR fixes** :
  Part of #7599

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area ci
/area devtools