### PR TITLE
🌱 Bump Kubernetes version used for testing to v1.37.0-beta.0

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -217,14 +217,14 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.36.1"
-  KUBERNETES_VERSION: "v1.36.1"
-  KUBERNETES_VERSION_CHAINED_UPGRADE_FROM: "v1.32.11" # Should always be KUBERNETES_VERSION_UPGRADE_TO - 4 minor
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.35.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.36.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.37.0-beta.0"
+  KUBERNETES_VERSION: "v1.37.0-beta.0"
+  KUBERNETES_VERSION_CHAINED_UPGRADE_FROM: "v1.33.12" # Should always be KUBERNETES_VERSION_UPGRADE_TO - 4 minor
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.36.1"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.37.0-beta.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.37"
-  ETCD_VERSION_UPGRADE_TO: "3.6.8-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.14.2"
+  ETCD_VERSION_UPGRADE_TO: "3.7.0-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.14.6"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "dual"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.36.0
+  version: v1.37.0-beta.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.36.0
+      version: v1.37.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.36.0
+  version: v1.37.0-beta.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -92,7 +92,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.36.0
+      version: v1.37.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -31,7 +31,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.36.0
+  version: v1.37.0-beta.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -74,7 +74,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.36.0
+      version: v1.37.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.36.0
+  version: v1.37.0-beta.0
   machineTemplate:
     spec:
       infrastructureRef:
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.36.0
+      version: v1.37.0-beta.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Tests will fail until k/k v1.37.0-beta.0 is released (Wednesday 15th July 2026)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13694

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->