### PR TITLE
[release-1.13] 🐛 Delete unhealthy Machines on old MS during in-place updates

### DIFF
--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -1006,12 +1006,36 @@ func (r *Reconciler) startMoveMachines(ctx context.Context, s *scope, targetMSNa
 
 	errs := []error{}
 	machinesMoved := []*clusterv1.Machine{}
+	machinesDeleted := []*clusterv1.Machine{}
 	for _, machine := range machinesToMoveByPriority {
 		if machinesToMove <= 0 {
 			break
 		}
 
 		log := log.WithValues("Machine", klog.KObj(machine))
+
+		// Note: Using the same logic to determine if a Machine should be remediated as in reconcileUnhealthyMachines.
+		//       But remediation will happen here by deleting the Machine and another Machine will be eventually
+		//       created for the new MachineSet (remediation means usually re-creating a Machine on the same MachineSet).
+		if collections.IsUnhealthyAndOwnerRemediated(machine) && machine.DeletionTimestamp.IsZero() {
+			machinesToMove--
+
+			if err := r.Client.Delete(ctx, machine); err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to delete Machine %s (tried to delete the Machine instead of moving it to MachineSet %s because Machine is marked for remediation)", klog.KObj(machine), klog.KObj(targetMS)))
+				continue
+			}
+			machinesDeleted = append(machinesDeleted, machine)
+
+			log.Info(fmt.Sprintf("Machine %s deleting (deleting the Machine instead of moving it to MachineSet %s because Machine is marked for remediation)", klog.KObj(machine), targetMS.Name))
+			r.recorder.Eventf(ms, corev1.EventTypeNormal, "SuccessfulDelete", "Deleted Machine %q", machine.Name)
+			continue
+		}
+
+		// If there are machines already deleting, wait for them to go away before further scaling down with move.
+		if !machine.DeletionTimestamp.IsZero() {
+			machinesToMove--
+			continue
+		}
 
 		// Make sure we are not moving machines still updating in place from a previous move (this includes also machines still pending AcknowledgeMove).
 		if inplace.IsUpdateInProgress(machine) {
@@ -1024,16 +1048,9 @@ func (r *Reconciler) startMoveMachines(ctx context.Context, s *scope, targetMSNa
 		}
 
 		// Note. Machines with the DeleteMachineAnnotation are going to be moved and the new MS
-		//       will take care of fulfilling this intent as soon as it scales down.
-		// Note. Also Machines marked as unhealthy by MHC are going to be moved, because otherwise
-		//       remediation will not complete as the Machine is owned by an old MS.
+		//       will take care of fulfilling this intent/prioritization as soon as it scales down.
 
 		machinesToMove--
-
-		// If there are machines already deleting, wait for them to go away before further scaling down with move.
-		if !machine.DeletionTimestamp.IsZero() {
-			continue
-		}
 
 		log.Info(fmt.Sprintf("Triggering in-place update for Machine %s (by moving to MachineSet %s)", machine.Name, targetMS.Name))
 
@@ -1082,6 +1099,9 @@ func (r *Reconciler) startMoveMachines(ctx context.Context, s *scope, targetMSNa
 
 	// Wait for cache update to ensure following reconcile gets latest change.
 	if err := clientutil.WaitForCacheToBeUpToDate(ctx, r.Client, "moving Machines", machinesMoved...); err != nil {
+		errs = append(errs, err)
+	}
+	if err := clientutil.WaitForObjectsToBeDeletedFromTheCache(ctx, r.Client, "Machine deletion (fallback for Machines marked for remediation)", machinesDeleted...); err != nil {
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
@@ -1556,6 +1576,9 @@ func (r *Reconciler) reconcileUnhealthyMachines(ctx context.Context, s *scope) (
 	if isDeploymentChild(ms) {
 		if owner.Annotations[clusterv1.RevisionAnnotation] != ms.Annotations[clusterv1.RevisionAnnotation] {
 			// MachineSet is part of a MachineDeployment but isn't the current revision, no remediations allowed.
+			// Note: While remediation won't delete these Machines deleteMachines or startMoveMachines will delete
+			// them as part of the rollout. After that deletion the MD controller will scale up the new MS and then
+			// a new Machine will be created accordingly.
 			if err := patchMachineConditions(ctx, r.Client, machinesToRemediate, metav1.Condition{
 				Type:    clusterv1.MachineOwnerRemediatedCondition,
 				Status:  metav1.ConditionFalse,

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -2957,18 +2957,21 @@ func TestMachineSetReconciler_startMoveMachines(t *testing.T) {
 		sort.Strings(msMachines)
 		return msMachines
 	}
+	healthCheckNotSucceeded := metav1.Condition{Type: clusterv1.MachineHealthCheckSucceededCondition, Status: metav1.ConditionFalse, Reason: clusterv1.MachineHealthCheckNodeStartupTimeoutReason, Message: "Health check failed:\n      * Node failed to report startup in 1h0m0s"}
+	ownerRemediated := metav1.Condition{Type: clusterv1.MachineOwnerRemediatedCondition, Status: metav1.ConditionFalse, Reason: clusterv1.MachineSetMachineCannotBeRemediatedReason, Message: "Machine won't be remediated because it is pending removal due to rollout"}
 
 	tests := []struct {
-		name                 string
-		ms                   *clusterv1.MachineSet
-		targetMS             *clusterv1.MachineSet
-		machines             []*clusterv1.Machine
-		machinesToMove       int
-		interceptorFuncs     interceptor.Funcs
-		wantMachinesNotMoved []string
-		wantMovedMachines    []string
-		wantErr              bool
-		wantErrorMessage     string
+		name                              string
+		ms                                *clusterv1.MachineSet
+		targetMS                          *clusterv1.MachineSet
+		machines                          []*clusterv1.Machine
+		machinesToMove                    int
+		interceptorFuncs                  interceptor.Funcs
+		wantMachinesNotMoved              []string
+		wantMovedMachines                 []string
+		wantMachinesWithDeletionTimestamp []string
+		wantErr                           bool
+		wantErrorMessage                  string
 	}{
 		{
 			name: "should fail when taget ms cannot be found",
@@ -3054,6 +3057,28 @@ func TestMachineSetReconciler_startMoveMachines(t *testing.T) {
 			wantErr:              false,
 		},
 		{
+			name: "should delete unhealthy Machines with OwnerRemediated set",
+			ms: newMachineSet("ms1", "cluster1", 2,
+				withDeletionOrder(clusterv1.NewestMachineSetDeletionOrder),
+				withMachineSetLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "123"}),
+				withMachineSetAnnotations(map[string]string{clusterv1.MachineSetMoveMachinesToMachineSetAnnotation: "ms2"}),
+			),
+			targetMS: newMachineSet("ms2", "cluster1", 2,
+				withMachineSetLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "456"}),
+				withMachineSetAnnotations(map[string]string{clusterv1.MachineSetReceiveMachinesFromMachineSetsAnnotation: "ms1,ms3"}),
+			),
+			machines: []*clusterv1.Machine{
+				fakeMachine("m1", withOwnerMachineSet("ms1"), withMachineLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "123"}), withMachineFinalizer(), withCreationTimestamp(time.Now().Add(-4*time.Minute)), withCondition(healthCheckNotSucceeded), withCondition(ownerRemediated)),
+				fakeMachine("m2", withOwnerMachineSet("ms1"), withMachineLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "123"}), withMachineFinalizer(), withCreationTimestamp(time.Now().Add(-3*time.Minute))),
+			},
+			machinesToMove:                    2,
+			interceptorFuncs:                  interceptor.Funcs{},
+			wantMachinesNotMoved:              []string{"m1", "m2"},
+			wantMovedMachines:                 []string{},
+			wantMachinesWithDeletionTimestamp: []string{"m1"},
+			wantErr:                           false,
+		},
+		{
 			name: "should not move machines not yet provisioned",
 			ms: newMachineSet("ms1", "cluster1", 2,
 				withDeletionOrder(clusterv1.NewestMachineSetDeletionOrder),
@@ -3091,11 +3116,12 @@ func TestMachineSetReconciler_startMoveMachines(t *testing.T) {
 				fakeMachine("m3", withOwnerMachineSet("ms1"), withMachineLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "123"}), withMachineFinalizer(), withCreationTimestamp(time.Now().Add(-2*time.Minute)), withHealthyNode()),
 				fakeMachine("m4", withOwnerMachineSet("ms1"), withMachineLabels(map[string]string{clusterv1.MachineDeploymentUniqueLabel: "123"}), withMachineFinalizer(), withCreationTimestamp(time.Now().Add(-1*time.Minute)), withHealthyNode(), withDeletionTimestamp()), // newest
 			},
-			machinesToMove:       2,
-			interceptorFuncs:     interceptor.Funcs{},
-			wantMachinesNotMoved: []string{"m1", "m2", "m4"},
-			wantMovedMachines:    []string{"m3"}, // newest machines moved first with NewestMachineSetDeletionOrder, but m4 is deleting so don't touch it
-			wantErr:              false,
+			machinesToMove:                    2,
+			interceptorFuncs:                  interceptor.Funcs{},
+			wantMachinesNotMoved:              []string{"m1", "m2", "m4"},
+			wantMovedMachines:                 []string{"m3"}, // newest machines moved first with NewestMachineSetDeletionOrder, but m4 is deleting so don't touch it
+			wantMachinesWithDeletionTimestamp: []string{"m4"},
+			wantErr:                           false,
 		},
 		{
 			name: "should not move more machines that are already updating in place, pick another machine instead",
@@ -3196,6 +3222,14 @@ func TestMachineSetReconciler_startMoveMachines(t *testing.T) {
 					}
 				}
 			}
+
+			var machinesWithDeletionTimestamp []string
+			for _, m := range machines.Items {
+				if !m.DeletionTimestamp.IsZero() {
+					machinesWithDeletionTimestamp = append(machinesWithDeletionTimestamp, m.Name)
+				}
+			}
+			g.Expect(machinesWithDeletionTimestamp).To(ConsistOf(tt.wantMachinesWithDeletionTimestamp))
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/13886

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->