### PR TITLE
📖 add Alibaba Cloud infrastructure provider to the provider list

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -40,7 +40,7 @@ source of inspiration and ideas for others.
 
 ## Infrastructure
 - [Akamai (Linode)](https://linode.github.io/cluster-api-provider-linode/)
-- [Alibaba Cloud](https://github.com/SammZhu/openshift-capi-alicloud)
+- [Alibaba Cloud (unofficial)](https://github.com/SammZhu/openshift-capi-alicloud)
 - [AWS](https://cluster-api-aws.sigs.k8s.io/)
 - [Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
 - [Azure Stack HCI](https://github.com/microsoft/cluster-api-provider-azurestackhci)

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -40,6 +40,7 @@ source of inspiration and ideas for others.
 
 ## Infrastructure
 - [Akamai (Linode)](https://linode.github.io/cluster-api-provider-linode/)
+- [Alibaba Cloud](https://github.com/SammZhu/openshift-capi-alicloud)
 - [AWS](https://cluster-api-aws.sigs.k8s.io/)
 - [Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
 - [Azure Stack HCI](https://github.com/microsoft/cluster-api-provider-azurestackhci)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds **Alibaba Cloud** to the Infrastructure provider list. [`openshift-capi-alicloud`](https://github.com/SammZhu/openshift-capi-alicloud) is a community-maintained Cluster API infrastructure provider for Alibaba Cloud ECS:

- Implements the **v1beta2** infrastructure contract.
- Installable via `clusterctl init --infrastructure alibabacloud` (release artifacts published as GitHub Release assets; webhook certs via cert-manager, so it installs on any conformant Kubernetes management cluster).
- Manages worker `Machine` lifecycle — create / scale / multi-AZ spread / `MachineHealthCheck` — with an externally-managed control plane.

This is an **unofficial, community project — not affiliated with or endorsed by Alibaba Cloud**. Per this page's stated policy ("everyone is welcome to add to the list below ... providers from other open-source repositories"), it is maintained in its own repository by its own maintainer.

Docs-only change: one line added to the Infrastructure list (alphabetical order).

**Which issue(s) this PR fixes**: none

\`\`\`release-note
NONE
\`\`\`