### PR TITLE
🌱 Remove the check on the errors returned by etcd's status response

### DIFF
--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -52,7 +52,6 @@ type Client struct {
 	EtcdClient  etcd
 	Endpoint    string
 	LeaderID    uint64
-	Errors      []string
 	CallTimeout time.Duration
 }
 
@@ -189,11 +188,13 @@ func newEtcdClient(ctx context.Context, etcdClient etcd, callTimeout time.Durati
 		return nil, errors.Wrap(err, "failed to get etcd status")
 	}
 
+	// We don't need to read or handle StatusResponse.Errors here. They
+	// are intended for human consumption, not for programmatic processing.
+	// KCP should rely only on alarms.
 	return &Client{
 		Endpoint:    endpoints[0],
 		EtcdClient:  etcdClient,
 		LeaderID:    status.Leader,
-		Errors:      status.Errors,
 		CallTimeout: callTimeout,
 	}, nil
 }

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -267,21 +267,6 @@ func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines 
 	}
 	defer etcdClient.Close()
 
-	// While creating a new client, forFirstAvailableNode also reads the status for the endpoint we are connected to; check if the endpoint has errors.
-	if len(etcdClient.Errors) > 0 {
-		for _, m := range machines {
-			v1beta1conditions.MarkFalse(m, controlplanev1.MachineEtcdMemberHealthyV1Beta1Condition, controlplanev1.EtcdMemberUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
-
-			conditions.Set(m, metav1.Condition{
-				Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyReason,
-				Message: fmt.Sprintf("Etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", ")),
-			})
-		}
-		return nil, nil, nil, errors.Errorf("etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
-	}
-
 	// Gets the list of etcd members in the cluster.
 	currentMembers, err := etcdClient.Members(ctx)
 	if err != nil {

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -286,44 +286,6 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			expectedEtcdLeader:                        nil,   // failure in reading members, we can not make assumptions.
 		},
 		{
-			name: "etcd client reporting status errors should be reflected into a false condition",
-			machines: []*clusterv1.Machine{
-				fakeMachine("m1", withNodeRef("n1")),
-			},
-			nodes: []*Node{
-				fakeNode("n1"),
-			},
-			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				client: &etcd.Client{
-					EtcdClient: &fake2.FakeEtcdClient{
-						EtcdEndpoints: []string{},
-					},
-					Endpoint: "n1",
-					Errors:   []string{"something went wrong"},
-				},
-			},
-			expectedKCPV1Beta1Condition: v1beta1conditions.FalseCondition(controlplanev1.EtcdClusterHealthyV1Beta1Condition, controlplanev1.EtcdClusterUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m1"),
-			expectedMachineV1Beta1Conditions: map[string]clusterv1.Conditions{
-				"m1": {
-					*v1beta1conditions.FalseCondition(controlplanev1.MachineEtcdMemberHealthyV1Beta1Condition, controlplanev1.EtcdMemberUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Etcd endpoint n1 reports errors: %s", "something went wrong"),
-				},
-			},
-			expectedKCPCondition: &metav1.Condition{
-				Type:   controlplanev1.KubeadmControlPlaneEtcdClusterHealthyCondition,
-				Status: metav1.ConditionFalse,
-				Reason: controlplanev1.KubeadmControlPlaneEtcdClusterNotHealthyReason,
-				Message: "* Machine m1:\n" +
-					"  * EtcdMemberHealthy: Etcd endpoint n1 reports errors: something went wrong",
-			},
-			expectedMachineConditions: map[string][]metav1.Condition{
-				"m1": {
-					{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyReason, Message: "Etcd endpoint n1 reports errors: something went wrong"},
-				},
-			},
-			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
-			expectedEtcdLeader:                        nil,   // without reading members, we can not make assumptions.
-		},
-		{
 			name: "failure listing members should report false condition in v1beta1, unknown in v1beta2",
 			machines: []*clusterv1.Machine{
 				fakeMachine("m1", withProviderID("n1"), withNodeRef("n1")),


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR cleans up the unnecessary check on errors returned by etcd's status response.  The statusResponse.Error is supposed to be read by human instead of machine/program. KCP should only rely on alarms.

Actually the errors come from alarms as well, or there isn't leader. refer to [here](https://github.com/etcd-io/etcd/blob/5f6496ad4b0a3c92cc99d200095ae8b89fbcbf0b/server/etcdserver/api/v3rpc/maintenance.go#L289-L294).

When there is any alarm, the code below already sets the conditions. But if we don't remove the check on statusResponse.Error, then the code below is dead code which is never reachable.
https://github.com/kubernetes-sigs/cluster-api/blob/42be0c67d7aeef3626c560c2f10af6782906c5b6/controlplane/kubeadm/internal/workload_cluster_conditions.go#L175-L185

If there isn't a leader, then any etcd client API calls (such as the following `etcdClient.Members(ctx)` and `etcdClient.Alarms(ctx)`) may fail.

So the check on statusResponse.Errors is unnecessary, nor recomended.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->