### PR TITLE
⚠️ Fix version validation in webhooks

### DIFF
--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
@@ -320,7 +320,10 @@ func validateKubeadmControlPlaneSpec(s controlplanev1.KubeadmControlPlaneSpec, p
 	// Validate the metadata of the MachineTemplate
 	allErrs = append(allErrs, s.MachineTemplate.ObjectMeta.Validate(pathPrefix.Child("machineTemplate", "metadata"))...)
 
-	if !version.KubeSemver.MatchString(s.Version) {
+	if !strings.HasPrefix(s.Version, "v") {
+		allErrs = append(allErrs, field.Invalid(pathPrefix.Child("version"), s.Version, "must start with v"))
+	}
+	if _, err := semver.Parse(strings.TrimPrefix(s.Version, "v")); err != nil {
 		allErrs = append(allErrs, field.Invalid(pathPrefix.Child("version"), s.Version, "must be a valid semantic version"))
 	}
 

--- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane_test.go
+++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane_test.go
@@ -146,6 +146,9 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 	invalidVersion2 := valid.DeepCopy()
 	invalidVersion2.Spec.Version = "1.16.6"
 
+	invalidVersion3 := valid.DeepCopy()
+	invalidVersion3.Spec.Version = "v1"
+
 	invalidCoreDNSVersion := valid.DeepCopy()
 	invalidCoreDNSVersion.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS.ImageTag = "1-7" // not a valid semantic version
 
@@ -234,6 +237,11 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 			name:      "should return error when given an invalid semantic version",
 			expectErr: true,
 			kcp:       invalidVersion1,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			expectErr: true,
+			kcp:       invalidVersion3,
 		},
 		{
 			name:      "should return error when given an invalid semantic CoreDNS version",

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -263,7 +263,17 @@ func (webhook *Cluster) validateTopology(ctx context.Context, oldCluster, newClu
 	}
 
 	// version should be valid.
-	if !version.KubeSemver.MatchString(newCluster.Spec.Topology.Version) {
+	if !strings.HasPrefix(newCluster.Spec.Topology.Version, "v") {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				fldPath.Child("version"),
+				newCluster.Spec.Topology.Version,
+				"must start with v",
+			),
+		)
+	}
+	if _, err := semver.Parse(strings.TrimPrefix(newCluster.Spec.Topology.Version, "v")); err != nil {
 		allErrs = append(
 			allErrs,
 			field.Invalid(

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -1703,6 +1703,24 @@ func TestClusterTopologyValidation(t *testing.T) {
 				Build(),
 		},
 		{
+			name:      "should return error when topology does not have valid version",
+			expectErr: true,
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("1.17.2").Build()).
+				Build(),
+		},
+		{
+			name:      "should return error when topology does not have valid version",
+			expectErr: true,
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1").Build()).
+				Build(),
+		},
+		{
 			name:      "should return error when downgrading topology version - major",
 			expectErr: true,
 			old: builder.Cluster("fooboo", "cluster1").

--- a/internal/webhooks/machine.go
+++ b/internal/webhooks/machine.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -30,7 +31,6 @@ import (
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/util/taints"
 	"sigs.k8s.io/cluster-api/util/labels"
-	"sigs.k8s.io/cluster-api/util/version"
 	"sigs.k8s.io/cluster-api/webhooks/conversion"
 )
 
@@ -116,7 +116,10 @@ func (webhook *Machine) validate(oldM, newM *clusterv1.Machine) error {
 	}
 
 	if newM.Spec.Version != "" {
-		if !version.KubeSemver.MatchString(newM.Spec.Version) {
+		if !strings.HasPrefix(newM.Spec.Version, "v") {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("version"), newM.Spec.Version, "must start with v"))
+		}
+		if _, err := semver.Parse(strings.TrimPrefix(newM.Spec.Version, "v")); err != nil {
 			allErrs = append(allErrs, field.Invalid(specPath.Child("version"), newM.Spec.Version, "must be a valid semantic version"))
 		}
 	}

--- a/internal/webhooks/machine_test.go
+++ b/internal/webhooks/machine_test.go
@@ -179,7 +179,7 @@ func TestMachineVersionValidation(t *testing.T) {
 		},
 		{
 			name:      "should return error when given an invalid semantic version",
-			version:   "1",
+			version:   "v1.17.2++",
 			expectErr: true,
 		},
 		{

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,6 @@ import (
 	"sigs.k8s.io/cluster-api/feature"
 	topologynames "sigs.k8s.io/cluster-api/internal/topology/names"
 	"sigs.k8s.io/cluster-api/internal/util/taints"
-	"sigs.k8s.io/cluster-api/util/version"
 	"sigs.k8s.io/cluster-api/webhooks/conversion"
 )
 
@@ -227,7 +227,10 @@ func (webhook *MachineDeployment) validate(oldMD, newMD *clusterv1.MachineDeploy
 	allErrs = append(allErrs, validateRemediationMaxInFlight(specPath.Child("remediation"), newMD.Spec.Remediation.MaxInFlight)...)
 
 	if newMD.Spec.Template.Spec.Version != "" {
-		if !version.KubeSemver.MatchString(newMD.Spec.Template.Spec.Version) {
+		if !strings.HasPrefix(newMD.Spec.Template.Spec.Version, "v") {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), newMD.Spec.Template.Spec.Version, "must start with v"))
+		}
+		if _, err := semver.Parse(strings.TrimPrefix(newMD.Spec.Template.Spec.Version, "v")); err != nil {
 			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), newMD.Spec.Template.Spec.Version, "must be a valid semantic version"))
 		}
 	}

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -606,7 +606,7 @@ func TestMachineDeploymentVersionValidation(t *testing.T) {
 		},
 		{
 			name:      "should return error when given an invalid semantic version",
-			version:   "1",
+			version:   "v1.17.2++",
 			expectErr: true,
 		},
 		{

--- a/internal/webhooks/machinepool.go
+++ b/internal/webhooks/machinepool.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,7 +33,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/feature"
-	"sigs.k8s.io/cluster-api/util/version"
 	"sigs.k8s.io/cluster-api/webhooks/conversion"
 )
 
