### PR TITLE
✨ Improve forward etcd leadership

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -92,6 +92,7 @@ type ControlPlane struct {
 	EtcdMembers                       []*etcd.Member
 	EtcdMembersAndMachinesAreMatching bool
 	EtcdMembersAlarms                 []etcd.MemberAlarm
+	EtcdLeader                        *etcd.Member
 
 	managementCluster ManagementCluster
 	workloadCluster   WorkloadCluster

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1490,13 +1490,8 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 	// Note: In regular deletion cases (remediation, scale down) the leader should have been already moved.
 	// We're doing this again here in case the Machine became leader again or the Machine deletion was
 	// triggered in another way (e.g. a user running kubectl delete machine)
-	etcdLeaderCandidate := controlPlane.Machines.Filter(collections.Not(collections.HasDeletionTimestamp)).Newest()
-	if etcdLeaderCandidate != nil {
-		if err := workloadCluster.ForwardEtcdLeadership(ctx, deletingMachine, etcdLeaderCandidate, controlPlane.Nodes); err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to move leadership to candidate Machine %s", etcdLeaderCandidate.Name)
-		}
-	} else {
-		log.Info("Skip forwarding etcd leadership, there is no other control plane Machine without a deletionTimestamp")
+	if err := r.forwardEtcdLeadership(ctx, workloadCluster, controlPlane, deletingMachine); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Note: Removing the etcd member will lead to the etcd and the kube-apiserver Pod on the Machine shutting down.
@@ -1521,6 +1516,97 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 
 	log.Info("Waiting for Machines to be deleted", "machines", strings.Join(controlPlane.Machines.Filter(collections.HasDeletionTimestamp).Names(), ", "))
 	return ctrl.Result{RequeueAfter: deleteRequeueAfter}, nil
+}
+
+func (r *KubeadmControlPlaneReconciler) forwardEtcdLeadership(ctx context.Context, workloadCluster internal.WorkloadCluster, controlPlane *internal.ControlPlane, deletingMachine *clusterv1.Machine) error {
+	log := ctrl.LoggerFrom(ctx)
+	if controlPlane.EtcdLeader == nil {
+		return errors.New("unable to move leadership, control plane has no etcd leader")
+	}
+
+	// No-op if the deleting machine not yet provisioned (we cannot infer the etcd member name yet).
+	if deletingMachine.Status.NodeRef.Name == "" {
+		return nil
+	}
+
+	// No-op if the deleting machine is not the current etcd leader.
+	// Note: This works on the assumption that member name is equal to the node name (kubeadm).
+	if deletingMachine.Status.NodeRef.Name != controlPlane.EtcdLeader.Name {
+		return nil
+	}
+
+	// Get candidate machines
+	candidateMachines := getCandidatesForEtcdLeadership(controlPlane.Machines, deletingMachine)
+	if len(candidateMachines) == 0 {
+		return errors.New("unable to move leadership, no candidate machines found")
+	}
+
+	// Try to move leadership to one of the candidateMachines.
+	for _, m := range candidateMachines {
+		if err := workloadCluster.ForwardEtcdLeadership(ctx, deletingMachine.Status.NodeRef.Name, m.Status.NodeRef.Name); err != nil {
+			log.Error(err, "Failed to move etcd leadership", "currentLeaderMachine", klog.KObj(deletingMachine), "candidateLeaderMachine", klog.KObj(m))
+			continue
+		}
+		log.Info("Moved etcd leadership", "currentLeaderMachine", klog.KObj(deletingMachine), "candidateLeaderMachine", klog.KObj(m))
+		return nil
+	}
+	return errors.New("failed to move leadership")
+}
+
+func getCandidatesForEtcdLeadership(machines collections.Machines, deletingMachine *clusterv1.Machine) []*clusterv1.Machine {
+	// Pick candidate machines to be used as a target to forward leadership to.
+	candidateMachines := machines.Filter(collections.And(
+		// Machines with a Node (core requirement to reach etcd)
+		collections.HasNode(),
+		// Machines not deleting (the corresponding etcd member might go away any moment)
+		// Note: When this function is called, there should never be a machine with deletion timestamp set other than the deletingMachine
+		// unless a manual deletion on a Machine has been performed.
+		collections.Not(collections.HasDeletionTimestamp)),
+		// The deletingMachine must be excluded from the list
+		collections.Not(func(machine *clusterv1.Machine) bool {
+			if machine == nil {
+				return false
+			}
+			return machine.Name == deletingMachine.Name && machine.Namespace == deletingMachine.Namespace
+		}),
+	).UnsortedList()
+
+	// Sort candidates so we can get the "most reliable" candidate first.
+	sort.Slice(candidateMachines, func(i, j int) bool {
+		// If one of the machine's etcd member is unhealthy, it should go last (forward leadership might fail).
+		etcdHealthyI := conditions.IsTrue(candidateMachines[i], controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition)
+		etcdHealthyJ := conditions.IsTrue(candidateMachines[j], controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition)
+		if etcdHealthyI && !etcdHealthyJ {
+			return true
+		}
+		if !etcdHealthyI && etcdHealthyJ {
+			return false
+		}
+
+		// If both machine's etcd member are in the same state, if one of the machine's is marked unhealthy by MHC, it should go last (it will be remediated soon).
+		mhcHealthyI := conditions.IsTrue(candidateMachines[i], clusterv1.MachineHealthCheckSucceededCondition)
+		mhcHealthyJ := conditions.IsTrue(candidateMachines[j], clusterv1.MachineHealthCheckSucceededCondition)
+		if mhcHealthyI && !mhcHealthyJ {
+			return true
+		}
+		if !mhcHealthyI && mhcHealthyJ {
+			return false
+		}
+
+		// If both machine's etcd member and unhealthy by MHC are in the same state, if one of the machine's is not up-to-date, it should go last (it will be rolled out soon).
+		upToDateI := conditions.IsTrue(candidateMachines[i], clusterv1.MachineUpToDateCondition)
+		upToDateJ := conditions.IsTrue(candidateMachines[j], clusterv1.MachineUpToDateCondition)
+		if upToDateI && !upToDateJ {
+			return true
+		}
+		if !upToDateI && upToDateJ {
+			return false
+		}
+
+		// If both machine's etcd member, unhealthy by MHC and UpToDate conditions are in the same state, pick the newest machine first.
+		return candidateMachines[j].CreationTimestamp.Before(&candidateMachines[i].CreationTimestamp)
+	})
+	return candidateMachines
 }
 
 func machineHasOtherPreTerminateHooks(machine *clusterv1.Machine) bool {

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1521,7 +1521,7 @@ func (r *KubeadmControlPlaneReconciler) reconcilePreTerminateHook(ctx context.Co
 func (r *KubeadmControlPlaneReconciler) forwardEtcdLeadership(ctx context.Context, workloadCluster internal.WorkloadCluster, controlPlane *internal.ControlPlane, deletingMachine *clusterv1.Machine) error {
 	log := ctrl.LoggerFrom(ctx)
 	if controlPlane.EtcdLeader == nil {
-		return errors.New("unable to move leadership, control plane has no etcd leader")
+		return errors.New("unable to move etcd leadership, failed to detect etcd leader")
 	}
 
 	// No-op if the deleting machine not yet provisioned (we cannot infer the etcd member name yet).
@@ -1538,7 +1538,7 @@ func (r *KubeadmControlPlaneReconciler) forwardEtcdLeadership(ctx context.Contex
 	// Get candidate machines
 	candidateMachines := getCandidatesForEtcdLeadership(controlPlane.Machines, deletingMachine)
 	if len(candidateMachines) == 0 {
-		return errors.New("unable to move leadership, no candidate machines found")
+		return errors.New("unable to move etcd leadership, no candidate machines for etcd leadership found")
 	}
 
 	// Try to move leadership to one of the candidateMachines.
@@ -1547,10 +1547,10 @@ func (r *KubeadmControlPlaneReconciler) forwardEtcdLeadership(ctx context.Contex
 			log.Error(err, "Failed to move etcd leadership", "currentLeaderMachine", klog.KObj(deletingMachine), "candidateLeaderMachine", klog.KObj(m))
 			continue
 		}
-		log.Info("Moved etcd leadership", "currentLeaderMachine", klog.KObj(deletingMachine), "candidateLeaderMachine", klog.KObj(m))
+		log.Info("Moved etcd leadership", "previousLeaderMachine", klog.KObj(deletingMachine), "newLeaderMachine", klog.KObj(m))
 		return nil
 	}
-	return errors.New("failed to move leadership")
+	return errors.New("failed to move etcd leadership")
 }
 
 func getCandidatesForEtcdLeadership(machines collections.Machines, deletingMachine *clusterv1.Machine) []*clusterv1.Machine {
@@ -1565,7 +1565,7 @@ func getCandidatesForEtcdLeadership(machines collections.Machines, deletingMachi
 		// The deletingMachine must be excluded from the list
 		collections.Not(func(machine *clusterv1.Machine) bool {
 			if machine == nil {
-				return false
+				return true
 			}
 			return machine.Name == deletingMachine.Name && machine.Namespace == deletingMachine.Namespace
 		}),

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -3343,7 +3343,7 @@ func TestKubeadmControlPlaneReconciler_forwardLeaderShip(t *testing.T) {
 				EtcdLeader: nil,
 			},
 			deletingMachine: m,
-			wantErrMessage:  "unable to move leadership, control plane has no etcd leader",
+			wantErrMessage:  "unable to move etcd leadership, failed to detect etcd leader",
 		},
 		{
 			name: "no op if deleting machine does not have a node",
@@ -3370,7 +3370,7 @@ func TestKubeadmControlPlaneReconciler_forwardLeaderShip(t *testing.T) {
 				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
 			},
 			deletingMachine: m,
-			wantErrMessage:  "unable to move leadership, no candidate machines found",
+			wantErrMessage:  "unable to move etcd leadership, no candidate machines for etcd leadership found",
 		},
 		{
 			name: "tries candidate machines in the expected order",
@@ -3396,7 +3396,7 @@ func TestKubeadmControlPlaneReconciler_forwardLeaderShip(t *testing.T) {
 				"m-mhc-unhealthy",  // etcd heathy, mhc unhealthy
 				"m-etcd-unhealthy", // etcd unhealthy
 			},
-			wantErrMessage: "failed to move leadership",
+			wantErrMessage: "failed to move etcd leadership",
 		},
 		{
 			name: "forward leadership",

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -3232,6 +3232,212 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 	}
 }
 
+func TestKubeadmControlPlaneReconciler_forwardLeaderShip(t *testing.T) {
+	now := time.Now()
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "m",
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m"},
+		},
+	}
+	mWithoutNode := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "m-without-node",
+		},
+	}
+	mWithDeletionTimestamp := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-with-deletion-timestamp",
+			DeletionTimestamp: new(metav1.Now()),
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-with-deletion-timestamp"},
+		},
+	}
+	mNewest := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-newest",
+			CreationTimestamp: metav1.Time{Time: now},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-newest"},
+			Conditions: []metav1.Condition{
+				{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	mEtcdUnhealthy := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-etcd-unhealthy",
+			CreationTimestamp: metav1.Time{Time: now},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-etcd-unhealthy"},
+			Conditions: []metav1.Condition{
+				{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionFalse},
+				{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	mMHCUnhealthy := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-mhc-unhealthy",
+			CreationTimestamp: metav1.Time{Time: now},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-mhc-unhealthy"},
+			Conditions: []metav1.Condition{
+				{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionFalse},
+				{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	mNotUpToDate := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-not-up-to-date",
+			CreationTimestamp: metav1.Time{Time: now},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-not-up-to-date"},
+			Conditions: []metav1.Condition{
+				{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionFalse},
+			},
+		},
+	}
+	mOldest := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m-oldest",
+			CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: clusterv1.MachineNodeReference{Name: "m-oldest"},
+			Conditions: []metav1.Condition{
+				{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionTrue},
+				{Type: clusterv1.MachineUpToDateCondition, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	r := &KubeadmControlPlaneReconciler{}
+
+	tests := []struct {
+		name              string
+		controlPlane      *internal.ControlPlane
+		deletingMachine   *clusterv1.Machine
+		moveLeaderError   error
+		wantErrMessage    string
+		wantTryCandidates []string
+	}{
+		{
+			name: "fails to forward leadership if etcd leader is not set",
+			controlPlane: &internal.ControlPlane{
+				EtcdLeader: nil,
+			},
+			deletingMachine: m,
+			wantErrMessage:  "unable to move leadership, control plane has no etcd leader",
+		},
+		{
+			name: "no op if deleting machine does not have a node",
+			controlPlane: &internal.ControlPlane{
+				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
+			},
+			deletingMachine: mWithoutNode,
+		},
+		{
+			name: "no op if deleting machine is not the current leader",
+			controlPlane: &internal.ControlPlane{
+				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
+			},
+			deletingMachine: mNewest,
+		},
+		{
+			name: "fails if no candidate nodes are found",
+			controlPlane: &internal.ControlPlane{
+				Machines: collections.FromMachines(
+					m,
+					mWithoutNode,
+					mWithDeletionTimestamp,
+				),
+				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
+			},
+			deletingMachine: m,
+			wantErrMessage:  "unable to move leadership, no candidate machines found",
+		},
+		{
+			name: "tries candidate machines in the expected order",
+			controlPlane: &internal.ControlPlane{
+				Machines: collections.FromMachines(
+					m,
+					mWithoutNode,
+					mWithDeletionTimestamp,
+					mNewest,
+					mEtcdUnhealthy,
+					mMHCUnhealthy,
+					mNotUpToDate,
+					mOldest,
+				),
+				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
+			},
+			moveLeaderError: errors.New("failed to forward leadership"),
+			deletingMachine: m,
+			wantTryCandidates: []string{
+				"m-newest",         // etcd heathy, mhc healthy, up-to-date, newest machine
+				"m-oldest",         // etcd heathy, mhc healthy, up-to-date, oldest machine
+				"m-not-up-to-date", // etcd heathy, mhc healthy, not up-to-date
+				"m-mhc-unhealthy",  // etcd heathy, mhc unhealthy
+				"m-etcd-unhealthy", // etcd unhealthy
+			},
+			wantErrMessage: "failed to move leadership",
+		},
+		{
+			name: "forward leadership",
+			controlPlane: &internal.ControlPlane{
+				Machines: collections.FromMachines(
+					m,
+					mNewest,
+					mOldest,
+				),
+				EtcdLeader: &etcd.Member{Name: m.Status.NodeRef.Name},
+			},
+			deletingMachine: m,
+			wantTryCandidates: []string{
+				"m-newest", // etcd heathy, mhc healthy, up-to-date, newest machine
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			var tryCandidates []string
+			w := &fakeWorkloadCluster{
+				OverrideForwardEtcdLeadership: func(_ context.Context, _, leaderCandidate string) error {
+					tryCandidates = append(tryCandidates, leaderCandidate)
+					return tt.moveLeaderError
+				},
+			}
+			err := r.forwardEtcdLeadership(t.Context(), w, tt.controlPlane, tt.deletingMachine)
+			g.Expect(tryCandidates).To(Equal(tt.wantTryCandidates))
+			if tt.wantErrMessage != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(Equal(tt.wantErrMessage))
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}
+
 type fakeClusterCache struct {
 	clustercache.ClusterCache
 	lastProbeSuccessTime time.Time
@@ -3751,6 +3957,7 @@ func TestKubeadmControlPlaneReconciler_reconcilePreTerminateHook(t *testing.T) {
 						return m
 					}(),
 				},
+				EtcdLeader: &etcd.Member{Name: deletingMachineWithKCPPreTerminateHook.Status.NodeRef.Name},
 			},
 			wantForwardEtcdLeadershipCalled: 1,
 			wantRemoveEtcdMemberCalled:      1,
@@ -3821,7 +4028,7 @@ func TestKubeadmControlPlaneReconciler_reconcilePreTerminateHook(t *testing.T) {
 			},
 		},
 		{
-			name: "Skip forward etcd leadership (no other non-deleting Machine), remove member and remove pre-terminate hook if > 1 CP Machines && Etcd is managed",
+			name: "Fails if no candidate for forwarding etcd leadership exists",
 			controlPlane: &internal.ControlPlane{
 				Cluster: cluster,
 				KCP: &controlplanev1.KubeadmControlPlane{
@@ -3846,12 +4053,11 @@ func TestKubeadmControlPlaneReconciler_reconcilePreTerminateHook(t *testing.T) {
 						return m
 					}(),
 				},
+				EtcdLeader: &etcd.Member{Name: deletingMachineWithKCPPreTerminateHook.Status.NodeRef.Name},
 			},
-			wantForwardEtcdLeadershipCalled: 0, // skipped as there is no non-deleting Machine to forward to.
-			wantRemoveEtcdMemberCalled:      1,
-			wantResult:                      ctrl.Result{RequeueAfter: deleteRequeueAfter},
+			wantErr: "failed to move leadership to candidate machines: unable to move leadership, no candidate machines found",
 			wantMachineAnnotations: map[string]map[string]string{
-				deletingMachineWithKCPPreTerminateHook.Name:        nil,                                                // pre-terminate hook has been removed
+				deletingMachineWithKCPPreTerminateHook.Name:        deletingMachineWithKCPPreTerminateHook.Annotations, // unchanged
 				deletingMachineWithKCPPreTerminateHook.Name + "-2": deletingMachineWithKCPPreTerminateHook.Annotations, // unchanged
 			},
 		},

--- a/controlplane/kubeadm/internal/controllers/fakes_test.go
+++ b/controlplane/kubeadm/internal/controllers/fakes_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
@@ -76,18 +75,19 @@ func (f *fakeManagementCluster) GetMachinePoolsForCluster(c context.Context, clu
 
 type fakeWorkloadCluster struct {
 	*internal.Workload
-	KubeadmConfigExist         bool
-	APIServerCertificateExpiry *time.Time
+	KubeadmConfigExist            bool
+	APIServerCertificateExpiry    *time.Time
+	OverrideForwardEtcdLeadership func(context.Context, string, string) error
 
 	forwardEtcdLeadershipCalled int
 	removeEtcdMemberCalled      int
 }
 
-func (f *fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine, leaderCandidate *clusterv1.Machine, _ []*internal.Node) error {
-	f.forwardEtcdLeadershipCalled++
-	if leaderCandidate == nil {
-		return errors.New("leaderCandidate is nil")
+func (f *fakeWorkloadCluster) ForwardEtcdLeadership(ctx context.Context, member, leaderCandidate string) error {
+	if f.OverrideForwardEtcdLeadership != nil {
+		return f.OverrideForwardEtcdLeadership(ctx, member, leaderCandidate)
 	}
+	f.forwardEtcdLeadershipCalled++
 	return nil
 }
 

--- a/controlplane/kubeadm/internal/controllers/remediation.go
+++ b/controlplane/kubeadm/internal/controllers/remediation.go
@@ -302,44 +302,21 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 			return ctrl.Result{}, nil
 		}
 
-		// Start remediating the unhealthy control plane machine by deleting it.
-		// A new machine will come up completing the operation as part of the regular reconcile.
-
-		// If the control plane is initialized, before deleting the machine:
-		// - if the machine hosts the etcd leader, forward etcd leadership to another machine.
-		// - delete the etcd member hosted on the machine being deleted.
-		// - remove the etcd member from the kubeadm config map (only for kubernetes version older than v1.22.0)
-		workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
-		if err != nil {
-			log.Error(err, "Failed to create client to workload cluster")
-			return ctrl.Result{}, errors.Wrapf(err, "failed to create client to workload cluster")
-		}
-
 		// If the machine that is about to be deleted is the etcd leader, move it to the newest member available.
 		if controlPlane.IsEtcdManaged() {
-			etcdLeaderCandidate := controlPlane.HealthyMachines().Newest()
-			if etcdLeaderCandidate == nil {
-				log.Info("A control plane machine needs remediation, but there is no healthy machine to forward etcd leadership to")
-				v1beta1conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.RemediationFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning,
-					"A control plane machine needs remediation, but there is no healthy machine to forward etcd leadership to. Skipping remediation")
-
-				conditions.Set(machineToBeRemediated, metav1.Condition{
-					Type:    clusterv1.MachineOwnerRemediatedCondition,
-					Status:  metav1.ConditionFalse,
-					Reason:  controlplanev1.KubeadmControlPlaneMachineCannotBeRemediatedReason,
-					Message: "KubeadmControlPlane can't remediate this Machine because there is no healthy Machine to forward etcd leadership to",
-				})
-				return ctrl.Result{}, nil
+			workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)
+			if err != nil {
+				log.Error(err, "Failed to create client to workload cluster")
+				return ctrl.Result{}, errors.Wrapf(err, "failed to create client to workload cluster")
 			}
-			if err := workloadCluster.ForwardEtcdLeadership(ctx, machineToBeRemediated, etcdLeaderCandidate, controlPlane.Nodes); err != nil {
-				log.Error(err, "Failed to move etcd leadership to candidate machine", "candidate", klog.KObj(etcdLeaderCandidate))
+			if err := r.forwardEtcdLeadership(ctx, workloadCluster, controlPlane, machineToBeRemediated); err != nil {
 				v1beta1conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.RemediationFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
 
 				conditions.Set(machineToBeRemediated, metav1.Condition{
 					Type:    clusterv1.MachineOwnerRemediatedCondition,
 					Status:  metav1.ConditionFalse,
-					Reason:  controlplanev1.KubeadmControlPlaneMachineRemediationInternalErrorReason,
-					Message: "Please check controller logs for errors",
+					Reason:  controlplanev1.KubeadmControlPlaneMachineCannotBeRemediatedReason,
+					Message: err.Error(),
 				})
 				return ctrl.Result{}, err
 			}
@@ -348,7 +325,8 @@ func (r *KubeadmControlPlaneReconciler) reconcileUnhealthyMachines(ctx context.C
 		}
 	}
 
-	// Delete the machine (waiting for cache to observe the deletion at the end of this func, so everything in between is always executed)
+	// Start remediating the unhealthy control plane machine by deleting it.
+	// A new machine will come up completing the operation as part of the regular reconcile.
 	if deletedMachine, err := r.machineClientWithDeleteResponse.Delete(ctx, machineToBeRemediated); err != nil {
 		v1beta1conditions.MarkFalse(machineToBeRemediated, clusterv1.MachineOwnerRemediatedV1Beta1Condition, clusterv1.RemediationFailedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", err.Error())
 

--- a/controlplane/kubeadm/internal/controllers/remediation_test.go
+++ b/controlplane/kubeadm/internal/controllers/remediation_test.go
@@ -992,8 +992,9 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2),
+			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1049,8 +1050,9 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2, m3),
+			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1106,8 +1108,9 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2, m3),
+			EtcdLeader: &etcd.Member{Name: m2.Status.NodeRef.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1164,8 +1167,9 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3, m4),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2, m3, m4),
+			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1222,8 +1226,9 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3, m4),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2, m3, m4),
+			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1256,51 +1261,6 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		err = env.Get(ctx, client.ObjectKey{Namespace: m1.Namespace, Name: m1.Name}, m1)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(m1.ObjectMeta.DeletionTimestamp.IsZero()).To(BeFalse())
-
-		removeFinalizer(g, m1)
-		g.Expect(env.Cleanup(ctx, m1, m2, m3, m4)).To(Succeed())
-	})
-	t.Run("Remediation fails gracefully if no healthy Control Planes are available to become etcd leader", func(t *testing.T) {
-		g := NewWithT(t)
-
-		m1 := createMachine(ctx, g, ns.Name, "m1-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer())
-		m2 := createMachine(ctx, g, ns.Name, "m2-healthy-", withMachineHealthCheckFailed(), withHealthyEtcdMember(), withHealthyK8sControlPlane())
-		m3 := createMachine(ctx, g, ns.Name, "m3-healthy-", withMachineHealthCheckFailed(), withHealthyEtcdMember(), withHealthyK8sControlPlane())
-		m4 := createMachine(ctx, g, ns.Name, "m4-healthy-", withMachineHealthCheckFailed(), withHealthyEtcdMember(), withHealthyK8sControlPlane())
-
-		controlPlane := &internal.ControlPlane{
-			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](4),
-					Version:  "v1.19.1",
-				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
-				},
-			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3, m4),
-		}
-		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
-
-		r := &KubeadmControlPlaneReconciler{
-			Client:            env.GetClient(),
-			recorder:          record.NewFakeRecorder(32),
-			managementCluster: &fakeManagementCluster{Workload: &fakeWorkloadCluster{}},
-		}
-		controlPlane.InjectTestManagementCluster(r.managementCluster)
-
-		_, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
-		g.Expect(err).ToNot(HaveOccurred())
-
-		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
-
-		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.RemediationFailedV1Beta1Reason, clusterv1.ConditionSeverityWarning,
-			"A control plane machine needs remediation, but there is no healthy machine to forward etcd leadership to. Skipping remediation")
-		assertMachineCondition(ctx, g, m1, clusterv1.MachineOwnerRemediatedCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachineCannotBeRemediatedReason,
-			"KubeadmControlPlane can't remediate this Machine because there is no healthy Machine to forward etcd leadership to")
 
 		removeFinalizer(g, m1)
 		g.Expect(env.Cleanup(ctx, m1, m2, m3, m4)).To(Succeed())
@@ -1546,8 +1506,9 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2),
+			EtcdLeader: &etcd.Member{Name: m1.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1564,8 +1525,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
@@ -1662,8 +1623,9 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 					},
 				},
 			},
