### PR TITLE
✨ Add MachinesUpToDate condition to MachinePool

### DIFF
--- a/api/core/v1beta2/machinepool_types.go
+++ b/api/core/v1beta2/machinepool_types.go
@@ -29,9 +29,7 @@ const (
 )
 
 /*
-NOTE: we are commenting const for MachinePool's V1Beta2 conditions and reasons because not yet implemented for the 1.9 CAPI release.
-However, we are keeping the v1beta2 struct in the MachinePool struct because the code that will collect conditions and replica
-counters at cluster level is already implemented.
+NOTE: constants for MachinePool's remaining v1beta2 conditions stay commented until the corresponding conditions are implemented.
 
 // Conditions that will be used for the MachinePool object in v1Beta2 API version.
 const (
@@ -47,9 +45,6 @@ const (
 	// MachinePoolMachinesReadyCondition surfaces detail of issues on the controlled machines, if any.
 	MachinePoolMachinesReadyCondition = clusterv1.MachinesReadyCondition
 
-	// MachinePoolMachinesUpToDateCondition surfaces details of controlled machines not up to date, if any.
-	MachinePoolMachinesUpToDateCondition = clusterv1.MachinesUpToDateCondition
-
 	// MachinePoolScalingUpCondition is true if available replicas < desired replicas.
 	MachinePoolScalingUpCondition = clusterv1.ScalingUpCondition
 
@@ -63,6 +58,33 @@ const (
 	MachinePoolDeletingCondition = clusterv1.DeletingCondition
 ).
 */
+
+// MachinePoolMachineSupportUnknownReason surfaces when the controller cannot determine if a MachinePool uses per-instance Machines.
+const MachinePoolMachineSupportUnknownReason = "MachineSupportUnknown"
+
+// MachinePool's MachinesUpToDate condition and corresponding reasons.
+const (
+	// MachinePoolMachinesUpToDateCondition surfaces details of controlled machines not up to date, if any.
+	// Note: New machines are considered 10s after machine creation. This gives time to the machine's owner controller to recognize the new machine and add the UpToDate condition.
+	MachinePoolMachinesUpToDateCondition = MachinesUpToDateCondition
+
+	// MachinePoolMachinesUpToDateReason surfaces when all the controlled machine's UpToDate conditions are true.
+	MachinePoolMachinesUpToDateReason = UpToDateReason
+
+	// MachinePoolMachinesNotUpToDateReason surfaces when at least one of the controlled machine's UpToDate conditions is false.
+	MachinePoolMachinesNotUpToDateReason = NotUpToDateReason
+
+	// MachinePoolMachinesUpToDateUnknownReason surfaces when at least one of the controlled machine's UpToDate conditions is unknown
+	// and none of the controlled machine's UpToDate conditions is false.
+	MachinePoolMachinesUpToDateUnknownReason = UpToDateUnknownReason
+
+	// MachinePoolMachinesUpToDateNoReplicasReason surfaces when no machines exist for the MachinePool.
+	MachinePoolMachinesUpToDateNoReplicasReason = NoReplicasReason
+
+	// MachinePoolMachinesUpToDateInternalErrorReason surfaces unexpected failures when listing machines
+	// or aggregating status.
+	MachinePoolMachinesUpToDateInternalErrorReason = InternalErrorReason
+)
 
 // MachinePoolSpec defines the desired state of MachinePool.
 type MachinePoolSpec struct {

--- a/core/reconcilers/machinepool/machinepool_controller.go
+++ b/core/reconcilers/machinepool/machinepool_controller.go
@@ -202,6 +202,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			}},
 			patch.WithOwnedConditions{Conditions: []string{
 				clusterv1.PausedCondition,
+				clusterv1.MachinesUpToDateCondition,
 			}},
 		}
 		if reterr == nil {

--- a/core/reconcilers/machinepool/machinepool_controller.go
+++ b/core/reconcilers/machinepool/machinepool_controller.go
@@ -101,6 +101,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 
 	c, err := capicontrollerutil.NewControllerManagedBy(mgr, *r.predicateLog).
 		For(&clusterv1.MachinePool{}).
+		Owns(&clusterv1.Machine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(mgr.GetScheme(), *r.predicateLog, r.WatchFilterValue)).
 		Watches(
@@ -202,7 +203,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			}},
 			patch.WithOwnedConditions{Conditions: []string{
 				clusterv1.PausedCondition,
-				clusterv1.MachinesUpToDateCondition,
+				clusterv1.MachinePoolMachinesUpToDateCondition,
 			}},
 		}
 		if reterr == nil {
@@ -442,6 +443,7 @@ func (r *Reconciler) getMachinesForMachinePool(ctx context.Context, s *scope) (c
 	}
 
 	s.machines = filteredMachines
+	s.getMachinesForMachinePoolSucceeded = true
 
 	return ctrl.Result{}, nil
 }

