### PR TITLE
🌱 Prevent CABPK to override controlling ownerRef for bootstrap secrets

### DIFF
--- a/bootstrap/kubeadm/reconcilers/kubeadmconfig/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/reconcilers/kubeadmconfig/kubeadmconfig_controller.go
@@ -1467,7 +1467,7 @@ func (r *Reconciler) ensureBootstrapSecretOwnersRef(ctx context.Context, scope *
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "failed to add KubeadmConfig %s as ownerReference to bootstrap Secret %s", scope.ConfigOwner.GetName(), secret.GetName())
+		return errors.Wrapf(err, "failed to add KubeadmConfig %s as ownerReference to bootstrap Secret %s", scope.Config.GetName(), secret.GetName())
 	}
 
 	configRef := metav1.OwnerReference{
@@ -1483,15 +1483,15 @@ func (r *Reconciler) ensureBootstrapSecretOwnersRef(ctx context.Context, scope *
 		return nil
 	}
 
-	// Otherwise replace existing controller OwnerReferences with the configRef.
+	// If there are unexpected controller OwnerReferences, report an error.
 	original := secret.DeepCopy()
-	if c := metav1.GetControllerOf(secret); c != nil && c.Kind != "KubeadmConfig" {
-		secret.SetOwnerReferences(util.RemoveOwnerRef(secret.GetOwnerReferences(), *c))
+	if c := metav1.GetControllerOf(secret); c != nil && c.Kind != configRef.Kind {
+		return errors.Errorf("could not add KubeadmConfig %s as ownerReference to bootstrap Secret %s, it is already controlled by %s %s", scope.Config.GetName(), secret.GetName(), c.Kind, c.Name)
 	}
 
 	secret.SetOwnerReferences(util.EnsureOwnerRef(secret.GetOwnerReferences(), configRef))
 	if err := r.Client.Patch(ctx, secret, client.MergeFrom(original)); err != nil {
-		return errors.Wrapf(err, "could not add KubeadmConfig %s as ownerReference to bootstrap Secret %s", scope.ConfigOwner.GetName(), secret.GetName())
+		return errors.Wrapf(err, "could not add KubeadmConfig %s as ownerReference to bootstrap Secret %s", scope.Config.GetName(), secret.GetName())
 	}
 	return nil
 }

--- a/bootstrap/kubeadm/reconcilers/kubeadmconfig/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/reconcilers/kubeadmconfig/kubeadmconfig_controller_test.go
@@ -209,7 +209,7 @@ func TestKubeadmConfigReconciler_TestSecretOwnerReferenceReconciliation(t *testi
 		g.Expect(controllerOwner.Kind).To(Equal("KubeadmConfig"))
 		g.Expect(controllerOwner.Name).To(Equal(config.Name))
 	})
-	t.Run("non-KubeadmConfig controller OwnerReference is replaced", func(*testing.T) {
+	t.Run("returns an error if the secret is already controlled by another kind", func(*testing.T) {
 		g.Expect(myclient.Get(ctx, key, actual)).To(Succeed())
 
 		actual.SetOwnerReferences([]metav1.OwnerReference{
@@ -224,14 +224,14 @@ func TestKubeadmConfigReconciler_TestSecretOwnerReferenceReconciliation(t *testi
 		g.Expect(myclient.Update(ctx, actual)).To(Succeed())
 
 		_, err = k.Reconcile(ctx, request)
-		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).To(HaveOccurred())
 
 		g.Expect(myclient.Get(ctx, key, actual)).To(Succeed())
 
 		controllerOwner := metav1.GetControllerOf(actual)
 		g.Expect(controllerOwner).To(Not(BeNil()))
-		g.Expect(controllerOwner.Kind).To(Equal("KubeadmConfig"))
-		g.Expect(controllerOwner.Name).To(Equal(config.Name))
+		g.Expect(controllerOwner.Kind).To(Equal("Machine"))
+		g.Expect(controllerOwner.Name).To(Equal(machine.Name))
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
CABPK creates a secret with the same name of the KubeadConfig

Today, if such a secret already exist and it is controlled by another object, CABPK deletes replaces existing controlling ownerRef and assigns it thot the KubeadConfig

This PR instead makes CABPK to fail in this scenario (this is probably a secret not meant to be controlled by the KubeadConfig)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->