### PR TITLE
🌱 Add stable BuildKit cache mount IDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,21 +46,21 @@ COPY api/go.sum api/go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go mod download
 
 # Copy the sources
 COPY ./ ./
 
 # Cache the go build into the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go build -o manager ${package}
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 # TODO: Remove fieldsv1string once build tag is switched (https://github.com/kubernetes/kubernetes/issues/137109#issuecomment-4697742098)
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -tags=fieldsv1string -trimpath -gcflags "${gcflags}" -ldflags "${ldflags} -extldflags '-static'" \
     -o manager ${package}

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -42,15 +42,15 @@ COPY api/go.sum api/go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go mod download
 
 # Copy the sources
 COPY ./ ./
 
 # Cache the go build into the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go build ./cmd/clusterctl
 
 # Build
@@ -60,8 +60,8 @@ ARG gcflags
 ARG ldflags
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -trimpath -gcflags "${gcflags}" -ldflags "${ldflags} -extldflags '-static'" \
     -o clusterctl ${package}

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -45,7 +45,7 @@ COPY api/go.sum api/go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go mod download
 
 # Copy the sources
@@ -55,16 +55,16 @@ COPY ./ ./
 WORKDIR /workspace/test/extension
 
 # Cache the go build into the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go build -o /workspace/manager ${package}
 
 # Essentially, change directories into test extension
 WORKDIR /workspace/test/extension
 
 # Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -trimpath -ldflags "${ldflags} -extldflags '-static'" \
     -o /workspace/manager ${package}

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -49,7 +49,7 @@ COPY test/go.sum go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     go mod download
 
 # This needs to build with the entire Cluster API context
@@ -64,8 +64,8 @@ WORKDIR /workspace/test/infrastructure/docker
 ARG ARCH
 
 # Build the CAPD manager using the compiler cache folder
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,id=go-build,target=/root/.cache/go-build \
+    --mount=type=cache,id=go-mod,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager .
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket


### PR DESCRIPTION
## Summary

This PR adds explicit stable `id` values to the existing BuildKit cache mounts used in the project's Dockerfiles.

## Changes

- Add `id=go-mod` for cache mounts targeting `/go/pkg/mod`
- Add `id=go-build` for cache mounts targeting `/root/.cache/go-build`

Using stable cache IDs makes BuildKit cache behavior more predictable across repeated and multi-stage builds while addressing the Rudolint `RDK1006` recommendation.

Fixes #13752