### PR TITLE
🐛 clusterctl: reject incomplete GitHub release asset URLs

### DIFF
--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -207,7 +207,7 @@ func (t *templateClient) getGitHubFileContent(ctx context.Context, rURL *url.URL
 		return getGithubFileContentFromCode(ctx, ghClient, rURL.Path, owner, repo, path, branch)
 
 	case "releases": // get a github release asset
-		if urlSplit[3] != "download" {
+		if len(urlSplit) < 6 || urlSplit[3] != "download" {
 			break
 		}
 		tag := urlSplit[4]

--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -469,6 +469,16 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Get asset from GitHub release with an incomplete URL",
+			args: args{
+				templateURL:         "https://github.com/some-owner/some-repo/releases/download/v1.0.0",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "Get from stdin",
 			args: args{
 				templateURL:         "-",


### PR DESCRIPTION
An incomplete GitHub release asset URL made clusterctl panic

It now returns an error, no stacktrace

Repro
```sh
clusterctl generate yaml --from https://github.com/example/example/releases/download/v1.0.0
```