### PR TITLE
🌱 test: wait for webhook CA bundle injection after clusterctl init/upgrade

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -128,6 +128,14 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 			})
 		}
 	}
+
+	// Provider Deployments being available doesn't guarantee that cert-manager's cainjector already
+	// injected the CA bundle into the provider webhook configurations. Wait for the injection to be
+	// completed, otherwise webhook calls for objects created right after init fail with
+	// "tls: failed to verify certificate: x509: certificate signed by unknown authority".
+	framework.WaitForWebhookCABundleInjection(ctx, framework.WaitForWebhookCABundleInjectionInput{
+		Lister: client,
+	}, intervals...)
 }
 
 // UpgradeManagementClusterAndWaitInput is the input type for UpgradeManagementClusterAndWait.
@@ -213,6 +221,14 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 			MetricsPath: filepath.Join(input.LogFolder, "metrics", deployment.GetNamespace()),
 		})
 	}
+
+	// Provider Deployments being available doesn't guarantee that cert-manager's cainjector already
+	// injected the CA bundle into the provider webhook configurations. Wait for the injection to be
+	// completed, otherwise webhook calls for objects created right after the upgrade fail with
+	// "tls: failed to verify certificate: x509: certificate signed by unknown authority".
+	framework.WaitForWebhookCABundleInjection(ctx, framework.WaitForWebhookCABundleInjectionInput{
+		Lister: client,
+	}, intervals...)
 }
 
 // ApplyClusterTemplateAndWaitInput is the input type for ApplyClusterTemplateAndWait.

