### PR TITLE
[release-1.13] 🐛 Bump kind image in clusterctl v1.10 upgrade test to avoid containerd segv

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -63,8 +63,11 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.10=>cu
 			InitWithProvidersContract:       "v1beta1",
 			// Note: Both InitWithKubernetesVersion and WorkloadKubernetesVersion should be the highest mgmt cluster version supported by the source Cluster API version.
 			// When picking this version, please check also the list of versions known by the source Cluster API version (rif. test/infrastructure/kind/mapper.go).
-			InitWithKubernetesVersion:   "v1.33.0",
-			WorkloadKubernetesVersion:   "v1.33.0",
+			// Note: Using v1.34.0 instead of v1.33.0 because we are getting the following error with containerd with the
+			//       v1.33.0 image and then afterward kubelet cannot communicate with containerd anymore:
+			//       > Jun 24 23:17:18.106114 clusterctl-upgrade-workload-2mklrf-lg6pq-tskhm systemd[1]: containerd.service: Main process exited, code=dumped, status=11/SEGV
+			InitWithKubernetesVersion:   "v1.34.0",
+			WorkloadKubernetesVersion:   "v1.34.0",
 			MgmtFlavor:                  "topology",
 			WorkloadFlavor:              "topology",
 			UseKindForManagementCluster: true,


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
No PR against main because the v1.10 upgrade test doesn't exist there.

Corresponding testgrid link: https://storage.googleapis.com/k8s-triage/index.html?date=2026-06-29&text=resourceVersions%20never%20became%20stable&job=.*cluster-api&xjob=.*-provider-

Should be pretty easy to confirm if the issue is fixed after a few days.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->