### PR TITLE
🌱 Align scale validator to upstream

### DIFF
--- a/controlplane/kubeadm/webhooks/admission/kubeadmcontrolplane_scale.go
+++ b/controlplane/kubeadm/webhooks/admission/kubeadmcontrolplane_scale.go
@@ -63,8 +63,8 @@ func (v *ScaleValidator) Handle(ctx context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, "failed to get KubeadmControlPlane %s/%s", scale.Namespace, scale.Name))
 	}
 
-	if scale.Spec.Replicas == 0 {
-		return admission.Denied("replicas cannot be 0")
+	if scale.Spec.Replicas <= 0 {
+		return admission.Denied("replicas should be greater than zero")
 	}
 
 	externalEtcd := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External.IsDefined()

--- a/controlplane/kubeadm/webhooks/admission/kubeadmcontrolplane_scale_test.go
+++ b/controlplane/kubeadm/webhooks/admission/kubeadmcontrolplane_scale_test.go
@@ -139,12 +139,23 @@ func TestKubeadmControlPlaneValidateScale(t *testing.T) {
 		{
 			name:              "should return error when trying to scale to zero",
 			expectRespAllowed: false,
-			expectRespMessage: "replicas cannot be 0",
+			expectRespMessage: "replicas should be greater than zero",
 			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
 				UID:       uuid.NewUUID(),
 				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
 				Operation: admissionv1.Update,
 				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-managed-etcd","namespace":"foo"},"spec":{"replicas":0}}`)},
+			}},
+		},
+		{
+			name:              "should return error when trying to scale to a negative number",
+			expectRespAllowed: false,
+			expectRespMessage: "replicas should be greater than zero",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-managed-etcd","namespace":"foo"},"spec":{"replicas":-1}}`)},
 			}},
 		},
 		{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
KCP does not allow to scale to 0, upstream (API server or kubectl) do not allow to scale to negative numbers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->