-			Cluster:  &clusterv1.Cluster{},
-			Machines: collections.FromMachines(m1, m2, m3),
+			Cluster:    &clusterv1.Cluster{},
+			Machines:   collections.FromMachines(m1, m2, m3),
+			EtcdLeader: &etcd.Member{Name: m1.Name},
 		}
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -2740,7 +2702,6 @@ func withWaitBeforeDeleteFinalizer() machineOption {
 		machine.Finalizers = []string{"wait-before-delete"}
 	}
 }
-
 func getMachine(namespace, name string, options ...machineOption) *clusterv1.Machine {
 	m := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controlplane/kubeadm/internal/controllers/scale.go
+++ b/controlplane/kubeadm/internal/controllers/scale.go
@@ -145,9 +145,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 			return ctrl.Result{}, errors.Wrap(controlPlane.NodeListError, "unable to forward etcd leadership")
 		}
 
-		etcdLeaderCandidate := controlPlane.Machines.Newest()
-		if err := workloadCluster.ForwardEtcdLeadership(ctx, machineToDelete, etcdLeaderCandidate, controlPlane.Nodes); err != nil {
-			log.Error(err, "Failed to move leadership to candidate machine", "candidate", etcdLeaderCandidate.Name)
+		if err := r.forwardEtcdLeadership(ctx, workloadCluster, controlPlane, machineToDelete); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/controlplane/kubeadm/internal/controllers/scale_test.go
+++ b/controlplane/kubeadm/internal/controllers/scale_test.go
@@ -38,6 +38,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/desiredstate"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/collections"
@@ -266,9 +267,11 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		machines := map[string]*clusterv1.Machine{
 			"one": machine("one"),
+			"two": machine("two"),
 		}
 		setMachineHealthy(machines["one"])
-		fakeClient := newFakeClient(machines["one"])
+		setMachineHealthy(machines["two"])
+		fakeClient := newFakeClient(machines["one"], machines["two"])
 
 		r := &KubeadmControlPlaneReconciler{
 			controller:                      capicontrollerutil.NewFakeController(),
@@ -289,9 +292,10 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 		}
 		setKCPHealthy(kcp)
 		controlPlane := &internal.ControlPlane{
-			KCP:      kcp,
-			Cluster:  cluster,
-			Machines: machines,
+			KCP:        kcp,
+			Cluster:    cluster,
+			Machines:   machines,
+			EtcdLeader: &etcd.Member{Name: "one"},
 		}
 		controlPlane.InjectTestManagementCluster(r.managementCluster)
 
@@ -303,7 +307,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		controlPlaneMachines := clusterv1.MachineList{}
 		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())