--- a/core/reconcilers/machinepool/machinepool_controller_scope.go
+++ b/core/reconcilers/machinepool/machinepool_controller_scope.go
@@ -46,17 +46,33 @@ type scope struct {
 
 	// machines holds a list of the machines associated with this machine pool.
 	machines []*clusterv1.Machine
+
+	// getMachinesForMachinePoolSucceeded is true if the machines associated with this machine pool
+	// were successfully listed.
+	getMachinesForMachinePoolSucceeded bool
 }
 
-func (s *scope) hasMachinePoolMachines() (bool, error) {
+type machinePoolMachinesState int
+
+const (
+	machinePoolMachinesStateUnknown machinePoolMachinesState = iota
+	machinePoolMachinesStateNotSupported
+	machinePoolMachinesStateSupported
+)
+
+func (s *scope) machinePoolMachinesState() (machinePoolMachinesState, error) {
 	if s.infraMachinePool == nil {
-		return false, errors.New("infra machine pool not set on scope")
+		return machinePoolMachinesStateUnknown, errors.New("infra machine pool not set on scope")
 	}
 
 	machineKind, found, err := unstructured.NestedString(s.infraMachinePool.Object, "status", "infrastructureMachineKind")
 	if err != nil {
-		return false, fmt.Errorf("failed to lookup infrastructureMachineKind: %w", err)
+		return machinePoolMachinesStateUnknown, fmt.Errorf("failed to lookup infrastructureMachineKind: %w", err)
 	}
 
-	return found && (machineKind != ""), nil
+	if !found || machineKind == "" {
+		return machinePoolMachinesStateNotSupported, nil
+	}
+
+	return machinePoolMachinesStateSupported, nil
 }

--- a/core/reconcilers/machinepool/machinepool_controller_scope_test.go
+++ b/core/reconcilers/machinepool/machinepool_controller_scope_test.go
@@ -23,45 +23,52 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestHasMachinePoolMachines(t *testing.T) {
+func TestMachinePoolMachinesState(t *testing.T) {
 	tests := []struct {
 		name      string
 		infraPool *unstructured.Unstructured
-		want      bool
+		want      machinePoolMachinesState
 		wantErr   bool
 	}{
 		{
 			name:    "returns error when infraMachinePool is nil",
-			want:    false,
+			want:    machinePoolMachinesStateUnknown,
 			wantErr: true,
 		},
 		{
-			name: "returns false when infrastructureMachineKind is absent",
+			name: "returns not supported when infrastructureMachineKind is absent",
 			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
 				"status": map[string]interface{}{},
 			}},
-			want:    false,
-			wantErr: false,
+			want: machinePoolMachinesStateNotSupported,
 		},
 		{
-			name: "returns false when infrastructureMachineKind is empty string",
+			name: "returns not supported when infrastructureMachineKind is empty",
 			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
 				"status": map[string]interface{}{
 					"infrastructureMachineKind": "",
 				},
 			}},
-			want:    false,
-			wantErr: false,
+			want: machinePoolMachinesStateNotSupported,
 		},
 		{
-			name: "returns true when infrastructureMachineKind is set",
+			name: "returns supported when infrastructureMachineKind is set",
 			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
 				"status": map[string]interface{}{
 					"infrastructureMachineKind": "DockerMachine",
 				},
 			}},
-			want:    true,
-			wantErr: false,
+			want: machinePoolMachinesStateSupported,
+		},
+		{
+			name: "returns error when infrastructureMachineKind is malformed",
+			infraPool: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"infrastructureMachineKind": int64(1),
+				},
+			}},
+			want:    machinePoolMachinesStateUnknown,
+			wantErr: true,
 		},
 	}
 
