### PR TITLE
✨ Allow patching of metadata.{labels,annotations} through ClusterClass patches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,10 +124,12 @@ linters:
             - sigs.k8s.io/cluster-api/test/extension
             - sigs.k8s.io/cluster-api/test/infrastructure/docker/api
             - sigs.k8s.io/cluster-api/test/infrastructure/kind$
+            - sigs.k8s.io/cluster-api/util/annotations$
             - sigs.k8s.io/cluster-api/util/cache$
             - sigs.k8s.io/cluster-api/util/conditions$
             - sigs.k8s.io/cluster-api/util/contract$
             - sigs.k8s.io/cluster-api/util/flags$
+            - sigs.k8s.io/cluster-api/util/labels$
             - sigs.k8s.io/cluster-api/util/util$
             - sigs.k8s.io/cluster-api/version$
             - sigs.k8s.io/controller-runtime

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace_canupdatemachine.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace_canupdatemachine.go
@@ -271,19 +271,19 @@ func cleanupUnstructured(u *unstructured.Unstructured) *unstructured.Unstructure
 
 func applyPatchesToRequest(ctx context.Context, req *runtimehooksv1.CanUpdateMachineRequest, resp *runtimehooksv1.CanUpdateMachineResponse) error {
 	if resp.MachinePatch.IsDefined() {
-		if err := patch.ApplyPatchToTypedObject(ctx, &req.Current.Machine, resp.MachinePatch, "spec"); err != nil {
+		if err := patch.ApplyPatchToTypedObject(ctx, &req.Current.Machine, resp.MachinePatch, []string{"spec"}); err != nil {
 			return err
 		}
 	}
 
 	if resp.BootstrapConfigPatch.IsDefined() {
-		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.BootstrapConfig, resp.BootstrapConfigPatch, "spec"); err != nil {
+		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.BootstrapConfig, resp.BootstrapConfigPatch, []string{"spec"}); err != nil {
 			return err
 		}
 	}
 
 	if resp.InfrastructureMachinePatch.IsDefined() {
-		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.InfrastructureMachine, resp.InfrastructureMachinePatch, "spec"); err != nil {
+		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.InfrastructureMachine, resp.InfrastructureMachinePatch, []string{"spec"}); err != nil {
 			return err
 		}
 	}

