### PR TITLE
🌱 Cleanup golangci-lint excludes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -255,11 +255,6 @@ linters:
           alias: infrav1beta1
         - pkg: sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2
           alias: infrav1
-        # CAPD exp
-        - pkg: sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1
-          alias: infraexpv1beta1
-        - pkg: sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta2
-          alias: infraexpv1
       no-unaliased: true
     nolintlint:
       require-specific: true
@@ -302,63 +297,32 @@ linters:
       - zz_generated.*\.go$
       - vendored_openapi\.go$
     rules:
-    # Specific exclude rules for deprecated fields that are still part of the codebase. These
-    # should be removed as the referenced deprecated item is removed from the project.
-      - linters:
-          - staticcheck
-        text: 'SA1019: (bootstrapv1.ClusterStatus|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped|dockerMachine.Spec.Backend.Docker.Bootstrapped|dockerMachine.Spec.Bootstrapped|devMachine.Spec.Backend.Docker.Bootstrapped|clusterv1.ClusterClassVariableMetadata|(variable|currentDefinition|specVar|newVariableDefinition|statusVarDefinition|out).DeprecatedV1Beta1Metadata) is deprecated'
-        # Deprecations for MHC MaxUnhealthy, UnhealthyRange
-      - linters:
-          - staticcheck
-        text: 'SA1019: (mhc|m)(.Spec.MaxUnhealthy|.Spec.UnhealthyRange) is deprecated'
-        # Specific exclude rules for deprecated packages that are still part of the codebase. These
-        # should be removed as the referenced deprecated packages are removed from the project.
-      - linters:
-          - staticcheck
-        text: 'SA1019: .* is deprecated: This package will be removed in one of the next releases.'
-      - linters:
-          - staticcheck
-        text: 'SA1019: .* is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
-        # Specific exclude rules for deprecated types that are still part of the codebase. These
-        # should be removed as the referenced deprecated types are removed from the project.
-        # v1Beta1 deprecated fields/types
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*\.Deprecated\.V1Beta1.* is deprecated'
-        # Docker resources are marked as deprecated.
-      - linters:
-          - staticcheck
-        text: 'SA1019: .*Docker.* is deprecated: .* Use Dev.* instead\.'
-      - linters:
-          - staticcheck
-        text: 'SA1019: clusterv1\.(Condition|Conditions|ConditionSeverity|ConditionType) is deprecated'
-      # TODO: var-naming: avoid meaningless package names by revive
-      #   * test/infrastructure/docker/internal/docker/types/
-      #   * bootstrap/kubeadm/types/
-      #   * internal/webhooks/util/
-      #   * util/
-      #   * exp/util/
-      #   * controlplane/kubeadm/internal/etcd/util/
-      #   * cmd/clusterctl/internal/util/
-      #   * bootstrap/util/
-      - linters:
-          - revive
-        text: 'var-naming: avoid meaningless package names'
-        path: test/infrastructure/docker/internal/docker/types/.*\.go$|bootstrap/kubeadm/types/.*\.go$|internal/webhooks/util/.*\.go$|util/.*\.go$|exp/util/.*\.go$|controlplane/kubeadm/internal/etcd/util/.*\.go$|cmd/clusterctl/internal/util/.*\.go$|bootstrap/util/.*\.go$
-      - linters:
-          - revive
-        text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
-      - linters:
-          - errcheck
-        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-        # deprecated feature gates
+      # TODO: Excludes that can be removed as part of the Cluster API v1.15 release.
       - linters:
           - staticcheck
         text: 'SA1019: feature.MachineWaitForVolumeDetachConsiderVolumeAttachments is deprecated'
-        # v1beta1 deprecated util packages
+
+      # TODO: Excludes that can be removed once we bumped to controller-runtime v0.25.
       - linters:
           - staticcheck
