### PR TITLE
🐛 clusterctl: raise management cluster client QPS and Burst

### DIFF
--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -152,9 +152,11 @@ func (k *proxy) GetConfig() (*rest.Config, error) {
 	}
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
-	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go doesn't generate throttling log messages
-	restConfig.QPS = 20
-	restConfig.Burst = 100
+	// Set QPS and Burst high enough that clusterctl doesn't get throttled when it enumerates large
+	// resource sets such as many CRDs, while still relying on API Priority and Fairness for
+	// server-side protection.
+	restConfig.QPS = 500
+	restConfig.Burst = 1000
 
 	restConfig.WarningHandler = k.warningHandler
 

--- a/cmd/clusterctl/client/cluster/proxy_test.go
+++ b/cmd/clusterctl/client/cluster/proxy_test.go
@@ -80,8 +80,8 @@ func TestProxyGetConfig(t *testing.T) {
 				// context
 				g.Expect(conf.Host).To(Equal(tt.expectedHost))
 				g.Expect(conf.UserAgent).To(Equal(fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)))
-				g.Expect(conf.QPS).To(BeEquivalentTo(20))
-				g.Expect(conf.Burst).To(BeEquivalentTo(100))
+				g.Expect(conf.QPS).To(BeEquivalentTo(500))
+				g.Expect(conf.Burst).To(BeEquivalentTo(1000))
 				g.Expect(conf.Timeout.String()).To(Equal("30s"))
 			})
 		}


### PR DESCRIPTION
`clusterctl move` and `clusterctl upgrade` enumerate every API resource on the management cluster. On clusters with many CRDs, such as when using Azure Service Operator, this exhausts clusterctl's hardcoded client-side rate limiter and fails with `client rate limiter Wait returned an error: context deadline exceeded`.

This raises the QPS and Burst for the management cluster client from 20/100 to 500/1000. That keeps client-side rate limiting in place, so we still rely on API Priority and Fairness for server-side protection, while giving clusterctl enough headroom to enumerate large resource sets.

Validated against kubernetes-sigs/cluster-api-provider-azure#6437, whose `apiversion-upgrade` job failed repeatedly on this error and then passed with these values: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/6437/pull-cluster-api-provider-azure-apiversion-upgrade/2074549994202861568

**Which issue(s) this PR fixes**:
Fixes #13867
Closes #13868

/area clusterctl
/kind bug