--- a/core/reconcilers/machinedeployment/machinedeployment_canupdatemachineset.go
+++ b/core/reconcilers/machinedeployment/machinedeployment_canupdatemachineset.go
@@ -236,19 +236,19 @@ func cleanupUnstructured(u *unstructured.Unstructured) *unstructured.Unstructure
 
 func applyPatchesToRequest(ctx context.Context, req *runtimehooksv1.CanUpdateMachineSetRequest, resp *runtimehooksv1.CanUpdateMachineSetResponse) error {
 	if resp.MachineSetPatch.IsDefined() {
-		if err := patch.ApplyPatchToTypedObject(ctx, &req.Current.MachineSet, resp.MachineSetPatch, "spec.template.spec"); err != nil {
+		if err := patch.ApplyPatchToTypedObject(ctx, &req.Current.MachineSet, resp.MachineSetPatch, []string{"spec", "template", "spec"}); err != nil {
 			return err
 		}
 	}
 
 	if resp.BootstrapConfigTemplatePatch.IsDefined() && req.Current.BootstrapConfigTemplate.Object != nil {
-		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.BootstrapConfigTemplate, resp.BootstrapConfigTemplatePatch, "spec.template.spec"); err != nil {
+		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.BootstrapConfigTemplate, resp.BootstrapConfigTemplatePatch, []string{"spec", "template", "spec"}); err != nil {
 			return err
 		}
 	}
 
 	if resp.InfrastructureMachineTemplatePatch.IsDefined() {
-		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.InfrastructureMachineTemplate, resp.InfrastructureMachineTemplatePatch, "spec.template.spec"); err != nil {
+		if _, err := patch.ApplyPatchToObject(ctx, &req.Current.InfrastructureMachineTemplate, resp.InfrastructureMachineTemplatePatch, []string{"spec", "template", "spec"}); err != nil {
 			return err
 		}
 	}

--- a/core/reconcilers/topology/cluster/patches/engine.go
+++ b/core/reconcilers/topology/cluster/patches/engine.go
@@ -277,8 +277,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 	// Add the InfrastructureClusterTemplate.
 	// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 	if err := patchUnstructured(ctx, blueprint.InfrastructureClusterTemplate, desired.InfrastructureCluster, []patchUnstructuredFields{
-		{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
-		{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+		{Src: []string{"metadata", "labels"}, Dest: []string{"spec", "template", "metadata", "labels"}},
+		{Src: []string{"metadata", "annotations"}, Dest: []string{"spec", "template", "metadata", "annotations"}},
 	}); err != nil {
 		return nil, errors.Wrapf(err, "failed to prepare %s %s for patching",
 			blueprint.InfrastructureClusterTemplate.GetKind(), klog.KObj(blueprint.InfrastructureClusterTemplate))
@@ -295,8 +295,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 	// Add the ControlPlaneTemplate.
 	// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 	if err := patchUnstructured(ctx, blueprint.ControlPlane.Template, desired.ControlPlane.Object, []patchUnstructuredFields{
-		{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
-		{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+		{Src: []string{"metadata", "labels"}, Dest: []string{"spec", "template", "metadata", "labels"}},
+		{Src: []string{"metadata", "annotations"}, Dest: []string{"spec", "template", "metadata", "annotations"}},
 	}); err != nil {
 		return nil, errors.Wrapf(err, "failed to prepare %s %s for patching",
 			blueprint.ControlPlane.Template.GetKind(), klog.KObj(blueprint.ControlPlane.Template))
@@ -315,8 +315,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 	if blueprint.HasControlPlaneInfrastructureMachine() {
 		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 		if err := patchUnstructured(ctx, blueprint.ControlPlane.InfrastructureMachineTemplate, desired.ControlPlane.InfrastructureMachineTemplate, []patchUnstructuredFields{
-			{Src: "metadata.labels", Dest: "metadata.labels"},
-			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+			{Src: []string{"metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+			{Src: []string{"metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
 		}); err != nil {
 			return nil, errors.Wrapf(err, "failed to prepare ControlPlane's %s %s for patching",
 				blueprint.ControlPlane.InfrastructureMachineTemplate.GetKind(), klog.KObj(blueprint.ControlPlane.InfrastructureMachineTemplate))
@@ -353,8 +353,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 		// Add the BootstrapTemplate.
 		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 		if err := patchUnstructured(ctx, mdClass.BootstrapTemplate, md.BootstrapTemplate, []patchUnstructuredFields{
-			{Src: "metadata.labels", Dest: "metadata.labels"},
-			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+			{Src: []string{"metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+			{Src: []string{"metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
 		}); err != nil {
 			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachineDeployment topology %s for patching",
 				mdClass.BootstrapTemplate.GetKind(), klog.KObj(mdClass.BootstrapTemplate), mdTopologyName)
@@ -371,8 +371,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 		// Add the InfrastructureMachineTemplate.
 		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 		if err := patchUnstructured(ctx, mdClass.InfrastructureMachineTemplate, md.InfrastructureMachineTemplate, []patchUnstructuredFields{
-			{Src: "metadata.labels", Dest: "metadata.labels"},
-			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+			{Src: []string{"metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+			{Src: []string{"metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
 		}); err != nil {
 			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachineDeployment topology %s for patching",
 				mdClass.InfrastructureMachineTemplate.GetKind(), klog.KObj(mdClass.InfrastructureMachineTemplate), mdTopologyName)
@@ -409,8 +409,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 		// Add the BootstrapTemplate.
 		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 		if err := patchUnstructured(ctx, mpClass.BootstrapTemplate, mp.BootstrapObject, []patchUnstructuredFields{
-			{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
-			{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+			{Src: []string{"metadata", "labels"}, Dest: []string{"spec", "template", "metadata", "labels"}},
+			{Src: []string{"metadata", "annotations"}, Dest: []string{"spec", "template", "metadata", "annotations"}},
 		}); err != nil {
 			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachinePool topology %s for patching",
 				mpClass.BootstrapTemplate.GetKind(), klog.KObj(mpClass.BootstrapTemplate), mpTopologyName)
@@ -427,8 +427,8 @@ func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desir
 		// Add the InfrastructureMachineTemplate.
 		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
 		if err := patchUnstructured(ctx, mpClass.InfrastructureMachinePoolTemplate, mp.InfrastructureMachinePoolObject, []patchUnstructuredFields{
-			{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
-			{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+			{Src: []string{"metadata", "labels"}, Dest: []string{"spec", "template", "metadata", "labels"}},
+			{Src: []string{"metadata", "annotations"}, Dest: []string{"spec", "template", "metadata", "annotations"}},
 		}); err != nil {
 			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachinePool topology %s for patching",
 				mpClass.InfrastructureMachinePoolTemplate.GetKind(), klog.KObj(mpClass.InfrastructureMachinePoolTemplate), mpTopologyName)
@@ -561,7 +561,8 @@ func applyPatchToRequest(ctx context.Context, req *runtimehooksv1.GeneratePatche
 
 	// Overwrite the spec of template.Template with the spec of the patchedTemplate,
 	// to ensure that we only pick up changes to the spec.
-	if err := patchutil.Patch(&requestItem.Object, patchedTemplate, "spec", "metadata.labels", "metadata.annotations"); err != nil {
+	// Note: By patching "spec" we'll be patching "spec.template.spec" and "spec.template.metadata".
+	if err := patchutil.Patch(&requestItem.Object, patchedTemplate, []string{"spec"}, []string{"metadata", "labels"}, []string{"metadata", "annotations"}); err != nil {
 		log.Error(err, fmt.Sprintf("Failed to apply patch to template with uid %q", requestItem.UID))
 		return errors.Wrap(err, "failed to apply patch to template")
 	}

--- a/core/reconcilers/topology/cluster/patches/engine.go
+++ b/core/reconcilers/topology/cluster/patches/engine.go
@@ -84,7 +84,7 @@ func (e *engine) Apply(ctx context.Context, blueprint *scope.ClusterBlueprint, d
 	}
 
 	// Create a patch generation request.
-	req, err := createRequest(blueprint, desired, controlPlaneContractVersion)
+	req, err := createRequest(ctx, blueprint, desired, controlPlaneContractVersion)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate patch request")
 	}
@@ -271,10 +271,18 @@ func getMPTopologyFromMP(blueprint *scope.ClusterBlueprint, mp *clusterv1.Machin
 // replicas of a MachineDeployment.
 // NOTE: A single GeneratePatchesRequest object is used to carry templates state across subsequent Generate calls.
 // NOTE: This function does not add variables to items for the request, as the variables depend on the specific patch.
-func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterState, controlPlaneContractVersion string) (*runtimehooksv1.GeneratePatchesRequest, error) {
+func createRequest(ctx context.Context, blueprint *scope.ClusterBlueprint, desired *scope.ClusterState, controlPlaneContractVersion string) (*runtimehooksv1.GeneratePatchesRequest, error) {
 	req := &runtimehooksv1.GeneratePatchesRequest{}
 
 	// Add the InfrastructureClusterTemplate.
+	// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+	if err := patchUnstructured(ctx, blueprint.InfrastructureClusterTemplate, desired.InfrastructureCluster, []patchUnstructuredFields{
+		{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
+		{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+	}); err != nil {
+		return nil, errors.Wrapf(err, "failed to prepare %s %s for patching",
+			blueprint.InfrastructureClusterTemplate.GetKind(), klog.KObj(blueprint.InfrastructureClusterTemplate))
+	}
 	t, err := newRequestItemBuilder(blueprint.InfrastructureClusterTemplate).
 		WithHolder(desired.Cluster, clusterv1.GroupVersion.WithKind("Cluster"), "spec.infrastructureRef").
 		Build()
@@ -285,6 +293,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 	req.Items = append(req.Items, *t)
 
 	// Add the ControlPlaneTemplate.
+	// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+	if err := patchUnstructured(ctx, blueprint.ControlPlane.Template, desired.ControlPlane.Object, []patchUnstructuredFields{
+		{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
+		{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+	}); err != nil {
+		return nil, errors.Wrapf(err, "failed to prepare %s %s for patching",
+			blueprint.ControlPlane.Template.GetKind(), klog.KObj(blueprint.ControlPlane.Template))
+	}
 	t, err = newRequestItemBuilder(blueprint.ControlPlane.Template).
 		WithHolder(desired.Cluster, clusterv1.GroupVersion.WithKind("Cluster"), "spec.controlPlaneRef").
 		Build()
@@ -297,6 +313,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 	// If the clusterClass mandates the controlPlane has infrastructureMachines,
 	// add the InfrastructureMachineTemplate for control plane machines.
 	if blueprint.HasControlPlaneInfrastructureMachine() {
+		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+		if err := patchUnstructured(ctx, blueprint.ControlPlane.InfrastructureMachineTemplate, desired.ControlPlane.InfrastructureMachineTemplate, []patchUnstructuredFields{
+			{Src: "metadata.labels", Dest: "metadata.labels"},
+			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to prepare ControlPlane's %s %s for patching",
+				blueprint.ControlPlane.InfrastructureMachineTemplate.GetKind(), klog.KObj(blueprint.ControlPlane.InfrastructureMachineTemplate))
+		}
 		t, err := newRequestItemBuilder(blueprint.ControlPlane.InfrastructureMachineTemplate).
 			WithHolder(desired.ControlPlane.Object, desired.ControlPlane.Object.GroupVersionKind(), getControlPlaneHolderFieldPath(controlPlaneContractVersion)).
 			Build()
@@ -327,6 +351,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 		}
 
 		// Add the BootstrapTemplate.
+		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+		if err := patchUnstructured(ctx, mdClass.BootstrapTemplate, md.BootstrapTemplate, []patchUnstructuredFields{
+			{Src: "metadata.labels", Dest: "metadata.labels"},
+			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachineDeployment topology %s for patching",
+				mdClass.BootstrapTemplate.GetKind(), klog.KObj(mdClass.BootstrapTemplate), mdTopologyName)
+		}
 		t, err := newRequestItemBuilder(mdClass.BootstrapTemplate).
 			WithHolder(md.Object, clusterv1.GroupVersion.WithKind("MachineDeployment"), "spec.template.spec.bootstrap.configRef").
 			Build()
@@ -337,6 +369,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 		req.Items = append(req.Items, *t)
 
 		// Add the InfrastructureMachineTemplate.
+		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+		if err := patchUnstructured(ctx, mdClass.InfrastructureMachineTemplate, md.InfrastructureMachineTemplate, []patchUnstructuredFields{
+			{Src: "metadata.labels", Dest: "metadata.labels"},
+			{Src: "metadata.annotations", Dest: "metadata.annotations"},
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachineDeployment topology %s for patching",
+				mdClass.InfrastructureMachineTemplate.GetKind(), klog.KObj(mdClass.InfrastructureMachineTemplate), mdTopologyName)
+		}
 		t, err = newRequestItemBuilder(mdClass.InfrastructureMachineTemplate).
 			WithHolder(md.Object, clusterv1.GroupVersion.WithKind("MachineDeployment"), "spec.template.spec.infrastructureRef").
 			Build()
@@ -367,6 +407,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 		}
 
 		// Add the BootstrapTemplate.
+		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+		if err := patchUnstructured(ctx, mpClass.BootstrapTemplate, mp.BootstrapObject, []patchUnstructuredFields{
+			{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
+			{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachinePool topology %s for patching",
+				mpClass.BootstrapTemplate.GetKind(), klog.KObj(mpClass.BootstrapTemplate), mpTopologyName)
+		}
 		t, err := newRequestItemBuilder(mpClass.BootstrapTemplate).
 			WithHolder(mp.Object, clusterv1.GroupVersion.WithKind("MachinePool"), "spec.template.spec.bootstrap.configRef").
 			Build()
@@ -377,6 +425,14 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 		req.Items = append(req.Items, *t)
 
 		// Add the InfrastructureMachineTemplate.
+		// Syncing labels/annotations added (during desired state computation) to the desired state back into the template, so the patch engine can consider them.
+		if err := patchUnstructured(ctx, mpClass.InfrastructureMachinePoolTemplate, mp.InfrastructureMachinePoolObject, []patchUnstructuredFields{
+			{Src: "metadata.labels", Dest: "spec.template.metadata.labels"},
+			{Src: "metadata.annotations", Dest: "spec.template.metadata.annotations"},
+		}); err != nil {
+			return nil, errors.Wrapf(err, "failed to prepare %s %s for MachinePool topology %s for patching",
+				mpClass.InfrastructureMachinePoolTemplate.GetKind(), klog.KObj(mpClass.InfrastructureMachinePoolTemplate), mpTopologyName)
+		}
 		t, err = newRequestItemBuilder(mpClass.InfrastructureMachinePoolTemplate).
 			WithHolder(mp.Object, clusterv1.GroupVersion.WithKind("MachinePool"), "spec.template.spec.infrastructureRef").
 			Build()
@@ -505,7 +561,7 @@ func applyPatchToRequest(ctx context.Context, req *runtimehooksv1.GeneratePatche
 
 	// Overwrite the spec of template.Template with the spec of the patchedTemplate,
 	// to ensure that we only pick up changes to the spec.
-	if err := patchutil.Patch(&requestItem.Object, patchedTemplate, "spec"); err != nil {
+	if err := patchutil.Patch(&requestItem.Object, patchedTemplate, "spec", "metadata.labels", "metadata.annotations"); err != nil {
 		log.Error(err, fmt.Sprintf("Failed to apply patch to template with uid %q", requestItem.UID))
 		return errors.Wrap(err, "failed to apply patch to template")
 	}
@@ -536,12 +592,21 @@ func convertToValidationRequest(generateRequest *runtimehooksv1.GeneratePatchesR
 func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatchesRequest, blueprint *scope.ClusterBlueprint, desired *scope.ClusterState, controlPlaneContractVersion string) error {
 	var err error
 
+	alwaysPreserveLabelsAndAnnotations := []contract.Path{
+		{"metadata", "labels", clusterv1.ClusterNameLabel},
+		{"metadata", "labels", clusterv1.ClusterTopologyOwnedLabel},
+		{"metadata", "labels", clusterv1.ClusterTopologyMachineDeploymentNameLabel},
+		{"metadata", "labels", clusterv1.ClusterTopologyMachinePoolNameLabel},
+		{"metadata", "annotations", clusterv1.TemplateClonedFromNameAnnotation},
+		{"metadata", "annotations", clusterv1.TemplateClonedFromGroupKindAnnotation},
+	}
+
 	// Update the InfrastructureCluster.
 	infrastructureClusterTemplate, err := getTemplateAsUnstructured(req, "Cluster", "spec.infrastructureRef", requestTopologyName{})
 	if err != nil {
 		return err
 	}
-	if err := patchObject(ctx, desired.InfrastructureCluster, infrastructureClusterTemplate); err != nil {
+	if err := patchObject(ctx, desired.InfrastructureCluster, infrastructureClusterTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 		return err
 	}
 
@@ -550,7 +615,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 	if err != nil {
 		return err
 	}
-	if err := patchObject(ctx, desired.ControlPlane.Object, controlPlaneTemplate, PreserveFields{
+	if err := patchObject(ctx, desired.ControlPlane.Object, controlPlaneTemplate, append(PreserveFields{
 		contract.ControlPlane().MachineTemplate().Metadata().Path(),
 		// Note: For simplicity we don't allow patching for the fields of both contracts to avoid
 		// requiring a client here to retrieve the contract version of the ControlPlane object.
@@ -568,7 +633,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		contract.ControlPlane().Replicas().Path(),
 		contract.ControlPlane().Version().Path(),
 		contract.ControlPlane().RolloutAfter().Path(),
-	}); err != nil {
+	}, alwaysPreserveLabelsAndAnnotations...)); err != nil {
 		return err
 	}
 
@@ -579,7 +644,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		if err != nil {
 			return err
 		}
-		if err := patchTemplate(ctx, desired.ControlPlane.InfrastructureMachineTemplate, infrastructureMachineTemplate); err != nil {
+		if err := patchTemplate(ctx, desired.ControlPlane.InfrastructureMachineTemplate, infrastructureMachineTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 			return err
 		}
 	}
@@ -592,7 +657,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		if err != nil {
 			return err
 		}
-		if err := patchTemplate(ctx, md.BootstrapTemplate, bootstrapTemplate); err != nil {
+		if err := patchTemplate(ctx, md.BootstrapTemplate, bootstrapTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 			return err
 		}
 
@@ -601,7 +666,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		if err != nil {
 			return err
 		}
-		if err := patchTemplate(ctx, md.InfrastructureMachineTemplate, infrastructureMachineTemplate); err != nil {
+		if err := patchTemplate(ctx, md.InfrastructureMachineTemplate, infrastructureMachineTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 			return err
 		}
 	}
@@ -614,7 +679,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		if err != nil {
 			return err
 		}
-		if err := patchObject(ctx, mp.BootstrapObject, bootstrapTemplate); err != nil {
+		if err := patchObject(ctx, mp.BootstrapObject, bootstrapTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 			return err
 		}
 
@@ -623,7 +688,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		if err != nil {
 			return err
 		}
-		if err := patchObject(ctx, mp.InfrastructureMachinePoolObject, infrastructureMachinePoolTemplate); err != nil {
+		if err := patchObject(ctx, mp.InfrastructureMachinePoolObject, infrastructureMachinePoolTemplate, PreserveFields(alwaysPreserveLabelsAndAnnotations)); err != nil {
 			return err
 		}
 	}

--- a/core/reconcilers/topology/cluster/patches/engine_test.go
+++ b/core/reconcilers/topology/cluster/patches/engine_test.go
@@ -41,6 +41,8 @@ import (
 	"sigs.k8s.io/cluster-api/exp/topology/scope"
 	"sigs.k8s.io/cluster-api/feature"
 	fakeruntimeclient "sigs.k8s.io/cluster-api/internal/runtime/client/fake"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/labels"
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
@@ -86,6 +88,21 @@ func TestApply(t *testing.T) {
 							JSONPatches: []clusterv1.JSONPatch{
 								{
 									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
 									Path:  "/spec/template/spec/resource",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`"infraCluster"`)},
 								},
@@ -100,6 +117,21 @@ func TestApply(t *testing.T) {
 								},
 							},
 							JSONPatches: []clusterv1.JSONPatch{
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
 								{
 									Op:    "add",
 									Path:  "/spec/template/spec/resource",
@@ -118,6 +150,31 @@ func TestApply(t *testing.T) {
 							JSONPatches: []clusterv1.JSONPatch{
 								{
 									Op:    "add",
+									Path:  "/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-label-1": "nested-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-annotation-1": "nested-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
 									Path:  "/spec/template/spec/resource",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`"controlPlaneInfrastructureMachineTemplate"`)},
 								},
@@ -128,13 +185,21 @@ func TestApply(t *testing.T) {
 			},
 			expectedFields: expectedFields{
 				infrastructureCluster: map[string]interface{}{
+					"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+					"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
 					"spec.resource": "infraCluster",
 				},
 				controlPlane: map[string]interface{}{
+					"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+					"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
 					"spec.resource": "controlPlane",
 				},
 				controlPlaneInfrastructureMachineTemplate: map[string]interface{}{
-					"spec.template.spec.resource": "controlPlaneInfrastructureMachineTemplate",
+					"metadata.labels.top-level-label-1":                      "top-level-label-value-1",
+					"metadata.annotations.top-level-annotation-1":            "top-level-annotation-value-1",
+					"spec.template.metadata.labels.nested-label-1":           "nested-label-value-1",
+					"spec.template.metadata.annotations.nested-annotation-1": "nested-annotation-value-1",
+					"spec.template.spec.resource":                            "controlPlaneInfrastructureMachineTemplate",
 				},
 			},
 		},
@@ -157,6 +222,31 @@ func TestApply(t *testing.T) {
 							JSONPatches: []clusterv1.JSONPatch{
 								{
 									Op:    "add",
+									Path:  "/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-label-1": "nested-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-annotation-1": "nested-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
 									Path:  "/spec/template/spec/resource",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-worker-infra"`)},
 								},
@@ -173,6 +263,31 @@ func TestApply(t *testing.T) {
 								},
 							},
 							JSONPatches: []clusterv1.JSONPatch{
+								{
+									Op:    "add",
+									Path:  "/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-label-1": "nested-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"nested-annotation-1": "nested-annotation-value-1"}`)},
+								},
 								{
 									Op:    "add",
 									Path:  "/spec/template/spec/resource",
@@ -193,6 +308,21 @@ func TestApply(t *testing.T) {
 							JSONPatches: []clusterv1.JSONPatch{
 								{
 									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
 									Path:  "/spec/template/spec/resource",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-infra"`)},
 								},
@@ -211,6 +341,21 @@ func TestApply(t *testing.T) {
 							JSONPatches: []clusterv1.JSONPatch{
 								{
 									Op:    "add",
+									Path:  "/spec/template/metadata",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/labels",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+								},
+								{
+									Op:    "add",
+									Path:  "/spec/template/metadata/annotations",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+								},
+								{
+									Op:    "add",
 									Path:  "/spec/template/spec/resource",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`"default-mp-worker-bootstrap"`)},
 								},
@@ -221,20 +366,60 @@ func TestApply(t *testing.T) {
 			},
 			expectedFields: expectedFields{
 				machineDeploymentBootstrapTemplate: map[string]map[string]interface{}{
-					"default-worker-topo1": {"spec.template.spec.resource": "default-worker-bootstrap"},
-					"default-worker-topo2": {"spec.template.spec.resource": "default-worker-bootstrap"},
+					"default-worker-topo1": {
+						"metadata.labels.top-level-label-1":                      "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1":            "top-level-annotation-value-1",
+						"spec.template.metadata.labels.nested-label-1":           "nested-label-value-1",
+						"spec.template.metadata.annotations.nested-annotation-1": "nested-annotation-value-1",
+						"spec.template.spec.resource":                            "default-worker-bootstrap",
+					},
+					"default-worker-topo2": {
+						"metadata.labels.top-level-label-1":                      "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1":            "top-level-annotation-value-1",
+						"spec.template.metadata.labels.nested-label-1":           "nested-label-value-1",
+						"spec.template.metadata.annotations.nested-annotation-1": "nested-annotation-value-1",
+						"spec.template.spec.resource":                            "default-worker-bootstrap",
+					},
 				},
 				machineDeploymentInfrastructureMachineTemplate: map[string]map[string]interface{}{
-					"default-worker-topo1": {"spec.template.spec.resource": "default-worker-infra"},
-					"default-worker-topo2": {"spec.template.spec.resource": "default-worker-infra"},
+					"default-worker-topo1": {
+						"metadata.labels.top-level-label-1":                      "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1":            "top-level-annotation-value-1",
+						"spec.template.metadata.labels.nested-label-1":           "nested-label-value-1",
+						"spec.template.metadata.annotations.nested-annotation-1": "nested-annotation-value-1",
+						"spec.template.spec.resource":                            "default-worker-infra",
+					},
+					"default-worker-topo2": {
+						"metadata.labels.top-level-label-1":                      "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1":            "top-level-annotation-value-1",
+						"spec.template.metadata.labels.nested-label-1":           "nested-label-value-1",
+						"spec.template.metadata.annotations.nested-annotation-1": "nested-annotation-value-1",
+						"spec.template.spec.resource":                            "default-worker-infra",
+					},
 				},
 				machinePoolBootstrapConfig: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "default-mp-worker-bootstrap"},
-					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-bootstrap"},
+					"default-mp-worker-topo1": {
+						"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
+						"spec.resource": "default-mp-worker-bootstrap",
+					},
+					"default-mp-worker-topo2": {
+						"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
+						"spec.resource": "default-mp-worker-bootstrap",
+					},
 				},
 				machinePoolInfrastructureMachinePool: map[string]map[string]interface{}{
-					"default-mp-worker-topo1": {"spec.resource": "default-mp-worker-infra"},
-					"default-mp-worker-topo2": {"spec.resource": "default-mp-worker-infra"},
+					"default-mp-worker-topo1": {
+						"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
+						"spec.resource": "default-mp-worker-infra",
+					},
+					"default-mp-worker-topo2": {
+						"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+						"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
+						"spec.resource": "default-mp-worker-infra",
+					},
 				},
 			},
 		},
@@ -316,6 +501,25 @@ func TestApply(t *testing.T) {
 							},
 							JSONPatches: []clusterv1.JSONPatch{
 								{
+									Op:    "replace",
+									Path:  "/spec/template/metadata/labels/cluster.x-k8s.io~1cluster-name",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`"different-cluster"`)},
+								},
+								{
+									Op:   "remove",
+									Path: "/spec/template/metadata/labels/topology.cluster.x-k8s.io~1owned",
+								},
+								{
+									Op:    "replace",
+									Path:  "/spec/template/metadata/annotations/cluster.x-k8s.io~1cloned-from-name",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`"different-cp-template-name"`)},
+								},
+								{
+									Op:    "replace",
+									Path:  "/spec/template/metadata/annotations/cluster.x-k8s.io~1cloned-from-groupkind",
+									Value: &apiextensionsv1.JSON{Raw: []byte(`"different-cp-template-kind"`)},
+								},
+								{
 									Op:    "add",
 									Path:  "/spec/template/spec/replicas",
 									Value: &apiextensionsv1.JSON{Raw: []byte(`1`)},
@@ -337,7 +541,7 @@ func TestApply(t *testing.T) {
 			},
 		},
 		{
-			name: "Should apply JSON patches without metadata",
+			name: "Should not apply JSON patches for metadata.name",
 			patches: []clusterv1.ClusterClassPatch{
 				{
 					Name: "fake-patch1",
@@ -425,6 +629,24 @@ func TestApply(t *testing.T) {
 							PatchType: runtimehooksv1.JSONPatchType,
 							Patch: bytesPatch([]jsonPatchRFC6902{{
 								Op:    "add",
+								Path:  "/spec/template/metadata/labels",
+								Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-label-1": "top-level-label-value-1"}`)},
+							}}),
+						},
+						{
+							UID:       "1",
+							PatchType: runtimehooksv1.JSONPatchType,
+							Patch: bytesPatch([]jsonPatchRFC6902{{
+								Op:    "add",
+								Path:  "/spec/template/metadata/annotations",
+								Value: &apiextensionsv1.JSON{Raw: []byte(`{"top-level-annotation-1": "top-level-annotation-value-1"}`)},
+							}}),
+						},
+						{
+							UID:       "1",
+							PatchType: runtimehooksv1.JSONPatchType,
+							Patch: bytesPatch([]jsonPatchRFC6902{{
+								Op:    "add",
 								Path:  "/spec/template/spec/resource",
 								Value: &apiextensionsv1.JSON{Raw: []byte(`"infraCluster"`)},
 							}}),
@@ -439,6 +661,8 @@ func TestApply(t *testing.T) {
 			},
 			expectedFields: expectedFields{
 				infrastructureCluster: map[string]interface{}{
+					"metadata.labels.top-level-label-1":           "top-level-label-value-1",
+					"metadata.annotations.top-level-annotation-1": "top-level-annotation-value-1",
 					"spec.resource": "infraCluster",
 				},
 			},
@@ -1030,25 +1254,25 @@ func TestApply(t *testing.T) {
 
 				// Set expected fields on the copy of the objects, so they can be used for comparison with the result of Apply.
 				if tt.expectedFields.infrastructureCluster != nil {
-					setSpecFields(expectedInfrastructureCluster, tt.expectedFields.infrastructureCluster)
+					setFields(expectedInfrastructureCluster, tt.expectedFields.infrastructureCluster)
 				}
 				if tt.expectedFields.controlPlane != nil {
-					setSpecFields(expectedControlPlane, tt.expectedFields.controlPlane)
+					setFields(expectedControlPlane, tt.expectedFields.controlPlane)
 				}
 				if tt.expectedFields.controlPlaneInfrastructureMachineTemplate != nil {
-					setSpecFields(expectedControlPlaneInfrastructureMachineTemplate, tt.expectedFields.controlPlaneInfrastructureMachineTemplate)
+					setFields(expectedControlPlaneInfrastructureMachineTemplate, tt.expectedFields.controlPlaneInfrastructureMachineTemplate)
 				}
 				for mdTopology, expectedFields := range tt.expectedFields.machineDeploymentBootstrapTemplate {
-					setSpecFields(expectedBootstrapTemplates[mdTopology], expectedFields)
+					setFields(expectedBootstrapTemplates[mdTopology], expectedFields)
 				}
 				for mdTopology, expectedFields := range tt.expectedFields.machineDeploymentInfrastructureMachineTemplate {
-					setSpecFields(expectedInfrastructureMachineTemplate[mdTopology], expectedFields)
+					setFields(expectedInfrastructureMachineTemplate[mdTopology], expectedFields)
 				}
 				for mpTopology, expectedFields := range tt.expectedFields.machinePoolBootstrapConfig {
-					setSpecFields(expectedBootstrapConfig[mpTopology], expectedFields)
+					setFields(expectedBootstrapConfig[mpTopology], expectedFields)
 				}
 				for mpTopology, expectedFields := range tt.expectedFields.machinePoolInfrastructureMachinePool {
-					setSpecFields(expectedInfrastructureMachinePool[mpTopology], expectedFields)
+					setFields(expectedInfrastructureMachinePool[mpTopology], expectedFields)
 				}
 
 				// Apply patches.
@@ -1270,11 +1494,11 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 
 	desired := &scope.ClusterState{
 		Cluster:               desiredCluster,
-		InfrastructureCluster: infrastructureCluster,
+		InfrastructureCluster: addStandardLabelsAndAnnotations(infrastructureCluster, cluster.Name, "", "", infrastructureClusterTemplate),
 		ControlPlane: &scope.ControlPlaneState{
-			Object: controlPlane,
+			Object: addStandardLabelsAndAnnotations(controlPlane, cluster.Name, "", "", controlPlaneTemplate),
 			// Make sure we're using an independent instance of the template.
-			InfrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate.DeepCopy(),
+			InfrastructureMachineTemplate: addStandardLabelsAndAnnotations(controlPlaneInfrastructureMachineTemplate.DeepCopy(), cluster.Name, "", "", controlPlaneInfrastructureMachineTemplate),
 		},
 		MachineDeployments: map[string]*scope.MachineDeploymentState{
 			"default-worker-topo1": {
@@ -1283,8 +1507,8 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					WithVersion("v1.21.2").
 					Build(),
 				// Make sure we're using an independent instance of the template.
-				InfrastructureMachineTemplate: workerInfrastructureMachineTemplate.DeepCopy(),
-				BootstrapTemplate:             workerBootstrapTemplate.DeepCopy(),
+				InfrastructureMachineTemplate: addStandardLabelsAndAnnotations(workerInfrastructureMachineTemplate.DeepCopy(), cluster.Name, "default-worker-topo1", "", workerInfrastructureMachineTemplate),
+				BootstrapTemplate:             addStandardLabelsAndAnnotations(workerBootstrapTemplate.DeepCopy(), cluster.Name, "default-worker-topo1", "", workerBootstrapTemplate),
 			},
 			"default-worker-topo2": {
 				Object: builder.MachineDeployment(metav1.NamespaceDefault, "md2").
@@ -1293,8 +1517,8 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					WithReplicas(5).
 					Build(),
 				// Make sure we're using an independent instance of the template.
-				InfrastructureMachineTemplate: workerInfrastructureMachineTemplate.DeepCopy(),
-				BootstrapTemplate:             workerBootstrapTemplate.DeepCopy(),
+				InfrastructureMachineTemplate: addStandardLabelsAndAnnotations(workerInfrastructureMachineTemplate.DeepCopy(), cluster.Name, "default-worker-topo2", "", workerInfrastructureMachineTemplate),
+				BootstrapTemplate:             addStandardLabelsAndAnnotations(workerBootstrapTemplate.DeepCopy(), cluster.Name, "default-worker-topo2", "", workerBootstrapTemplate),
 			},
 		},
 		MachinePools: map[string]*scope.MachinePoolState{
@@ -1304,8 +1528,8 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					WithVersion("v1.21.2").
 					Build(),
 				// Make sure we're using an independent instance of the template.
-				InfrastructureMachinePoolObject: workerInfrastructureMachinePool.DeepCopy(),
-				BootstrapObject:                 workerBootstrapConfig.DeepCopy(),
+				InfrastructureMachinePoolObject: addStandardLabelsAndAnnotations(workerInfrastructureMachinePool.DeepCopy(), cluster.Name, "", "default-mp-worker-topo1", workerInfrastructureMachinePoolTemplate),
+				BootstrapObject:                 addStandardLabelsAndAnnotations(workerBootstrapConfig.DeepCopy(), cluster.Name, "", "default-mp-worker-topo1", workerBootstrapTemplate),
 			},
 			"default-mp-worker-topo2": {
 				Object: builder.MachinePool(metav1.NamespaceDefault, "mp2").
@@ -1314,23 +1538,45 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 					WithReplicas(5).
 					Build(),
 				// Make sure we're using an independent instance of the template.
-				InfrastructureMachinePoolObject: workerInfrastructureMachinePool.DeepCopy(),
-				BootstrapObject:                 workerBootstrapConfig.DeepCopy(),
+				InfrastructureMachinePoolObject: addStandardLabelsAndAnnotations(workerInfrastructureMachinePool.DeepCopy(), cluster.Name, "", "default-mp-worker-topo2", workerInfrastructureMachinePoolTemplate),
+				BootstrapObject:                 addStandardLabelsAndAnnotations(workerBootstrapConfig.DeepCopy(), cluster.Name, "", "default-mp-worker-topo2", workerBootstrapTemplate),
 			},
 		},
 	}
 	return blueprint, desired
 }
 
-// setSpecFields sets fields on an unstructured object from a map.
-func setSpecFields(obj *unstructured.Unstructured, fields map[string]interface{}) {
+func addStandardLabelsAndAnnotations(obj *unstructured.Unstructured, clusterName, mdTopologyName, mpTopologyName string, templateClonedFrom *unstructured.Unstructured) *unstructured.Unstructured {
+	labels.AddLabels(obj, map[string]string{
+		clusterv1.ClusterNameLabel:          clusterName,
+		clusterv1.ClusterTopologyOwnedLabel: "",
+	})
+	if mdTopologyName != "" {
+		labels.AddLabels(obj, map[string]string{
+			clusterv1.ClusterTopologyMachineDeploymentNameLabel: mdTopologyName,
+		})
+	}
+	if mpTopologyName != "" {
+		labels.AddLabels(obj, map[string]string{
+			clusterv1.ClusterTopologyMachinePoolNameLabel: mpTopologyName,
+		})
+	}
+	annotations.AddAnnotations(obj, map[string]string{
+		clusterv1.TemplateClonedFromNameAnnotation:      templateClonedFrom.GetName(),
+		clusterv1.TemplateClonedFromGroupKindAnnotation: templateClonedFrom.GroupVersionKind().GroupKind().String(),
+	})
+	return obj
+}
+
+// setFields sets fields on an unstructured object from a map.
+func setFields(obj *unstructured.Unstructured, fields map[string]interface{}) {
 	for k, v := range fields {
 		fieldParts := strings.Split(k, ".")
 		if len(fieldParts) == 0 {
 			panic(fmt.Errorf("fieldParts invalid"))
 		}
-		if fieldParts[0] != "spec" {
-			panic(fmt.Errorf("can not set fields outside spec"))
+		if !strings.HasPrefix(k, "spec.") && !strings.HasPrefix(k, "metadata.labels") && !strings.HasPrefix(k, "metadata.annotations") {
+			panic(fmt.Errorf("can not set fields outside spec or metadata.labels/annotations"))
 		}
 		if err := unstructured.SetNestedField(obj.UnstructuredContent(), v, strings.Split(k, ".")...); err != nil {
 			panic(err)

--- a/core/reconcilers/topology/cluster/patches/patch.go
+++ b/core/reconcilers/topology/cluster/patches/patch.go
@@ -63,44 +63,66 @@ func (i PreserveFields) ApplyToHelper(opts *PatchOptions) {
 // For example, ControlPlane.spec will be overwritten with the patched
 // ControlPlaneTemplate.spec.template.spec but preserving spec.version and spec.replicas
 // which are previously set by the topology controller and shouldn't be overwritten.
-func patchObject(ctx context.Context, object, modifiedObject *unstructured.Unstructured, opts ...PatchOption) error {
-	return patchUnstructured(ctx, object, modifiedObject, "spec.template.spec", "spec", opts...)
+func patchObject(ctx context.Context, dest, src *unstructured.Unstructured, opts ...PatchOption) error {
+	return patchUnstructured(ctx, dest, src, []patchUnstructuredFields{
+		{Src: "spec.template.spec", Dest: "spec"},
+		{Src: "spec.template.metadata.labels", Dest: "metadata.labels"},
+		{Src: "spec.template.metadata.annotations", Dest: "metadata.annotations"},
+	}, opts...)
 }
 
 // patchTemplate overwrites spec.template.spec in template with spec.template.spec of modifiedTemplate,
 // while preserving the configured fields.
 // For example, it's possible to patch BootstrapTemplate.spec.template.spec with a patched
 // BootstrapTemplate.spec.template.spec while preserving fields configured via opts.fieldsToPreserve.
-func patchTemplate(ctx context.Context, template, modifiedTemplate *unstructured.Unstructured, opts ...PatchOption) error {
-	return patchUnstructured(ctx, template, modifiedTemplate, "spec.template.spec", "spec.template.spec", opts...)
+func patchTemplate(ctx context.Context, dest, src *unstructured.Unstructured, opts ...PatchOption) error {
+	return patchUnstructured(ctx, dest, src, []patchUnstructuredFields{
+		{Src: "metadata.labels", Dest: "metadata.labels"},
+		{Src: "metadata.annotations", Dest: "metadata.annotations"},
+		{Src: "spec.template.spec", Dest: "spec.template.spec"},
+		{Src: "spec.template.metadata.labels", Dest: "spec.template.metadata.labels"},
+		{Src: "spec.template.metadata.annotations", Dest: "spec.template.metadata.annotations"},
+	}, opts...)
+}
+
+type patchUnstructuredFields struct {
+	Src  string
+	Dest string
 }
 
 // patchUnstructured overwrites original.destSpecPath with modified.srcSpecPath.
 // NOTE: Original won't be changed at all, if there is no diff.
-func patchUnstructured(ctx context.Context, original, modified *unstructured.Unstructured, srcSpecPath, destSpecPath string, opts ...PatchOption) error {
+func patchUnstructured(ctx context.Context, dest, src *unstructured.Unstructured, patchFields []patchUnstructuredFields, opts ...PatchOption) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	patchOptions := &PatchOptions{}
 	patchOptions.ApplyOptions(opts)
 
 	// Create a copy to store the result of the patching temporarily.
-	patched := original.DeepCopy()
+	patched := dest.DeepCopy()
+
+	fields := make([]patchutil.CopyFieldsInputField, 0, len(patchFields))
+	for _, patchField := range patchFields {
+		fields = append(fields, patchutil.CopyFieldsInputField{
+			Src:  patchField.Src,
+			Dest: patchField.Dest,
+		})
+	}
 
 	// copySpec overwrites patched.destSpecPath with modified.srcSpecPath.
-	if err := patchutil.CopySpec(patchutil.CopySpecInput{
-		Src:              modified,
+	if err := patchutil.CopyFields(patchutil.CopyFieldsInput{
+		Src:              src,
 		Dest:             patched,
-		SrcSpecPath:      srcSpecPath,
-		DestSpecPath:     destSpecPath,
+		Fields:           fields,
 		FieldsToPreserve: patchOptions.preserveFields,
 	}); err != nil {
-		return errors.Wrapf(err, "failed to apply patch to %s %s", original.GetKind(), klog.KObj(original))
+		return errors.Wrapf(err, "failed to apply patch to %s %s", dest.GetKind(), klog.KObj(dest))
 	}
 
 	// Calculate diff.
-	diff, err := calculateDiff(original, patched)
+	diff, err := calculateDiff(dest, patched)
 	if err != nil {
-		return errors.Wrapf(err, "failed to apply patch to %s %s: failed to calculate diff", original.GetKind(), klog.KObj(original))
+		return errors.Wrapf(err, "failed to apply patch to %s %s: failed to calculate diff", dest.GetKind(), klog.KObj(dest))
 	}
 
 	// Return if there is no diff.
@@ -109,21 +131,36 @@ func patchUnstructured(ctx context.Context, original, modified *unstructured.Uns
 	}
 
 	// Log the delta between the object before and after applying the accumulated patches.
-	log.V(4).Info(fmt.Sprintf("Applying accumulated patches to desired state of %s", original.GetKind()), original.GetKind(), klog.KObj(original), "patch", string(diff))
+	log.V(4).Info(fmt.Sprintf("Applying accumulated patches to desired state of %s", dest.GetKind()), dest.GetKind(), klog.KObj(dest), "patch", string(diff))
 
 	// Overwrite original.
-	*original = *patched
+	*dest = *patched
 	return nil
 }
 
 // calculateDiff calculates the diff between two Unstructured objects.
 func calculateDiff(original, patched *unstructured.Unstructured) ([]byte, error) {
-	originalJSON, err := json.Marshal(original.Object["spec"])
+	originalDiffObject := map[string]any{
+		"metadata": map[string]any{
+			"annotations": original.GetAnnotations(),
+			"labels":      original.GetLabels(),
+		},
+		"spec": original.Object["spec"],
+	}
+	patchedDiffObject := map[string]any{
+		"metadata": map[string]any{
+			"annotations": patched.GetAnnotations(),
+			"labels":      patched.GetLabels(),
+		},
+		"spec": patched.Object["spec"],
+	}
+
+	originalJSON, err := json.Marshal(originalDiffObject)
 	if err != nil {
 		return nil, errors.Errorf("failed to marshal original object")
 	}
 
-	patchedJSON, err := json.Marshal(patched.Object["spec"])
+	patchedJSON, err := json.Marshal(patchedDiffObject)
 	if err != nil {
 		return nil, errors.Errorf("failed to marshal patched object")
 	}

--- a/core/reconcilers/topology/cluster/patches/patch.go
+++ b/core/reconcilers/topology/cluster/patches/patch.go
@@ -65,9 +65,9 @@ func (i PreserveFields) ApplyToHelper(opts *PatchOptions) {
 // which are previously set by the topology controller and shouldn't be overwritten.
 func patchObject(ctx context.Context, dest, src *unstructured.Unstructured, opts ...PatchOption) error {
 	return patchUnstructured(ctx, dest, src, []patchUnstructuredFields{
-		{Src: "spec.template.spec", Dest: "spec"},
-		{Src: "spec.template.metadata.labels", Dest: "metadata.labels"},
-		{Src: "spec.template.metadata.annotations", Dest: "metadata.annotations"},
+		{Src: []string{"spec", "template", "spec"}, Dest: []string{"spec"}},
+		{Src: []string{"spec", "template", "metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+		{Src: []string{"spec", "template", "metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
 	}, opts...)
 }
 
@@ -77,17 +77,17 @@ func patchObject(ctx context.Context, dest, src *unstructured.Unstructured, opts
 // BootstrapTemplate.spec.template.spec while preserving fields configured via opts.fieldsToPreserve.
 func patchTemplate(ctx context.Context, dest, src *unstructured.Unstructured, opts ...PatchOption) error {
 	return patchUnstructured(ctx, dest, src, []patchUnstructuredFields{
-		{Src: "metadata.labels", Dest: "metadata.labels"},
-		{Src: "metadata.annotations", Dest: "metadata.annotations"},
-		{Src: "spec.template.spec", Dest: "spec.template.spec"},
-		{Src: "spec.template.metadata.labels", Dest: "spec.template.metadata.labels"},
-		{Src: "spec.template.metadata.annotations", Dest: "spec.template.metadata.annotations"},
+		{Src: []string{"metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+		{Src: []string{"metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
+		{Src: []string{"spec", "template", "spec"}, Dest: []string{"spec", "template", "spec"}},
+		{Src: []string{"spec", "template", "metadata", "labels"}, Dest: []string{"spec", "template", "metadata", "labels"}},
+		{Src: []string{"spec", "template", "metadata", "annotations"}, Dest: []string{"spec", "template", "metadata", "annotations"}},
 	}, opts...)
 }
 
 type patchUnstructuredFields struct {
-	Src  string
-	Dest string
+	Src  []string
+	Dest []string
 }
 
 // patchUnstructured overwrites original.destSpecPath with modified.srcSpecPath.
@@ -139,6 +139,9 @@ func patchUnstructured(ctx context.Context, dest, src *unstructured.Unstructured
 }
 
 // calculateDiff calculates the diff between two Unstructured objects.
+// Note: This func is diff'ing only metadata.labels/annotations and spec (which includes
+// spec.template.spec and spec.template.metadata) of the objects because
+// patchUnstructured (the func where calculateDiff is used) only patches these fields.
 func calculateDiff(original, patched *unstructured.Unstructured) ([]byte, error) {
 	originalDiffObject := map[string]any{
 		"metadata": map[string]any{

--- a/core/reconcilers/topology/cluster/patches/template.go
+++ b/core/reconcilers/topology/cluster/patches/template.go
@@ -103,7 +103,15 @@ func cleanupUnstructured(template *unstructured.Unstructured) {
 	if annotations := template.GetAnnotations(); annotations != nil {
 		delete(annotations, corev1.LastAppliedConfigAnnotation)
 		delete(annotations, conversionutil.DataAnnotation)
-		template.SetAnnotations(annotations)
+		if len(annotations) > 0 {
+			template.SetAnnotations(annotations)
+		} else {
+			// If there are no more annotations we should cleanup the empty annotations map.
+			// Otherwise we send an empty annotation map via GeneratePatches which can lead to
+			// a remove /metadata/annotations patch from a Runtime Extension (because of the
+			// way json.Marshal/Unmarshal handles maps).
+			template.SetAnnotations(nil)
+		}
 	}
 }
 

--- a/internal/util/patch/patch.go
+++ b/internal/util/patch/patch.go
@@ -39,7 +39,7 @@ import (
 )
 
 // ApplyPatchToTypedObject applies the patch to a typed obj.
-func ApplyPatchToTypedObject[T any](ctx context.Context, currentMachine *T, machinePath runtimehooksv1.Patch, patchPath string) error {
+func ApplyPatchToTypedObject[T any](ctx context.Context, currentMachine *T, machinePath runtimehooksv1.Patch, patchPath []string) error {
 	// Note: Machine needs special handling because it is not a runtime.RawExtension. Simply converting it here to
 	//       a runtime.RawExtension so we can avoid making the code in applyPatchToObject more complex.
 	currentMachineRaw, err := ConvertToRawExtension(currentMachine)
@@ -68,7 +68,7 @@ func ApplyPatchToTypedObject[T any](ctx context.Context, currentMachine *T, mach
 // ApplyPatchToObject applies the patch to the obj.
 // Note: This is following the same general structure that is used in the applyPatchToRequest func in
 // internal/controllers/topology/cluster/patches/engine.go.
-func ApplyPatchToObject(ctx context.Context, obj *runtime.RawExtension, patch runtimehooksv1.Patch, patchPath string) (objChanged bool, reterr error) {
+func ApplyPatchToObject(ctx context.Context, obj *runtime.RawExtension, patch runtimehooksv1.Patch, patchPath []string) (objChanged bool, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if patch.PatchType == "" {
@@ -156,7 +156,7 @@ func ConvertToRawExtension(object any) (runtime.RawExtension, error) {
 }
 
 // Patch overwrites spec in object with spec of patchedObjectBytes.
-func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPaths ...string) error {
+func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPaths ...[]string) error {
 	objectUnstructured, err := bytesToUnstructured(object.Raw)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert object to Unstructured")
@@ -203,8 +203,8 @@ type CopyFieldsInput struct {
 
 // CopyFieldsInputField contains a single field that should be copied.
 type CopyFieldsInputField struct {
-	Src  string
-	Dest string
+	Src  []string
+	Dest []string
 }
 
 type preservedField struct {
@@ -232,17 +232,17 @@ func CopyFields(in CopyFieldsInput) error {
 
 	for _, field := range in.Fields {
 		// Get fieldValue from src.
-		fieldValue, found, err := unstructured.NestedFieldNoCopy(in.Src.Object, strings.Split(field.Src, ".")...)
+		fieldValue, found, err := unstructured.NestedFieldNoCopy(in.Src.Object, field.Src...)
 		if !found {
 			// Continue if field.Src does not exist in src, nothing to do.
 			continue
 		} else if err != nil {
-			return errors.Wrapf(err, "failed to get field %q from %s %s", field.Src, in.Src.GetKind(), klog.KObj(in.Src))
+			return errors.Wrapf(err, "failed to get field %q from %s %s", strings.Join(field.Src, "."), in.Src.GetKind(), klog.KObj(in.Src))
 		}
 
 		// Set fieldValue in dest.
-		if err := unstructured.SetNestedField(in.Dest.Object, fieldValue, strings.Split(field.Dest, ".")...); err != nil {
-			return errors.Wrapf(err, "failed to set field %q on %s %s", field.Dest, in.Dest.GetKind(), klog.KObj(in.Dest))
+		if err := unstructured.SetNestedField(in.Dest.Object, fieldValue, field.Dest...); err != nil {
+			return errors.Wrapf(err, "failed to set field %q on %s %s", strings.Join(field.Dest, "."), in.Dest.GetKind(), klog.KObj(in.Dest))
 		}
 	}
 

--- a/internal/util/patch/patch.go
+++ b/internal/util/patch/patch.go
@@ -156,7 +156,7 @@ func ConvertToRawExtension(object any) (runtime.RawExtension, error) {
 }
 
 // Patch overwrites spec in object with spec of patchedObjectBytes.
-func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPath string) error {
+func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPaths ...string) error {
 	objectUnstructured, err := bytesToUnstructured(object.Raw)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert object to Unstructured")
@@ -166,12 +166,19 @@ func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPath st
 		return errors.Wrap(err, "failed to convert patched object to Unstructured")
 	}
 
+	fields := make([]CopyFieldsInputField, 0, len(patchPaths))
+	for _, patchPath := range patchPaths {
+		fields = append(fields, CopyFieldsInputField{
+			Src:  patchPath,
+			Dest: patchPath,
+		})
+	}
+
 	// Copy spec from patchedObjectUnstructured to objectUnstructured.
-	if err := CopySpec(CopySpecInput{
-		Src:          patchedObjectUnstructured,
-		Dest:         objectUnstructured,
-		SrcSpecPath:  patchPath,
-		DestSpecPath: patchPath,
+	if err := CopyFields(CopyFieldsInput{
+		Src:    patchedObjectUnstructured,
+		Dest:   objectUnstructured,
+		Fields: fields,
 	}); err != nil {
 		return errors.Wrap(err, "failed to apply patch to object")
 	}
@@ -186,20 +193,29 @@ func Patch(object *runtime.RawExtension, patchedObjectBytes []byte, patchPath st
 	return nil
 }
 
-// CopySpecInput is a struct containing the input parameters of CopySpec.
-type CopySpecInput struct {
+// CopyFieldsInput is a struct containing the input parameters of CopyFields.
+type CopyFieldsInput struct {
 	Src              *unstructured.Unstructured
 	Dest             *unstructured.Unstructured
-	SrcSpecPath      string
-	DestSpecPath     string
+	Fields           []CopyFieldsInputField
 	FieldsToPreserve []contract.Path
 }
 
-// CopySpec copies a field from a srcSpecPath in src to a destSpecPath in dest,
-// while preserving fieldsToPreserve.
-func CopySpec(in CopySpecInput) error {
+// CopyFieldsInputField contains a single field that should be copied.
+type CopyFieldsInputField struct {
+	Src  string
+	Dest string
+}
+
+type preservedField struct {
+	Field contract.Path
+	Value interface{}
+}
+
+// CopyFields copies fields from src to dest while preserving fieldsToPreserve.
+func CopyFields(in CopyFieldsInput) error {
 	// Backup fields that should be preserved from dest.
-	preservedFields := map[string]interface{}{}
+	var preservedFields []preservedField
 	for _, field := range in.FieldsToPreserve {
 		value, found, err := unstructured.NestedFieldNoCopy(in.Dest.Object, field...)
 		if !found {
@@ -208,27 +224,32 @@ func CopySpec(in CopySpecInput) error {
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to get field %q from %s %s", strings.Join(field, "."), in.Dest.GetKind(), klog.KObj(in.Dest))
 		}
-		preservedFields[strings.Join(field, ".")] = value
+		preservedFields = append(preservedFields, preservedField{
+			Field: field,
+			Value: value,
+		})
 	}
 
-	// Get spec from src.
-	srcSpec, found, err := unstructured.NestedFieldNoCopy(in.Src.Object, strings.Split(in.SrcSpecPath, ".")...)
-	if !found {
-		// Return if srcSpecPath does not exist in src, nothing to do.
-		return nil
-	} else if err != nil {
-		return errors.Wrapf(err, "failed to get field %q from %s %s", in.SrcSpecPath, in.Src.GetKind(), klog.KObj(in.Src))
-	}
+	for _, field := range in.Fields {
+		// Get fieldValue from src.
+		fieldValue, found, err := unstructured.NestedFieldNoCopy(in.Src.Object, strings.Split(field.Src, ".")...)
+		if !found {
+			// Continue if field.Src does not exist in src, nothing to do.
+			continue
+		} else if err != nil {
+			return errors.Wrapf(err, "failed to get field %q from %s %s", field.Src, in.Src.GetKind(), klog.KObj(in.Src))
+		}
 
-	// Set spec in dest.
-	if err := unstructured.SetNestedField(in.Dest.Object, srcSpec, strings.Split(in.DestSpecPath, ".")...); err != nil {
-		return errors.Wrapf(err, "failed to set field %q on %s %s", in.DestSpecPath, in.Dest.GetKind(), klog.KObj(in.Dest))
+		// Set fieldValue in dest.
+		if err := unstructured.SetNestedField(in.Dest.Object, fieldValue, strings.Split(field.Dest, ".")...); err != nil {
+			return errors.Wrapf(err, "failed to set field %q on %s %s", field.Dest, in.Dest.GetKind(), klog.KObj(in.Dest))
+		}
 	}
 
 	// Restore preserved fields.
-	for path, value := range preservedFields {
-		if err := unstructured.SetNestedField(in.Dest.Object, value, strings.Split(path, ".")...); err != nil {
-			return errors.Wrapf(err, "failed to set field %q on %s %s", path, in.Dest.GetKind(), klog.KObj(in.Dest))
+	for _, preservedField := range preservedFields {
+		if err := unstructured.SetNestedField(in.Dest.Object, preservedField.Value, preservedField.Field...); err != nil {
+			return errors.Wrapf(err, "failed to set field %q on %s %s", preservedField.Field, in.Dest.GetKind(), klog.KObj(in.Dest))
 		}
 	}
 	return nil

--- a/internal/util/patch/patch_test.go
+++ b/internal/util/patch/patch_test.go
@@ -52,8 +52,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -84,8 +84,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -124,8 +124,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -168,8 +168,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -200,8 +200,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -232,8 +232,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -268,8 +268,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec.template.spec",
-						Dest: "spec",
+						Src:  []string{"spec", "template", "spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -304,8 +304,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec.template.spec",
-						Dest: "spec",
+						Src:  []string{"spec", "template", "spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -360,8 +360,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec.template.spec",
-						Dest: "spec",
+						Src:  []string{"spec", "template", "spec"},
+						Dest: []string{"spec"},
 					},
 				},
 				FieldsToPreserve: []contract.Path{
@@ -407,8 +407,8 @@ func TestCopyFields(t *testing.T) {
 				},
 				Fields: []CopyFieldsInputField{
 					{
-						Src:  "spec",
-						Dest: "spec",
+						Src:  []string{"spec"},
+						Dest: []string{"spec"},
 					},
 				},
 			},
@@ -462,9 +462,9 @@ func TestCopyFields(t *testing.T) {
 					},
 				},
 				Fields: []CopyFieldsInputField{
-					{Src: "doesnotexist", Dest: "doesnotexist"}, // Should not influence metadata copying
-					{Src: "metadata.labels", Dest: "metadata.labels"},
-					{Src: "metadata.annotations", Dest: "metadata.annotations"},
+					{Src: []string{"doesnotexist"}, Dest: []string{"doesnotexist"}}, // Should not influence metadata copying
+					{Src: []string{"metadata", "labels"}, Dest: []string{"metadata", "labels"}},
+					{Src: []string{"metadata", "annotations"}, Dest: []string{"metadata", "annotations"}},
 				},
 				FieldsToPreserve: []contract.Path{
 					{"metadata", "labels", clusterv1.ClusterNameLabel},

--- a/internal/util/patch/patch_test.go
+++ b/internal/util/patch/patch_test.go
@@ -22,19 +22,20 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/internal/contract"
 )
 
-func TestCopySpec(t *testing.T) {
+func TestCopyFields(t *testing.T) {
 	tests := []struct {
 		name    string
-		input   CopySpecInput
+		input   CopyFieldsInput
 		want    *unstructured.Unstructured
 		wantErr bool
 	}{
 		{
 			name: "Field both in src and dest, no-op when equal",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -49,8 +50,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -62,7 +67,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Field both in src and dest, overwrite dest when different",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -77,8 +82,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -90,7 +99,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Nested field both in src and dest, no-op when equal",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -113,8 +122,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -130,7 +143,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Nested field both in src and dest, overwrite dest when different",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -153,8 +166,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -170,7 +187,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Field only in src, copy to dest",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -181,8 +198,12 @@ func TestCopySpec(t *testing.T) {
 				Dest: &unstructured.Unstructured{
 					Object: map[string]interface{}{},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -194,7 +215,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Nested field only in src, copy to dest",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -209,8 +230,12 @@ func TestCopySpec(t *testing.T) {
 				Dest: &unstructured.Unstructured{
 					Object: map[string]interface{}{},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -226,7 +251,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Copy field from spec.template.spec in src to spec in dest",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -241,8 +266,12 @@ func TestCopySpec(t *testing.T) {
 				Dest: &unstructured.Unstructured{
 					Object: map[string]interface{}{},
 				},
-				SrcSpecPath:  "spec.template.spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec.template.spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -254,7 +283,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Copy field from spec.template.spec in src to spec in dest (overwrite when different)",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -273,8 +302,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec.template.spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec.template.spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -286,7 +319,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Field both in src and dest, overwrite when different and preserve fields",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"spec": map[string]interface{}{
@@ -325,8 +358,12 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec.template.spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec.template.spec",
+						Dest: "spec",
+					},
+				},
 				FieldsToPreserve: []contract.Path{
 					{"spec", "machineTemplate", "infrastructureRef"},
 					{"spec", "replicas"},
@@ -353,7 +390,7 @@ func TestCopySpec(t *testing.T) {
 		},
 		{
 			name: "Field not in src, no-op",
-			input: CopySpecInput{
+			input: CopyFieldsInput{
 				Src: &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"differentSpec": map[string]interface{}{
@@ -368,13 +405,95 @@ func TestCopySpec(t *testing.T) {
 						},
 					},
 				},
-				SrcSpecPath:  "spec",
-				DestSpecPath: "spec",
+				Fields: []CopyFieldsInputField{
+					{
+						Src:  "spec",
+						Dest: "spec",
+					},
+				},
 			},
 			want: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"spec": map[string]interface{}{
 						"A": "A",
+					},
+				},
+			},
+		},
+		{
+			name: "Copy metadata.labels & metadata.annotations",
+			input: CopyFieldsInput{
+				Src: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"label-keep":   "label-keep-value",
+								"label-update": "label-update-new-value",
+								"label-add":    "label-add-value",
+							},
+							"annotations": map[string]interface{}{
+								"annotation-keep":   "annotation-keep-value",
+								"annotation-update": "annotation-update-new-value",
+								"annotation-add":    "annotation-add-value",
+							},
+						},
+					},
+				},
+				Dest: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								clusterv1.ClusterNameLabel:                          "cluster-1",
+								clusterv1.ClusterTopologyOwnedLabel:                 "",
+								clusterv1.ClusterTopologyMachineDeploymentNameLabel: "md-topology-1",
+								clusterv1.ClusterTopologyMachinePoolNameLabel:       "mp-topology-1",
+								"label-keep":   "label-keep-value",
+								"label-update": "label-update-value",
+								"label-delete": "label-delete-value",
+							},
+							"annotations": map[string]interface{}{
+								clusterv1.TemplateClonedFromNameAnnotation:      "cloned-from-name",
+								clusterv1.TemplateClonedFromGroupKindAnnotation: "cloned-from-kind",
+								"annotation-keep":   "annotation-keep-value",
+								"annotation-update": "annotation-update-value",
+								"annotation-delete": "annotation-delete-value",
+							},
+						},
+					},
+				},
+				Fields: []CopyFieldsInputField{
+					{Src: "doesnotexist", Dest: "doesnotexist"}, // Should not influence metadata copying
+					{Src: "metadata.labels", Dest: "metadata.labels"},
+					{Src: "metadata.annotations", Dest: "metadata.annotations"},
+				},
+				FieldsToPreserve: []contract.Path{
+					{"metadata", "labels", clusterv1.ClusterNameLabel},
+					{"metadata", "labels", clusterv1.ClusterTopologyOwnedLabel},
+					{"metadata", "labels", clusterv1.ClusterTopologyMachineDeploymentNameLabel},
+					{"metadata", "labels", clusterv1.ClusterTopologyMachinePoolNameLabel},
+					{"metadata", "annotations", clusterv1.TemplateClonedFromNameAnnotation},
+					{"metadata", "annotations", clusterv1.TemplateClonedFromGroupKindAnnotation},
+				},
+			},
+			want: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							clusterv1.ClusterNameLabel:                          "cluster-1",
+							clusterv1.ClusterTopologyOwnedLabel:                 "",
+							clusterv1.ClusterTopologyMachineDeploymentNameLabel: "md-topology-1",
+							clusterv1.ClusterTopologyMachinePoolNameLabel:       "mp-topology-1",
+							"label-keep":   "label-keep-value",
+							"label-update": "label-update-new-value",
+							"label-add":    "label-add-value",
+						},
+						"annotations": map[string]interface{}{
+							clusterv1.TemplateClonedFromNameAnnotation:      "cloned-from-name",
+							clusterv1.TemplateClonedFromGroupKindAnnotation: "cloned-from-kind",
+							"annotation-keep":   "annotation-keep-value",
+							"annotation-update": "annotation-update-new-value",
+							"annotation-add":    "annotation-add-value",
+						},
 					},
 				},
 			},
@@ -385,7 +504,7 @@ func TestCopySpec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			err := CopySpec(tt.input)
+			err := CopyFields(tt.input)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return

--- a/test/e2e/clusterclass_rollout.go
+++ b/test/e2e/clusterclass_rollout.go
@@ -589,13 +589,13 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 		controlPlaneContractVersion, err := contract.GetContractVersionForVersion(ctx, clusterProxy.GetClient(), clusterObjects.ControlPlane.GroupVersionKind().GroupKind(), clusterObjects.ControlPlane.GroupVersionKind().Version)
 		g.Expect(err).ToNot(HaveOccurred())
 		By("Checking ControlPlane object has the right labels, annotations and selectors")
-		assertControlPlane(g, clusterClassObjects, clusterObjects, cluster, clusterClass)
+		assertControlPlane(g, clusterClassObjects, clusterObjects, cluster, clusterClass, filterMetadataBeforeValidation)
 		By("Checking ControlPlane machines objects have the right labels, annotations and selectors")
 		assertControlPlaneMachines(g, clusterObjects, cluster, controlPlaneContractVersion, filterMetadataBeforeValidation)
 
 		// MachineDeployments
 		By("Checking MachineDeployments objects have the right labels, annotations and selectors")
-		assertMachineDeployments(g, clusterClassObjects, clusterObjects, cluster, clusterClass)
+		assertMachineDeployments(g, clusterClassObjects, clusterObjects, cluster, clusterClass, filterMetadataBeforeValidation)
 		By("Checking MachineSets objects have the right labels, annotations and selectors")
 		assertMachineSets(g, clusterObjects, cluster)
 		By("Checking MachineSets machines objects have the right labels, annotations and selectors")
@@ -603,7 +603,7 @@ func assertClusterObjects(ctx context.Context, clusterProxy framework.ClusterPro
 
 		// MachinePools
 		By("Checking MachinePools objects have the right labels, annotations and selectors")
-		assertMachinePools(g, clusterClassObjects, clusterObjects, cluster, clusterClass)
+		assertMachinePools(g, clusterClassObjects, clusterObjects, cluster, clusterClass, filterMetadataBeforeValidation)
 
 		By("All cluster objects have the right labels, annotations and selectors")
 	}, 30*time.Second, 1*time.Second).Should(Succeed())
@@ -634,7 +634,7 @@ func assertInfrastructureCluster(g Gomega, clusterClassObjects clusterClassObjec
 	)
 }
 
-func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {
+func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, filterMetadataBeforeValidation func(object client.Object) clusterv1.ObjectMeta) {
 	ccControlPlaneTemplateTemplateMetadata := mustMetadata(contract.ControlPlaneTemplate().Template().Metadata().Get(clusterClassObjects.ControlPlaneTemplate))
 	ccControlPlaneTemplateMachineTemplateMetadata := mustMetadata(contract.ControlPlaneTemplate().Template().MachineTemplate().Metadata().Get(clusterClassObjects.ControlPlaneTemplate))
 	ccControlPlaneInfrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(clusterClassObjects.ControlPlaneInfrastructureMachineTemplate))
@@ -642,7 +642,8 @@ func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clust
 	controlPlaneInfrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(clusterObjects.ControlPlaneInfrastructureMachineTemplate))
 
 	// ControlPlane.metadata
-	expectMapsToBeEquivalent(g, clusterObjects.ControlPlane.GetLabels(),
+	controlPlaneMetadata := filterMetadataBeforeValidation(clusterObjects.ControlPlane)
+	expectMapsToBeEquivalent(g, controlPlaneMetadata.Labels,
 		union(
 			map[string]string{
 				clusterv1.ClusterNameLabel:          cluster.Name,
@@ -653,7 +654,7 @@ func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clust
 			ccControlPlaneTemplateTemplateMetadata.Labels,
 		),
 	)
-	expectMapsToBeEquivalent(g, clusterObjects.ControlPlane.GetAnnotations(),
+	expectMapsToBeEquivalent(g, controlPlaneMetadata.Annotations,
 		union(
 			map[string]string{
 				clusterv1.TemplateClonedFromGroupKindAnnotation: clusterClass.Spec.ControlPlane.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -689,7 +690,8 @@ func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clust
 	)
 
 	// ControlPlane InfrastructureMachineTemplate.metadata
-	expectMapsToBeEquivalent(g, clusterObjects.ControlPlaneInfrastructureMachineTemplate.GetLabels(),
+	controlPlaneInfrastructureMachineTemplateMetadata := filterMetadataBeforeValidation(clusterObjects.ControlPlaneInfrastructureMachineTemplate)
+	expectMapsToBeEquivalent(g, controlPlaneInfrastructureMachineTemplateMetadata.Labels,
 		union(
 			map[string]string{
 				clusterv1.ClusterNameLabel:          cluster.Name,
@@ -698,7 +700,7 @@ func assertControlPlane(g Gomega, clusterClassObjects clusterClassObjects, clust
 			clusterClassObjects.ControlPlaneInfrastructureMachineTemplate.GetLabels(),
 		),
 	)
-	expectMapsToBeEquivalent(g, clusterObjects.ControlPlaneInfrastructureMachineTemplate.GetAnnotations(),
+	expectMapsToBeEquivalent(g, controlPlaneInfrastructureMachineTemplateMetadata.Annotations,
 		union(
 			map[string]string{
 				clusterv1.TemplateClonedFromGroupKindAnnotation: clusterClass.Spec.ControlPlane.MachineInfrastructure.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -818,7 +820,7 @@ func assertControlPlaneMachines(g Gomega, clusterObjects ClusterObjects, cluster
 	}
 }
 
-func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {
+func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, filterMetadataBeforeValidation func(object client.Object) clusterv1.ObjectMeta) {
 	for _, machineDeployment := range clusterObjects.MachineDeployments {
 		mdTopology := getMDTopology(cluster, machineDeployment)
 		mdClass := getMDClass(cluster, clusterClass, machineDeployment)
@@ -879,7 +881,8 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 		ccInfrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(ccInfrastructureMachineTemplate))
 		infrastructureMachineTemplate := clusterObjects.InfrastructureMachineTemplateByMachineDeployment[machineDeployment.Name]
 		infrastructureMachineTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachineTemplate().Template().Metadata().Get(infrastructureMachineTemplate))
-		expectMapsToBeEquivalent(g, infrastructureMachineTemplate.GetLabels(),
+		infrastructureMachineTemplateMetadata := filterMetadataBeforeValidation(infrastructureMachineTemplate)
+		expectMapsToBeEquivalent(g, infrastructureMachineTemplateMetadata.Labels,
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                          cluster.Name,
@@ -889,7 +892,7 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 				ccInfrastructureMachineTemplate.GetLabels(),
 			),
 		)
-		expectMapsToBeEquivalent(g, infrastructureMachineTemplate.GetAnnotations(),
+		expectMapsToBeEquivalent(g, infrastructureMachineTemplateMetadata.Annotations,
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: mdClass.Infrastructure.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -911,7 +914,8 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 		ccBootstrapConfigTemplateTemplateMetadata := mustMetadata(contract.BootstrapConfigTemplate().Template().Metadata().Get(ccBootstrapConfigTemplate))
 		bootstrapConfigTemplate := clusterObjects.BootstrapConfigTemplateByMachineDeployment[machineDeployment.Name]
 		bootstrapConfigTemplateTemplateMetadata := mustMetadata(contract.BootstrapConfigTemplate().Template().Metadata().Get(bootstrapConfigTemplate))
-		expectMapsToBeEquivalent(g, bootstrapConfigTemplate.GetLabels(),
+		bootstrapConfigTemplateMetadata := filterMetadataBeforeValidation(bootstrapConfigTemplate)
+		expectMapsToBeEquivalent(g, bootstrapConfigTemplateMetadata.Labels,
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                          cluster.Name,
@@ -921,7 +925,7 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 				ccBootstrapConfigTemplate.GetLabels(),
 			),
 		)
-		expectMapsToBeEquivalent(g, bootstrapConfigTemplate.GetAnnotations(),
+		expectMapsToBeEquivalent(g, bootstrapConfigTemplateMetadata.Annotations,
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: mdClass.Bootstrap.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -943,7 +947,7 @@ func assertMachineDeployments(g Gomega, clusterClassObjects clusterClassObjects,
 	}
 }
 
-func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) {
+func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clusterObjects ClusterObjects, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, filterMetadataBeforeValidation func(object client.Object) clusterv1.ObjectMeta) {
 	for _, machinePool := range clusterObjects.MachinePools {
 		mpTopology := getMPTopology(cluster, machinePool)
 		mpClass := getMPClass(cluster, clusterClass, machinePool)
@@ -990,7 +994,8 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 		ccInfrastructureMachinePoolTemplate := clusterClassObjects.InfrastructureMachinePoolTemplateByMachinePoolClass[mpClass.Class]
 		ccInfrastructureMachinePoolTemplateTemplateMetadata := mustMetadata(contract.InfrastructureMachinePoolTemplate().Template().Metadata().Get(ccInfrastructureMachinePoolTemplate))
 		infrastructureMachinePool := clusterObjects.InfrastructureMachinePoolByMachinePool[machinePool.Name]
-		expectMapsToBeEquivalent(g, infrastructureMachinePool.GetLabels(),
+		infrastructureMachinePoolMetadata := filterMetadataBeforeValidation(infrastructureMachinePool)
+		expectMapsToBeEquivalent(g, infrastructureMachinePoolMetadata.Labels,
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                    cluster.Name,
@@ -1000,7 +1005,7 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 				ccInfrastructureMachinePoolTemplateTemplateMetadata.Labels,
 			),
 		)
-		expectMapsToBeEquivalent(g, infrastructureMachinePool.GetAnnotations(),
+		expectMapsToBeEquivalent(g, infrastructureMachinePoolMetadata.Annotations,
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: mpClass.Infrastructure.TemplateRef.GroupVersionKind().GroupKind().String(),
@@ -1014,7 +1019,8 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 		ccBootstrapConfigTemplate := clusterClassObjects.BootstrapConfigTemplateByMachinePoolClass[mpClass.Class]
 		ccBootstrapConfigTemplateTemplateMetadata := mustMetadata(contract.BootstrapConfigTemplate().Template().Metadata().Get(ccBootstrapConfigTemplate))
 		bootstrapConfig := clusterObjects.BootstrapConfigByMachinePool[machinePool.Name]
-		expectMapsToBeEquivalent(g, bootstrapConfig.GetLabels(),
+		bootstrapConfigMetadata := filterMetadataBeforeValidation(bootstrapConfig)
+		expectMapsToBeEquivalent(g, bootstrapConfigMetadata.Labels,
 			union(
 				map[string]string{
 					clusterv1.ClusterNameLabel:                    cluster.Name,
@@ -1024,7 +1030,7 @@ func assertMachinePools(g Gomega, clusterClassObjects clusterClassObjects, clust
 				ccBootstrapConfigTemplateTemplateMetadata.Labels,
 			),
 		)
-		expectMapsToBeEquivalent(g, bootstrapConfig.GetAnnotations(),
+		expectMapsToBeEquivalent(g, bootstrapConfigMetadata.Annotations,
 			union(
 				map[string]string{
 					clusterv1.TemplateClonedFromGroupKindAnnotation: mpClass.Bootstrap.TemplateRef.GroupVersionKind().GroupKind().String(),

--- a/test/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/clusterclass_rollout_test.go
@@ -48,6 +48,7 @@ var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("Clu
 				delete(annotations, "inmemorycluster.infrastructure.cluster.x-k8s.io/listener")
 				delete(annotations, "machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped")
 				// Labels & Annotations added by the test extension
+				// TODO: Implement validation that these labels/annotations are set.
 				delete(labels, "top-level-label-1")
 				delete(annotations, "top-level-annotation-1")
 				return clusterv1.ObjectMeta{

--- a/test/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/clusterclass_rollout_test.go
@@ -43,10 +43,15 @@ var _ = Describe("When testing ClusterClass rollouts [ClusterClass]", Label("Clu
 			ExtensionServiceName:      "test-extension-webhook-service",
 			FilterMetadataBeforeValidation: func(object client.Object) clusterv1.ObjectMeta {
 				annotations := object.GetAnnotations()
+				labels := object.GetLabels()
+				// Annotations added by the CAPDev in-memory backend.
 				delete(annotations, "inmemorycluster.infrastructure.cluster.x-k8s.io/listener")
 				delete(annotations, "machine.inmemory.infrastructure.cluster.x-k8s.io/bootstrapped")
+				// Labels & Annotations added by the test extension
+				delete(labels, "top-level-label-1")
+				delete(annotations, "top-level-annotation-1")
 				return clusterv1.ObjectMeta{
-					Labels:      object.GetLabels(),
+					Labels:      labels,
 					Annotations: annotations,
 				}
 			},

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-in-memory.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-in-memory.yaml
@@ -78,6 +78,11 @@ metadata:
   name: in-memory
 spec:
   controlPlane:
+    metadata:
+      labels:
+        ClusterClass.controlPlane.label: "ClusterClass.controlPlane.labelValue"
+      annotations:
+        ClusterClass.controlPlane.annotation: "ClusterClass.controlPlane.annotationValue"
     machineInfrastructure:
       templateRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -104,6 +109,11 @@ spec:
   workers:
     machineDeployments:
       - class: default-worker
+        metadata:
+          labels:
+            ClusterClass.machineDeployment.label: "ClusterClass.machineDeployment.labelValue"
+          annotations:
+            ClusterClass.machineDeployment.annotation: "ClusterClass.machineDeployment.annotationValue"
         bootstrap:
           templateRef:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta2

--- a/test/e2e/kcp_infra_adoption.go
+++ b/test/e2e/kcp_infra_adoption.go
@@ -68,7 +68,7 @@ type KCPInfraAdoptionSpecInput struct {
 	InfrastructureProvider *string
 
 	// Flavor, if specified, must refer to a template that is
-	// specially crafted with FIXME: describe requirements for the template
+	// specially crafted with TODO: describe requirements for the template
 	Flavor *string
 
 	// ExtensionConfigName is the name of the ExtensionConfig. Defaults to "kcp-infra-adoption".

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
@@ -45,6 +46,8 @@ import (
 	infrav1beta1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 	"sigs.k8s.io/cluster-api/test/infrastructure/kind"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/labels"
 )
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;patch;update;create
@@ -153,6 +156,15 @@ func patchDevClusterTemplate(_ context.Context, obj runtime.Object, templateVari
 		return errors.New("object is not a DevClusterTemplate")
 	}
 
+	if devClusterTemplate.Spec.Template.ObjectMeta.Labels == nil {
+		devClusterTemplate.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
+	devClusterTemplate.Spec.Template.ObjectMeta.Labels["top-level-label-1"] = "top-level-label-value-1"
+	if devClusterTemplate.Spec.Template.ObjectMeta.Annotations == nil {
+		devClusterTemplate.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	devClusterTemplate.Spec.Template.ObjectMeta.Annotations["top-level-annotation-1"] = "top-level-annotation-value-1"
+
 	if devClusterTemplate.Spec.Template.Spec.Backend.Docker != nil {
 		devClusterTemplate.Spec.Template.Spec.Backend.Docker.LoadBalancer.ImageRepository = imageRepo
 	}
@@ -174,6 +186,15 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 	// 1) Set extraArgs
 	switch obj := obj.(type) {
 	case *controlplanev1beta1.KubeadmControlPlaneTemplate:
+		if obj.Spec.Template.ObjectMeta.Labels == nil {
+			obj.Spec.Template.ObjectMeta.Labels = map[string]string{}
+		}
+		obj.Spec.Template.ObjectMeta.Labels["top-level-label-1"] = "top-level-label-value-1"
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["top-level-annotation-1"] = "top-level-annotation-value-1"
+
 		if obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
 			obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration = &bootstrapv1beta1.ClusterConfiguration{}
 		}
@@ -210,6 +231,15 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 		obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["v"] = "2"
 		obj.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["node-labels"] = fmt.Sprintf("kubernetesVersion=%s", strings.ReplaceAll(cpVersion, "+", "_"))
 	case *controlplanev1.KubeadmControlPlaneTemplate:
+		if obj.Spec.Template.ObjectMeta.Labels == nil {
+			obj.Spec.Template.ObjectMeta.Labels = map[string]string{}
+		}
+		obj.Spec.Template.ObjectMeta.Labels["top-level-label-1"] = "top-level-label-value-1"
+		if obj.Spec.Template.ObjectMeta.Annotations == nil {
+			obj.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+		}
+		obj.Spec.Template.ObjectMeta.Annotations["top-level-annotation-1"] = "top-level-annotation-value-1"
+
 		obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs = append(obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs, bootstrapv1.Arg{Name: "v", Value: ptr.To("2")})
 
 		obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraArgs = append(obj.Spec.Template.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager.ExtraArgs, bootstrapv1.Arg{Name: "v", Value: ptr.To("2")})
@@ -295,6 +325,9 @@ func patchKubeadmControlPlaneTemplate(ctx context.Context, obj runtime.Object, t
 
 // patchKubeadmConfigTemplate patches the ControlPlaneTemplate.
 func patchKubeadmConfigTemplate(_ context.Context, obj runtime.Object, templateVariables map[string]apiextensionsv1.JSON) error {
+	labels.AddLabels(obj.(metav1.Object), map[string]string{"top-level-label-1": "top-level-label-value-1"})
+	annotations.AddAnnotations(obj.(metav1.Object), map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"})
+
 	// 1) Set extraArgs
 	switch obj := obj.(type) {
 	case *bootstrapv1beta1.KubeadmConfigTemplate:
@@ -392,6 +425,9 @@ func convertToKubeadmConfigFiles(files []fileVariable) []bootstrapv1.File {
 func patchDevMachineTemplate(ctx context.Context, obj runtime.Object, templateVariables map[string]apiextensionsv1.JSON) error {
 	log := ctrl.LoggerFrom(ctx)
 
+	labels.AddLabels(obj.(metav1.Object), map[string]string{"top-level-label-1": "top-level-label-value-1"})
+	annotations.AddAnnotations(obj.(metav1.Object), map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"})
+
 	devMachineTemplate, ok := obj.(*infrav1.DevMachineTemplate)
 	if !ok {
 		return errors.New("object is not a DevMachineTemplate")
@@ -462,6 +498,15 @@ func patchDevMachinePoolTemplate(ctx context.Context, obj runtime.Object, templa
 	if !ok {
 		return errors.New("object is not a DevMachinePoolTemplate")
 	}
+
+	if devMachinePoolTemplate.Spec.Template.ObjectMeta.Labels == nil {
+		devMachinePoolTemplate.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
+	devMachinePoolTemplate.Spec.Template.ObjectMeta.Labels["top-level-label-1"] = "top-level-label-value-1"
+	if devMachinePoolTemplate.Spec.Template.ObjectMeta.Annotations == nil {
+		devMachinePoolTemplate.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	devMachinePoolTemplate.Spec.Template.ObjectMeta.Annotations["top-level-annotation-1"] = "top-level-annotation-value-1"
 
 	// If the DevMachinePoolTemplate belongs to a MachinePool, set the images the MachinePool version.
 	// NOTE: MachinePool version might be different from Cluster.version or other MachinePool's versions;

--- a/test/extension/handlers/topologymutation/handler_test.go
+++ b/test/extension/handlers/topologymutation/handler_test.go
@@ -33,6 +33,7 @@ import (
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
 )
@@ -82,6 +83,10 @@ func Test_patchDevClusterTemplate(t *testing.T) {
 			expectedTemplate: &infrav1.DevClusterTemplate{
 				Spec: infrav1.DevClusterTemplateSpec{
 					Template: infrav1.DevClusterTemplateResource{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+							Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+						},
 						Spec: infrav1.DevClusterSpec{
 							Backend: infrav1.DevClusterBackendSpec{
 								Docker: &infrav1.DockerClusterBackendSpec{
@@ -133,6 +138,10 @@ func Test_patchKubeadmControlPlaneTemplate(t *testing.T) {
 			expectedTemplate: &controlplanev1.KubeadmControlPlaneTemplate{
 				Spec: controlplanev1.KubeadmControlPlaneTemplateSpec{
 					Template: controlplanev1.KubeadmControlPlaneTemplateResource{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+							Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+						},
 						Spec: controlplanev1.KubeadmControlPlaneTemplateResourceSpec{
 							Rollout: controlplanev1.KubeadmControlPlaneRolloutSpec{
 								Strategy: controlplanev1.KubeadmControlPlaneRolloutStrategy{
@@ -203,11 +212,16 @@ func Test_patchDevMachineTemplate(t *testing.T) {
 		expectedErr      bool
 	}{
 		{
-			name:             "fails if builtin.controlPlane.version nor builtin.machineDeployment.version is not set",
-			template:         &infrav1.DevMachineTemplate{},
-			variables:        nil,
-			expectedTemplate: &infrav1.DevMachineTemplate{},
-			expectedErr:      true,
+			name:      "fails if builtin.controlPlane.version nor builtin.machineDeployment.version is not set",
+			template:  &infrav1.DevMachineTemplate{},
+			variables: nil,
+			expectedTemplate: &infrav1.DevMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+					Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+				},
+			},
+			expectedErr: true,
 		},
 		{
 			name: "sets customImage for templates linked to ControlPlane",
@@ -230,6 +244,10 @@ func Test_patchDevMachineTemplate(t *testing.T) {
 				})},
 			},
 			expectedTemplate: &infrav1.DevMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+					Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+				},
 				Spec: infrav1.DevMachineTemplateSpec{
 					Template: infrav1.DevMachineTemplateResource{
 						Spec: infrav1.DevMachineSpec{
@@ -264,6 +282,10 @@ func Test_patchDevMachineTemplate(t *testing.T) {
 				})},
 			},
 			expectedTemplate: &infrav1.DevMachineTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+					Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+				},
 				Spec: infrav1.DevMachineTemplateSpec{
 					Template: infrav1.DevMachineTemplateResource{
 						Spec: infrav1.DevMachineSpec{
@@ -302,11 +324,20 @@ func Test_patchDevMachinePoolTemplate(t *testing.T) {
 		expectedErr      bool
 	}{
 		{
-			name:             "fails if builtin.controlPlane.version nor builtin.machinePool.version is not set",
-			template:         &infrav1.DevMachinePoolTemplate{},
-			variables:        nil,
-			expectedTemplate: &infrav1.DevMachinePoolTemplate{},
-			expectedErr:      true,
+			name:      "fails if builtin.controlPlane.version nor builtin.machinePool.version is not set",
+			template:  &infrav1.DevMachinePoolTemplate{},
+			variables: nil,
+			expectedTemplate: &infrav1.DevMachinePoolTemplate{
+				Spec: infrav1.DevMachinePoolTemplateSpec{
+					Template: infrav1.DevMachinePoolTemplateResource{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+							Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+						},
+					},
+				},
+			},
+			expectedErr: true,
 		},
 		{
 			name: "sets customImage for templates linked to ControlPlane",
@@ -335,6 +366,10 @@ func Test_patchDevMachinePoolTemplate(t *testing.T) {
 			expectedTemplate: &infrav1.DevMachinePoolTemplate{
 				Spec: infrav1.DevMachinePoolTemplateSpec{
 					Template: infrav1.DevMachinePoolTemplateResource{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Annotations: map[string]string{"top-level-annotation-1": "top-level-annotation-value-1"},
+							Labels:      map[string]string{"top-level-label-1": "top-level-label-value-1"},
+						},
 						Spec: infrav1.DevMachinePoolSpec{
 							Backend: infrav1.DevMachinePoolBackendSpec{
 								Docker: &infrav1.DockerMachinePoolBackendSpec{
@@ -469,6 +504,14 @@ func TestHandler_GeneratePatches(t *testing.T) {
   "path" : "/spec",
   "value" : {
     "template" : {
+      "metadata" : {
+        "annotations" : {
+          "top-level-annotation-1": "top-level-annotation-value-1"
+        },
+        "labels" : {
+          "top-level-label-1": "top-level-label-value-1"
+        }
+      },
       "spec" : {
         "kubeadmConfigSpec" : {
           "clusterConfiguration" : {
@@ -525,18 +568,25 @@ func TestHandler_GeneratePatches(t *testing.T) {
       }
     }
   }
-} ]`),
+}
+]`),
 					responseItem("2", `[
-{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"}
+{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"},
+{"op":"add","path":"/metadata/annotations","value":{"top-level-annotation-1": "top-level-annotation-value-1"}},
+{"op":"add","path":"/metadata/labels","value":{"top-level-label-1": "top-level-label-value-1"}}
 ]`),
 					responseItem("3", `[
-{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"}
+{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"},
+{"op":"add","path":"/metadata/annotations","value":{"top-level-annotation-1": "top-level-annotation-value-1"}},
+{"op":"add","path":"/metadata/labels","value":{"top-level-label-1": "top-level-label-value-1"}}
 ]`),
 					responseItem("4", `[
-{"op":"add","path":"/spec/template/spec/backend/docker/loadBalancer/imageRepository","value":"docker.io"}
+{"op":"add","path":"/spec/template/spec/backend/docker/loadBalancer/imageRepository","value":"docker.io"},
+{"op":"add","path":"/spec/template/metadata","value":{"annotations":{"top-level-annotation-1": "top-level-annotation-value-1"},"labels":{"top-level-label-1": "top-level-label-value-1"}}}
 ]`),
 					responseItem("6", `[
-{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"}
+{"op":"add","path":"/spec/template/spec/backend/docker/customImage","value":"kindest/node:v1.23.0"},
+{"op":"add","path":"/spec/template/metadata","value":{"annotations":{"top-level-annotation-1": "top-level-annotation-value-1"},"labels":{"top-level-label-1": "top-level-label-value-1"}}}
 ]`),
 				},
 			},

--- a/util/labels/helpers.go
+++ b/util/labels/helpers.go
@@ -26,6 +26,26 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
+// AddLabels sets the desired labels on the object and returns true if the labels have changed.
+func AddLabels(o metav1.Object, desired map[string]string) bool {
+	if len(desired) == 0 {
+		return false
+	}
+	labels := o.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	hasChanged := false
+	for k, v := range desired {
+		if cur, ok := labels[k]; !ok || cur != v {
+			labels[k] = v
+			hasChanged = true
+		}
+	}
+	o.SetLabels(labels)
+	return hasChanged
+}
+
 // IsTopologyOwned returns true if the object has the `topology.cluster.x-k8s.io/owned` label.
 func IsTopologyOwned(o metav1.Object) bool {
 	_, ok := o.GetLabels()[clusterv1.ClusterTopologyOwnedLabel]

--- a/util/labels/helpers_test.go
+++ b/util/labels/helpers_test.go
@@ -23,9 +23,171 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
+
+func TestAddLabels(t *testing.T) {
+	g := NewWithT(t)
+
+	testcases := []struct {
+		name     string
+		obj      metav1.Object
+		input    map[string]string
+		expected map[string]string
+		changed  bool
+	}{
+		{
+			name: "should return false if no changes are made",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "bar",
+			},
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			changed: false,
+		},
+		{
+			name: "should do nothing if no labels are provided",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{},
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			changed: false,
+		},
+		{
+			name: "should do nothing if no labels are provided and have been nil before",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: nil,
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input:    map[string]string{},
+			expected: nil,
+			changed:  false,
+		},
+		{
+			name: "should return true if labels are added",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			expected: map[string]string{
+				"foo":    "bar",
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			changed: true,
+		},
+		{
+			name: "should return true if labels are changed",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should return true if labels are changed and have been nil before",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: nil,
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should add labels to an empty unstructured",
+			obj:  &unstructured.Unstructured{},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should add labels to a non empty unstructured",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+			input: map[string]string{
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			expected: map[string]string{
+				"foo":    "bar",
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			changed: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(*testing.T) {
+			res := AddLabels(tc.obj, tc.input)
+			g.Expect(res).To(Equal(tc.changed))
+			g.Expect(tc.obj.GetLabels()).To(Equal(tc.expected))
+		})
+	}
+}
 
 func TestHasWatchLabel(t *testing.T) {
 	g := NewWithT(t)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR extends the ClusterClass patch engine to allow patching metadata of objects of a Cluster topology.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->