### PR TITLE
🐛 Fix TestHealthCheckTargets flake

### DIFF
--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -280,7 +280,8 @@ func (r *Reconciler) reconcile(ctx context.Context, logger logr.Logger, cluster 
 	}
 
 	// health check all targets and reconcile mhc status
-	healthy, unhealthy, nextCheckTimes := r.healthCheckTargets(targets, logger, metav1.Duration{Duration: time.Duration(*nodeStartupTimeout) * time.Second})
+	reconciliationTime := time.Now()
+	healthy, unhealthy, nextCheckTimes := r.healthCheckTargets(targets, logger, reconciliationTime, metav1.Duration{Duration: time.Duration(*nodeStartupTimeout) * time.Second})
 	m.Status.CurrentHealthy = ptr.To(int32(len(healthy)))
 
 	// check MHC current health against UnhealthyLessThanOrEqualTo

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
@@ -77,7 +77,7 @@ type healthCheckTarget struct {
 //
 // Returns true if remediation is needed, and a duration indicating when to recheck if remediation
 // is not immediately required. The target should be requeued after this duration.
-func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachineToHaveNode metav1.Duration) (bool, time.Duration) {
+func (t *healthCheckTarget) needsRemediation(logger logr.Logger, reconciliationTime time.Time, timeoutForMachineToHaveNode metav1.Duration) (bool, time.Duration) {
 	if annotations.HasRemediateMachine(t.Machine) {
 		v1beta1conditions.MarkFalse(t.Machine, clusterv1.MachineHealthCheckSucceededV1Beta1Condition, clusterv1.HasRemediateMachineAnnotationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "Marked for remediation via remediate-machine annotation")
 		logger.V(3).Info("Target is marked for remediation via remediate-machine annotation")
@@ -107,10 +107,10 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 	}
 
 	// Check machine conditions
-	unhealthyMachineMessages, nextMachineCheck := t.machineChecks(logger)
+	unhealthyMachineMessages, nextMachineCheck := t.machineChecks(logger, reconciliationTime)
 
 	// Check node conditions
-	nodeConditionReason, nodeV1beta1ConditionReason, unhealthyNodeMessages, nextNodeCheck := t.nodeChecks(logger, timeoutForMachineToHaveNode)
+	nodeConditionReason, nodeV1beta1ConditionReason, unhealthyNodeMessages, nextNodeCheck := t.nodeChecks(logger, reconciliationTime, timeoutForMachineToHaveNode)
 
 	// Combine results
 	if len(unhealthyMachineMessages) == 0 && len(unhealthyNodeMessages) == 0 {
@@ -163,10 +163,9 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 	return true, time.Duration(0)
 }
 
-func (t *healthCheckTarget) machineChecks(logger logr.Logger) ([]string, time.Duration) {
+func (t *healthCheckTarget) machineChecks(logger logr.Logger, reconciliationTime time.Time) ([]string, time.Duration) {
 	var unhealthyMachineMessages []string
 	var nextCheckTimes []time.Duration
-	now := time.Now()
 
 	// Always check machine conditions first, regardless of node state
 	for _, c := range t.MHC.Spec.Checks.UnhealthyMachineConditions {
@@ -182,7 +181,7 @@ func (t *healthCheckTarget) machineChecks(logger logr.Logger) ([]string, time.Du
 		// timeout, mark as unhealthy and collect the message.
 		timeoutSecondsDuration := time.Duration(ptr.Deref(c.TimeoutSeconds, 0)) * time.Second
 
-		if machineCondition.LastTransitionTime.Add(timeoutSecondsDuration).Before(now) {
+		if machineCondition.LastTransitionTime.Add(timeoutSecondsDuration).Before(reconciliationTime) {
 			unhealthyMachineMessages = append(unhealthyMachineMessages, fmt.Sprintf("Condition %s on Machine is reporting status %s with reason %s for more than %s",
 				c.Type, c.Status, machineCondition.Reason, timeoutSecondsDuration.String()))
 			logger.V(3).Info(fmt.Sprintf("Target is unhealthy: Machine condition is in unhealthy state more than %s", timeoutSecondsDuration.String()),
@@ -190,7 +189,7 @@ func (t *healthCheckTarget) machineChecks(logger logr.Logger) ([]string, time.Du
 			continue
 		}
 
-		durationUnhealthy := now.Sub(machineCondition.LastTransitionTime.Time)
+		durationUnhealthy := reconciliationTime.Sub(machineCondition.LastTransitionTime.Time)
 		nextCheck := timeoutSecondsDuration - durationUnhealthy + time.Second
 		if nextCheck > 0 {
 			nextCheckTimes = append(nextCheckTimes, nextCheck)
@@ -203,9 +202,8 @@ func (t *healthCheckTarget) machineChecks(logger logr.Logger) ([]string, time.Du
 	return nil, minDuration(nextCheckTimes)
 }
 
-func (t *healthCheckTarget) nodeChecks(logger logr.Logger, timeoutForMachineToHaveNode metav1.Duration) (string, string, []string, time.Duration) {
+func (t *healthCheckTarget) nodeChecks(logger logr.Logger, reconciliationTime time.Time, timeoutForMachineToHaveNode metav1.Duration) (string, string, []string, time.Duration) {
 	var nextCheckTimes []time.Duration
-	now := time.Now()
 
 	// Machine has Status.NodeRef set, although we couldn't find the node in the workload cluster.
 	if t.nodeMissing {
@@ -247,13 +245,13 @@ func (t *healthCheckTarget) nodeChecks(logger logr.Logger, timeoutForMachineToHa
 		logger.V(5).Info("Using comparison time", "time", comparisonTime)
 
 		timeoutDuration := timeoutForMachineToHaveNode.Duration
-		if comparisonTime.Add(timeoutForMachineToHaveNode.Duration).Before(now) {
+		if comparisonTime.Add(timeoutForMachineToHaveNode.Duration).Before(reconciliationTime) {
 			logger.V(3).Info("Target is unhealthy: machine has no node", "duration", timeoutDuration)
 			nodeTimeoutMessage := fmt.Sprintf("Node failed to report startup in %s", timeoutDuration)
 			return clusterv1.MachineHealthCheckNodeStartupTimeoutReason, clusterv1.NodeStartupTimeoutV1Beta1Reason, []string{nodeTimeoutMessage}, time.Duration(0)
 		}
 
-		durationUnhealthy := now.Sub(comparisonTime)
+		durationUnhealthy := reconciliationTime.Sub(comparisonTime)
 		nextCheck := timeoutDuration - durationUnhealthy + time.Second
 		return "", "", nil, nextCheck
 	}
@@ -273,7 +271,7 @@ func (t *healthCheckTarget) nodeChecks(logger logr.Logger, timeoutForMachineToHa
 		// timeout, mark as unhealthy and collect the message.
 		timeoutSecondsDuration := time.Duration(ptr.Deref(c.TimeoutSeconds, 0)) * time.Second
 
-		if nodeCondition.LastTransitionTime.Add(timeoutSecondsDuration).Before(now) {
+		if nodeCondition.LastTransitionTime.Add(timeoutSecondsDuration).Before(reconciliationTime) {
 			unhealthyNodeMessages = append(unhealthyNodeMessages, fmt.Sprintf("Condition %s on Node is reporting status %s with reason %s for more than %s",
 				c.Type, c.Status, nodeCondition.Reason, timeoutSecondsDuration.String()))
 			logger.V(3).Info(fmt.Sprintf("Target is unhealthy: Node condition is in unhealthy state more than %s", timeoutSecondsDuration.String()),
@@ -281,7 +279,7 @@ func (t *healthCheckTarget) nodeChecks(logger logr.Logger, timeoutForMachineToHa
 			continue
 		}
 
-		durationUnhealthy := now.Sub(nodeCondition.LastTransitionTime.Time)
+		durationUnhealthy := reconciliationTime.Sub(nodeCondition.LastTransitionTime.Time)
 		nextCheck := timeoutSecondsDuration - durationUnhealthy + time.Second
 		if nextCheck > 0 {
 			nextCheckTimes = append(nextCheckTimes, nextCheck)
@@ -384,7 +382,7 @@ func (r *Reconciler) getNodeFromMachine(ctx context.Context, clusterClient clien
 
 // healthCheckTargets health checks a slice of targets
 // and gives a data to measure the average health.
-func (r *Reconciler) healthCheckTargets(targets []healthCheckTarget, logger logr.Logger, timeoutForMachineToHaveNode metav1.Duration) ([]healthCheckTarget, []healthCheckTarget, []time.Duration) {
+func (r *Reconciler) healthCheckTargets(targets []healthCheckTarget, logger logr.Logger, reconciliationTime time.Time, timeoutForMachineToHaveNode metav1.Duration) ([]healthCheckTarget, []healthCheckTarget, []time.Duration) {
 	var nextCheckTimes []time.Duration
 	var unhealthy []healthCheckTarget
 	var healthy []healthCheckTarget
@@ -392,7 +390,7 @@ func (r *Reconciler) healthCheckTargets(targets []healthCheckTarget, logger logr
 	for _, t := range targets {
 		logger := logger.WithValues("Machine", klog.KObj(t.Machine), "Node", klog.KObj(t.Node))
 		logger.V(3).Info("Health checking target")
-		needsRemediation, nextCheck := t.needsRemediation(logger, timeoutForMachineToHaveNode)
+		needsRemediation, nextCheck := t.needsRemediation(logger, reconciliationTime, timeoutForMachineToHaveNode)
 
 		if needsRemediation {
 			unhealthy = append(unhealthy, t)

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets_test.go
@@ -265,9 +265,13 @@ func TestHealthCheckTargets(t *testing.T) {
 		},
 	}
 
+	// Truncating with 1s because e.g. conditions.Set also truncates to 1s. So truncating here makes the test cases
+	// below easier to reason through.
+	now := time.Now().Truncate(1 * time.Second)
+
 	testMachine := newTestMachine("machine1", namespace, clusterName, "node1", mhcSelector)
 	testMachineWithInfraReady := testMachine.DeepCopy()
-	testMachineWithInfraReady.CreationTimestamp = metav1.NewTime(time.Now().Add(-100 * time.Second))
+	testMachineWithInfraReady.CreationTimestamp = metav1.NewTime(now.Add(-100 * time.Second))
 	conditions.Set(testMachineWithInfraReady, metav1.Condition{Type: clusterv1.MachineInfrastructureReadyCondition, Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(testMachineWithInfraReady.CreationTimestamp.Add(50 * time.Second))})
 
 	nodeNotYetStartedTargetAndInfraReady := healthCheckTarget{
@@ -279,7 +283,7 @@ func TestHealthCheckTargets(t *testing.T) {
 
 	// Targets for when the node has not yet been seen by the Machine controller
 	testMachineCreated1200s := testMachine.DeepCopy()
-	nowMinus1200s := metav1.NewTime(time.Now().Add(-1200 * time.Second))
+	nowMinus1200s := metav1.NewTime(now.Add(-1200 * time.Second))
 	testMachineCreated1200s.CreationTimestamp = nowMinus1200s
 
 	nodeNotYetStartedTarget1200s := healthCheckTarget{
@@ -292,7 +296,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	nodeNotYetStartedTarget1200sV1Beta2Condition := newFailedHealthCheckCondition(clusterv1.MachineHealthCheckNodeStartupTimeoutReason, "Health check failed:\n  * Node failed to report startup in %s", timeoutForMachineToHaveNode)
 
 	testMachineCreated400s := testMachine.DeepCopy()
-	nowMinus400s := metav1.NewTime(time.Now().Add(-400 * time.Second))
+	nowMinus400s := metav1.NewTime(now.Add(-400 * time.Second))
 	testMachineCreated400s.CreationTimestamp = nowMinus400s
 
 	nodeNotYetStartedTarget400s := healthCheckTarget{
@@ -362,7 +366,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 
 	// Target for when the node has been in an unknown state for shorter than the timeout
-	testNodeUnknown200 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", 200*time.Second)
+	testNodeUnknown200 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", now, 200*time.Second)
 	nodeUnknown200 := healthCheckTarget{
 		Cluster:     cluster,
 		MHC:         testMHC,
@@ -372,7 +376,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 
 	// Second Target for when the node has been in an unknown state for shorter than the timeout
-	testNodeUnknown100 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", 100*time.Second)
+	testNodeUnknown100 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", now, 100*time.Second)
 	nodeUnknown100 := healthCheckTarget{
 		Cluster:     cluster,
 		MHC:         testMHC,
@@ -382,7 +386,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 
 	// Target for when the node has been in an unknown state for longer than the timeout
-	testNodeUnknown400 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", 400*time.Second)
+	testNodeUnknown400 := newTestUnhealthyNode("node1", corev1.NodeReady, corev1.ConditionUnknown, "NodeStatusUnknown", now, 400*time.Second)
 	nodeUnknown400 := healthCheckTarget{
 		Cluster:     cluster,
 		MHC:         testMHC,
@@ -405,7 +409,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 
 	// Machine unhealthy for shorter than timeout
-	testMachineUnhealthy200 := newTestUnhealthyMachine("machine1", namespace, clusterName, "node1", mhcSelector, controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachinePodFailedReason, 200*time.Second)
+	testMachineUnhealthy200 := newTestUnhealthyMachine("machine1", namespace, clusterName, "node1", mhcSelector, controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachinePodFailedReason, now, 200*time.Second)
 	machineUnhealthy200 := healthCheckTarget{
 		Cluster:     cluster,
 		MHC:         testMHC,
@@ -415,7 +419,7 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 
 	// Machine unhealthy for longer than timeout
-	testMachineUnhealthy400 := newTestUnhealthyMachine("machine1", namespace, clusterName, "node1", mhcSelector, controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachinePodFailedReason, 400*time.Second)
+	testMachineUnhealthy400 := newTestUnhealthyMachine("machine1", namespace, clusterName, "node1", mhcSelector, controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachinePodFailedReason, now, 400*time.Second)
 	machineUnhealthy400 := healthCheckTarget{
 		Cluster:     cluster,
 		MHC:         testMHC,
@@ -463,14 +467,14 @@ func TestHealthCheckTargets(t *testing.T) {
 			targets:                  []healthCheckTarget{nodeNotYetStartedTarget400s},
 			expectedHealthy:          []healthCheckTarget{},
 			expectedNeedsRemediation: []healthCheckTarget{},
-			expectedNextCheckTimes:   []time.Duration{timeoutForMachineToHaveNode - 400*time.Second},
+			expectedNextCheckTimes:   []time.Duration{timeoutForMachineToHaveNode - 400*time.Second + 1*time.Second},
 		},
 		{
 			desc:                     "when the node has not yet started for shorter than the timeout, and infra is ready",
 			targets:                  []healthCheckTarget{nodeNotYetStartedTargetAndInfraReady},
 			expectedHealthy:          []healthCheckTarget{},
 			expectedNeedsRemediation: []healthCheckTarget{},
-			expectedNextCheckTimes:   []time.Duration{timeoutForMachineToHaveNode - 50*time.Second},
+			expectedNextCheckTimes:   []time.Duration{timeoutForMachineToHaveNode - 50*time.Second + 1*time.Second},
 		},
 		{
 			desc:                                     "when the node has not yet started for longer than the timeout",
@@ -495,7 +499,7 @@ func TestHealthCheckTargets(t *testing.T) {
 			targets:                  []healthCheckTarget{nodeUnknown200},
 			expectedHealthy:          []healthCheckTarget{},
 			expectedNeedsRemediation: []healthCheckTarget{},
-			expectedNextCheckTimes:   []time.Duration{100 * time.Second},
+			expectedNextCheckTimes:   []time.Duration{100*time.Second + 1*time.Second},
 		},
 		{
 			desc:                                     "when the node has been in an unknown state for longer than the timeout",
@@ -511,7 +515,7 @@ func TestHealthCheckTargets(t *testing.T) {
 			targets:                  []healthCheckTarget{machineUnhealthy200},
 			expectedHealthy:          []healthCheckTarget{},
 			expectedNeedsRemediation: []healthCheckTarget{},
-			expectedNextCheckTimes:   []time.Duration{100 * time.Second}, // 300s timeout - 200s elapsed = 100s remaining
+			expectedNextCheckTimes:   []time.Duration{100*time.Second + 1*time.Second}, // 300s timeout - 200s elapsed + 1s = 100s remaining
 		},
 		{
 			desc:                                     "when the machine condition has been unhealthy for longer than the timeout",
@@ -536,7 +540,7 @@ func TestHealthCheckTargets(t *testing.T) {
 			expectedNeedsRemediation:                 []healthCheckTarget{nodeUnknown400},
 			expectedNeedsRemediationCondition:        []clusterv1.Condition{nodeUnknown400Condition},
 			expectedNeedsRemediationV1Beta2Condition: []metav1.Condition{nodeUnknown400V1Beta2Condition},
-			expectedNextCheckTimes:                   []time.Duration{200 * time.Second, 100 * time.Second},
+			expectedNextCheckTimes:                   []time.Duration{200*time.Second + 1*time.Second, 100*time.Second + 1*time.Second},
 		},
 		{
 			desc:                        "when the node has not started for a long time but the startup timeout is disabled",
@@ -589,17 +593,7 @@ func TestHealthCheckTargets(t *testing.T) {
 				timeout.Duration = *tc.timeoutForMachineToHaveNode
 			}
 
-			healthy, unhealthy, nextCheckTimes := reconciler.healthCheckTargets(tc.targets, ctrl.LoggerFrom(ctx), timeout)
-
-			// Round durations down to nearest second account for minute differences
-			// in timing when running tests
-			roundDurations := func(in []time.Duration) []time.Duration {
-				out := []time.Duration{}
-				for _, d := range in {
-					out = append(out, d.Truncate(time.Second))
-				}
-				return out
-			}
+			healthy, unhealthy, nextCheckTimes := reconciler.healthCheckTargets(tc.targets, ctrl.LoggerFrom(ctx), now, timeout)
 
 			// Remove the last transition time of the given conditions. Used for comparison with expected conditions.
 			removeLastTransitionTimes := func(in clusterv1.Conditions) clusterv1.Conditions {
@@ -624,7 +618,7 @@ func TestHealthCheckTargets(t *testing.T) {
 
 			gs.Expect(healthy).To(ConsistOf(tc.expectedHealthy))
 			gs.Expect(unhealthy).To(ConsistOf(tc.expectedNeedsRemediation))
-			gs.Expect(nextCheckTimes).To(WithTransform(roundDurations, ConsistOf(tc.expectedNextCheckTimes)))
+			gs.Expect(nextCheckTimes).To(ConsistOf(tc.expectedNextCheckTimes))
 			for i, expectedMachineCondition := range tc.expectedNeedsRemediationCondition {
 				actualConditions := unhealthy[i].Machine.GetV1Beta1Conditions()
 				conditionsMatcher := WithTransform(removeLastTransitionTimes, ContainElements(expectedMachineCondition))
@@ -681,7 +675,7 @@ func newTestNode(name string) *corev1.Node {
 	}
 }
 
-func newTestUnhealthyNode(name string, condition corev1.NodeConditionType, status corev1.ConditionStatus, reason string, unhealthyDuration time.Duration) *corev1.Node {
+func newTestUnhealthyNode(name string, condition corev1.NodeConditionType, status corev1.ConditionStatus, reason string, now time.Time, unhealthyDuration time.Duration) *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -693,14 +687,14 @@ func newTestUnhealthyNode(name string, condition corev1.NodeConditionType, statu
 					Type:               condition,
 					Status:             status,
 					Reason:             reason,
-					LastTransitionTime: metav1.NewTime(time.Now().Add(-unhealthyDuration)),
+					LastTransitionTime: metav1.NewTime(now.Add(-unhealthyDuration)),
 				},
 			},
 		},
 	}
 }
 
-func newTestUnhealthyMachine(name, namespace, clusterName, nodeName string, labels map[string]string, condition string, status metav1.ConditionStatus, reason string, unhealthyDuration time.Duration) *clusterv1.Machine {
+func newTestUnhealthyMachine(name, namespace, clusterName, nodeName string, labels map[string]string, condition string, status metav1.ConditionStatus, reason string, now time.Time, unhealthyDuration time.Duration) *clusterv1.Machine {
 	// Copy the labels so that the map is unique to each test Machine
 	l := make(map[string]string)
 	for k, v := range labels {
@@ -727,7 +721,7 @@ func newTestUnhealthyMachine(name, namespace, clusterName, nodeName string, labe
 					Type:               condition,
 					Status:             status,
 					Reason:             reason,
-					LastTransitionTime: metav1.NewTime(time.Now().Add(-unhealthyDuration)),
+					LastTransitionTime: metav1.NewTime(now.Add(-unhealthyDuration)),
 				},
 			},
 			Initialization: clusterv1.MachineInitializationStatus{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

xref: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-mink8s-main/2071370488285761536
```
{Failed  === RUN   TestHealthCheckTargets/when_the_node_has_not_yet_started_for_shorter_than_the_timeout,_and_infra_is_ready
I0628 23:17:15.000515   31541 machinehealthcheck_targets.go:403] "Target is likely to go unhealthy" Machine="test-mhc/machine1" Node="" timeUntilUnhealthy="9m9s"
    machinehealthcheck_targets_test.go:627: 
        Expected
            <[]time.Duration | len:1, cap:1>: [549000000000]
        to consist of
            <[]time.Duration | len:1, cap:1>: [550000000000]
        the missing elements were
            <[]time.Duration | len:1, cap:1>: [550000000000]
        the extra elements were
            <[]time.Duration | len:1, cap:1>: [549000000000]
--- FAIL: TestHealthCheckTargets/when_the_node_has_not_yet_started_for_shorter_than_the_timeout,_and_infra_is_ready (0.00s)
}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->