### PR TITLE
🌱 Report consistency errors in release note draft

### DIFF
--- a/hack/tools/release/notes/generator.go
+++ b/hack/tools/release/notes/generator.go
@@ -49,7 +49,7 @@ type pr struct {
 
 // prLister returns a list of PRs.
 type prLister interface {
-	listPRs(previousRelease ref) ([]pr, error)
+	listPRs(previousRelease ref) ([]pr, []string, error)
 }
 
 // notesEntry represents a line item for the release notes.
@@ -67,13 +67,13 @@ type prProcessor interface {
 // entriesPrinter formats and outputs to stdout the notes
 // based on a list of entries.
 type entriesPrinter interface {
-	print([]notesEntry, int, string, ref)
+	print([]notesEntry, int, string, ref, []string)
 }
 
 // run generating and prints the notes.
 func (g *notesGenerator) run(previousReleaseRef ref) error {
 	if previousReleaseRef.value != "" {
-		previousReleasePRs, err := g.lister.listPRs(previousReleaseRef)
+		previousReleasePRs, consistencyErrors, err := g.lister.listPRs(previousReleaseRef)
 		if err != nil {
 			return err
 		}
@@ -84,10 +84,10 @@ func (g *notesGenerator) run(previousReleaseRef ref) error {
 			return err
 		}
 
-		g.printer.print(previousEntries, len(previousReleasePRs), dependencies, previousReleaseRef)
+		g.printer.print(previousEntries, len(previousReleasePRs), dependencies, previousReleaseRef, consistencyErrors)
 	}
 
-	prs, err := g.lister.listPRs(ref{})
+	prs, consistencyErrors, err := g.lister.listPRs(ref{})
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func (g *notesGenerator) run(previousReleaseRef ref) error {
 	}
 
 	// Pass in length of PRs to printer as some PRs are excluded from the entries list
-	g.printer.print(entries, len(prs), dependencies, ref{})
+	g.printer.print(entries, len(prs), dependencies, ref{}, consistencyErrors)
 
 	return nil
 }

--- a/hack/tools/release/notes/github_test.go
+++ b/hack/tools/release/notes/github_test.go
@@ -156,3 +156,10 @@ func newMockGithubClientForInvalidRef() *mockGithubClient {
 	mock.diffError = fmt.Errorf("invalid ref")
 	return mock
 }
+
+// newMockGithubClientWithConsistencyErrors creates a mock client that simulates consistency errors.
+func newMockGithubClientWithConsistencyErrors() *mockGithubClient {
+	mock := newMockGithubClient()
+	mock.prsResponse = nil
+	return mock
+}

--- a/hack/tools/release/notes/list.go
+++ b/hack/tools/release/notes/list.go
@@ -24,8 +24,6 @@ import (
 	"log"
 	"regexp"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // githubFromToPRLister lists PRs from GitHub contained between two refs.
@@ -34,17 +32,15 @@ type githubFromToPRLister struct {
 	fromRef, toRef ref
 	// branch is optional. It helps optimize the PR query by restricting
 	// the results to PRs merged in the selected branch and in main
-	branch               string
-	skipConsistencyCheck bool
+	branch string
 }
 
-func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string, skipConsistencyCheck bool) *githubFromToPRLister {
+func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string) *githubFromToPRLister {
 	return &githubFromToPRLister{
-		client:               &githubClient{repo: repo},
-		fromRef:              fromRef,
-		toRef:                toRef,
-		branch:               branch,
-		skipConsistencyCheck: skipConsistencyCheck,
+		client:  &githubClient{repo: repo},
+		fromRef: fromRef,
+		toRef:   toRef,
+		branch:  branch,
 	}
 }
 
@@ -56,7 +52,7 @@ func newGithubFromToPRLister(repo string, fromRef, toRef ref, branch string, ski
 // between fromRef and toRef, discarding any PR not seeing in the commits list.
 // This ensures we don't include any PR merged in the same date range that
 // doesn't belong to our git timeline.
-func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
+func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, []string, error) {
 	var (
 		diff *githubDiff
 		err  error
@@ -69,13 +65,13 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 		diff, err = l.client.getDiffAllCommits(l.fromRef.value, l.toRef.value)
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	log.Printf("Reading ref %s for upper limit", l.toRef)
 	toRef, err := l.client.getRef(l.toRef.String())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var toCommitSHA string
@@ -83,7 +79,7 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 		log.Printf("Reading tag info %s for upper limit", toRef.Object.SHA)
 		toTag, err := l.client.getTag(toRef.Object.SHA)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		toCommitSHA = toTag.Object.SHA
 	} else {
@@ -93,7 +89,7 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 	log.Printf("Reading commit %s for upper limit", toCommitSHA)
 	toCommit, err := l.client.getCommit(toCommitSHA)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	fromDate := diff.MergeBaseCommit.Commit.Committer.Date
@@ -109,7 +105,7 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 	// need the PRs from other release branches.
 	gPRs, err := l.client.listMergedPRs(fromDate, toDate, l.branch, "main")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	log.Printf("Found %d PRs in github", len(gPRs))
@@ -136,20 +132,18 @@ func (l *githubFromToPRLister) listPRs(previousReleaseRef ref) ([]pr, error) {
 	}
 
 	// Report consistency problems
+	var consistencyErrors []string
 	for sp, found := range selectedPRNumbers {
 		if found {
 			continue
 		}
+		consistencyErrors = append(consistencyErrors, fmt.Sprintf("PR number %s identified from commits, not found in the PR list", sp))
 		log.Printf("PR number %s identified from commits, not found in the PR list", sp)
 	}
 
 	log.Printf("%d PRs match the commits from the git diff", len(prs))
 
-	if len(prs) != len(selectedPRNumbers) && !l.skipConsistencyCheck {
-		return nil, errors.Errorf("expected %d PRs from commit list but only found %d", len(selectedPRNumbers), len(prs))
-	}
-
-	return prs, nil
+	return prs, consistencyErrors, nil
 }
 
 var (

--- a/hack/tools/release/notes/list_test.go
+++ b/hack/tools/release/notes/list_test.go
@@ -79,11 +79,12 @@ func Test_buildSetOfPRNumbers(t *testing.T) {
 
 func Test_githubFromToPRLister_listPRs(t *testing.T) {
 	tests := []struct {
-		name    string
-		lister  *githubFromToPRLister
-		args    ref
-		want    []pr
-		wantErr bool
+		name                 string
+		lister               *githubFromToPRLister
+		args                 ref
+		want                 []pr
+		wantConsistencyError []string
+		wantErr              bool
 	}{
 		{
 			name: "Successful PR Listing",
@@ -181,16 +182,33 @@ func Test_githubFromToPRLister_listPRs(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "Successful PR Listing",
+			lister: newGithubFromToPRListerWithClient(
+				newMockGithubClientWithConsistencyErrors(),
+				ref{reType: "tags", value: "v0.26.0"},
+				ref{reType: "tags", value: "v0.27.0"},
+				"main",
+			),
+			args: ref{
+				reType: "tags",
+				value:  "v0.26.0",
+			},
+			want:                 []pr{},
+			wantConsistencyError: []string{"PR number 1234 identified from commits, not found in the PR list"},
+			wantErr:              false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			got, err := tt.lister.listPRs(tt.args)
+			got, gotConsistencyError, err := tt.lister.listPRs(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("githubFromToPRLister.listPRs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			g.Expect(got).To(Equal(tt.want))
+			g.Expect(gotConsistencyError).To(Equal(tt.wantConsistencyError))
 		})
 	}
 }

--- a/hack/tools/release/notes/main.go
+++ b/hack/tools/release/notes/main.go
@@ -66,7 +66,6 @@ type notesCmdConfig struct {
 	previousReleaseVersion      string
 	prefixAreaLabel             bool
 	deprecation                 bool
-	skipConsistencyCheck        bool
 	addKubernetesVersionSupport bool
 }
 
@@ -84,7 +83,6 @@ func readCmdConfig() *notesCmdConfig {
 	flag.BoolVar(&config.prefixAreaLabel, "prefix-area-label", true, "If enabled, will prefix the area label.")
 	flag.BoolVar(&config.deprecation, "deprecation", true, "If enabled, will add a templated deprecation warning header.")
 	flag.BoolVar(&config.addKubernetesVersionSupport, "add-kubernetes-version-support", true, "If enabled, will add the Kubernetes version support header.")
-	flag.BoolVar(&config.skipConsistencyCheck, "skip-consistency-check", false, "If enabled, the tool will skip the check about consistency between PRs and commits from the git diff.")
 
 	flag.Parse()
 
@@ -129,7 +127,7 @@ func (cmd *notesCmd) run() error {
 	printer.printKubernetesSupport = cmd.config.addKubernetesVersionSupport
 
 	generator := newNotesGenerator(
-		newGithubFromToPRLister(cmd.config.repo, from, to, cmd.config.branch, cmd.config.skipConsistencyCheck),
+		newGithubFromToPRLister(cmd.config.repo, from, to, cmd.config.branch),
 		newPREntryProcessor(cmd.config.prefixAreaLabel),
 		printer,
 		newDependenciesProcessor(cmd.config.repo, from.value, to.value),

--- a/hack/tools/release/notes/print.go
+++ b/hack/tools/release/notes/print.go
@@ -60,7 +60,7 @@ func newReleaseNotesPrinter(repo, fromTag string) *releaseNotesPrinter {
 }
 
 // print outputs to stdout the release notes.
-func (p *releaseNotesPrinter) print(entries []notesEntry, commitsInRelease int, dependencies string, previousReleaseRef ref) {
+func (p *releaseNotesPrinter) print(entries []notesEntry, commitsInRelease int, dependencies string, previousReleaseRef ref, consistencyErrors []string) {
 	merges := map[string][]string{
 		release.Features:      {},
 		release.Bugs:          {},
@@ -81,6 +81,14 @@ func (p *releaseNotesPrinter) print(entries []notesEntry, commitsInRelease int, 
 	if p.releaseType != "" && !isPreReleasePrinted {
 		fmt.Printf("🚨 This is a %s. Use it only for testing purposes. If you find any bugs, file an [issue](https://github.com/%s/issues/new).\n", p.releaseType, p.repo)
 		isPreReleasePrinted = true
+	}
+
+	if len(consistencyErrors) > 0 {
+		fmt.Println("## FIXME: Consistency errors!")
+		for _, err := range consistencyErrors {
+			fmt.Println(err)
+		}
+		fmt.Println()
 	}
 
 	if p.releaseType != "" && previousReleaseRef.value == "" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
As of today release note generation implement a consistency check between commits and PRs, and it case it fails release note generation fails which might be annoying during a release.

This PR changes this behaviour by removing the hard error, and replacing with a FIXME note in the generated release note draft.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->