### PR TITLE
🌱 Add Code Freeze date field to `provider_issues.go` to be used for beta communication 

### DIFF
--- a/hack/tools/release/internal/update_providers/README.md
+++ b/hack/tools/release/internal/update_providers/README.md
@@ -29,6 +29,13 @@
   export RELEASE_DATE="2023-11-28"
   ```
 
+- Export `RELEASE_CODE_FREEZE_DATE` to the targeted CAPI release version date. Fetch the target code freeze date from latest [release file](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases). The `RELEASE_CODE_FREEZE_DATE` should be in the format `YYYY-MM-DD`.
+  Example:
+
+  ```sh
+  export RELEASE_CODE_FREEZE_DATE="2023-11-13"
+  ```
+
 ## How to run the tool
 
 - Finish the pre-requites [tasks](#pre-requisites).

--- a/hack/tools/release/internal/update_providers/provider_issues.go
+++ b/hack/tools/release/internal/update_providers/provider_issues.go
@@ -74,11 +74,12 @@ type IssueResponse struct {
 
 // releaseDetails is the struct for the release details.
 type releaseDetails struct {
-	ReleaseTag       string
-	PreReleaseTag    string
-	ReleaseLink      string
-	ReleaseDate      string
-	ReleaseNotesLink string
+	ReleaseTag            string
+	PreReleaseTag         string
+	ReleaseLink           string
+	ReleaseDate           string
+	ReleaseCodeFreezeDate string
+	ReleaseNotesLink      string
 }
 
 // Example command:
@@ -296,17 +297,29 @@ func getReleaseDetails() (releaseDetails, error) {
 		return releaseDetails{}, errors.New("unable to parse the date")
 	}
 
+	// Parse the release code freeze date
+	codeFreezeDate, keySet := os.LookupEnv("RELEASE_CODE_FREEZE_DATE")
+	if !keySet || codeFreezeDate == "" {
+		return releaseDetails{}, errors.New("release code freeze date is a required environmental variable. Refer to README.md in folder for more information")
+	}
+
+	formattedCodeFreezeDate, err := formatDate(codeFreezeDate)
+	if err != nil {
+		return releaseDetails{}, errors.New("unable to parse the code freeze date")
+	}
+
 	majorMinorWithoutPrefixV := fmt.Sprintf("%s.%s", major, minor) // e.g. 1.7 . Note that there is no "v" in the majorMinor
 	releaseTag := fmt.Sprintf("v%s.%s.%s", major, minor, patch)    // e.g. v1.7.0
 	releaseLink := fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-%s.md#timeline", majorMinorWithoutPrefixV)
 	releaseNotesLink := fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/releases/tag/%s", releaseSemVer)
 
 	return releaseDetails{
-		ReleaseDate:      formattedReleaseDate,
-		ReleaseTag:       releaseTag,
-		PreReleaseTag:    releaseSemVer,
-		ReleaseLink:      releaseLink,
-		ReleaseNotesLink: releaseNotesLink,
+		ReleaseDate:           formattedReleaseDate,
+		ReleaseTag:            releaseTag,
+		PreReleaseTag:         releaseSemVer,
+		ReleaseLink:           releaseLink,
+		ReleaseNotesLink:      releaseNotesLink,
+		ReleaseCodeFreezeDate: formattedCodeFreezeDate,
 	}, nil
 }
 
@@ -352,6 +365,8 @@ Looking forward to your feedback before {{.ReleaseTag}} release!
 ## Following are the planned dates for the upcoming releases
 
 CAPI {{.ReleaseTag}} will be released on **{{.ReleaseDate}}**.
+
+Code Freeze for {{.ReleaseTag}} is scheduled to begin on **{{.ReleaseCodeFreezeDate}}**.
 
 More details of the upcoming schedule can be seen at [CAPI {{.ReleaseTag}} release timeline]({{.ReleaseLink}}).
 

--- a/hack/tools/release/internal/update_providers/provider_issues_test.go
+++ b/hack/tools/release/internal/update_providers/provider_issues_test.go
@@ -27,49 +27,56 @@ import (
 
 func Test_GetReleaseDetails(t *testing.T) {
 	tests := []struct {
-		name        string
-		releaseTag  string
-		releaseDate string
-		want        releaseDetails
-		expectErr   bool
-		err         string
+		name                  string
+		releaseTag            string
+		releaseDate           string
+		releaseCodeFreezeDate string
+		want                  releaseDetails
+		expectErr             bool
+		err                   string
 	}{
 		{
-			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for alpha",
-			releaseTag:  "v1.7.0-alpha.0",
-			releaseDate: "2024-04-16",
+			name:                  "Correct RELEASE_TAG, RELEASE_DATE and RELEASE_CODE_FREEZE_DATE are set for alpha",
+			releaseTag:            "v1.7.0-alpha.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024-04-01",
 			want: releaseDetails{
-				ReleaseDate:      "Tuesday, 16th April 2024",
-				ReleaseTag:       "v1.7.0",
-				PreReleaseTag:    "v1.7.0-alpha.0",
-				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
-				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-alpha.0",
+				ReleaseDate:           "Tuesday, 16th April 2024",
+				ReleaseCodeFreezeDate: "Monday, 1st April 2024",
+				ReleaseTag:            "v1.7.0",
+				PreReleaseTag:         "v1.7.0-alpha.0",
+				ReleaseLink:           "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink:      "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-alpha.0",
 			},
 			expectErr: false,
 		},
 		{
-			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for beta",
-			releaseTag:  "v1.7.0-beta.0",
-			releaseDate: "2024-04-16",
+			name:                  "Correct RELEASE_TAG, RELEASE_DATE and RELEASE_CODE_FREEZE_DATE are set for beta",
+			releaseTag:            "v1.7.0-beta.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024-04-01",
 			want: releaseDetails{
-				ReleaseDate:      "Tuesday, 16th April 2024",
-				ReleaseTag:       "v1.7.0",
-				PreReleaseTag:    "v1.7.0-beta.0",
-				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
-				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-beta.0",
+				ReleaseDate:           "Tuesday, 16th April 2024",
+				ReleaseCodeFreezeDate: "Monday, 1st April 2024",
+				ReleaseTag:            "v1.7.0",
+				PreReleaseTag:         "v1.7.0-beta.0",
+				ReleaseLink:           "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink:      "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-beta.0",
 			},
 			expectErr: false,
 		},
 		{
-			name:        "Correct RELEASE_TAG and RELEASE_DATE are set for rc",
-			releaseTag:  "v1.7.0-rc.0",
-			releaseDate: "2024-04-16",
+			name:                  "Correct RELEASE_TAG, RELEASE_DATE and RELEASE_CODE_FREEZE_DATE are set for rc",
+			releaseTag:            "v1.7.0-rc.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024-04-01",
 			want: releaseDetails{
-				ReleaseDate:      "Tuesday, 16th April 2024",
-				ReleaseTag:       "v1.7.0",
-				PreReleaseTag:    "v1.7.0-rc.0",
-				ReleaseLink:      "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
-				ReleaseNotesLink: "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-rc.0",
+				ReleaseDate:           "Tuesday, 16th April 2024",
+				ReleaseCodeFreezeDate: "Monday, 1st April 2024",
+				ReleaseTag:            "v1.7.0",
+				PreReleaseTag:         "v1.7.0-rc.0",
+				ReleaseLink:           "https://github.com/kubernetes-sigs/cluster-api/tree/main/docs/release/releases/release-1.7.md#timeline",
+				ReleaseNotesLink:      "https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.7.0-rc.0",
 			},
 			expectErr: false,
 		},
@@ -122,6 +129,30 @@ func Test_GetReleaseDetails(t *testing.T) {
 			expectErr:   true,
 			err:         "unable to parse the date",
 		},
+		{
+			name:                  "invalid yyyy/dd/mm RELEASE_CODE_FREEZE_DATE entered",
+			releaseTag:            "v1.7.0-beta.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024/1/4",
+			expectErr:             true,
+			err:                   "unable to parse the code freeze date",
+		},
+		{
+			name:                  "invalid yyyy/mm/dd RELEASE_CODE_FREEZE_DATE entered",
+			releaseTag:            "v1.7.0-beta.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024/4/1",
+			expectErr:             true,
+			err:                   "unable to parse the code freeze date",
+		},
+		{
+			name:                  "invalid yyyy/mm/dd RELEASE_CODE_FREEZE_DATE entered",
+			releaseTag:            "v1.7.0-beta.0",
+			releaseDate:           "2024-04-16",
+			releaseCodeFreezeDate: "2024-4-1",
+			expectErr:             true,
+			err:                   "unable to parse the code freeze date",
+		},
 	}
 
 	for _, tt := range tests {
@@ -130,12 +161,14 @@ func Test_GetReleaseDetails(t *testing.T) {
 
 			t.Setenv("RELEASE_TAG", tt.releaseTag)
 			t.Setenv("RELEASE_DATE", tt.releaseDate)
+			t.Setenv("RELEASE_CODE_FREEZE_DATE", tt.releaseCodeFreezeDate)
 
 			got, err := getReleaseDetails()
 			if tt.expectErr {
 				g.Expect(err.Error()).To(Equal(tt.err))
 			} else {
 				g.Expect(got.ReleaseDate).To(Equal(tt.want.ReleaseDate))
+				g.Expect(got.ReleaseCodeFreezeDate).To(Equal(tt.want.ReleaseCodeFreezeDate))
 				g.Expect(got.ReleaseTag).To(Equal(tt.want.ReleaseTag))
 				g.Expect(got.PreReleaseTag).To(Equal(tt.want.PreReleaseTag))
 				g.Expect(got.ReleaseLink).To(Equal(tt.want.ReleaseLink))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
When we need to communicate/announce about CAPI beta release, we need to mention the code freeze date for providers.
this automates this step instead of release team members need to re-write that comment in every created issue.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area release