@@ -160,7 +160,10 @@ func (webhook *MachinePool) validate(oldObj, newObj *clusterv1.MachinePool) erro
 	}
 
 	if newObj.Spec.Template.Spec.Version != "" {
-		if !version.KubeSemver.MatchString(newObj.Spec.Template.Spec.Version) {
+		if !strings.HasPrefix(newObj.Spec.Template.Spec.Version, "v") {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), newObj.Spec.Template.Spec.Version, "must start with v"))
+		}
+		if _, err := semver.Parse(strings.TrimPrefix(newObj.Spec.Template.Spec.Version, "v")); err != nil {
 			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), newObj.Spec.Template.Spec.Version, "must be a valid semantic version"))
 		}
 	}

--- a/internal/webhooks/machinepool_test.go
+++ b/internal/webhooks/machinepool_test.go
@@ -410,9 +410,14 @@ func TestMachinePoolVersionValidation(t *testing.T) {
 			version:   "v1.19.0-alpha.1",
 		},
 		{
-			name:      "should fail if version is not a valid semver",
+			name:      "should return error when given an invalid semantic version",
+			version:   "v1.17.2++",
 			expectErr: true,
-			version:   "v1.1",
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "v1",
+			expectErr: true,
 		},
 		{
 			name:      "should fail if version is missing a v prefix",

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,7 +41,6 @@ import (
 	topologynames "sigs.k8s.io/cluster-api/internal/topology/names"
 	"sigs.k8s.io/cluster-api/internal/util/taints"
 	"sigs.k8s.io/cluster-api/util/labels/format"
-	"sigs.k8s.io/cluster-api/util/version"
 	"sigs.k8s.io/cluster-api/webhooks/conversion"
 )
 
@@ -198,7 +198,16 @@ func (webhook *MachineSet) validate(oldMS, newMS *clusterv1.MachineSet) error {
 	}
 
 	if newMS.Spec.Template.Spec.Version != "" {
-		if !version.KubeSemver.MatchString(newMS.Spec.Template.Spec.Version) {
+		if !strings.HasPrefix(newMS.Spec.Template.Spec.Version, "v") {
+			allErrs = append(
+				allErrs,
+				field.Invalid(specPath.Child("template", "spec", "version"),
+					newMS.Spec.Template.Spec.Version,
+					"must start with v",
+				),
+			)
+		}
+		if _, err := semver.Parse(strings.TrimPrefix(newMS.Spec.Template.Spec.Version, "v")); err != nil {
 			allErrs = append(
 				allErrs,
 				field.Invalid(

--- a/internal/webhooks/machineset_test.go
+++ b/internal/webhooks/machineset_test.go
@@ -503,7 +503,7 @@ func TestMachineSetVersionValidation(t *testing.T) {
 		},
 		{
 			name:      "should return error when given an invalid semantic version",
-			version:   "1",
+			version:   "v1.17.2++",
 			expectErr: true,
 		},
 		{

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -18,16 +18,10 @@ limitations under the License.
 package version
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/blang/semver/v4"
-)
-
-var (
-	// KubeSemver is the regex for Kubernetes versions. It requires the "v" prefix.
-	KubeSemver = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
 )
 
 // MajorMinorPatch returns a version that only has Major / Minor / Patch fields set.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Looks like that the version validation in our web hooks is not correct, because allows invalid pre-release or build tags.

A few example of invalid pre-release or build tags
- v1.2.3abc (no -/+ separator)
- v1.2.3_foo (underscore, not allowed in semantic versions) 
- v1.2.3- (empty identifier)
- v1.2.3-01 (numeric identifier with leading zero)
- v1.2.3++
- v1.2.3-alpha..1 (empty dot-separated identifier)

This lead to issues when in the codebase we parse version / do version comparison (and there are many places where we are doing this).

This PR fixes it, an now we accept only valid semantic versions with a v prefix

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->