-		g.Expect(controlPlaneMachines.Items).To(BeEmpty())
+		g.Expect(controlPlaneMachines.Items).To(HaveLen(1))
 	})
 	t.Run("deletes the oldest control plane Machine even if preflight checks fails", func(t *testing.T) {
 		g := NewWithT(t)
@@ -342,9 +346,10 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 			},
 		}
 		controlPlane := &internal.ControlPlane{
-			KCP:      kcp,
-			Cluster:  cluster,
-			Machines: machines,
+			KCP:        kcp,
+			Cluster:    cluster,
+			Machines:   machines,
+			EtcdLeader: &etcd.Member{Name: "one"},
 		}
 		controlPlane.InjectTestManagementCluster(r.managementCluster)
 

--- a/controlplane/kubeadm/internal/controllers/update_test.go
+++ b/controlplane/kubeadm/internal/controllers/update_test.go
@@ -40,6 +40,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/desiredstate"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
@@ -177,6 +178,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 		setMachineHealthy(&bothMachines.Items[i])
 	}
 	controlPlane.Machines = collections.FromMachineList(bothMachines)
+	controlPlane.EtcdLeader = &etcd.Member{Name: controlPlane.Machines.UnsortedList()[0].Name}
 
 	machinesRequireUpgrade := collections.Machines{}
 	for i := range bothMachines.Items {
@@ -280,6 +282,7 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleDown(t *testing.T) {
 	// run upgrade, expect we scale down
 	needingUpgrade := collections.FromMachineList(machineList)
 	controlPlane.Machines = needingUpgrade
+	controlPlane.EtcdLeader = &etcd.Member{Name: controlPlane.Machines.UnsortedList()[0].Name}
 	machinesUpToDateResults := map[string]internal.UpToDateResult{}
 	for _, m := range needingUpgrade {
 		machinesUpToDateResults[m.Name] = internal.UpToDateResult{EligibleForInPlaceUpdate: false}

--- a/controlplane/kubeadm/internal/etcd_client_generator.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
@@ -41,8 +40,6 @@ type EtcdClientGenerator struct {
 }
 
 type clientCreator func(ctx context.Context, endpoint string) (*etcd.Client, error)
-
-var errEtcdNodeConnection = errors.New("failed to connect to etcd node")
 
 // NewEtcdClientGenerator returns a new etcdClientGenerator instance.
 func NewEtcdClientGenerator(restConfig *rest.Config, tlsConfig *tls.Config, etcdDialTimeout, etcdCallTimeout time.Duration, etcdLogger *zap.Logger) *EtcdClientGenerator {
@@ -87,77 +84,4 @@ func (c *EtcdClientGenerator) forFirstAvailableNode(ctx context.Context, nodeNam
 		return client, nil
 	}
 	return nil, errors.Wrapf(kerrors.NewAggregate(errs), "could not establish a connection to etcd members hosted on %s", strings.Join(nodeNames, ","))
-}
-
-// forLeader takes a list of nodes and returns a client to the leader node.
-func (c *EtcdClientGenerator) forLeader(ctx context.Context, nodeNames []string) (*etcd.Client, error) {
-	// This is an additional safeguard for avoiding this func to return nil, nil.
-	if len(nodeNames) == 0 {
-		return nil, errors.New("invalid argument: forLeader can't be called with an empty list of nodes")
-	}
-
-	nodes := sets.Set[string]{}
-	for _, n := range nodeNames {
-		nodes.Insert(n)
-	}
-
-	// Loop through the existing control plane nodes.
-	var errs []error
-	for _, nodeName := range nodeNames {
-		cl, err := c.getLeaderClient(ctx, nodeName, nodes)
-		if err != nil {
-			if errors.Is(err, errEtcdNodeConnection) {
-				errs = append(errs, err)
-				continue
-			}
-			return nil, err
-		}
-
-		return cl, nil
-	}
-	return nil, errors.Wrap(kerrors.NewAggregate(errs), "could not establish a connection to the etcd leader")
-}
-
-// getLeaderClient provides an etcd client connected to the leader. It returns an
-// errEtcdNodeConnection if there was a connection problem with the given etcd
-// node, which should be considered non-fatal by the caller.
-func (c *EtcdClientGenerator) getLeaderClient(ctx context.Context, nodeName string, allNodes sets.Set[string]) (*etcd.Client, error) {
-	// Get a temporary client to the etcd instance hosted on the node.
-	client, err := c.forFirstAvailableNode(ctx, []string{nodeName})
-	if err != nil {
-		return nil, kerrors.NewAggregate([]error{err, errEtcdNodeConnection})
-	}
-	defer client.Close()
-
-	// Get the list of members.
-	members, err := client.Members(ctx)
-	if err != nil {
-		return nil, kerrors.NewAggregate([]error{err, errEtcdNodeConnection})
-	}
-
-	// Get the leader member.
-	var leaderMember *etcd.Member
-	for _, member := range members {
-		if member.ID == client.LeaderID {
-			leaderMember = member
-			break
-		}
-	}
-
-	// If we found the leader, and it is one of the nodes,
-	// get a connection to the etcd leader via the node hosting it.
-	if leaderMember != nil {
-		if !allNodes.Has(leaderMember.Name) {
-			return nil, errors.Errorf("etcd leader is reported as %x with name %q, but we couldn't find a corresponding Node in the cluster", leaderMember.ID, leaderMember.Name)
-		}
-		client, err = c.forFirstAvailableNode(ctx, []string{leaderMember.Name})
-		return client, err
-	}
-
-	// If it is not possible to get a connection to the leader via existing nodes,
-	// it means that the control plane is an invalid state, with an etcd member - the current leader -
-	// without a corresponding node.
-	// TODO: In future we can eventually try to automatically remediate this condition by moving the leader
-	//  to another member with a corresponding node.
-	return nil, errors.Errorf("etcd leader is reported as %x, but we couldn't find any matching member", client.LeaderID)
 }

--- a/controlplane/kubeadm/internal/etcd_client_generator_test.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator_test.go
@@ -24,14 +24,11 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
-	etcdfake "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/fake"
 )
 
 var (
@@ -101,128 +98,6 @@ func TestFirstAvailableNode(t *testing.T) {
 			if tt.expectedErr != "" {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).Should(BeComparableTo(tt.expectedErr))
-			} else {
-				g.Expect(*client).Should(BeComparableTo(tt.expectedClient))
-			}
-		})
-	}
-}
-
-func TestForLeader(t *testing.T) {
-	tests := []struct {
-		name  string
-		nodes []string
-		cc    clientCreator
-
-		expectedErr    string
-		expectedClient etcd.Client
-	}{
-		{
-			name:  "Returns client for leader successfully",
-			nodes: []string{"node-1", "node-leader"},
-			cc: func(_ context.Context, endpoint string) (*etcd.Client, error) {
-				return &etcd.Client{
-					Endpoint: endpoint,
-					LeaderID: 1729,
-					EtcdClient: &etcdfake.FakeEtcdClient{
-						MemberListResponse: &clientv3.MemberListResponse{
-							Members: []*etcdserverpb.Member{
-								{ID: 1234, Name: "node-1"},
-								{ID: 1729, Name: "node-leader"},
-							},
-						},
-						AlarmResponse: &clientv3.AlarmResponse{},
-					}}, nil
-			},
-			expectedClient: etcd.Client{
-				Endpoint: "etcd-node-leader",
-				LeaderID: 1729, EtcdClient: &etcdfake.FakeEtcdClient{
-					MemberListResponse: &clientv3.MemberListResponse{
-						Members: []*etcdserverpb.Member{
-							{ID: 1234, Name: "node-1"},
-							{ID: 1729, Name: "node-leader"},
-						},
-					},
-					AlarmResponse: &clientv3.AlarmResponse{},
-				}},
-		},
-		{
-			name:  "Returns client for leader even when one or more nodes are down",
-			nodes: []string{"node-down-1", "node-down-2", "node-leader"},
-			cc: func(_ context.Context, endpoint string) (*etcd.Client, error) {
-				if strings.Contains(endpoint, "node-down") {
-					return nil, errors.New("node down")
-				}
-				return &etcd.Client{
-					Endpoint: endpoint,
-					LeaderID: 1729,
-					EtcdClient: &etcdfake.FakeEtcdClient{
-						MemberListResponse: &clientv3.MemberListResponse{
-							Members: []*etcdserverpb.Member{
-								{ID: 1729, Name: "node-leader"},
-							},
-						},
-						AlarmResponse: &clientv3.AlarmResponse{},
-					}}, nil
-			},
-			expectedClient: etcd.Client{
-				Endpoint: "etcd-node-leader",
-				LeaderID: 1729, EtcdClient: &etcdfake.FakeEtcdClient{
-					MemberListResponse: &clientv3.MemberListResponse{
-						Members: []*etcdserverpb.Member{
-							{ID: 1729, Name: "node-leader"},
-						},
-					},
-					AlarmResponse: &clientv3.AlarmResponse{},
-				}},
-		},
-		{
-			name:        "Fails when called with an empty node list",
-			nodes:       nil,
-			cc:          nil,
-			expectedErr: "invalid argument: forLeader can't be called with an empty list of nodes",
-		},
-		{
-			name:  "Returns error when the leader does not have a corresponding node",
-			nodes: []string{"node-1"},
-			cc: func(_ context.Context, endpoint string) (*etcd.Client, error) {
-				return &etcd.Client{
-					Endpoint: endpoint,
-					LeaderID: 1729,
-					EtcdClient: &etcdfake.FakeEtcdClient{
-						MemberListResponse: &clientv3.MemberListResponse{
-							Members: []*etcdserverpb.Member{
-								{ID: 1234, Name: "node-1"},
-								{ID: 1729, Name: "node-leader"},
-							},
-						},
-						AlarmResponse: &clientv3.AlarmResponse{},
-					}}, nil
-			},
-			expectedErr: "etcd leader is reported as 6c1 with name \"node-leader\", but we couldn't find a corresponding Node in the cluster",
-		},
-		{
-			name:  "Returns error when all nodes are down",
-			nodes: []string{"node-down-1", "node-down-2", "node-down-3"},
-			cc: func(context.Context, string) (*etcd.Client, error) {
-				return nil, errors.New("node down")
-			},
-			expectedErr: "could not establish a connection to the etcd leader: [could not establish a connection to etcd members hosted on node-down-1: node down, failed to connect to etcd node, could not establish a connection to etcd members hosted on node-down-2: node down, could not establish a connection to etcd members hosted on node-down-3: node down]",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			subject = NewEtcdClientGenerator(&rest.Config{}, &tls.Config{MinVersion: tls.VersionTLS12}, 0, 0, etcdClientLogger)
-			subject.createClient = tt.cc
-
-			client, err := subject.forLeader(ctx, tt.nodes)
-
-			if tt.expectedErr != "" {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).Should(Equal(tt.expectedErr))
 			} else {
 				g.Expect(*client).Should(BeComparableTo(tt.expectedClient))
 			}

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -41,7 +41,6 @@ import (
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	kubeadmtypes "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/desiredstate"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
@@ -81,7 +80,7 @@ type WorkloadCluster interface {
 	UpdateKubeProxyImageInfo(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error
 	UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error
 	RemoveEtcdMember(ctx context.Context, m *etcd.Member, nodes []*Node) error
-	ForwardEtcdLeadership(ctx context.Context, machine *clusterv1.Machine, leaderCandidate *clusterv1.Machine, nodes []*Node) error
+	ForwardEtcdLeadership(ctx context.Context, fromMember, toMember string) error
 	EnsureKubeadmPermissions(ctx context.Context, version semver.Version) error
 	UpdateClusterConfiguration(ctx context.Context, version semver.Version, mutators ...func(*bootstrapv1.ClusterConfiguration)) error
 }

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -91,8 +91,7 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 	}
 
 	// Update etcd member healthy conditions for provisioning machines (machines without a node yet, and thus without a matching etcd member).
-	provisioningMachines := controlPlane.Machines.Filter(collections.Not(collections.HasNode()))
-	for _, machine := range provisioningMachines {
+	for _, machine := range controlPlane.Machines.Filter(collections.Not(collections.HasNode())) {
 		var msg string
 		if machine.Spec.ProviderID != "" {
 			// If the machine is at the end of the provisioning phase, with ProviderID set, but still waiting
@@ -125,10 +124,11 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 	// Update etcd member healthy conditions for machines not provisioning or deleting.
 	// This is implemented by reading info about members and alarms from etcd.
 	machinesNotProvisioningOrDeleting := controlPlane.Machines.Filter(collections.And(collections.HasNode(), collections.Not(collections.HasDeletionTimestamp)))
-	currentMembers, alarms, err := w.getCurrentEtcdMembersAndAlarms(ctx, machinesNotProvisioningOrDeleting, controlPlane.Nodes)
+	currentMembers, etcdLeader, alarms, err := w.getCurrentEtcdMembersAndAlarms(ctx, machinesNotProvisioningOrDeleting, controlPlane.Nodes)
 	if err == nil {
 		controlPlane.EtcdMembers = currentMembers
 		controlPlane.EtcdMembersAlarms = alarms
+		controlPlane.EtcdLeader = etcdLeader
 
 		for _, machine := range machinesNotProvisioningOrDeleting {
 			// Retrieve the member hosted on the machine.
@@ -242,12 +242,12 @@ func unwrapAll(err error) error {
 // getCurrentEtcdMembersAndAlarms returns the current list of etcd member and alarms.
 // Considering that the underlying etcd SDK calls (MemberList and AlarmList) requires quorum across all etcd members, it is possible
 // to run those calls towards any etcd Pod hosting an etcd member.
-func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines collections.Machines, nodes []*Node) ([]*etcd.Member, []etcd.MemberAlarm, error) {
+func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines collections.Machines, nodes []*Node) ([]*etcd.Member, *etcd.Member, []etcd.MemberAlarm, error) {
 	// Get the list of nodes hosting an etcd member sorted by the last known etcd health,
 	// so the client generator in the following line will try to connect first to nodes with higher chance to answer.
 	nodeNames := getNodeNamesSortedByLastKnownEtcdHealth(nodes, machines)
 	if len(nodeNames) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	// Create the etcd Client for one of the etcd Pods running on the given nodes.
@@ -263,7 +263,7 @@ func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines 
 				Message: fmt.Sprintf("Failed to connect to etcd: %s", unwrapAll(err)),
 			})
 		}
-		return nil, nil, errors.Wrapf(err, "failed to get an etcd client for %s Nodes", strings.Join(nodeNames, ","))
+		return nil, nil, nil, errors.Wrapf(err, "failed to get an etcd client for %s Nodes", strings.Join(nodeNames, ","))
 	}
 	defer etcdClient.Close()
 
@@ -279,7 +279,7 @@ func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines 
 				Message: fmt.Sprintf("Etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", ")),
 			})
 		}
-		return nil, nil, errors.Errorf("etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
+		return nil, nil, nil, errors.Errorf("etcd endpoint %s reports errors: %s", etcdClient.Endpoint, strings.Join(etcdClient.Errors, ", "))
 	}
 
 	// Gets the list of etcd members in the cluster.
@@ -295,7 +295,18 @@ func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines 
 				Message: fmt.Sprintf("Failed to get etcd members: %s", unwrapAll(err)),
 			})
 		}
