### PR TITLE
🚀 Release v1.12.10

### DIFF
--- a/CHANGELOG/v1.12.10.md
+++ b/CHANGELOG/v1.12.10.md
@@ -1,0 +1,33 @@
+## 👌 Kubernetes version support
+
+- Management Cluster: v1.31.x -> v1.35.x
+- Workload Cluster: v1.29.x -> v1.35.x
+
+[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+## Changes since v1.12.9
+## :chart_with_upwards_trend: Overview
+- 5 new commits merged
+- 2 bugs fixed 🐛
+
+## :bug: Bug Fixes
+- e2e: Bump kind image in clusterctl v1.10 upgrade test to avoid containerd segv (#13855)
+- e2e: Fix PrettyPrint in WaitForControlPlaneToBeReady (#13845)
+
+## :seedling: Others
+- clusterctl: Bump cert-manager to v1.20.3 (#13852)
+- Dependency: Add CVEs to .trivyignore (#13865)
+- Dependency: Bump Go version to v1.25.12 (#13907)
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
What this PR does / why we need it:
🚀 Release v1.12.10

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/13625

/area release