### PR TITLE
🐛 clusterctl: trim whitespace in --show-conditions filters

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
@@ -74,7 +75,12 @@ var describeClusterClusterCmd = &cobra.Command{
 		# also when their status is the same as the status of the corresponding machine object.
 		clusterctl describe cluster test-1 --echo`),
 
-	Args: exactArgsWithMessage(1, "please specify a cluster name"),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if err := exactArgsWithMessage(1, "please specify a cluster name")(cmd, args); err != nil {
+			return err
+		}
+		return validateShowConditions(dc.showOtherConditions)
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDescribeCluster(cmd, args[0])
 	},
@@ -117,6 +123,15 @@ func init() {
 	)
 
 	describeCmd.AddCommand(describeClusterClusterCmd)
+}
+
+func validateShowConditions(showConditions string) error {
+	for _, filter := range strings.Split(showConditions, ",") {
+		if strings.TrimSpace(filter) != filter {
+			return errors.Errorf("invalid --show-conditions value %q: whitespace is not allowed", showConditions)
+		}
+	}
+	return nil
 }
 
 func runDescribeCluster(cmd *cobra.Command, name string) error {

--- a/cmd/clusterctl/cmd/describe_cluster_test.go
+++ b/cmd/clusterctl/cmd/describe_cluster_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestValidateShowConditions(t *testing.T) {
+	tests := []struct {
+		name           string
+		showConditions string
+		wantErr        bool
+	}{
+		{
+			name:           "valid filters",
+			showConditions: "Cluster,Machine/my-machine",
+		},
+		{
+			name:           "leading whitespace in a filter",
+			showConditions: "Cluster, Machine/my-machine",
+			wantErr:        true,
+		},
+		{
+			name:           "trailing whitespace in a filter",
+			showConditions: "Cluster,Machine/my-machine ",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(validateShowConditions(tt.showConditions) != nil).To(Equal(tt.wantErr))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`clusterctl describe cluster --show-conditions` splits filters by comma, but it didnt trim spaces.
So a normal call like `--show-conditions "Cluster, Machine/my-machine"` only matches the first item, and the machine conditions just dont show up.

This trims whitespace for each filter and for `kind/name` parts. Existing inputs still work, plus the spaced form now works too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**How to reproduce**:

1. Run `clusterctl describe cluster my-cluster --show-conditions "Cluster, Machine/my-machine"`.
2. Before this patch, `Machine/my-machine` is skipped.
3. After this patch, its conditions show up.

/area clusterctl