-		return nil, nil, errors.Wrapf(err, "failed to get etcd members")
+		return nil, nil, nil, errors.Wrapf(err, "failed to get etcd members")
+	}
+
+	var etcdLeader *etcd.Member
+	for _, m := range currentMembers {
+		if m.ID == etcdClient.LeaderID {
+			etcdLeader = m
+			break
+		}
+	}
+	if etcdLeader == nil {
+		return nil, nil, nil, errors.Errorf("failed to get etcd leader")
 	}
 
 	// Gets the list of etcd alarms.
@@ -311,10 +322,10 @@ func (w *Workload) getCurrentEtcdMembersAndAlarms(ctx context.Context, machines 
 				Message: fmt.Sprintf("Failed to get etcd alarms: %s", unwrapAll(err)),
 			})
 		}
-		return nil, nil, errors.Wrapf(err, "failed to get etcd alarms")
+		return nil, nil, nil, errors.Wrapf(err, "failed to get etcd alarms")
 	}
 
-	return currentMembers, alarms, nil
+	return currentMembers, etcdLeader, alarms, nil
 }
 
 // getNodeNamesSortedByLastKnownEtcdHealth return the list of nodes hosting an etcd member sorted by the last known etcd health.

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -68,7 +68,7 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(_ []string) (*etcd.Client, error) {
+				clientFunc: func(_ []string) (*etcd.Client, error) {
 					callCount++
 					return nil, errors.New("fake error")
 				},
@@ -89,7 +89,7 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(_ []string) (*etcd.Client, error) {
+				clientFunc: func(_ []string) (*etcd.Client, error) {
 					callCount++
 					return nil, errors.New("fake error")
 				},
@@ -110,7 +110,7 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(_ []string) (*etcd.Client, error) {
+				clientFunc: func(_ []string) (*etcd.Client, error) {
 					callCount++
 					return &etcd.Client{
 						EtcdClient: &fake2.FakeEtcdClient{
@@ -171,6 +171,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 		expectedMachineConditions                 map[string][]metav1.Condition
 		expectedEtcdMembers                       []string
 		expectedEtcdMembersAndMachinesAreMatching bool
+		expectedEtcdLeader                        *etcd.Member
 	}{
 		{
 			name: "if list nodes return an error should report all the conditions Unknown",
@@ -196,6 +197,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading nodes, we can not make assumptions.
+			expectedEtcdLeader:                        nil,   // without reading nodes, we can not make assumptions.
 		},
 		{
 			name: "If there are provisioning machines, a node without machine should be ignored in v1beta1, reported in v1beta2 (without providerID)",
@@ -222,6 +224,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: true, // there is a single provisioning machine, member list not yet available (too early to say members and machines do not match).
+			expectedEtcdLeader:                        nil,  // there is a single provisioning machine, member list not yet available.
 		},
 		{
 			name: "If there are provisioning machines, a node without machine should be ignored in v1beta1, reported in v1beta2 (with providerID)",
@@ -248,6 +251,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: true,
+			expectedEtcdLeader:                        nil, // there is a single provisioning machine, member list not yet available.
 		},
 		{
 			name: "failure creating the etcd client should report unknown condition",
@@ -258,7 +262,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesErr: errors.New("something went wrong"),
+				err: errors.New("something went wrong"),
 			},
 			expectedKCPV1Beta1Condition: v1beta1conditions.UnknownCondition(controlplanev1.EtcdClusterHealthyV1Beta1Condition, controlplanev1.EtcdClusterUnknownV1Beta1Reason, "Following Machines are reporting unknown etcd member status: m1"),
 			expectedMachineV1Beta1Conditions: map[string]clusterv1.Conditions{
@@ -279,6 +283,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: false, // failure in reading members, we can not make assumptions.
+			expectedEtcdLeader:                        nil,   // failure in reading members, we can not make assumptions.
 		},
 		{
 			name: "etcd client reporting status errors should be reflected into a false condition",
@@ -289,7 +294,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints: []string{},
 					},
@@ -316,6 +321,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
+			expectedEtcdLeader:                        nil,   // without reading members, we can not make assumptions.
 		},
 		{
 			name: "failure listing members should report false condition in v1beta1, unknown in v1beta2",
@@ -326,7 +332,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints:   []string{},
 						MemberListError: errors.New("something went wrong"),
@@ -352,6 +358,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				},
 			},
 			expectedEtcdMembersAndMachinesAreMatching: false, // without reading members, we can not make assumptions.
+			expectedEtcdLeader:                        nil,   // without reading members, we can not make assumptions.
 		},
 		{
 			name: "an etcd member in learner mode should be reported",
@@ -362,7 +369,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints: []string{},
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -374,6 +381,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 							Alarms: []*pb.AlarmMember{},
 						},
 					},
+					LeaderID: uint64(1),
 				},
 			},
 			expectedKCPV1Beta1Condition: v1beta1conditions.FalseCondition(controlplanev1.EtcdClusterHealthyV1Beta1Condition, controlplanev1.EtcdClusterUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m1"),
@@ -396,6 +404,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			},
 			expectedEtcdMembers:                       []string{"n1"},
 			expectedEtcdMembersAndMachinesAreMatching: true,
