### PR TITLE
🌱 Follow-ups for Surface aggregated machine versions in status

### DIFF
--- a/api/core/v1beta1/common_types.go
+++ b/api/core/v1beta1/common_types.go
@@ -269,7 +269,7 @@ type StatusVersion struct {
 	Version string `json:"version,omitempty"`
 
 	// replicas is the number of replicas at this version.
-	// +required
+	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas,omitempty"`
 }

--- a/api/core/v1beta2/common_types.go
+++ b/api/core/v1beta2/common_types.go
@@ -276,7 +276,7 @@ type StatusVersion struct {
 	Version string `json:"version,omitempty"`
 
 	// replicas is the number of replicas at this version.
-	// +required
+	// +optional
 	// +kubebuilder:validation:Minimum=1
 	Replicas int32 `json:"replicas,omitempty"`
 }

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1739,7 +1739,6 @@ spec:
                               minLength: 1
                               type: string
                           required:
-                          - replicas
                           - version
                           type: object
                         maxItems: 100
@@ -1801,7 +1800,6 @@ spec:
                               minLength: 1
                               type: string
                           required:
-                          - replicas
                           - version
                           type: object
                         maxItems: 100
@@ -3570,7 +3568,6 @@ spec:
                           minLength: 1
                           type: string
                       required:
-                      - replicas
                       - version
                       type: object
                     maxItems: 100
@@ -3786,7 +3783,6 @@ spec:
                           minLength: 1
                           type: string
                       required:
-                      - replicas
                       - version
                       type: object
                     maxItems: 100

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -845,7 +845,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100
@@ -1709,7 +1708,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -697,7 +697,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100
@@ -1437,7 +1436,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -737,7 +737,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100
@@ -1503,7 +1502,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2850,7 +2850,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100
@@ -5984,7 +5983,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                  - replicas
                   - version
                   type: object
                 maxItems: 100

--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -1146,6 +1146,17 @@ func reconcileMachineUpToDateCondition(_ context.Context, controlPlane *internal
 			continue
 		}
 
