### PR TITLE
🐛 clusterctl: detect cert-manager image changes during upgrade

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	_ "embed"
+	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -370,10 +371,16 @@ func (cm *certManagerClient) shouldUpgrade(desiredVersion string, objs, installO
 			currentVersion = objVersion
 			needUpgrade = true
 		case c == 0:
-			// The installed version is equal to the desired version. Upgrade is required only if the number
-			// of available objects and objects to install differ. This would act as a re-install.
+			// The installed version is equal to the desired version. Upgrade is required if the number
+			// of available objects and objects to install differ or if the images differ. This would act as a re-install.
 			currentVersion = objVersion
 			needUpgrade = len(relevantObjs) != len(installObjs)
+			if !needUpgrade {
+				needUpgrade, err = certManagerImagesDiffer(relevantObjs, installObjs)
+				if err != nil {
+					return "", false, err
+				}
+			}
 		case c > 0:
 			// The installed version is greater than the desired version. Upgrade is not required.
 			currentVersion = objVersion
@@ -384,6 +391,25 @@ func (cm *certManagerClient) shouldUpgrade(desiredVersion string, objs, installO
 		}
 	}
 	return currentVersion, needUpgrade, nil
+}
+
+func certManagerImagesDiffer(objs, installObjs []unstructured.Unstructured) (bool, error) {
+	currentImages, err := util.InspectImages(objs)
+	if err != nil {
+		return false, err
+	}
+	desiredImages, err := util.InspectImages(installObjs)
+	if err != nil {
+		return false, err
+	}
+
+	slices.Sort(currentImages)
+	slices.Sort(desiredImages)
+
+	if len(currentImages) == 0 || len(currentImages) != len(desiredImages) {
+		return false, nil
+	}
+	return !slices.Equal(currentImages, desiredImages), nil
 }
 
 func (cm *certManagerClient) getWaitTimeout() time.Duration {

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -406,8 +406,11 @@ func certManagerImagesDiffer(objs, installObjs []unstructured.Unstructured) (boo
 	slices.Sort(currentImages)
 	slices.Sort(desiredImages)
 
-	if len(currentImages) == 0 || len(currentImages) != len(desiredImages) {
+	if len(currentImages) == 0 && len(desiredImages) == 0 {
 		return false, nil
+	}
+	if len(currentImages) != len(desiredImages) {
+		return true, nil
 	}
 	return !slices.Equal(currentImages, desiredImages), nil
 }

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -207,6 +208,15 @@ func Test_GetTimeout(t *testing.T) {
 }
 
 func Test_shouldUpgrade(t *testing.T) {
+	g := NewWithT(t)
+	certManagerObjs, err := utilyaml.ToUnstructured(certManagerDeploymentYaml)
+	g.Expect(err).ToNot(HaveOccurred())
+	certManagerObjs = addCerManagerAnnotations(certManagerObjs, config.CertManagerDefaultVersion)
+
+	overriddenCertManagerObjs, err := utilyaml.ToUnstructured([]byte(strings.ReplaceAll(string(certManagerDeploymentYaml), "quay.io/jetstack/cert-manager:v1.1.0", "myorg.io/local-repo/cert-manager:v1.1.0")))
+	g.Expect(err).ToNot(HaveOccurred())
+	overriddenCertManagerObjs = addCerManagerAnnotations(overriddenCertManagerObjs, config.CertManagerDefaultVersion)
+
 	type args struct {
 		objs []unstructured.Unstructured
 	}
@@ -216,6 +226,7 @@ func Test_shouldUpgrade(t *testing.T) {
 		args               args
 		wantFromVersion    string
 		hasDiffInstallObjs bool
+		installObjs        []unstructured.Unstructured
 		want               bool
 		wantErr            bool
 	}{
@@ -375,6 +386,17 @@ func Test_shouldUpgrade(t *testing.T) {
 			wantErr:            false,
 		},
 		{
+			name:          "Version is equal, but should upgrade because images differ",
+			configVersion: config.CertManagerDefaultVersion,
+			args: args{
+				objs: certManagerObjs,
+			},
+			wantFromVersion: config.CertManagerDefaultVersion,
+			installObjs:     overriddenCertManagerObjs,
+			want:            true,
+			wantErr:         false,
+		},
+		{
 			name:          "Version is older, should upgrade",
 			configVersion: config.CertManagerDefaultVersion,
 			args: args{
@@ -455,6 +477,9 @@ func Test_shouldUpgrade(t *testing.T) {
 				installObjs = make([]unstructured.Unstructured, len(tt.args.objs))
 				copy(installObjs, tt.args.objs)
 				installObjs = append(installObjs, unstructured.Unstructured{})
+			}
+			if tt.installObjs != nil {
+				installObjs = tt.installObjs
 			}
 
 			fromVersion, got, err := cm.shouldUpgrade(tt.configVersion, tt.args.objs, installObjs)

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -724,6 +724,16 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 						Labels:      map[string]string{clusterctlv1.ClusterctlCoreLabel: clusterctlv1.ClusterctlCoreLabelCertManagerValue},
 						Annotations: map[string]string{clusterctlv1.CertManagerVersionAnnotation: config.CertManagerDefaultVersion},
 					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "manager",
+									Image: "quay.io/jetstack/cert-manager:v1.1.0",
+								}},
+							},
+						},
+					},
 				},
 			},
 			expectErr: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes `clusterctl upgrade apply` so clusterctl-managed cert-manager is re-applied when the desired cert-manager images change due to image overrides, even if the cert-manager version stays the same.

Previously, when the installed cert-manager version matched the configured version, `shouldUpgrade` only compared the number of installed objects with the number of desired objects. As a result, changing image override settings in `clusterctl.yaml`, for example `images.all.repository`, did not trigger a cert-manager update when the manifest object count stayed the same.

This change keeps the existing object-count check and additionally compares the installed cert-manager images with the desired manifest images.

**Which issue(s) this PR fixes**:
Fixes #12119

/kind bug
/area clusterctl

**Testing**:

```sh
go test ./cmd/clusterctl/client/cluster -run 'Test_shouldUpgrade|Test_certManagerClient_PlanUpgrade'