+			expectedEtcdLeader:                        &etcd.Member{ID: uint64(1), Name: "n1", IsLearner: true},
 		},
 		{
 			name: "an etcd member with alarms should report false condition",
@@ -406,7 +415,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n1"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						EtcdEndpoints: []string{},
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -420,6 +429,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 							},
 						},
 					},
+					LeaderID: uint64(1),
 				},
 			},
 			expectedKCPV1Beta1Condition: v1beta1conditions.FalseCondition(controlplanev1.EtcdClusterHealthyV1Beta1Condition, controlplanev1.EtcdClusterUnhealthyV1Beta1Reason, clusterv1.ConditionSeverityError, "Following Machines are reporting etcd member errors: %s", "m1"),
@@ -442,6 +452,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			},
 			expectedEtcdMembers:                       []string{"n1"},
 			expectedEtcdMembersAndMachinesAreMatching: true,
+			expectedEtcdLeader:                        &etcd.Member{ID: uint64(1), Name: "n1"},
 		},
 		{
 			name: "a machine without a member should report false condition",
@@ -454,7 +465,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n2"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+				clientFunc: func(nodeNames []string) (*etcd.Client, error) {
 					var errs []error
 					for _, n := range nodeNames {
 						switch n {
@@ -475,6 +486,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 										Alarms: []*pb.AlarmMember{},
 									},
 								},
+								LeaderID: uint64(1),
 							}, nil
 						default:
 							errs = append(errs, errors.New("no client for this node"))