-        text: 'SA1019: .* is deprecated'
+        text: 'SA1019: (env|mgr).GetEventRecorderFor is deprecated'
+
+      # TODO: Excludes for v1beta1, can be removed once v1beta1 has been removed (current plan: Cluster API v1.19).
+      - linters:
+          - staticcheck
+        text: 'SA1019: (clusterv1.ClusterClassVariableMetadata|currentDefinition.DeprecatedV1Beta1Metadata|newVariableDefinition.DeprecatedV1Beta1Metadata|specVar.DeprecatedV1Beta1Metadata|statusVarDefinition.DeprecatedV1Beta1Metadata|out.DeprecatedV1Beta1Metadata|variable.DeprecatedV1Beta1Metadata) is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .* is deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .*\.Deprecated\.V1Beta1.* is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: clusterv1\.(Condition|Conditions|ConditionSeverity|ConditionType) is deprecated'
+      - linters:
+          - staticcheck
+        text: 'SA1019: .* is deprecated|'
         path: util/deprecated/v1beta1/.*\.go$
       - linters:
           - staticcheck
@@ -368,11 +332,26 @@ linters:
           - importas
         text: 'imported as ".*" but must be ".*" according to config'
         path: util/deprecated/v1beta1/.*\.go$
-      # Excludes for controller-runtime deprecations that we should migrate away from sooner or later
+
+      # TODO: Excludes for Docker*, can be removed when Docker* API types have been removed.
       - linters:
           - staticcheck
-        text: 'SA1019: (env|mgr).GetEventRecorderFor is deprecated'
-        # Exclude some packages or code to require comments, for example test code, or fake clients.
+        text: 'SA1019: .*Docker.* is deprecated: .* Use Dev.* instead\.'
+
+      # TODO: Excludes that can be removed once the code organization proposal has been implemented.
+      - linters:
+          - revive
+        text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
+
+      # Exclude rules that we are going to keep permanently.
+      - linters:
+          - revive
+        text: 'var-naming: avoid meaningless package names'
+        path: test/infrastructure/docker/internal/docker/types/.*\.go$|bootstrap/kubeadm/types/.*\.go$|internal/webhooks/util/.*\.go$|util/.*\.go$|exp/util/.*\.go$|controlplane/kubeadm/internal/etcd/util/.*\.go$|cmd/clusterctl/internal/util/.*\.go$|bootstrap/util/.*\.go$
+      - linters:
+          - errcheck
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+      ## Exclude some packages or code to require comments, for example test code, or fake clients.
       - linters:
           - revive
         text: exported (method|function|type|const) (.+) should have comment or be unexported
@@ -389,13 +368,11 @@ linters:
           - revive
         path: (framework|e2e)/.*.go
         text: exported (method|function|type|const) (.+) should have comment or be unexported
-        # Disable unparam "always receives" which might not be really
-        # useful when building libraries.
+      ## Disable unparam "always receives" which might not be really useful when building libraries.
       - linters:
           - unparam
         text: always receives
-        # Dot imports for gomega and ginkgo are allowed
-        # within test files and test utils.
+      ## Dot imports for gomega and ginkgo are allowed within test files and test utils.
       - linters:
           - revive
           - staticcheck
@@ -406,27 +383,21 @@ linters:
           - staticcheck
         path: (framework|e2e)/.*.go
         text: should not use dot imports
-        # Large parts of this file are duplicate from k/k. Let's ignore "emptyStringTest" to reduce the noise in diffs
-        # and to avoid making mistakes by diverging from upstream just because of this purely stylistic linter finding.
+      ## Large parts of this file are duplicate from k/k. Let's ignore "emptyStringTest" to reduce the noise in diffs
+      ## and to avoid making mistakes by diverging from upstream just because of this purely stylistic linter finding.
       - linters:
           - gocritic
         path: internal/topology/variables/clusterclass_variable_validation.go
         text: emptyStringTest
-        # Append should be able to assign to a different var/slice.
+      ## Append should be able to assign to a different var/slice.
       - linters:
           - gocritic
         text: 'appendAssign: append result not assigned to the same slice'
