### PR TITLE
🌱 Add 20 MB read limits for Runtime SDK client & server

### DIFF
--- a/exp/runtime/server/server.go
+++ b/exp/runtime/server/server.go
@@ -41,6 +41,13 @@ import (
 // DefaultPort is the default port that the webhook server serves.
 var DefaultPort = 9443
 
+// maxExtensionRequestBodyBytes bounds the request body a runtime extension handler
+// will buffer. Without a limit, any peer that can reach the extension's TLS port
+// (if mTLS is not configured) can stream an arbitrarily large body that io.ReadAll
+// buffers whole, OOM-killing the process. 20 MiB is above any legitimate hook request
+// (e.g. a GeneratePatchesRequest carrying the cluster's topology objects).
+const maxExtensionRequestBodyBytes = 20 << 20 // 20 MiB
+
 // Server is a runtime webhook server.
 type Server struct {
 	webhook.Server
@@ -302,7 +309,10 @@ func (s *Server) callHandler(handler ExtensionHandler, r *http.Request) runtimeh
 	request := handler.requestObject.DeepCopyObject()
 	response := handler.responseObject.DeepCopyObject().(runtimehooksv1.ResponseObject)
 
-	requestBody, err := io.ReadAll(r.Body)
+	maxBytesReader := http.MaxBytesReader(nil, r.Body, maxExtensionRequestBodyBytes)
+	defer maxBytesReader.Close()
+
+	requestBody, err := io.ReadAll(maxBytesReader)
 	if err != nil {
 		response.SetStatus(runtimehooksv1.ResponseStatusFailure)
 		response.SetMessage(fmt.Sprintf("error reading request: %v", err))

--- a/exp/runtime/server/server_test.go
+++ b/exp/runtime/server/server_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	runtimecatalog "sigs.k8s.io/cluster-api/api/runtime/catalog"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/api/runtime/hooks/v1alpha1"
+)
+
+func TestCallHandlerRequestBodyLimit(t *testing.T) {
+	t.Run("oversized body is rejected without invoking the handler", func(t *testing.T) {
+		g := NewWithT(t)
+		s, reached := newTestServerWithDiscoveryHandler(g)
+
+		// Valid JSON followed by whitespace, exceeding the limit.
+		body := "{}" + strings.Repeat(" ", maxExtensionRequestBodyBytes+1)
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/test", strings.NewReader(body))
+
+		resp := s.callHandler(firstHandler(s), req)
+
+		g.Expect(*reached).To(BeFalse())
+		g.Expect(resp.GetStatus()).To(Equal(runtimehooksv1.ResponseStatusFailure))
+		g.Expect(resp.GetMessage()).To(ContainSubstring("error reading request"))
+	})
+
+	t.Run("normal body is processed", func(t *testing.T) {
+		g := NewWithT(t)
+		s, reached := newTestServerWithDiscoveryHandler(g)
+
+		req := httptest.NewRequestWithContext(t.Context(), "POST", "/test", strings.NewReader("{}"))
+
+		resp := s.callHandler(firstHandler(s), req)
+
+		g.Expect(*reached).To(BeTrue())
+		g.Expect(resp.GetStatus()).To(Equal(runtimehooksv1.ResponseStatusSuccess))
+	})
+}
+
+func newTestServerWithDiscoveryHandler(g *WithT) (*Server, *bool) {
+	catalog := runtimecatalog.New()
+	g.Expect(runtimehooksv1.AddToCatalog(catalog)).To(Succeed())
+
+	s, err := New(Options{Catalog: catalog})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	reached := false
+	g.Expect(s.AddExtensionHandler(ExtensionHandler{
+		Hook: runtimehooksv1.Discovery,
+		Name: "test",
+		HandlerFunc: func(_ context.Context, _ *runtimehooksv1.DiscoveryRequest, resp *runtimehooksv1.DiscoveryResponse) {
+			reached = true
+			resp.SetStatus(runtimehooksv1.ResponseStatusSuccess)
+		},
+	})).To(Succeed())
+
+	return s, &reached
+}
+
+func firstHandler(s *Server) ExtensionHandler {
+	for _, h := range s.handlers {
+		return h
+	}
+	return ExtensionHandler{}
+}

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -63,6 +63,13 @@ type errCallingExtensionHandler error
 
 const defaultDiscoveryTimeout = 10 * time.Second
 
+// maxExtensionResponseBodyBytes bounds the response body a runtime client
+// will buffer. Without a limit, an extension server can
+// stream an arbitrarily large body that io.ReadAll buffers whole, OOM-killing the
+// process. 20 MiB is above any legitimate hook response (e.g. a
+// GeneratePatchesResponse carrying patches for the cluster's topology objects).
+const maxExtensionResponseBodyBytes = 20 << 20 // 20 MiB
+
 // Options are creation options for a Client.
 type Options struct {
 	CertFile string // Path of the PEM-encoded client certificate.
@@ -638,15 +645,22 @@ func httpCall(ctx context.Context, request, response runtime.Object, opts *httpC
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
+		maxBytesReader := http.MaxBytesReader(nil, resp.Body, maxExtensionResponseBodyBytes)
+		defer maxBytesReader.Close()
+
+		respBody, err := io.ReadAll(maxBytesReader)
 		if err != nil {
 			return errCallingExtensionHandler(
 				errors.Errorf("http call failed: got response with status code %d != 200: failed to read response body", resp.StatusCode),
 			)
 		}
 
+		respBodyStr := string(respBody)
+		if len(respBodyStr) > 512 {
+			respBodyStr = respBodyStr[:512] + "..."
+		}
 		return errCallingExtensionHandler(
-			errors.Errorf("http call failed: got response with status code %d != 200: response: %q", resp.StatusCode, string(respBody)),
+			errors.Errorf("http call failed: got response with status code %d != 200: response : %q", resp.StatusCode, respBodyStr),
 		)
 	}
 

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,11 +59,12 @@ func TestClient_httpCall(t *testing.T) {
 	g := NewWithT(t)
 
 	tableTests := []struct {
-		name     string
-		request  runtime.Object
-		response runtime.Object
-		opts     *httpCallOptions
-		wantErr  bool
+		name            string
+		request         runtime.Object
+		response        runtime.Object
+		responseHandler func(w http.ResponseWriter, _ *http.Request)
+		opts            *httpCallOptions
+		wantErr         bool
 	}{
 		{
 			name:     "error if request, response and options are nil",
@@ -190,6 +192,31 @@ func TestClient_httpCall(t *testing.T) {
 			}(),
 			wantErr: false,
 		},
+		{
+			name:     "error if response is too large",
+			request:  &fakev1alpha1.FakeRequest{},
+			response: &fakev1alpha1.FakeResponse{},
+			responseHandler: func(w http.ResponseWriter, _ *http.Request) {
+				respBody := "{}" + strings.Repeat(" ", maxExtensionResponseBodyBytes+1)
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(respBody))
+			},
+			opts: func() *httpCallOptions {
+				c := runtimecatalog.New()
+				g.Expect(fakev1alpha1.AddToCatalog(c)).To(Succeed())
+
+				// get same gvh for hook by using the FakeHook and catalog
+				gvh, err := c.GroupVersionHook(fakev1alpha1.FakeHook)
+				g.Expect(err).To(Succeed())
+
+				return &httpCallOptions{
+					catalog:         c,
+					registrationGVH: gvh,
+					hookGVH:         gvh,
+				}
+			}(),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tableTests {
 		t.Run(tt.name, func(*testing.T) {
@@ -197,7 +224,11 @@ func TestClient_httpCall(t *testing.T) {
 			if tt.opts != nil && tt.opts.catalog != nil {
 				// create http server with fakeHookHandler
 				mux := http.NewServeMux()
-				mux.HandleFunc("/", fakeHookHandler)
+				if tt.responseHandler != nil {
+					mux.HandleFunc("/", tt.responseHandler)
+				} else {
+					mux.HandleFunc("/", fakeHookHandler)
+				}
 
 				srv := newUnstartedTLSServer(mux)
 				srv.StartTLS()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->