@@ -509,6 +521,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			},
 			expectedEtcdMembers:                       []string{"n1"},
 			expectedEtcdMembersAndMachinesAreMatching: false,
+			expectedEtcdLeader:                        &etcd.Member{ClusterID: 1, ID: uint64(1), Name: "n1"},
 		},
 		{
 			name: "healthy etcd members should report true",
@@ -521,7 +534,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n2"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+				clientFunc: func(nodeNames []string) (*etcd.Client, error) {
 					var errs []error
 					for _, n := range nodeNames {
 						switch n {
@@ -542,6 +555,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 										Alarms: []*pb.AlarmMember{},
 									},
 								},
+								LeaderID: uint64(1),
 							}, nil
 						case "n2":
 							return &etcd.Client{
@@ -560,6 +574,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 										Alarms: []*pb.AlarmMember{},
 									},
 								},
+								LeaderID: uint64(1),
 							}, nil
 						default:
 							errs = append(errs, errors.New("no client for this node"))
@@ -592,6 +607,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			},
 			expectedEtcdMembers:                       []string{"n1", "n2"},
 			expectedEtcdMembersAndMachinesAreMatching: true,
+			expectedEtcdLeader:                        &etcd.Member{ClusterID: 1, ID: uint64(1), Name: "n1"},
 		},
 		{
 			name: "etcd members without a name when there are no provisioning machines should be reported",
@@ -604,7 +620,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 				fakeNode("n2"),
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(nodeNames []string) (*etcd.Client, error) {
+				clientFunc: func(nodeNames []string) (*etcd.Client, error) {
 					var errs []error
 					for _, n := range nodeNames {
 						switch n {
@@ -626,6 +642,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 										Alarms: []*pb.AlarmMember{},
 									},
 								},
+								LeaderID: uint64(1),
 							}, nil
 						case "n2":
 							return &etcd.Client{
@@ -645,6 +662,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 										Alarms: []*pb.AlarmMember{},
 									},
 								},
+								LeaderID: uint64(1),
 							}, nil
 						default:
 							errs = append(errs, errors.New("no client for this node"))