@@ -70,7 +77,7 @@ func TestHasMachinePoolMachines(t *testing.T) {
 			g := NewWithT(t)
 
 			s := &scope{infraMachinePool: tt.infraPool}
-			got, err := s.hasMachinePoolMachines()
+			got, err := s.machinePoolMachinesState()
 
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/core/reconcilers/machinepool/machinepool_controller_status.go
+++ b/core/reconcilers/machinepool/machinepool_controller_status.go
@@ -32,23 +32,34 @@ import (
 )
 
 func (r *Reconciler) updateStatus(ctx context.Context, s *scope) error {
-	log := ctrl.LoggerFrom(ctx)
-
-	if s.infraMachinePool == nil {
-		log.V(4).Info("infra machine pool isn't set, skipping setting status")
-		return nil
+	var retErr error
+	var machinePoolMachinesStateErr error
+	machinePoolMachinesState := machinePoolMachinesStateUnknown
+	if s.infraMachinePool != nil {
+		machinePoolMachinesState, machinePoolMachinesStateErr = s.machinePoolMachinesState()
+		if machinePoolMachinesStateErr != nil {
+			retErr = fmt.Errorf("determining if there are machine pool machines: %w", machinePoolMachinesStateErr)
+		}
 	}
-	hasMachinePoolMachines, err := s.hasMachinePoolMachines()
-	if err != nil {
-		return fmt.Errorf("determining if there are machine pool machines: %w", err)
+
+	// Existing Machines prove this is a machine-backed pool even if the infrastructure object could not be read.
+	if machinePoolMachinesState == machinePoolMachinesStateUnknown &&
+		s.getMachinesForMachinePoolSucceeded && len(s.machines) > 0 {
+		machinePoolMachinesState = machinePoolMachinesStateSupported
 	}
 
-	setReplicas(s.machinePool, hasMachinePoolMachines, s.machines, s.nodeRefMap)
+	switch machinePoolMachinesState {
+	case machinePoolMachinesStateNotSupported:
+		setReplicas(s.machinePool, false, nil, s.nodeRefMap)
+	case machinePoolMachinesStateSupported:
+		if s.getMachinesForMachinePoolSucceeded {
+			setReplicas(s.machinePool, true, s.machines, s.nodeRefMap)
+		}
+	}
 
-	// Set MachinesUpToDate condition to surface when machines are not up-to-date with the spec.
-	setMachinesUpToDateCondition(ctx, s.machinePool, s.machines, hasMachinePoolMachines)
+	setMachinesUpToDateCondition(ctx, s.machinePool, s.machines, machinePoolMachinesState, machinePoolMachinesStateErr, s.getMachinesForMachinePoolSucceeded)
 
-	return nil
+	return retErr
 }
 
 func setReplicas(mp *clusterv1.MachinePool, hasMachinePoolMachines bool, machines []*clusterv1.Machine, nodeRefMap map[string]*corev1.Node) {
@@ -109,63 +120,83 @@ func versionsFromNodeRefs(nodeRefs []corev1.ObjectReference, nodeRefMap map[stri
 	return internalversion.AggregateStatusVersions(versions)
 }
 
-// setMachinesUpToDateCondition sets the MachinesUpToDate condition on the MachinePool.
-func setMachinesUpToDateCondition(ctx context.Context, mp *clusterv1.MachinePool, machines []*clusterv1.Machine, hasMachinePoolMachines bool) {
+func machinesUpToDateConditionCanBeSet(mp *clusterv1.MachinePool, machinePoolMachinesState machinePoolMachinesState, machinePoolMachinesStateErr error, getMachinesSucceeded bool) bool {
+	switch machinePoolMachinesState {
+	case machinePoolMachinesStateNotSupported:
+		conditions.Delete(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+		return false
+	case machinePoolMachinesStateUnknown:
+		if machinePoolMachinesStateErr != nil || !getMachinesSucceeded {
+			conditions.Set(mp, metav1.Condition{
+				Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachinePoolMachinesUpToDateInternalErrorReason,
+				Message: "Please check controller logs for errors",
+			})
+			return false
+		}
+		conditions.Set(mp, metav1.Condition{
+			Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.MachinePoolMachineSupportUnknownReason,
+			Message: "Machine support could not be determined",
+		})
+		return false
+	case machinePoolMachinesStateSupported:
+		if !getMachinesSucceeded {
+			conditions.Set(mp, metav1.Condition{
+				Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachinePoolMachinesUpToDateInternalErrorReason,
+				Message: "Please check controller logs for errors",
+			})
+			return false
+		}
+	}
+
+	return true
+}
+
+func setMachinesUpToDateCondition(ctx context.Context, mp *clusterv1.MachinePool, machines []*clusterv1.Machine, machinePoolMachinesState machinePoolMachinesState, machinePoolMachinesStateErr error, getMachinesSucceeded bool) {
 	log := ctrl.LoggerFrom(ctx)
 
-	// For MachinePool providers that don't use Machine objects (like managed pools),
-	// we derive the MachinesUpToDate condition from the infrastructure status.
-	// If InfrastructureProvisioned is False, machines are not up-to-date.
-	if !hasMachinePoolMachines {
-		// Check if infrastructure is ready by looking at the initialization status
-		if !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
-			log.V(4).Info("setting MachinesUpToDate to false for machineless MachinePool: infrastructure not yet provisioned")
-			conditions.Set(mp, metav1.Condition{
-				Type:    clusterv1.MachinesUpToDateCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  clusterv1.NotUpToDateReason,
-				Message: "Infrastructure is not yet provisioned",
-			})
-			return
-		}
+	// Machines are not listed during deletion, so leave the last reported condition unchanged.
+	if !mp.DeletionTimestamp.IsZero() && !getMachinesSucceeded {
+		return
+	}
 
-		conditions.Set(mp, metav1.Condition{
-			Type:   clusterv1.MachinesUpToDateCondition,
-			Status: metav1.ConditionTrue,
-			Reason: clusterv1.UpToDateReason,
-		})
+	if !machinesUpToDateConditionCanBeSet(mp, machinePoolMachinesState, machinePoolMachinesStateErr, getMachinesSucceeded) {
 		return
 	}
 
 	// Only consider Machines that have an UpToDate condition or are older than 10s.
 	// This is done to ensure the MachinesUpToDate condition doesn't flicker after a new Machine is created,
 	// because it can take a bit until the UpToDate condition is set on a new Machine.
-	filteredMachines := make([]*clusterv1.Machine, 0, len(machines))
+	upToDateMachines := make([]*clusterv1.Machine, 0, len(machines))
 	for _, machine := range machines {
 		if conditions.Has(machine, clusterv1.MachineUpToDateCondition) || time.Since(machine.CreationTimestamp.Time) > 10*time.Second {
-			filteredMachines = append(filteredMachines, machine)
+			upToDateMachines = append(upToDateMachines, machine)
 		}
 	}
 
-	if len(filteredMachines) == 0 {
+	if len(upToDateMachines) == 0 {
 		conditions.Set(mp, metav1.Condition{
-			Type:   clusterv1.MachinesUpToDateCondition,
+			Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
 			Status: metav1.ConditionTrue,
-			Reason: clusterv1.NoReplicasReason,
+			Reason: clusterv1.MachinePoolMachinesUpToDateNoReplicasReason,
 		})
 		return
 	}
 
 	upToDateCondition, err := conditions.NewAggregateCondition(
-		filteredMachines, clusterv1.MachineUpToDateCondition,
-		conditions.TargetConditionType(clusterv1.MachinesUpToDateCondition),
-		// Using a custom merge strategy to override reasons applied during merge.
+		upToDateMachines, clusterv1.MachineUpToDateCondition,
+		conditions.TargetConditionType(clusterv1.MachinePoolMachinesUpToDateCondition),
 		conditions.CustomMergeStrategy{
 			MergeStrategy: conditions.DefaultMergeStrategy(
 				conditions.ComputeReasonFunc(conditions.GetDefaultComputeMergeReasonFunc(
-					clusterv1.NotUpToDateReason,
-					clusterv1.UpToDateUnknownReason,
-					clusterv1.UpToDateReason,
+					clusterv1.MachinePoolMachinesNotUpToDateReason,
+					clusterv1.MachinePoolMachinesUpToDateUnknownReason,
+					clusterv1.MachinePoolMachinesUpToDateReason,
 				)),
 			),
 		},
@@ -173,9 +204,9 @@ func setMachinesUpToDateCondition(ctx context.Context, mp *clusterv1.MachinePool
 	if err != nil {
 		log.Error(err, "Failed to aggregate Machine's UpToDate conditions")
 		conditions.Set(mp, metav1.Condition{
-			Type:    clusterv1.MachinesUpToDateCondition,
+			Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
 			Status:  metav1.ConditionUnknown,
-			Reason:  clusterv1.InternalErrorReason,
+			Reason:  clusterv1.MachinePoolMachinesUpToDateInternalErrorReason,
 			Message: "Please check controller logs for errors",
 		})
 		return

--- a/core/reconcilers/machinepool/machinepool_controller_status.go
+++ b/core/reconcilers/machinepool/machinepool_controller_status.go
@@ -19,8 +19,10 @@ package machinepool
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -43,7 +45,8 @@ func (r *Reconciler) updateStatus(ctx context.Context, s *scope) error {
 
 	setReplicas(s.machinePool, hasMachinePoolMachines, s.machines, s.nodeRefMap)
 
-	// TODO: in future add setting conditions here
+	// Set MachinesUpToDate condition to surface when machines are not up-to-date with the spec.
+	setMachinesUpToDateCondition(ctx, s.machinePool, s.machines, hasMachinePoolMachines)
 
 	return nil
 }
@@ -104,4 +107,79 @@ func versionsFromNodeRefs(nodeRefs []corev1.ObjectReference, nodeRefMap map[stri
 	}
 
 	return internalversion.AggregateStatusVersions(versions)
+}
+
+// setMachinesUpToDateCondition sets the MachinesUpToDate condition on the MachinePool.
+func setMachinesUpToDateCondition(ctx context.Context, mp *clusterv1.MachinePool, machines []*clusterv1.Machine, hasMachinePoolMachines bool) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// For MachinePool providers that don't use Machine objects (like managed pools),
+	// we derive the MachinesUpToDate condition from the infrastructure status.
+	// If InfrastructureProvisioned is False, machines are not up-to-date.
+	if !hasMachinePoolMachines {
+		// Check if infrastructure is ready by looking at the initialization status
+		if !ptr.Deref(mp.Status.Initialization.InfrastructureProvisioned, false) {
+			log.V(4).Info("setting MachinesUpToDate to false for machineless MachinePool: infrastructure not yet provisioned")
+			conditions.Set(mp, metav1.Condition{
+				Type:    clusterv1.MachinesUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.NotUpToDateReason,
+				Message: "Infrastructure is not yet provisioned",
+			})
+			return
+		}
+
+		conditions.Set(mp, metav1.Condition{
+			Type:   clusterv1.MachinesUpToDateCondition,
+			Status: metav1.ConditionTrue,
+			Reason: clusterv1.UpToDateReason,
+		})
+		return
+	}
+
+	// Only consider Machines that have an UpToDate condition or are older than 10s.
+	// This is done to ensure the MachinesUpToDate condition doesn't flicker after a new Machine is created,
+	// because it can take a bit until the UpToDate condition is set on a new Machine.
+	filteredMachines := make([]*clusterv1.Machine, 0, len(machines))
+	for _, machine := range machines {
+		if conditions.Has(machine, clusterv1.MachineUpToDateCondition) || time.Since(machine.CreationTimestamp.Time) > 10*time.Second {
+			filteredMachines = append(filteredMachines, machine)
+		}
+	}
+
+	if len(filteredMachines) == 0 {
+		conditions.Set(mp, metav1.Condition{
+			Type:   clusterv1.MachinesUpToDateCondition,
+			Status: metav1.ConditionTrue,
+			Reason: clusterv1.NoReplicasReason,
+		})
+		return
+	}
+
+	upToDateCondition, err := conditions.NewAggregateCondition(
+		filteredMachines, clusterv1.MachineUpToDateCondition,
+		conditions.TargetConditionType(clusterv1.MachinesUpToDateCondition),
+		// Using a custom merge strategy to override reasons applied during merge.
+		conditions.CustomMergeStrategy{
+			MergeStrategy: conditions.DefaultMergeStrategy(
+				conditions.ComputeReasonFunc(conditions.GetDefaultComputeMergeReasonFunc(
+					clusterv1.NotUpToDateReason,
+					clusterv1.UpToDateUnknownReason,
+					clusterv1.UpToDateReason,
+				)),
+			),
+		},
+	)
+	if err != nil {
+		log.Error(err, "Failed to aggregate Machine's UpToDate conditions")
+		conditions.Set(mp, metav1.Condition{
+			Type:    clusterv1.MachinesUpToDateCondition,
+			Status:  metav1.ConditionUnknown,
+			Reason:  clusterv1.InternalErrorReason,
+			Message: "Please check controller logs for errors",
+		})
+		return
+	}
+
+	conditions.Set(mp, *upToDateCondition)
 }

--- a/core/reconcilers/machinepool/machinepool_controller_status_test.go
+++ b/core/reconcilers/machinepool/machinepool_controller_status_test.go
@@ -18,13 +18,16 @@ package machinepool
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 func Test_setReplicas(t *testing.T) {
@@ -109,4 +112,280 @@ func Test_setReplicas(t *testing.T) {
 			{Version: "v1.32.0", Replicas: 1},
 		}))
 	})
+}
+
+func Test_updateStatus_machineListFailurePreservesCounters(t *testing.T) {
+	g := NewWithT(t)
+	mp := &clusterv1.MachinePool{
+		Status: clusterv1.MachinePoolStatus{
+			ReadyReplicas:     ptr.To[int32](2),
+			AvailableReplicas: ptr.To[int32](2),
+			UpToDateReplicas:  ptr.To[int32](1),
+		},
+	}
+	infraMachinePool := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"infrastructureMachineKind": "GenericInfrastructureMachine",
+		},
+	}}
+
+	r := &Reconciler{}
+	err := r.updateStatus(ctx, &scope{
+		machinePool:      mp,
+		infraMachinePool: infraMachinePool,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(mp.Status.ReadyReplicas).To(Equal(ptr.To[int32](2)))
+	g.Expect(mp.Status.AvailableReplicas).To(Equal(ptr.To[int32](2)))
+	g.Expect(mp.Status.UpToDateReplicas).To(Equal(ptr.To[int32](1)))
+	condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+	g.Expect(condition).ToNot(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(condition.Reason).To(Equal(clusterv1.MachinePoolMachinesUpToDateInternalErrorReason))
+}
+
+func Test_updateStatus_knownMachinelessPoolRemovesMachinesUpToDateCondition(t *testing.T) {
+	g := NewWithT(t)
+	mp := &clusterv1.MachinePool{}
+	conditions.Set(mp, metav1.Condition{
+		Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+		Status: metav1.ConditionTrue,
+		Reason: "PreviouslyReported",
+	})
+
+	r := &Reconciler{}
+	err := r.updateStatus(ctx, &scope{
+		machinePool:                        mp,
+		infraMachinePool:                   &unstructured.Unstructured{},
+		getMachinesForMachinePoolSucceeded: true,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)).To(BeNil())
+}
+
+func Test_updateStatus_unknownMachinePoolMachinesStateReportsUnknown(t *testing.T) {
+	g := NewWithT(t)
+	mp := &clusterv1.MachinePool{}
+
+	r := &Reconciler{}
+	err := r.updateStatus(ctx, &scope{
+		machinePool:                        mp,
+		getMachinesForMachinePoolSucceeded: true,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+	g.Expect(condition).ToNot(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(condition.Reason).To(Equal(clusterv1.MachinePoolMachineSupportUnknownReason))
+	g.Expect(condition.Message).To(Equal("Machine support could not be determined"))
+}
+
+func Test_updateStatus_existingMachinesProveMachineBacked(t *testing.T) {
+	g := NewWithT(t)
+	mp := &clusterv1.MachinePool{}
+	machine := machinePoolTestMachine("machine-1", metav1.Condition{
+		Type:   clusterv1.MachineUpToDateCondition,
+		Status: metav1.ConditionTrue,
+		Reason: clusterv1.MachineUpToDateReason,
+	})
+
+	r := &Reconciler{}
+	err := r.updateStatus(ctx, &scope{
+		machinePool:                        mp,
+		machines:                           []*clusterv1.Machine{machine},
+		getMachinesForMachinePoolSucceeded: true,
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(mp.Status.UpToDateReplicas).To(Equal(ptr.To[int32](1)))
+	condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+	g.Expect(condition).ToNot(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(condition.Reason).To(Equal(clusterv1.MachinePoolMachinesUpToDateReason))
+}
+
+func Test_updateStatus_malformedInfrastructureMachineKind(t *testing.T) {
+	g := NewWithT(t)
+	mp := &clusterv1.MachinePool{}
+	infraMachinePool := &unstructured.Unstructured{Object: map[string]interface{}{
+		"status": map[string]interface{}{
+			"infrastructureMachineKind": int64(1),
+		},
+	}}
+
+	r := &Reconciler{}
+	err := r.updateStatus(ctx, &scope{
+		machinePool:                        mp,
+		infraMachinePool:                   infraMachinePool,
+		getMachinesForMachinePoolSucceeded: true,
+	})
+	g.Expect(err).To(HaveOccurred())
+
+	condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+	g.Expect(condition).ToNot(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionUnknown))
+	g.Expect(condition.Reason).To(Equal(clusterv1.MachinePoolMachinesUpToDateInternalErrorReason))
+}
+
+func Test_setMachinesUpToDateConditionDeletingWithoutMachineObservation(t *testing.T) {
+	g := NewWithT(t)
+	deletionTimestamp := metav1.Now()
+	mp := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &deletionTimestamp, Finalizers: []string{"test"}},
+	}
+	conditions.Set(mp, metav1.Condition{
+		Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+		Status: metav1.ConditionTrue,
+		Reason: clusterv1.MachinePoolMachinesUpToDateReason,
+	})
+
+	setMachinesUpToDateCondition(ctx, mp, nil, machinePoolMachinesStateUnknown, nil, false)
+
+	condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+	g.Expect(condition).ToNot(BeNil())
+	g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(condition.Reason).To(Equal(clusterv1.MachinePoolMachinesUpToDateReason))
+}
+
+func Test_setMachinesUpToDateCondition(t *testing.T) {
+	upToDateCondition := metav1.Condition{
+		Type:   clusterv1.MachineUpToDateCondition,
+		Status: metav1.ConditionTrue,
+		Reason: clusterv1.MachineUpToDateReason,
+	}
+
+	tests := []struct {
+		name                     string
+		machines                 []*clusterv1.Machine
+		machinePoolMachinesState machinePoolMachinesState
+		getMachinesSucceeded     bool
+		initialCondition         *metav1.Condition
+		expectSet                bool
+		expectCondition          metav1.Condition
+	}{
+		{
+			name:                     "known machineless pool removes a stale condition",
+			machinePoolMachinesState: machinePoolMachinesStateNotSupported,
+			getMachinesSucceeded:     true,
+			initialCondition: &metav1.Condition{
+				Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: "PreviouslyReported",
+			},
+			expectSet: false,
+		},
+		{
+			name:                     "unknown Machine support",
+			machinePoolMachinesState: machinePoolMachinesStateUnknown,
+			getMachinesSucceeded:     true,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachinePoolMachineSupportUnknownReason,
+				Message: "Machine support could not be determined",
+			},
+		},
+		{
+			name:                     "Machine list failure",
+			machinePoolMachinesState: machinePoolMachinesStateSupported,
+			getMachinesSucceeded:     false,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status:  metav1.ConditionUnknown,
+				Reason:  clusterv1.MachinePoolMachinesUpToDateInternalErrorReason,
+				Message: "Please check controller logs for errors",
+			},
+		},
+		{
+			name:                     "no Machines",
+			machinePoolMachinesState: machinePoolMachinesStateSupported,
+			getMachinesSucceeded:     true,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachinePoolMachinesUpToDateNoReplicasReason,
+			},
+		},
+		{
+			name: "recently created Machine without condition is ignored",
+			machines: []*clusterv1.Machine{{
+				ObjectMeta: metav1.ObjectMeta{Name: "machine-new", CreationTimestamp: metav1.NewTime(time.Now())},
+			}},
+			machinePoolMachinesState: machinePoolMachinesStateSupported,
+			getMachinesSucceeded:     true,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachinePoolMachinesUpToDateNoReplicasReason,
+			},
+		},
+		{
+			name: "all Machines up to date",
+			machines: []*clusterv1.Machine{
+				machinePoolTestMachine("machine-1", upToDateCondition),
+			},
+			machinePoolMachinesState: machinePoolMachinesStateSupported,
+			getMachinesSucceeded:     true,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:   clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachinePoolMachinesUpToDateReason,
+			},
+		},
+		{
+			name: "one Machine not up to date",
+			machines: []*clusterv1.Machine{
+				machinePoolTestMachine("machine-1", metav1.Condition{
+					Type:    clusterv1.MachineUpToDateCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  "VersionNotUpToDate",
+					Message: "Version is not up to date",
+				}),
+			},
+			machinePoolMachinesState: machinePoolMachinesStateSupported,
+			getMachinesSucceeded:     true,
+			expectSet:                true,
+			expectCondition: metav1.Condition{
+				Type:    clusterv1.MachinePoolMachinesUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachinePoolMachinesNotUpToDateReason,
+				Message: "* Machine machine-1: Version is not up to date",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mp := &clusterv1.MachinePool{}
+			if tt.initialCondition != nil {
+				conditions.Set(mp, *tt.initialCondition)
+			}
+
+			setMachinesUpToDateCondition(ctx, mp, tt.machines, tt.machinePoolMachinesState, nil, tt.getMachinesSucceeded)
+
+			condition := conditions.Get(mp, clusterv1.MachinePoolMachinesUpToDateCondition)
+			if !tt.expectSet {
+				g.Expect(condition).To(BeNil())
+				return
+			}
+			g.Expect(condition).ToNot(BeNil())
+			g.Expect(*condition).To(conditions.MatchCondition(tt.expectCondition, conditions.IgnoreLastTransitionTime(true)))
+		})
+	}
+}
+
+func machinePoolTestMachine(name string, machineConditions ...metav1.Condition) *clusterv1.Machine {
+	machine := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	for _, condition := range machineConditions {
+		conditions.Set(machine, condition)
+	}
+	return machine
 }

--- a/core/reconcilers/machinepool/machinepool_controller_test.go
+++ b/core/reconcilers/machinepool/machinepool_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
@@ -46,7 +45,6 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	externalfake "sigs.k8s.io/cluster-api/controllers/external/fake"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/conditions"
 	v1beta1conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
@@ -1159,57 +1157,6 @@ func TestMachinePoolConditions(t *testing.T) {
 				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
 			},
 		},
-		{
-			name:                "MachinesUpToDate condition set when infrastructure ready",
-			dataSecretCreated:   true,
-			infrastructureReady: true,
-			beforeFunc: func(_, _ *unstructured.Unstructured, mp *clusterv1.MachinePool, _ *corev1.NodeList) {
-				mp.Spec.ProviderIDList = []string{"azure://westus2/id-node-4", "aws://us-east-1/id-node-1"}
-				mp.Status.NodeRefs = []corev1.ObjectReference{
-					{Name: "node-1"},
-					{Name: "azure-node-4"},
-				}
-				mp.Status.Replicas = ptr.To(int32(2))
-			},
-			conditionAssertFunc: func(t *testing.T, getter v1beta1conditions.Getter) {
-				t.Helper()
-				g := NewWithT(t)
-
-				// Check that MachinesUpToDate condition is set (v1beta2 condition)
-				mp, ok := getter.(*clusterv1.MachinePool)
-				g.Expect(ok).To(BeTrue())
-				machinesUpToDateCondition := conditions.Get(mp, clusterv1.MachinesUpToDateCondition)
-				g.Expect(machinesUpToDateCondition).ToNot(BeNil())
-				g.Expect(machinesUpToDateCondition.Status).To(Equal(metav1.ConditionTrue))
-				g.Expect(machinesUpToDateCondition.Reason).To(Equal(clusterv1.UpToDateReason))
-			},
-		},
-		{
-			name:                "MachinesUpToDate condition is false when infrastructure not ready",
-			dataSecretCreated:   true,
-			infrastructureReady: false,
-			beforeFunc: func(_, _ *unstructured.Unstructured, mp *clusterv1.MachinePool, _ *corev1.NodeList) {
-				mp.Spec.ProviderIDList = []string{"azure://westus2/id-node-4", "aws://us-east-1/id-node-1"}
-				mp.Status.NodeRefs = []corev1.ObjectReference{
-					{Name: "node-1"},
-					{Name: "azure-node-4"},
-				}
-				mp.Status.Replicas = ptr.To(int32(2))
-			},
-			conditionAssertFunc: func(t *testing.T, getter v1beta1conditions.Getter) {
-				t.Helper()
-				g := NewWithT(t)
-
-				// Check that MachinesUpToDate condition is False when infrastructure is not ready
-				mp, ok := getter.(*clusterv1.MachinePool)
-				g.Expect(ok).To(BeTrue())
-				machinesUpToDateCondition := conditions.Get(mp, clusterv1.MachinesUpToDateCondition)
-				g.Expect(machinesUpToDateCondition).ToNot(BeNil())
-				g.Expect(machinesUpToDateCondition.Status).To(Equal(metav1.ConditionFalse))
-				g.Expect(machinesUpToDateCondition.Reason).To(Equal(clusterv1.NotUpToDateReason))
-				g.Expect(machinesUpToDateCondition.Message).To(Equal("Infrastructure is not yet provisioned"))
-			},
-		},
 	}
 
 	for _, tt := range testcases {
@@ -1240,7 +1187,6 @@ func TestMachinePoolConditions(t *testing.T) {
 				Client:       clientFake,
 				APIReader:    clientFake,
 				ClusterCache: clustercache.NewFakeClusterCache(clientFake, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
-				recorder:     record.NewFakeRecorder(32),
 				externalTracker: external.ObjectTracker{
 					Controller:      externalfake.Controller{},
 					Cache:           &informertest.FakeInformers{},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This PR continues the work from #13234 and implements the first focused part of the MachinePool v1beta2 condition set.

It adds the `MachinesUpToDate` condition for MachinePools that expose per-instance CAPI Machines.

The implementation:

- Adds MachinePool-specific `MachinesUpToDate` condition and reason constants.
- Aggregates the `UpToDate` conditions from controlled Machines.
- Watches owned Machines so child condition changes trigger MachinePool reconciliation.
- Distinguishes between Machine support being supported, not supported, and unknown.
- Removes a stale `MachinesUpToDate` condition when a pool is known not to support per-instance Machines.
- Reports `Unknown` when Machine support or the Machine list cannot be observed.
- Allows existing Machines to prove that a pool is machine-backed when the infrastructure object cannot be read.
- Preserves existing replica counters when Machine listing fails.
- Ignores newly created Machines without an `UpToDate` condition for 10 seconds, matching the MachineSet and MachineDeployment behavior.

For known machineless pools, this condition is intentionally not reported. Deriving it from `status.initialization.infrastructureProvisioned` would be incorrect because that field represents one-time initialization rather than current rollout state.

This PR does not fully resolve #10059 for managed or machineless pools. A complete solution requires an authoritative rollout signal from the infrastructure provider and will be handled separately.

This is the first PR in a planned series implementing the remaining MachinePool v1beta2 conditions.

**Which issue(s) this PR fixes**:

Part of #9005.

Continues #13234.

Related to #10059, but does not close it.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->
/area machinepool