+		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" && machine.Status.NodeInfo.KubeletVersion != machine.Spec.Version {
+			conditions.Set(machine, metav1.Condition{
+				Type:   clusterv1.MachineUpToDateCondition,
+				Status: metav1.ConditionFalse,
+				Reason: clusterv1.MachineUpToDateUpdatingReason,
+				Message: fmt.Sprintf("* Node.status.nodeInfo.kubeletVersion %s, %s required",
+					machine.Status.NodeInfo.KubeletVersion, machine.Spec.Version),
+			})
+			continue
+		}
+
 		conditions.Set(machine, metav1.Condition{
 			Type:   clusterv1.MachineUpToDateCondition,
 			Status: metav1.ConditionTrue,

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -2538,6 +2538,95 @@ func TestKubeadmControlPlaneReconciler_reconcileControlPlaneAndMachinesCondition
 			},
 		},
 		{
+			name: "Machines.spec.version out of sync with kubeletVersion, machine not up-to-date date",
+			controlPlane: func() *internal.ControlPlane {
+				controlPlane, err := internal.NewControlPlane(ctx, nil, env.GetClient(), defaultCluster, defaultKCP.DeepCopy(), collections.FromMachines(
+					func() *clusterv1.Machine {
+						m := defaultMachine1.DeepCopy()
+						m.Status.NodeInfo = &corev1.NodeSystemInfo{KubeletVersion: "v1.30.0"}
+						return m
+					}(),
+				))
+				if err != nil {
+					panic(err)
+				}
+				return controlPlane
+			}(),
+			managementCluster: &fakeManagementCluster{
+				Workload: &fakeWorkloadCluster{
+					Workload: &internal.Workload{
+						Client: fake.NewClientBuilder().Build(),
+					},
+				},
+			},
+			lastProbeSuccessTime: now.Add(-3 * time.Minute),
+			expectKCPConditions: []metav1.Condition{
+				{
+					Type:   controlplanev1.KubeadmControlPlaneInitializedCondition,
+					Status: metav1.ConditionTrue,
+					Reason: controlplanev1.KubeadmControlPlaneInitializedReason,
+				},
+				{
+					Type:   controlplanev1.KubeadmControlPlaneEtcdClusterHealthyCondition,
+					Status: metav1.ConditionUnknown,
+					Reason: controlplanev1.KubeadmControlPlaneEtcdClusterHealthUnknownReason,
+					Message: "* Machine machine1-test:\n" +
+						"  * EtcdMemberHealthy: Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:   controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthyCondition,
+					Status: metav1.ConditionUnknown,
+					Reason: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthUnknownReason,
+					Message: "* Machine machine1-test:\n" +
+						"  * Control plane components: Waiting for a Node with spec.providerID foo to exist",
+				},
+			},
+			expectMachineConditions: []metav1.Condition{
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineNodeKubeadmLabelsAndTaintsSetCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachineNodeKubeadmLabelsAndTaintsInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachinePodInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachinePodInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineSchedulerPodHealthyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachinePodInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachinePodInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition,
+					Status:  metav1.ConditionUnknown,
+					Reason:  controlplanev1.KubeadmControlPlaneMachineEtcdMemberInspectionFailedReason,
+					Message: "Waiting for a Node with spec.providerID foo to exist",
+				},
+				{
+					Type:    clusterv1.MachineUpToDateCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  clusterv1.MachineUpToDateUpdatingReason,
+					Message: "* Node.status.nodeInfo.kubeletVersion v1.30.0, v1.31.0 required",
+				},
+			},
+		},
+		{
 			name: "Machines not up to date",
 			controlPlane: func() *internal.ControlPlane {
 				controlPlane, err := internal.NewControlPlane(ctx, nil, env.GetClient(), defaultCluster, defaultKCP.DeepCopy(), collections.FromMachines(

--- a/docs/book/src/developer/providers/contracts/control-plane.md
+++ b/docs/book/src/developer/providers/contracts/control-plane.md
@@ -412,7 +412,8 @@ at least one of the following fields.
 
 `status.versions` is the preferred source of truth for surfacing control plane versions.
 Entries in this list MUST be ordered from the older to the newer version.
-Each entry MUST include a valid semantic version and the number of replicas at that version.
+Each entry MUST include a valid semantic version and if control of the number of replicas is supported
+the number of replicas at that version must be set as well.
 
 ```go
 type FooControlPlaneStatus struct {

--- a/docs/book/src/reference/api/crd-api-reference-v1beta1.md
+++ b/docs/book/src/reference/api/crd-api-reference-v1beta1.md
@@ -3575,7 +3575,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | version is the Kubernetes version. |  | MaxLength: 256 <br />MinLength: 1 <br />Required: \{\} <br /> |
-| `replicas` _integer_ | replicas is the number of replicas at this version. |  | Minimum: 1 <br />Required: \{\} <br /> |
+| `replicas` _integer_ | replicas is the number of replicas at this version. |  | Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### Topology

--- a/docs/book/src/reference/api/crd-api-reference.md
+++ b/docs/book/src/reference/api/crd-api-reference.md
@@ -4600,7 +4600,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _string_ | version is the Kubernetes version. |  | MaxLength: 256 <br />MinLength: 1 <br />Required: \{\} <br /> |
-| `replicas` _integer_ | replicas is the number of replicas at this version. |  | Minimum: 1 <br />Required: \{\} <br /> |
+| `replicas` _integer_ | replicas is the number of replicas at this version. |  | Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### Topology

--- a/hack/tools/runtime-openapi-gen/api/core/v1beta2/zz_generated.openapi.go
+++ b/hack/tools/runtime-openapi-gen/api/core/v1beta2/zz_generated.openapi.go
@@ -6991,7 +6991,7 @@ func schema_cluster_api_api_core_v1beta2_StatusVersion(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"version", "replicas"},
+				Required: []string{"version"},
 			},
 		},
 	}

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -91,6 +91,12 @@ func (v *StatusVersions) Get(obj *unstructured.Unstructured) ([]clusterv1.Status
 func (v *StatusVersions) Set(obj *unstructured.Unstructured, value []clusterv1.StatusVersion) error {
 	interfaces := make([]interface{}, 0, len(value))
 	for _, statusVersion := range value {
+		if statusVersion.Replicas == 0 {
+			interfaces = append(interfaces, map[string]interface{}{
+				"version": statusVersion.Version,
+			})
+			continue
+		}
 		interfaces = append(interfaces, map[string]interface{}{
 			"version":  statusVersion.Version,
 			"replicas": int64(statusVersion.Replicas),
@@ -291,6 +297,9 @@ func (c *ControlPlaneContract) IsProvisioning(obj *unstructured.Unstructured) (b
 // - at least one status.versions entry is not at spec.version.
 // - if status.versions does not exist, spec.version is greater than status.version.
 // Note: A control plane is considered not upgrading if the status or status.versions/status.version is not set.
+// Note: status.versions are computed by Machine.status.nodeInfo.kubeletVersion and Machine.spec.version. kubeletVersion
+// has the higher priority and accordingly during in-place upgrades IsUpgrading returns true until the kubelet also reports
+// the new version.
 func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool, error) {
 	specVersion, err := c.Version().Get(obj)
 	if err != nil {
@@ -307,9 +316,8 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 	}
 	if err == nil && len(statusVersions) > 0 {
 		for _, statusVersion := range statusVersions {
-			if statusVersion.Replicas == 0 {
-				continue
-			}
+			// Note: IsUpgrading should return true even if no replicas are reported, because
+			// not all control plane providers support replicas.
 			statusV, err := semver.ParseTolerant(statusVersion.Version)
 			if err != nil {
 				return false, errors.Wrap(err, "failed to parse control plane status version")

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -293,7 +293,7 @@ func (c *ControlPlaneContract) IsProvisioning(obj *unstructured.Unstructured) (b
 	// time by looking at controlplane.status.versions (or status.version as fallback). If the version in status is set to a valid
 	// value then the control plane was already provisioned at a previous time. If not, we can
 	// assume that the control plane is being created for the first time.
-	statusVersion, err := c.currentStatusVersion(obj)
+	statusVersion, err := c.CurrentStatusVersion(obj)
 	if err != nil {
 		if errors.Is(err, ErrFieldNotFound) {
 			return true, nil
@@ -364,7 +364,8 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 	return version.Compare(specV, statusV, version.WithBuildTags()) >= 1, nil
 }
 
-func (c *ControlPlaneContract) currentStatusVersion(obj *unstructured.Unstructured) (*string, error) {
+// CurrentStatusVersion provides access to the .status.version(s) fields in a ControlPlane object status, if any.
+func (c *ControlPlaneContract) CurrentStatusVersion(obj *unstructured.Unstructured) (*string, error) {
 	statusVersions, err := c.StatusVersions().Get(obj)
 	if err != nil && !errors.Is(err, ErrFieldNotFound) {
 		return nil, err

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -47,7 +47,7 @@ func (v *StatusVersions) Path() Path {
 
 // Get gets the status versions value.
 func (v *StatusVersions) Get(obj *unstructured.Unstructured) ([]clusterv1.StatusVersion, error) {
-	items, ok, err := unstructured.NestedSlice(obj.UnstructuredContent(), v.path...)
+	slice, ok, err := unstructured.NestedSlice(obj.UnstructuredContent(), v.path...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get %s from object", "."+strings.Join(v.path, "."))
 	}
@@ -55,54 +55,34 @@ func (v *StatusVersions) Get(obj *unstructured.Unstructured) ([]clusterv1.Status
 		return nil, errors.Wrapf(ErrFieldNotFound, "path %s", "."+strings.Join(v.path, "."))
 	}
 
-	versions := make([]clusterv1.StatusVersion, 0, len(items))
-	var previousVersion semver.Version
-	var previousVersionValue string
-	for i, item := range items {
-		itemMap, ok := item.(map[string]interface{})
-		if !ok {
-			return nil, errors.Errorf("failed to cast %s[%d] from object", "."+strings.Join(v.path, "."), i)
-		}
-		versionValue, ok := itemMap["version"].(string)
-		if !ok || versionValue == "" {
-			return nil, errors.Errorf("failed to cast %s[%d].version from object", "."+strings.Join(v.path, "."), i)
-		}
-		parsedVersion, err := semver.ParseTolerant(versionValue)
+	versions := make([]clusterv1.StatusVersion, len(slice))
+	s, err := json.Marshal(slice)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshall field at %s to json", "."+strings.Join(v.path, "."))
+	}
+	err = json.Unmarshal(s, &versions)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshall field at %s to json", "."+strings.Join(v.path, "."))
+	}
+
+	var previousParsedVersion semver.Version
+	var previousVersion string
+	for i, currentVersion := range versions {
+		currentParsedVersion, err := semver.ParseTolerant(currentVersion.Version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse %s[%d].version from object", "."+strings.Join(v.path, "."), i)
 		}
-		if i > 0 {
-			switch version.Compare(previousVersion, parsedVersion, version.WithBuildTags()) {
-			case -1, 0, 2:
-			default:
-				return nil, errors.Errorf("version %q and %q are in the wrong order", previousVersionValue, versionValue)
-			}
+
+		if previousVersion != "" && version.Compare(currentParsedVersion, previousParsedVersion, version.WithBuildTags()) < 0 {
+			return nil, errors.Errorf("version %q and %q are in the wrong order", previousVersion, currentVersion.Version)
 		}
-		statusVersion := clusterv1.StatusVersion{Version: versionValue}
-		replicasValue, ok := itemMap["replicas"]
-		if !ok {
-			return nil, errors.Errorf("failed to cast %s[%d].replicas from object", "."+strings.Join(v.path, "."), i)
-		}
-		var replicas int32
-		switch replicasTyped := replicasValue.(type) {
-		case float64:
-			replicas = int32(replicasTyped)
-		case int64:
-			replicas = int32(replicasTyped)
-		case int32:
-			replicas = replicasTyped
-		case int:
-			replicas = int32(replicasTyped)
-		default:
-			return nil, errors.Errorf("failed to cast %s[%d].replicas from object", "."+strings.Join(v.path, "."), i)
-		}
-		if replicas < 0 {
+
+		if currentVersion.Replicas < 0 {
 			return nil, errors.Errorf("%s[%d].replicas must not be negative", "."+strings.Join(v.path, "."), i)
 		}
-		statusVersion.Replicas = replicas
-		versions = append(versions, statusVersion)
-		previousVersion = parsedVersion
-		previousVersionValue = versionValue
+
+		previousParsedVersion = currentParsedVersion
+		previousVersion = currentVersion.Version
 	}
 	return versions, nil
 }

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -805,7 +805,7 @@ func TestControlPlaneIsUpgrading(t *testing.T) {
 			wantUpgrading: true,
 		},
 		{
-			name: "should return false if status.versions entry not at spec.version has zero replicas",
+			name: "should return true if status.versions entry not at spec.version has zero replicas",
 			obj: &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"version": "v1.2.3",
@@ -823,7 +823,26 @@ func TestControlPlaneIsUpgrading(t *testing.T) {
 					},
 				},
 			}},
-			wantUpgrading: false,
+			wantUpgrading: true,
+		},
+		{
+			name: "should return true if status.versions entry not at spec.version without replicas set",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+				"status": map[string]interface{}{
+					"versions": []interface{}{
+						map[string]interface{}{
+							"version": "v1.2.2",
+						},
+						map[string]interface{}{
+							"version": "v1.2.3",
+						},
+					},
+				},
+			}},
+			wantUpgrading: true,
 		},
 		{
 			name: "should return false if status.versions entry is newer than spec.version",

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -914,22 +914,6 @@ func TestControlPlaneIsUpgrading(t *testing.T) {
 			wantUpgrading: true,
 		},
 		{
-			name: "should return error if status.versions replicas is missing",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"version": "v1.2.3",
-				},
-				"status": map[string]interface{}{
-					"versions": []interface{}{
-						map[string]interface{}{
-							"version": "v1.2.3",
-						},
-					},
-				},
-			}},
-			wantErr: true,
-		},
-		{
 			name: "should return error if status.versions replicas is negative",
 			obj: &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{

--- a/internal/controllers/machine/machine_controller_status.go
+++ b/internal/controllers/machine/machine_controller_status.go
@@ -723,6 +723,17 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 		return
 	}
 
+	if m.Status.NodeInfo != nil && m.Status.NodeInfo.KubeletVersion != "" && m.Status.NodeInfo.KubeletVersion != m.Spec.Version {
+		conditions.Set(m, metav1.Condition{
+			Type:   clusterv1.MachineUpToDateCondition,
+			Status: metav1.ConditionFalse,
+			Reason: clusterv1.MachineUpToDateUpdatingReason,
+			Message: fmt.Sprintf("* Node.status.nodeInfo.kubeletVersion %s, %s required",
+				m.Status.NodeInfo.KubeletVersion, m.Spec.Version),
+		})
+		return
+	}
+
 	conditions.Set(m, metav1.Condition{
 		Type:   clusterv1.MachineUpToDateCondition,
 		Status: metav1.ConditionTrue,

--- a/internal/controllers/machine/machine_controller_status_test.go
+++ b/internal/controllers/machine/machine_controller_status_test.go
@@ -1552,6 +1552,43 @@ func TestSetUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "kubeletVersion out of sync",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version: "v1.31.0",
+				},
+				Status: clusterv1.MachineStatus{
+					NodeInfo: &corev1.NodeSystemInfo{
+						KubeletVersion: "v1.30.0",
+					},
+				},
+			},
+			expectCondition: &metav1.Condition{
+				Type:    clusterv1.MachineUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineUpToDateUpdatingReason,
+				Message: "* Node.status.nodeInfo.kubeletVersion v1.30.0, v1.31.0 required",
+			},
+		},
+		{
 			name: "updating (message from Updating)",
 			machineDeployment: &clusterv1.MachineDeployment{
 				Spec: clusterv1.MachineDeploymentSpec{

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -84,17 +84,27 @@ func VersionsFromMachines(machines []*clusterv1.Machine) []clusterv1.StatusVersi
 	versionIndexes := map[string]int{}
 	versions := []orderedStatusVersion{}
 	for _, machine := range sortedMachines {
-		if machine == nil || machine.Spec.Version == "" {
+		if machine == nil {
 			continue
 		}
-		if index, ok := versionIndexes[machine.Spec.Version]; ok {
+
+		version := machine.Spec.Version
+		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" {
+			version = machine.Status.NodeInfo.KubeletVersion
+		}
+
+		if version == "" {
+			continue
+		}
+
+		if index, ok := versionIndexes[version]; ok {
 			versions[index].Replicas++
 			continue
 		}
-		versionIndexes[machine.Spec.Version] = len(versions)
+		versionIndexes[version] = len(versions)
 		versions = append(versions, orderedStatusVersion{
 			StatusVersion: clusterv1.StatusVersion{
-				Version:  machine.Spec.Version,
+				Version:  version,
 				Replicas: 1,
 			},
 			order: len(versions),

--- a/internal/util/version/version_test.go
+++ b/internal/util/version/version_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -91,13 +92,18 @@ func TestVersionsFromMachines(t *testing.T) {
 		g := NewWithT(t)
 
 		machines := []*clusterv1.Machine{
+			nil,
+			{},
 			{Spec: clusterv1.MachineSpec{Version: "v1.32.0"}},
 			{Spec: clusterv1.MachineSpec{Version: "v1.31.1"}},
 			{Spec: clusterv1.MachineSpec{Version: "v1.31.1"}},
+			{Spec: clusterv1.MachineSpec{Version: "v1.31.1"}, Status: clusterv1.MachineStatus{NodeInfo: &corev1.NodeSystemInfo{KubeletVersion: "v1.30.0"}}},
+			{Spec: clusterv1.MachineSpec{Version: "v1.31.1"}, Status: clusterv1.MachineStatus{NodeInfo: &corev1.NodeSystemInfo{KubeletVersion: "v1.31.1"}}},
 		}
 
 		g.Expect(VersionsFromMachines(machines)).To(Equal([]clusterv1.StatusVersion{
-			{Version: "v1.31.1", Replicas: 2},
+			{Version: "v1.30.0", Replicas: 1},
+			{Version: "v1.31.1", Replicas: 3},
 			{Version: "v1.32.0", Replicas: 1},
 		}))
 	})

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -1202,34 +1202,28 @@ func clusterConditionShowsHookBlocking(cluster *clusterv1.Cluster, hookName stri
 func waitControlPlaneVersion(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, version string, intervals []interface{}) {
 	Byf("Waiting for control plane to have version %s", version)
 
-	Eventually(func(_ Gomega) bool {
+	Eventually(func(g Gomega) bool {
 		controlPlane, err := external.GetObjectFromContractVersionedRef(ctx, c, cluster.Spec.ControlPlaneRef, cluster.Namespace)
-		if err != nil {
-			return false
-		}
+		g.Expect(err).ToNot(HaveOccurred())
+
 		v, err := contract.ControlPlane().Version().Get(controlPlane)
-		if err != nil {
-			return false
-		}
+		g.Expect(err).ToNot(HaveOccurred())
 		if *v != version {
 			return false
 		}
 
-		sv, err := contract.ControlPlane().StatusVersion().Get(controlPlane)
-		if err != nil {
-			return false
-		}
+		sv, err := contract.ControlPlane().CurrentStatusVersion(controlPlane)
+		g.Expect(err).ToNot(HaveOccurred())
 		if *sv != version {
 			return false
 		}
 
 		machineList := &clusterv1.MachineList{}
-		if err := c.List(ctx, machineList, client.InNamespace(cluster.Namespace), client.MatchingLabels{
+		err = c.List(ctx, machineList, client.InNamespace(cluster.Namespace), client.MatchingLabels{
 			clusterv1.ClusterNameLabel:         cluster.Name,
 			clusterv1.MachineControlPlaneLabel: "",
-		}); err != nil {
-			return false
-		}
+		})
+		g.Expect(err).ToNot(HaveOccurred())
 
 		for i := range machineList.Items {
 			machine := &machineList.Items[i]


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Did some additional testing and realized we should make a few improvements:
* Made StatusVersion.replicas optional to also support control plane providers without replicas (e.g. managed control planes)
* If Machine.status.nodeInfo.kubeletVersion is set use it instead of Machine.spec.version to compute status versions to also cover cases where the version differs, e.g. in-place Kubernetes upgrades.
* Surface in Machine UpToDate condition if the kubeletVersion differs from Machine.spec.version (and Machine is otherwise up-to-date and not in-place updating)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to #13303

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->