### PR TITLE
🌱 Bump Go to v1.26.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.26.4
+GO_VERSION ?= 1.26.5
 GO_DIRECTIVE_VERSION ?= 1.26.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -174,7 +174,7 @@ def load_provider_tilt_files():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.26.4 as tilt-helper
+FROM golang:1.26.5 as tilt-helper
 # Install delve. Note this should be kept in step with the Go release minor version.
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.26
 # Support live reloading with Tilt
@@ -185,7 +185,7 @@ RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com
 """
 
 tilt_dockerfile_header = """
-FROM golang:1.26.4 as tilt
+FROM golang:1.26.5 as tilt
 WORKDIR /
 COPY --from=tilt-helper /process.txt .
 COPY --from=tilt-helper /start.sh .

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.26.4"
+    GO_VERSION = "1.26.5"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
What this PR does / why we need it:

This PR updates the Go toolchain from v1.26.3 to v1.26.5.

The latest Go patch release includes fixes for recently disclosed Go standard library vulnerabilities. Updating the toolchain ensures that binaries are built with the patched version and resolves the vulnerabilities reported by the project's weekly security scans.

Which issue(s) this PR fixes (optional, in fixes #<issue number> format):

N/A