--- a/test/framework/webhook_helpers.go
+++ b/test/framework/webhook_helpers.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
+)
+
+// injectCAFromAnnotation is the annotation cert-manager's cainjector uses to discover
+// webhook configurations and CRDs it has to inject the CA bundle into.
+const injectCAFromAnnotation = "cert-manager.io/inject-ca-from"
+
+// WaitForWebhookCABundleInjectionInput is the input for WaitForWebhookCABundleInjection.
+type WaitForWebhookCABundleInjectionInput struct {
+	Lister Lister
+}
+
+// WaitForWebhookCABundleInjection waits until cert-manager's cainjector has injected the CA bundle
+// into all ValidatingWebhookConfigurations, MutatingWebhookConfigurations and CRD conversion
+// webhooks belonging to Cluster API providers and annotated with cert-manager.io/inject-ca-from.
+// Provider Deployments becoming available doesn't guarantee that the CA bundle is already injected;
+// until injection is done the kube-apiserver fails webhook calls with "tls: failed to verify
+// certificate: x509: certificate signed by unknown authority". Waiting for injection avoids those
+// errors when objects are created right after providers have been installed (e.g. on clusterctl move).
+func WaitForWebhookCABundleInjection(ctx context.Context, input WaitForWebhookCABundleInjectionInput, intervals ...interface{}) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForWebhookCABundleInjection")
+	Expect(input.Lister).ToNot(BeNil(), "Invalid argument. input.Lister can't be nil when calling WaitForWebhookCABundleInjection")
+
+	Byf("Waiting for CA bundles to be injected into provider webhook configurations")
+	Eventually(func() error {
+		validatingWebhookConfigurations := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+		if err := input.Lister.List(ctx, validatingWebhookConfigurations, capiProviderOptions()...); err != nil {
+			return errors.Wrap(err, "failed to list ValidatingWebhookConfigurations")
+		}
+		mutatingWebhookConfigurations := &admissionregistrationv1.MutatingWebhookConfigurationList{}
+		if err := input.Lister.List(ctx, mutatingWebhookConfigurations, capiProviderOptions()...); err != nil {
+			return errors.Wrap(err, "failed to list MutatingWebhookConfigurations")
+		}
+		crds := &apiextensionsv1.CustomResourceDefinitionList{}
+		if err := input.Lister.List(ctx, crds, capiProviderOptions()...); err != nil {
+			return errors.Wrap(err, "failed to list CustomResourceDefinitions")
+		}
+
+		if pending := pendingCABundleInjections(validatingWebhookConfigurations, mutatingWebhookConfigurations, crds); len(pending) > 0 {
+			return errors.Errorf("CA bundle not yet injected into: %s", strings.Join(pending, ", "))
+		}
+		return nil
+	}, intervals...).Should(Succeed(), "Failed to wait for CA bundle injection into provider webhook configurations")
+}
+
+// pendingCABundleInjections returns the annotated webhook configurations and CRDs which don't have
+// a valid CA bundle injected yet.
+func pendingCABundleInjections(validatingWebhookConfigurations *admissionregistrationv1.ValidatingWebhookConfigurationList, mutatingWebhookConfigurations *admissionregistrationv1.MutatingWebhookConfigurationList, crds *apiextensionsv1.CustomResourceDefinitionList) []string {
+	pending := []string{}
+
+	for _, webhookConfiguration := range validatingWebhookConfigurations.Items {
+		if _, ok := webhookConfiguration.Annotations[injectCAFromAnnotation]; !ok {
+			continue
+		}
+		for _, webhook := range webhookConfiguration.Webhooks {
+			if !caBundleContainsCertificate(webhook.ClientConfig.CABundle) {
+				pending = append(pending, fmt.Sprintf("ValidatingWebhookConfiguration/%s", webhookConfiguration.Name))
+				break
+			}
+		}
+	}
+
+	for _, webhookConfiguration := range mutatingWebhookConfigurations.Items {
+		if _, ok := webhookConfiguration.Annotations[injectCAFromAnnotation]; !ok {
+			continue
+		}
+		for _, webhook := range webhookConfiguration.Webhooks {
+			if !caBundleContainsCertificate(webhook.ClientConfig.CABundle) {
+				pending = append(pending, fmt.Sprintf("MutatingWebhookConfiguration/%s", webhookConfiguration.Name))
+				break
+			}
+		}
+	}
+
+	for _, crd := range crds.Items {
+		if _, ok := crd.Annotations[injectCAFromAnnotation]; !ok {
+			continue
+		}
+		if crd.Spec.Conversion == nil || crd.Spec.Conversion.Strategy != apiextensionsv1.WebhookConverter {
+			continue
+		}
+		if crd.Spec.Conversion.Webhook == nil || crd.Spec.Conversion.Webhook.ClientConfig == nil ||
+			!caBundleContainsCertificate(crd.Spec.Conversion.Webhook.ClientConfig.CABundle) {
+			pending = append(pending, fmt.Sprintf("CustomResourceDefinition/%s", crd.Name))
+		}
+	}
+
+	return pending
+}
+
+// caBundleContainsCertificate returns true if the given CA bundle contains at least one PEM-encoded
+// certificate. This guards against both empty CA bundles and placeholder values like "\n"
+// (caBundle: Cg==) which are used in webhook manifests before cert-manager injects the actual CA.
+func caBundleContainsCertificate(caBundle []byte) bool {
+	for block, rest := pem.Decode(caBundle); block != nil; block, rest = pem.Decode(rest) {
+		if block.Type == "CERTIFICATE" {
+			return true
+		}
+	}
+	return false
+}