@@ -678,6 +696,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			},
 			expectedEtcdMembers:                       []string{"n1", "n2", ""},
 			expectedEtcdMembersAndMachinesAreMatching: false,
+			expectedEtcdLeader:                        &etcd.Member{ClusterID: 1, ID: uint64(1), Name: "n1"},
 		},
 	}
 	for _, tt := range tests {
@@ -713,6 +732,7 @@ func TestUpdateManagedEtcdConditions(t *testing.T) {
 			}
 
 			g.Expect(controlPane.EtcdMembersAndMachinesAreMatching).To(Equal(tt.expectedEtcdMembersAndMachinesAreMatching), "EtcdMembersAndMachinesAreMatching does not match")
+			g.Expect(controlPane.EtcdLeader).To(Equal(tt.expectedEtcdLeader), "EtcdLeader does not match")
 
 			var membersNames []string
 			for _, m := range controlPane.EtcdMembers {

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -22,14 +22,12 @@ import (
 	"github.com/pkg/errors"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	etcdutil "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/util"
 )
 
 type etcdClientFor interface {
 	forFirstAvailableNode(ctx context.Context, nodeNames []string) (*etcd.Client, error)
-	forLeader(ctx context.Context, nodeNames []string) (*etcd.Client, error)
 }
 
 // UpdateEtcdLocalInKubeadmConfigMap sets etcd local configuration in the kubeadm config map.
@@ -93,22 +91,10 @@ func (w *Workload) RemoveEtcdMember(ctx context.Context, m *etcd.Member, nodes [
 }
 
 // ForwardEtcdLeadership forwards etcd leadership to the first follower.
-func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1.Machine, leaderCandidate *clusterv1.Machine, nodes []*Node) error {
-	if machine == nil || !machine.Status.NodeRef.IsDefined() {
-		return nil
-	}
-	if leaderCandidate == nil {
-		return errors.New("leader candidate cannot be nil")
-	}
-	if !leaderCandidate.Status.NodeRef.IsDefined() {
-		return errors.New("leader candidate has no node reference")
-	}
-
-	nodeNames := make([]string, 0, len(nodes))
-	for _, node := range nodes {
-		nodeNames = append(nodeNames, node.Name)
-	}
-	etcdClient, err := w.etcdClientGenerator.forLeader(ctx, nodeNames)
+func (w *Workload) ForwardEtcdLeadership(ctx context.Context, fromMember, toMember string) error {
+	// Move etcd member has to be called on the current etcd leader, so create a client on the corresponding node.
+	// Note: This works on the assumption that member name is equal to the node name (kubeadm).
+	etcdClient, err := w.etcdClientGenerator.forFirstAvailableNode(ctx, []string{fromMember})
 	if err != nil {
 		return errors.Wrap(err, "failed to create etcd client")
 	}
@@ -119,19 +105,19 @@ func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1
 		return errors.Wrap(err, "failed to list etcd members using etcd client")
 	}
 
-	currentMember := etcdutil.MemberForName(members, machine.Status.NodeRef.Name)
+	currentMember := etcdutil.MemberForName(members, fromMember)
 	if currentMember == nil || currentMember.ID != etcdClient.LeaderID {
-		// nothing to do, this is not the etcd leader
+		// nothing to do, member is not the leader
 		return nil
 	}
 
 	// Move the leader to the provided candidate.
-	nextLeader := etcdutil.MemberForName(members, leaderCandidate.Status.NodeRef.Name)
+	nextLeader := etcdutil.MemberForName(members, toMember)
 	if nextLeader == nil {
-		return errors.Errorf("failed to get etcd member from node %q", leaderCandidate.Status.NodeRef.Name)
+		return errors.Errorf("failed to get etcd member for leader candidate %q", toMember)
 	}
 	if err := etcdClient.MoveLeader(ctx, nextLeader.ID); err != nil {
-		return errors.Wrapf(err, "failed to move leader")
+		return errors.Wrap(err, "failed to move leader")
 	}
 	return nil
 }

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -33,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	fake2 "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/fake"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
@@ -246,14 +245,14 @@ func TestRemoveEtcdMember(t *testing.T) {
 		{
 			name:                "returns an error if it fails to create the etcd client",
 			memberToDelete:      &etcd.Member{ID: uint64(1), Name: "cp1"},
-			etcdClientGenerator: &fakeEtcdClientGenerator{forNodesErr: errors.New("no client")},
+			etcdClientGenerator: &fakeEtcdClientGenerator{err: errors.New("no client")},
 			expectErr:           true,
 		},
 		{
 			name:           "returns an error if the client errors getting etcd members",
 			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListError: errors.New("cannot get etcd members"),
 					},
@@ -265,7 +264,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 			name:           "no op if the member already does not exist",
 			memberToDelete: &etcd.Member{ID: uint64(2), Name: "cp2"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
 							Members: []*pb.Member{
@@ -281,7 +280,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 			name:           "returns an error if there is only one member",
 			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
 							Members: []*pb.Member{
@@ -297,7 +296,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 			name:           "returns an error if the client errors removing the etcd member",
 			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
 							Members: []*pb.Member{
@@ -315,7 +314,7 @@ func TestRemoveEtcdMember(t *testing.T) {
 			name:           "removes the member from etcd",
 			memberToDelete: &etcd.Member{ID: uint64(1), Name: "cp1"},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClient: &etcd.Client{
+				client: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
 							Members: []*pb.Member{
@@ -352,54 +351,47 @@ func TestRemoveEtcdMember(t *testing.T) {
 func TestForwardEtcdLeadership(t *testing.T) {
 	t.Run("handles errors correctly", func(t *testing.T) {
 		tests := []struct {
-			name                string
-			machine             *clusterv1.Machine
-			leaderCandidate     *clusterv1.Machine
-			etcdClientGenerator etcdClientFor
-			expectErr           bool
+			name                 string
+			fromMember, toMember string
+			etcdClientGenerator  etcdClientFor
+			expectErr            bool
 		}{
 			{
-				name:      "does nothing if the machine is nil",
-				machine:   nil,
-				expectErr: false,
-			},
-			{
-				name: "does nothing if machine's NodeRef is nil",
-				machine: defaultMachine(func(m *clusterv1.Machine) {
-					m.Status.NodeRef = clusterv1.MachineNodeReference{}
-				}),
-				expectErr: false,
-			},
-			{
-				name:            "returns an error if the leader candidate is nil",
-				machine:         defaultMachine(),
-				leaderCandidate: nil,
-				expectErr:       true,
-			},
-			{
-				name:    "returns an error if the leader candidate's noderef is nil",
-				machine: defaultMachine(),
-				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
-					m.Status.NodeRef = clusterv1.MachineNodeReference{}
-				}),
-				expectErr: true,
-			},
-			{
 				name:                "returns an error if it can't create an etcd client",
-				machine:             defaultMachine(),
-				leaderCandidate:     defaultMachine(),
-				etcdClientGenerator: &fakeEtcdClientGenerator{forLeaderErr: errors.New("no etcdClient")},
+				fromMember:          "m1",
+				toMember:            "m2",
+				etcdClientGenerator: &fakeEtcdClientGenerator{err: errors.New("no etcdClient")},
 				expectErr:           true,
 			},
 			{
-				name:            "returns error if it fails to get etcd members",
-				machine:         defaultMachine(),
-				leaderCandidate: defaultMachine(),
+				name:       "returns error if it fails to get etcd members",
+				fromMember: "m1",
+				toMember:   "m2",
 				etcdClientGenerator: &fakeEtcdClientGenerator{
-					forLeaderClient: &etcd.Client{
+					client: &etcd.Client{
 						EtcdClient: &fake2.FakeEtcdClient{
 							MemberListError: errors.New("cannot get etcd members"),
 						},
+					},
+				},
+				expectErr: true,
+			},
+			{
+				name:       "returns an error if it fails to move leadership",
+				fromMember: "m1",
+				toMember:   "m2",
+				etcdClientGenerator: &fakeEtcdClientGenerator{
+					client: &etcd.Client{
+						EtcdClient: &fake2.FakeEtcdClient{
+							MemberListResponse: &clientv3.MemberListResponse{
+								Members: []*pb.Member{
+									{Name: "m1", ID: uint64(1)},
+									{Name: "m2", ID: uint64(2)},
+								},
+							},
+							MoveLeaderError: errors.New("cannot move leadership"),
+						},
+						LeaderID: 1,
 					},
 				},
 				expectErr: true,
@@ -411,8 +403,7 @@ func TestForwardEtcdLeadership(t *testing.T) {
 				w := &Workload{
 					etcdClientGenerator: tt.etcdClientGenerator,
 				}
-				// Note: no need to pass the list of nodes because fakeEtcdClientGenerator is used to simulate various combinations of node availability.
-				err := w.ForwardEtcdLeadership(ctx, tt.machine, tt.leaderCandidate, nil)
+				err := w.ForwardEtcdLeadership(ctx, tt.fromMember, tt.toMember)
 				if tt.expectErr {
 					g.Expect(err).To(HaveOccurred())
 					return
@@ -424,152 +415,64 @@ func TestForwardEtcdLeadership(t *testing.T) {
 
 	t.Run("does nothing if the machine is not the leader", func(t *testing.T) {
 		g := NewWithT(t)
-		fakeEtcdClient := &fake2.FakeEtcdClient{
+		etcdClient := &fake2.FakeEtcdClient{
 			MemberListResponse: &clientv3.MemberListResponse{
 				Members: []*pb.Member{
-					{Name: "machine-node", ID: uint64(101)},
+					{Name: "m1", ID: uint64(1)},
+					{Name: "m2", ID: uint64(2)},
 				},
-			},
-			AlarmResponse: &clientv3.AlarmResponse{
-				Alarms: []*pb.AlarmMember{},
 			},
 		}
 		etcdClientGenerator := &fakeEtcdClientGenerator{
-			forLeaderClient: &etcd.Client{
-				EtcdClient: fakeEtcdClient,
-				LeaderID:   555,
+			client: &etcd.Client{
+				EtcdClient: etcdClient,
+				LeaderID:   2,
 			},
 		}
 
 		w := &Workload{
-			Client: &fakeClient{list: &corev1.NodeList{
-				Items: []corev1.Node{nodeNamed("leader-node")},
-			}},
 			etcdClientGenerator: etcdClientGenerator,
 		}
-		// Note: no need to pass the list of nodes because fakeEtcdClientGenerator is used to simulate various combinations of node availability.
-		err := w.ForwardEtcdLeadership(ctx, defaultMachine(), defaultMachine(), nil)
+		err := w.ForwardEtcdLeadership(ctx, "m1", "m2")
 		g.Expect(err).ToNot(HaveOccurred())
-		g.Expect(fakeEtcdClient.MovedLeader).To(BeEquivalentTo(0))
+		g.Expect(etcdClient.MovedLeader).To(BeEquivalentTo(0))
 	})
 
 	t.Run("move etcd leader", func(t *testing.T) {
-		tests := []struct {
-			name               string
-			leaderCandidate    *clusterv1.Machine
-			etcdMoveErr        error
-			expectedMoveLeader uint64
-			expectErr          bool
-		}{
-			{
-				name: "it moves the etcd leadership to the leader candidate",
-				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
-					m.Status.NodeRef.Name = "candidate-node"
-				}),
-				expectedMoveLeader: 12345,
+		g := NewWithT(t)
+		etcdClient := &fake2.FakeEtcdClient{
+			MemberListResponse: &clientv3.MemberListResponse{
+				Members: []*pb.Member{
+					{Name: "m1", ID: uint64(1)},
+					{Name: "m2", ID: uint64(2)},
+				},
 			},
-			{
-				name: "returns error if failed to move to the leader candidate",
-				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
-					m.Status.NodeRef.Name = "candidate-node"
-				}),
-				etcdMoveErr: errors.New("move err"),
-				expectErr:   true,
-			},
-			{
-				name: "returns error if the leader candidate doesn't exist in etcd",
-				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
-					m.Status.NodeRef.Name = "some other node"
-				}),
-				expectErr: true,
+		}
+		etcdClientGenerator := &fakeEtcdClientGenerator{
+			client: &etcd.Client{
+				EtcdClient: etcdClient,
+				LeaderID:   1,
 			},
 		}
 
-		currentLeader := defaultMachine(func(m *clusterv1.Machine) {
-			m.Status.NodeRef.Name = "current-leader"
-		})
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				g := NewWithT(t)
-				fakeEtcdClient := &fake2.FakeEtcdClient{
-					MemberListResponse: &clientv3.MemberListResponse{
-						Members: []*pb.Member{
-							{Name: currentLeader.Status.NodeRef.Name, ID: uint64(101)},
-							{Name: "other-node", ID: uint64(1034)},
-							{Name: "candidate-node", ID: uint64(12345)},
-						},
-					},
-					AlarmResponse: &clientv3.AlarmResponse{
-						Alarms: []*pb.AlarmMember{},
-					},
-					MoveLeaderError: tt.etcdMoveErr,
-				}
-
-				etcdClientGenerator := &fakeEtcdClientGenerator{
-					forLeaderClient: &etcd.Client{
-						EtcdClient: fakeEtcdClient,
-						// this etcdClient belongs to the machine-node
-						LeaderID: 101,
-					},
-				}
-
-				w := &Workload{
-					etcdClientGenerator: etcdClientGenerator,
-					Client: &fakeClient{list: &corev1.NodeList{
-						Items: []corev1.Node{nodeNamed("leader-node"), nodeNamed("other-node"), nodeNamed("candidate-node")},
-					}},
-				}
-				// Note: no need to pass the list of nodes because fakeEtcdClientGenerator is used to simulate various combinations of node availability.
-				err := w.ForwardEtcdLeadership(ctx, currentLeader, tt.leaderCandidate, nil)
-				if tt.expectErr {
-					g.Expect(err).To(HaveOccurred())
-					return
-				}
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(fakeEtcdClient.MovedLeader).To(BeEquivalentTo(tt.expectedMoveLeader))
-			})
+		w := &Workload{
+			etcdClientGenerator: etcdClientGenerator,
 		}
+		err := w.ForwardEtcdLeadership(ctx, "m1", "m2")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(etcdClient.MovedLeader).To(BeEquivalentTo(2))
 	})
 }
 
 type fakeEtcdClientGenerator struct {
-	forNodesClient     *etcd.Client
-	forNodesClientFunc func([]string) (*etcd.Client, error)
-	forLeaderClient    *etcd.Client
-	forNodesErr        error
-	forLeaderErr       error
+	client     *etcd.Client
+	clientFunc func([]string) (*etcd.Client, error)
+	err        error
 }
 
 func (c *fakeEtcdClientGenerator) forFirstAvailableNode(_ context.Context, n []string) (*etcd.Client, error) {
-	if c.forNodesClientFunc != nil {
-		return c.forNodesClientFunc(n)
+	if c.clientFunc != nil {
+		return c.clientFunc(n)
 	}
-	return c.forNodesClient, c.forNodesErr
-}
-
-func (c *fakeEtcdClientGenerator) forLeader(_ context.Context, _ []string) (*etcd.Client, error) {
-	return c.forLeaderClient, c.forLeaderErr
-}
-
-func defaultMachine(transforms ...func(m *clusterv1.Machine)) *clusterv1.Machine {
-	m := &clusterv1.Machine{
-		Status: clusterv1.MachineStatus{
-			NodeRef: clusterv1.MachineNodeReference{
-				Name: "machine-node",
-			},
-		},
-	}
-	for _, t := range transforms {
-		t(m)
-	}
-	return m
-}
-
-func nodeNamed(name string) corev1.Node {
-	node := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-	return node
+	return c.client, c.err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
As of today, before deleting a machines, KCP tries to forward leadership to another machine so that the removal of the etcd member hosted in the machine goes smoothly. 

This PR improves this feature by:
- returning fast if the machine being deleted is not the current etcd leader (without performing any other check)
- add code for trying to forward leadership to another machine if for any reason the operation fails on the preferred candidate machine (it actually tries all the possible candidates from the "most preferred" to the "least preferred")

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->