-        # Disable linters for conversion
+      ## Disable linters for conversion
       - linters:
           - staticcheck
         path: api/core/v1beta1/conversion.go|webhooks/conversion/.*\.go
         text: 'SA1019: in.(.+) is deprecated'
-      - linters:
-          - revive
-        # Ignoring stylistic checks for generated code
-        path: .*(api|types|test)\/.*\/conversion.*\.go$
-        # Checking if an error is nil to just after return the error or nil is redundant
-        text: 'if-return: redundant if ...; err != nil check, just return error instead'
       - linters:
           - revive
         # Ignoring stylistic checks for generated code
@@ -442,7 +413,7 @@ linters:
       - linters:
           - revive
         # Ignoring stylistic checks for generated code
-        path: .*(api|types|test)\/.*\/conversion.*\.go$
+        path: bootstrap/kubeadm/types/upstreamv1beta3/conversion.go|bootstrap/kubeadm/types/upstreamv1beta4/conversion.go|internal/topology/upgrade/test/t1/v1beta1/conversion.go|internal/topology/upgrade/test/t2/v1beta1/conversion.go|test/infrastructure/docker/api/v1beta1/conversion.go
         # By convention, receiver names in a method should reflect their identity.
         text: 'receiver-naming: receiver name'
       - linters:
@@ -453,48 +424,25 @@ linters:
           - staticcheck
         path: .*(api|types)\/.*\/conversion.*\.go$
         text: 'ST1016: methods on the same type should have the same receiver name'
-        # We don't care about defer in for loops in test files.
+      ## We don't care about defer in for loops in test files.
       - linters:
           - gocritic
         path: _test\.go
         text: 'deferInLoop: Possible resource leak, ''defer'' is called in the ''for'' loop'
-        # Ignore non-constant format string in call to condition utils
-      - linters:
-          - govet
-        text: non-constant format string in call to sigs\.k8s\.io\/cluster-api\/util\/conditions\.
-      - linters:
-          - govet
-        text: non-constant format string in call to sigs\.k8s\.io\/cluster-api\/util\/deprecated\/v1beta1\/conditions\.
       - linters:
           - goconst
         path: (.+)_test\.go
-        # It's clearer to see that a field gets accessed or func gets called on the embedded objects 
+      ## It's clearer to see that a field gets accessed or func gets called on the embedded objects
       - linters:
           - staticcheck
         path: (.+)\.go$
         text: 'QF1008: could remove embedded field'
-      - linters:
-          - revive
-        path: errors/.*\.go$
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: internal/util/hash/.*\.go$
-        text: 'var-naming: avoid package names that conflict with Go standard library package names'
-      - linters:
-          - revive
-        path: internal/controllers/topology/cluster/patches/api/.*\.go$
-        text: 'var-naming: avoid meaningless package names'
-      - linters:
-          - revive
-        path: test/infrastructure/inmemory/pkg/server/api/.*\.go$
-        text: 'var-naming: avoid meaningless package names'
-        # Exclude G101 findings in test files: test fixtures legitimately contain fake credentials.
+      ## Exclude G101 findings in test files: test fixtures legitimately contain fake credentials.
       - linters:
           - gosec
         path: _test\.go
         text: 'G101:'
-        # Preallocating slices in test files is not worth the readability cost.
+      ## Preallocating slices in test files is not worth the effort and readability cost.
       - linters:
           - prealloc
         path: _test\.go

--- a/test/infrastructure/docker/api/v1beta1/doc.go
+++ b/test/infrastructure/docker/api/v1beta1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +groupName=infrastructure.cluster.x-k8s.io
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2
 //
-// Deprecated: This package will be removed in one of the next releases.
+// Deprecated: This package is deprecated and is going to be removed when support for v1beta1 will be dropped.
 package v1beta1


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR restructures golangci-lint excludes. Remaining TODOs will be tracked in #12695

(I also removed a lot of excludes that were not needed anymore)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12695

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->