### PR TITLE
✨ clusterctl: allow overriding management cluster client QPS and Burst

### DIFF
--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -47,6 +47,18 @@ var (
 	localScheme = scheme.Scheme
 )
 
+const (
+	// defaultKubeAPIQPS is the default QPS for the clusterctl management cluster client.
+	defaultKubeAPIQPS = 20
+	// defaultKubeAPIBurst is the default Burst for the clusterctl management cluster client.
+	defaultKubeAPIBurst = 100
+
+	// KubeAPIQPSEnvVar is the environment variable used to override the QPS of the clusterctl management cluster client.
+	KubeAPIQPSEnvVar = "CLUSTERCTL_KUBE_API_QPS"
+	// KubeAPIBurstEnvVar is the environment variable used to override the Burst of the clusterctl management cluster client.
+	KubeAPIBurstEnvVar = "CLUSTERCTL_KUBE_API_BURST"
+)
+
 // Proxy defines a client proxy interface.
 type Proxy interface {
 	// GetConfig returns the rest.Config
@@ -152,9 +164,18 @@ func (k *proxy) GetConfig() (*rest.Config, error) {
 	}
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
-	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go doesn't generate throttling log messages
-	restConfig.QPS = 20
-	restConfig.Burst = 100
+	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go doesn't generate throttling log messages.
+	// The defaults can be overridden via the CLUSTERCTL_KUBE_API_QPS and CLUSTERCTL_KUBE_API_BURST environment variables. This is
+	// useful for management clusters with a large number of CRDs (for example Azure Service Operator), where clusterctl move and
+	// upgrade would otherwise exhaust the client-side rate limiter while enumerating API resources.
+	restConfig.QPS = defaultKubeAPIQPS
+	if qps, err := strconv.ParseFloat(os.Getenv(KubeAPIQPSEnvVar), 32); err == nil && qps > 0 {
+		restConfig.QPS = float32(qps)
+	}
+	restConfig.Burst = defaultKubeAPIBurst
+	if burst, err := strconv.Atoi(os.Getenv(KubeAPIBurstEnvVar)); err == nil && burst > 0 {
+		restConfig.Burst = burst
+	}
 
 	restConfig.WarningHandler = k.warningHandler
 

--- a/cmd/clusterctl/client/cluster/proxy_test.go
+++ b/cmd/clusterctl/client/cluster/proxy_test.go
@@ -127,6 +127,40 @@ func TestProxyGetConfig(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("configure QPS and Burst via env vars", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv(KubeAPIQPSEnvVar, "50")
+		t.Setenv(KubeAPIBurstEnvVar, "250")
+
+		dir := t.TempDir()
+		configFile := filepath.Join(dir, ".test-kubeconfig.yaml")
+		g.Expect(os.WriteFile(configFile, []byte(kubeconfig("management", "default")), 0600)).To(Succeed())
+
+		proxy := NewProxy(Kubeconfig{Path: configFile, Context: "management"})
+		conf, err := proxy.GetConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(conf).ToNot(BeNil())
+		g.Expect(conf.QPS).To(BeEquivalentTo(50))
+		g.Expect(conf.Burst).To(BeEquivalentTo(250))
+	})
+
+	t.Run("falls back to defaults when QPS and Burst env vars are invalid", func(t *testing.T) {
+		g := NewWithT(t)
+		t.Setenv(KubeAPIQPSEnvVar, "not-a-number")
+		t.Setenv(KubeAPIBurstEnvVar, "-1")
+
+		dir := t.TempDir()
+		configFile := filepath.Join(dir, ".test-kubeconfig.yaml")
+		g.Expect(os.WriteFile(configFile, []byte(kubeconfig("management", "default")), 0600)).To(Succeed())
+
+		proxy := NewProxy(Kubeconfig{Path: configFile, Context: "management"})
+		conf, err := proxy.GetConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(conf).ToNot(BeNil())
+		g.Expect(conf.QPS).To(BeEquivalentTo(20))
+		g.Expect(conf.Burst).To(BeEquivalentTo(100))
+	})
 }
 
 // These tests are emulating the files passed in via KUBECONFIG env var by

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -298,3 +298,16 @@ If you do not want to use the flag every time you issue a command you can set th
 ## Skip checking for updates
 
 `clusterctl` automatically checks for new versions every time it is used. If you do not want `clusterctl` to check for new updates you can set the environment variable `CLUSTERCTL_DISABLE_VERSIONCHECK` to `"true"` or set the variable in the `clusterctl` config file located by default at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`.
+
+## Tuning the management cluster client rate limiter
+
+When `clusterctl` talks to the management cluster it uses a client-side rate limiter. The defaults (QPS `20`, Burst `100`) are sufficient for most clusters, but operations such as `clusterctl move` and `clusterctl upgrade` enumerate every API resource on the cluster. On management clusters with a very large number of CRDs (for example when using [Azure Service Operator](https://azure.github.io/azure-service-operator/)) this can exhaust the rate limiter and fail with `client rate limiter Wait returned an error: context deadline exceeded`.
+
+You can raise the limits with the `CLUSTERCTL_KUBE_API_QPS` and `CLUSTERCTL_KUBE_API_BURST` environment variables:
+
+```bash
+export CLUSTERCTL_KUBE_API_QPS=50
+export CLUSTERCTL_KUBE_API_BURST=250
+```
+
+Invalid or non-positive values are ignored and the defaults are used.


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterctl move` and `clusterctl upgrade` enumerate every API resource on the management cluster. On clusters with a large number of CRDs (for example when using Azure Service Operator) this can exhaust the proxy client's hardcoded client-side rate limiter and fail with `client rate limiter Wait returned an error: context deadline exceeded`.

This makes the QPS and Burst configurable via the `CLUSTERCTL_KUBE_API_QPS` and `CLUSTERCTL_KUBE_API_BURST` environment variables, keeping the current values (20 / 100) as defaults. Invalid or non-positive values are ignored.

**Which issue(s) this PR fixes**:
Fixes #13867

/area clusterctl
