### PR TITLE
🐛 Fix ClusterClass rollout test with k8s latest

### DIFF
--- a/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
+++ b/test/infrastructure/docker/internal/controllers/backends/inmemory/inmemorymachine_backend.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/certs"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	containerutil "sigs.k8s.io/cluster-api/util/container"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
@@ -974,7 +975,7 @@ func (r *MachineBackendReconciler) reconcileNormalKubeProxy(ctx context.Context,
 					Containers: []corev1.Container{
 						{
 							Name:  "kube-proxy",
-							Image: fmt.Sprintf("registry.k8s.io/kube-proxy:%s", machine.Spec.Version),
+							Image: fmt.Sprintf("registry.k8s.io/kube-proxy:%s", containerutil.SemverToOCIImageTag(machine.Spec.Version)),
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/pull/13806 introduced an issue in the periodic-cluster-api-e2e-latestk8s-main e2e test.

Example: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-latestk8s-main/2074082899379884032

The problem was:
* the CAPDev in-memory backend used an invalid kube-proxy image tag
* KCP failed to parse this image tag in UpdateKubeProxyImageInfo
* Accordingly KCP never executed reconcileCertificateExpiries
* Then the cert expiry annotation was missing on the KubeadmConfig and the ClusterClass rollout test failed


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13879




Thx to Claude for helping to debug this

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->