### PR TITLE
🌱 Block ExecProvider/AuthProvider in ClusterCache, deprecate remote funcs

### DIFF
--- a/controllers/clustercache/cluster_accessor_client.go
+++ b/controllers/clustercache/cluster_accessor_client.go
@@ -133,6 +133,15 @@ func createRESTConfig(ctx context.Context, clientConfig *clusterAccessorClientCo
 		return nil, errors.WithMessage(err, "error creating REST config: error parsing kubeconfig")
 	}
 
+	// Note: Using ExecProvider is not supported in ClusterCache as we don't want our controllers to exec.
+	if restConfig.ExecProvider != nil {
+		return nil, errors.New("ExecProvider is not supported in ClusterCache")
+	}
+	// Note: Using AuthProvider is not supported as we are not registering plugins like e.g. oidc in Cluster API.
+	if restConfig.AuthProvider != nil {
+		return nil, errors.New("AuthProvider is not supported in ClusterCache")
+	}
+
 	restConfig.UserAgent = clientConfig.UserAgent
 	restConfig.Timeout = clientConfig.Timeout
 	restConfig.QPS = clientConfig.QPS

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -33,9 +33,13 @@ const (
 )
 
 // ClusterClientGetter returns a new remote client.
+//
+// Deprecated: This type is deprecated and will be removed in an upcoming release of Cluster API.
 type ClusterClientGetter func(ctx context.Context, sourceName string, c client.Client, cluster client.ObjectKey) (client.Client, error)
 
 // NewClusterClient returns a Client for interacting with a remote Cluster using the given scheme for encoding and decoding objects.
+//
+// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API, please use ClusterCache or inline this function instead.
 func NewClusterClient(ctx context.Context, sourceName string, c client.Client, cluster client.ObjectKey) (client.Client, error) {
 	restConfig, err := RESTConfig(ctx, sourceName, c, cluster)
 	if err != nil {
@@ -49,6 +53,8 @@ func NewClusterClient(ctx context.Context, sourceName string, c client.Client, c
 }
 
 // RESTConfig returns a configuration instance to be used with a Kubernetes client.
+//
+// Deprecated: This function is deprecated and will be removed in an upcoming release of Cluster API, please use ClusterCache or inline this function instead.
 func RESTConfig(ctx context.Context, sourceName string, c client.Reader, cluster client.ObjectKey) (*restclient.Config, error) {
 	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
 	if err != nil {

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -25,6 +25,8 @@ import (
 
 // NewClusterClient returns the same client passed as input, as output. It is assumed that the client is a
 // fake controller-runtime client.
+//
+// Deprecated: This type is deprecated and will be removed in an upcoming release of Cluster API.
 func NewClusterClient(_ context.Context, _ string, c client.Client, _ client.ObjectKey) (client.Client, error) {
 	return c, nil
 }

--- a/docs/book/src/developer/providers/migrations/v1.13-to-v1.14.md
+++ b/docs/book/src/developer/providers/migrations/v1.13-to-v1.14.md
@@ -88,7 +88,11 @@ Any feedback or contributions to improve following documentation is welcome!
 
 ## Deprecation
 
--
+- The following functions and types have been deprecated, please use ClusterCache or inline them instead:
+  - `controllers/remote.NewClusterClient`
+  - `controllers/remote.RESTConfig`
+  - `controllers/remote.ClusterClientGetter`
+  - `controllers/remote/fake.NewClusterClient`
 
 ## Removals
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->