### PR TITLE
🌱 Give resource versions more time to become stable in e2e tests

### DIFF
--- a/test/framework/resourceversion_helpers.go
+++ b/test/framework/resourceversion_helpers.go
@@ -48,7 +48,7 @@ func ValidateResourceVersionStable(ctx context.Context, input ValidateResourceVe
 	var previousObjects map[string]client.Object
 	waitToBecomeStable := input.WaitToBecomeStable
 	if len(waitToBecomeStable) == 0 {
-		waitToBecomeStable = []any{"2m", "15s"}
+		waitToBecomeStable = []any{"4m", "15s"}
 	}
 	Eventually(func(g Gomega) {
 		objectsWithResourceVersion, objects, err := getObjectsWithResourceVersion(ctx, input.ClusterProxy, input.Namespace, input.OwnerGraphFilterFunction)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
To fix this flake: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-mink8s-main/2072228660772868096

In the run linked above the following happened:
* 09:22:28: Node `quick-start-jpv15y-md-md-0-cknt4-sbjlz-v6rld` was created
* 09:22:38: e2e test: `Checking that resourceVersions are stable`
  * 2m timeout, 15s interval, has to succeed 4x in a row
* 09:23:13: Node  `quick-start-jpv15y-md-md-0-cknt4-sbjlz-v6rld` reported true
* 09:23:18: Various conditions flipped to true on Machine, ... (after 5s minReadySeconds)
* 09:24:38: e2e Test timed out (there was not enough time for the resourceVersions to stay stable 4x in a row)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Reported as part of https://github.com/kubernetes-sigs/cluster-api/issues/13754
Fixes #13884

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->