### PR TITLE
🐛 Fix v1beta1 describe output stream

### DIFF
--- a/internal/util/tree/tree.go
+++ b/internal/util/tree/tree.go
@@ -141,7 +141,11 @@ func PrintObjectTree(tree *tree.ObjectTree, w io.Writer) error {
 // PrintObjectTreeV1Beta1 prints the cluster status to stdout.
 // Note: this function is exposed only for usage in clusterctl and Cluster API E2E tests.
 func PrintObjectTreeV1Beta1(tree *tree.ObjectTree) error {
-	tbl := createObjectTreeV1Beta1(os.Stdin)
+	return printObjectTreeV1Beta1ToWriter(tree, os.Stdout)
+}
+
+func printObjectTreeV1Beta1ToWriter(tree *tree.ObjectTree, w io.Writer) error {
+	tbl := createObjectTreeV1Beta1(w)
 	tbl.Header([]string{"NAME", "READY", "SEVERITY", "REASON", "SINCE", "MESSAGE"})
 
 	// Add row for the root object, the cluster, and recursively for all the nodes representing the cluster status.

--- a/internal/util/tree/tree_test.go
+++ b/internal/util/tree/tree_test.go
@@ -19,6 +19,8 @@ package tree
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -675,4 +677,40 @@ func Test_formatParagraph(t *testing.T) {
 			g.Expect("\n" + formatParagraph(tt.text, tt.maxWidth)).To(BeEquivalentTo("\n" + tt.want))
 		})
 	}
+}
+
+func TestPrintObjectTreeV1Beta1_WritesToStdout(t *testing.T) {
+	g := NewWithT(t)
+
+	root := fakeObject("root", withV1Beta1Condition(v1beta1conditions.TrueCondition(clusterv1.ReadyV1Beta1Condition)))
+	objectTree := tree.NewObjectTree(root, tree.ObjectTreeOptions{V1Beta1: true})
+
+	originalStdout := os.Stdout
+	originalStdin := os.Stdin
+
+	readOnlyFile, err := os.CreateTemp(t.TempDir(), "stdin")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(readOnlyFile.Close()).To(Succeed())
+	readOnlyFile, err = os.Open(readOnlyFile.Name())
+	g.Expect(err).ToNot(HaveOccurred())
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	os.Stdin = readOnlyFile
+	os.Stdout = stdoutWriter
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		os.Stdout = originalStdout
+		_ = readOnlyFile.Close()
+		_ = stdoutReader.Close()
+	})
+
+	err = PrintObjectTreeV1Beta1(objectTree)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(stdoutWriter.Close()).To(Succeed())
+
+	out, err := io.ReadAll(stdoutReader)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(out)).To(ContainSubstring("Object ns/root"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterctl describe cluster <name> --v1beta2=false` goes through the v1beta1 printer.
That printer writes to `stdin`, so on a normal terminal it can bail with `bad file descriptor` and print nothing. Not great.
This switches it to `stdout` and adds a small regression test.

Repro:
1. Run `clusterctl describe cluster <name> --v1beta2=false`
2. Before this patch, the v1beta1 printer can try to write to fd `0` and fail with `bad file descriptor`
3. After this patch, the tree prints normally

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A
