### PR TITLE
🌱 Unit testing to determine if provider allows individual machines to be deleted.

### DIFF
--- a/core/reconcilers/machinepool/machinepool_controller_scope_test.go
+++ b/core/reconcilers/machinepool/machinepool_controller_scope_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machinepool
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasMachinePoolMachines(t *testing.T) {
+	tests := []struct {
+		name      string
+		infraPool *unstructured.Unstructured
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:    "returns error when infraMachinePool is nil",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "returns false when infrastructureMachineKind is absent",
+			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			}},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "returns false when infrastructureMachineKind is empty string",
+			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"infrastructureMachineKind": "",
+				},
+			}},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "returns true when infrastructureMachineKind is set",
+			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"infrastructureMachineKind": "DockerMachine",
+				},
+			}},
+			want:    true,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			s := &scope{infraMachinePool: tt.infraPool}
+			got, err := s.hasMachinePoolMachines()
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Unit tests are missing for functionality to check if cloud provider allows deletion of individual machines in the machine pool.
If the provider has set `status.infrastructureMachineKind`, then the machine can be deleted through CAPI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Mentioned in source PR [here](https://github.com/kubernetes-sigs/cluster-api/issues/9005); part of the effort to graduate machinepool from experimental to stable API.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machinepool