--- a/test/framework/webhook_helpers_test.go
+++ b/test/framework/webhook_helpers_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// validCABundle is a PEM-encoded self-signed certificate (only used to test PEM parsing).
+var validCABundle = []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----
+`)
+
+func Test_caBundleContainsCertificate(t *testing.T) {
+	tests := []struct {
+		name     string
+		caBundle []byte
+		want     bool
+	}{
+		{
+			name:     "nil CA bundle",
+			caBundle: nil,
+			want:     false,
+		},
+		{
+			name:     "empty CA bundle",
+			caBundle: []byte{},
+			want:     false,
+		},
+		{
+			name:     "placeholder CA bundle (caBundle: Cg==)",
+			caBundle: []byte("\n"),
+			want:     false,
+		},
+		{
+			name:     "garbage CA bundle",
+			caBundle: []byte("not a certificate"),
+			want:     false,
+		},
+		{
+			name:     "valid PEM certificate",
+			caBundle: validCABundle,
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(caBundleContainsCertificate(tt.caBundle)).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_pendingCABundleInjections(t *testing.T) {
+	annotations := map[string]string{injectCAFromAnnotation: "capd-system/capd-serving-cert"}
+
+	validatingWebhookConfiguration := func(name string, annotations map[string]string, caBundles ...[]byte) admissionregistrationv1.ValidatingWebhookConfiguration {
+		webhookConfiguration := admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+		}
+		for _, caBundle := range caBundles {
+			webhookConfiguration.Webhooks = append(webhookConfiguration.Webhooks, admissionregistrationv1.ValidatingWebhook{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle},
+			})
+		}
+		return webhookConfiguration
+	}
+	mutatingWebhookConfiguration := func(name string, annotations map[string]string, caBundles ...[]byte) admissionregistrationv1.MutatingWebhookConfiguration {
+		webhookConfiguration := admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+		}
+		for _, caBundle := range caBundles {
+			webhookConfiguration.Webhooks = append(webhookConfiguration.Webhooks, admissionregistrationv1.MutatingWebhook{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: caBundle},
+			})
+		}
+		return webhookConfiguration
+	}
+	crd := func(name string, annotations map[string]string, conversion *apiextensionsv1.CustomResourceConversion) apiextensionsv1.CustomResourceDefinition {
+		return apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			Spec:       apiextensionsv1.CustomResourceDefinitionSpec{Conversion: conversion},
+		}
+	}
+	webhookConversion := func(caBundle []byte) *apiextensionsv1.CustomResourceConversion {
+		return &apiextensionsv1.CustomResourceConversion{
+			Strategy: apiextensionsv1.WebhookConverter,
+			Webhook: &apiextensionsv1.WebhookConversion{
+				ClientConfig: &apiextensionsv1.WebhookClientConfig{CABundle: caBundle},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                            string
+		validatingWebhookConfigurations []admissionregistrationv1.ValidatingWebhookConfiguration
+		mutatingWebhookConfigurations   []admissionregistrationv1.MutatingWebhookConfiguration
+		crds                            []apiextensionsv1.CustomResourceDefinition
+		want                            []string
+	}{
+		{
+			name: "all injected",
+			validatingWebhookConfigurations: []admissionregistrationv1.ValidatingWebhookConfiguration{
+				validatingWebhookConfiguration("capd-validating-webhook-configuration", annotations, validCABundle),
+			},
+			mutatingWebhookConfigurations: []admissionregistrationv1.MutatingWebhookConfiguration{
+				mutatingWebhookConfiguration("capd-mutating-webhook-configuration", annotations, validCABundle),
+			},
+			crds: []apiextensionsv1.CustomResourceDefinition{
+				crd("dockermachinetemplates.infrastructure.cluster.x-k8s.io", annotations, webhookConversion(validCABundle)),
+			},
+			want: []string{},
+		},
+		{
+			name: "pending injection into webhook configurations and CRD",
+			validatingWebhookConfigurations: []admissionregistrationv1.ValidatingWebhookConfiguration{
+				validatingWebhookConfiguration("capd-validating-webhook-configuration", annotations, nil),
+			},
+			mutatingWebhookConfigurations: []admissionregistrationv1.MutatingWebhookConfiguration{
+				mutatingWebhookConfiguration("capd-mutating-webhook-configuration", annotations, []byte("\n")),
+			},
+			crds: []apiextensionsv1.CustomResourceDefinition{
+				crd("dockermachinetemplates.infrastructure.cluster.x-k8s.io", annotations, webhookConversion(nil)),
+			},
+			want: []string{
+				"ValidatingWebhookConfiguration/capd-validating-webhook-configuration",
+				"MutatingWebhookConfiguration/capd-mutating-webhook-configuration",
+				"CustomResourceDefinition/dockermachinetemplates.infrastructure.cluster.x-k8s.io",
+			},
+		},
+		{
+			name: "one webhook of many without CA bundle",
+			validatingWebhookConfigurations: []admissionregistrationv1.ValidatingWebhookConfiguration{
+				validatingWebhookConfiguration("capd-validating-webhook-configuration", annotations, validCABundle, nil),
+			},
+			want: []string{"ValidatingWebhookConfiguration/capd-validating-webhook-configuration"},
+		},
+		{
+			name: "objects without the inject annotation are ignored",
+			validatingWebhookConfigurations: []admissionregistrationv1.ValidatingWebhookConfiguration{
+				validatingWebhookConfiguration("some-other-webhook-configuration", nil, nil),
+			},
+			mutatingWebhookConfigurations: []admissionregistrationv1.MutatingWebhookConfiguration{
+				mutatingWebhookConfiguration("some-other-webhook-configuration", nil, nil),
+			},
+			crds: []apiextensionsv1.CustomResourceDefinition{
+				crd("machines.cluster.x-k8s.io", nil, webhookConversion(nil)),
+			},
+			want: []string{},
+		},
+		{
+			name: "annotated CRD without webhook conversion is ignored",
+			crds: []apiextensionsv1.CustomResourceDefinition{
+				crd("dockermachinetemplates.infrastructure.cluster.x-k8s.io", annotations, nil),
+				crd("dockerclusters.infrastructure.cluster.x-k8s.io", annotations, &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}),
+			},
+			want: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := pendingCABundleInjections(
+				&admissionregistrationv1.ValidatingWebhookConfigurationList{Items: tt.validatingWebhookConfigurations},
+				&admissionregistrationv1.MutatingWebhookConfigurationList{Items: tt.mutatingWebhookConfigurations},
+				&apiextensionsv1.CustomResourceDefinitionList{Items: tt.crds},
+			)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e flake in #13300 (`failed calling webhook ... tls: failed to verify certificate: x509: certificate signed by unknown authority`) is still occurring, most recently in [periodic-cluster-api-e2e-release-1-11/2078254091703685120](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-release-1-11/2078254091703685120) (2026-07-18), where `clusterctl move` in the self-hosted HA spec failed creating CAPD templates after 10 retry attempts (~40s) per object.

Looking at the CAPD controller log of that run, the webhook server loaded its serving cert once at startup (`certwatcher "Updated current TLS certificate"` at 23:32:50, never again), and then logged `http: TLS handshake error ... remote error: tls: bad certificate` continuously from 23:33:15 to 23:35:29+ — every handshake error lining up with a `clusterctl move` retry. So the serving cert never changed; what was missing is the CA bundle on the apiserver side: cert-manager's cainjector had not yet injected the CA into the CAPD webhook configurations when the test proceeded.

`InitManagementClusterAndWatchControllerLogs` (and `UpgradeManagementClusterAndWait`) currently only wait for the provider Deployments to become available, which doesn't guarantee CA injection has happened. The self-hosted specs run `clusterctl move` right after init, so they hit this window; the same window exists for object creation right after the upgrade in the clusterctl upgrade specs.

This PR adds `framework.WaitForWebhookCABundleInjection`, which waits until all provider-owned (`cluster.x-k8s.io/provider` label) ValidatingWebhookConfigurations, MutatingWebhookConfigurations and CRD conversion webhooks annotated with `cert-manager.io/inject-ca-from` have a CA bundle containing an actual PEM certificate (guarding against the `caBundle: Cg==` placeholder), and calls it after the provider deployments are available in init and upgrade.

**Which issue(s) this PR fixes**:
Related to #13300 (intentionally not auto-closing until CI confirms the flake is gone)

/area e2e-testing

<!-- oss-radar:idempotency=auto-20260718-151827.w3.kubernetes-sigs_cluster-api.13300 -->
