### PR TITLE
🚀 Release v1.13.4

### DIFF
--- a/CHANGELOG/v1.13.4.md
+++ b/CHANGELOG/v1.13.4.md
@@ -1,0 +1,42 @@
+## 👌 Kubernetes version support
+
+- Management Cluster: v1.32.x -> v1.36.x
+- Workload Cluster: v1.30.x -> v1.36.x
+
+[More information about version support can be found here](https://cluster-api.sigs.k8s.io/reference/versions.html)
+
+## Changes since v1.13.3
+## :chart_with_upwards_trend: Overview
+- 7 new commits merged
+- 4 bugs fixed 🐛
+
+## :bug: Bug Fixes
+- clusterctl: Raise management cluster client QPS and Burst (#13901)
+- e2e: Bump kind image in clusterctl v1.10 upgrade test to avoid containerd segv (#13854)
+- e2e: Fix PrettyPrint in WaitForControlPlaneToBeReady (#13844)
+- MachineSet: Delete unhealthy Machines on old MS during in-place updates (#13888)
+
+## :seedling: Others
+- clusterctl: Bump cert-manager to v1.20.3 (#13851)
+- Dependency: Bump Go version to v1.25.12 (#13906)
+- Dependency: Bump golang.org/x/crypto version to v0.53.0 (#13864)
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+- golang.org/x/crypto: v0.51.0 → v0.53.0
+- golang.org/x/mod: v0.35.0 → v0.36.0
+- golang.org/x/sync: v0.20.0 → v0.21.0
+- golang.org/x/sys: v0.45.0 → v0.46.0
+- golang.org/x/telemetry: be6f6cb → 42602be
+- golang.org/x/term: v0.43.0 → v0.44.0
+- golang.org/x/text: v0.37.0 → v0.38.0
+- golang.org/x/tools: v0.44.0 → v0.45.0
+
+### Removed
+_Nothing has changed._
+
+_Thanks to all our contributors!_ 😊


### PR DESCRIPTION
What this PR does / why we need it:
🚀 Release v1.13.4

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/13625

/area release