### PR TITLE
✨ clusterctl: Validate apiVersion for reliant CRDs

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -559,10 +559,6 @@ func scaleDownDeployment(ctx context.Context, c client.Client, deploy appsv1.Dep
 // checkClusterClassRefs checks that upgrading providers won't break any
 // ClusterClass by dropping CRD apiVersions still pinned in templateRefs.
 func (u *providerUpgrader) checkClusterClassRefs(ctx context.Context, upgradePlan *UpgradePlan) error {
-	if len(upgradePlan.Providers) == 0 {
-		return nil
-	}
-
 	log := logf.Log
 
 	c, err := u.proxy.NewClient(ctx)

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -25,6 +26,9 @@ import (
 	"github.com/blang/semver/v4"
 	pkgerrors "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -410,6 +414,12 @@ func (u *providerUpgrader) doUpgrade(ctx context.Context, upgradePlan *UpgradePl
 		return providers[a].GetProviderType().Order() < providers[b].GetProviderType().Order()
 	})
 
+	// Check that upgrading won't break ClusterClass templateRefs by dropping CRD
+	// apiVersions that are still pinned.
+	if err := u.checkClusterClassRefs(ctx, upgradePlan); err != nil {
+		return err
+	}
+
 	// Scale down all providers.
 	// This is done to ensure all Pods of all "old" provider Deployments have been deleted.
 	// Otherwise it can happen that a provider Pod survives the upgrade because we create
@@ -544,6 +554,151 @@ func scaleDownDeployment(ctx context.Context, c client.Client, deploy appsv1.Dep
 	}
 
 	return nil
+}
+
+// checkClusterClassRefs checks that upgrading providers won't break any
+// ClusterClass by dropping CRD apiVersions still pinned in templateRefs.
+func (u *providerUpgrader) checkClusterClassRefs(ctx context.Context, upgradePlan *UpgradePlan) error {
+	if len(upgradePlan.Providers) == 0 {
+		return nil
+	}
+
+	log := logf.Log
+
+	c, err := u.proxy.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	clusterClasses := &clusterv1.ClusterClassList{}
+	if err := c.List(ctx, clusterClasses); err != nil {
+		return pkgerrors.Wrap(err, "failed to list ClusterClasses for upgrade pre-flight check")
+	}
+	if len(clusterClasses.Items) == 0 {
+		return nil
+	}
+
+	type gkvKey struct {
+		schema.GroupKind
+		version string
+	}
+	refsByGKV := map[gkvKey][]string{}
+	referencedGKs := sets.New[schema.GroupKind]()
+	for i := range clusterClasses.Items {
+		cc := &clusterClasses.Items[i]
+		ccName := client.ObjectKeyFromObject(cc).String()
+		for _, ref := range clusterClassTemplateRefs(cc) {
+			if ref.apiVersion == "" || ref.kind == "" {
+				continue
+			}
+			gv, err := schema.ParseGroupVersion(ref.apiVersion)
+			if err != nil {
+				continue
+			}
+			gk := schema.GroupKind{Group: gv.Group, Kind: ref.kind}
+			referencedGKs.Insert(gk)
+			key := gkvKey{GroupKind: gk, version: gv.Version}
+			refsByGKV[key] = append(refsByGKV[key], ccName)
+		}
+	}
+	if referencedGKs.Len() == 0 {
+		return nil
+	}
+
+	log.V(5).Info("Checking ClusterClass templateRefs for compatibility with CRD version changes")
+
+	var msgs []string
+	for _, upgradeItem := range upgradePlan.Providers {
+		if upgradeItem.NextVersion == "" {
+			continue
+		}
+
+		components, err := u.getUpgradeComponents(ctx, upgradeItem)
+		if err != nil {
+			return pkgerrors.Wrapf(err, "failed to get upgrade components for %s", upgradeItem.InstanceName())
+		}
+
+		for _, obj := range components.Objs() {
+			if obj.GetKind() != "CustomResourceDefinition" {
+				continue
+			}
+
+			newCRD := &apiextensionsv1.CustomResourceDefinition{}
+			if err := localScheme.Convert(&obj, newCRD, nil); err != nil {
+				return pkgerrors.Wrapf(err, "failed to convert CRD %s", obj.GetName())
+			}
+
+			gk := schema.GroupKind{Group: newCRD.Spec.Group, Kind: newCRD.Spec.Names.Kind}
+			if !referencedGKs.Has(gk) {
+				continue
+			}
+
+			existingCRD := &apiextensionsv1.CustomResourceDefinition{}
+			if err := c.Get(ctx, client.ObjectKeyFromObject(newCRD), existingCRD); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return pkgerrors.Wrapf(err, "failed to get existing CRD %s", newCRD.Name)
+			}
+
+			for _, v := range sets.List(droppedCRDVersions(existingCRD, newCRD)) {
+				affected := refsByGKV[gkvKey{GroupKind: gk, version: v}]
+				if len(affected) > 0 {
+					msgs = append(msgs, fmt.Sprintf(
+						"upgrading %s would remove apiVersion %q from %s/%s, which is still referenced by ClusterClass(es) %v; "+
+							"update the ClusterClass templateRefs to a served apiVersion before upgrading",
+						upgradeItem.InstanceName(), v, gk.Group, gk.Kind, affected,
+					))
+				}
+			}
+		}
+	}
+
+	if len(msgs) > 0 {
+		return pkgerrors.Errorf("upgrade pre-flight check failed:\n- %s", strings.Join(msgs, "\n- "))
+	}
+	return nil
+}
+
+func droppedCRDVersions(oldCRD, newCRD *apiextensionsv1.CustomResourceDefinition) sets.Set[string] {
+	oldVersions := sets.New[string]()
+	for _, v := range oldCRD.Spec.Versions {
+		oldVersions.Insert(v.Name)
+	}
+	newVersions := sets.New[string]()
+	for _, v := range newCRD.Spec.Versions {
+		newVersions.Insert(v.Name)
+	}
+	return oldVersions.Difference(newVersions)
+}
+
+type templateRef struct {
+	apiVersion string
+	kind       string
+}
+
+func clusterClassTemplateRefs(cc *clusterv1.ClusterClass) []templateRef {
+	var refs []templateRef
+	add := func(apiVersion, kind string) {
+		refs = append(refs, templateRef{apiVersion: apiVersion, kind: kind})
+	}
+
+	add(cc.Spec.Infrastructure.TemplateRef.APIVersion, cc.Spec.Infrastructure.TemplateRef.Kind)
+	add(cc.Spec.ControlPlane.TemplateRef.APIVersion, cc.Spec.ControlPlane.TemplateRef.Kind)
+	add(cc.Spec.ControlPlane.MachineInfrastructure.TemplateRef.APIVersion, cc.Spec.ControlPlane.MachineInfrastructure.TemplateRef.Kind)
+	add(cc.Spec.ControlPlane.HealthCheck.Remediation.TemplateRef.APIVersion, cc.Spec.ControlPlane.HealthCheck.Remediation.TemplateRef.Kind)
+
+	for _, md := range cc.Spec.Workers.MachineDeployments {
+		add(md.Bootstrap.TemplateRef.APIVersion, md.Bootstrap.TemplateRef.Kind)
+		add(md.Infrastructure.TemplateRef.APIVersion, md.Infrastructure.TemplateRef.Kind)
+		add(md.HealthCheck.Remediation.TemplateRef.APIVersion, md.HealthCheck.Remediation.TemplateRef.Kind)
+	}
+	for _, mp := range cc.Spec.Workers.MachinePools {
+		add(mp.Bootstrap.TemplateRef.APIVersion, mp.Bootstrap.TemplateRef.Kind)
+		add(mp.Infrastructure.TemplateRef.APIVersion, mp.Infrastructure.TemplateRef.Kind)
+	}
+
+	return refs
 }
 
 func newProviderUpgrader(configClient config.Client, proxy Proxy, repositoryClientFactory RepositoryClientFactory, providerInventory InventoryClient, providerComponents ComponentsClient, currentContractVersion string, getCompatibleContractVersions func(string) sets.Set[string]) *providerUpgrader {

--- a/cmd/clusterctl/client/cluster/upgrader_preflight_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_preflight_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+)
+
+func fakeCRD(name, group, kind string, versions ...string) *apiextensionsv1.CustomResourceDefinition {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: kind},
+		},
+	}
+	for _, v := range versions {
+		crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+			Name:    v,
+			Served:  true,
+			Storage: v == versions[len(versions)-1],
+		})
+	}
+	return crd
+}
+
+func fakeCRDYAML(name, group, kind string, versions ...string) []byte {
+	out, _ := yaml.Marshal(fakeCRD(name, group, kind, versions...))
+	return out
+}
+
+func Test_providerUpgrader_checkClusterClassRefs(t *testing.T) {
+	const (
+		infraGroup = "infrastructure.cluster.x-k8s.io"
+		infraKind  = "TestInfraClusterTemplate"
+		crdName    = "testinfraclustertemplates.infrastructure.cluster.x-k8s.io"
+	)
+
+	infraRepo := func(newVersions ...string) *repository.MemoryRepository {
+		return repository.NewMemoryRepository().
+			WithPaths("", "components.yaml").
+			WithVersions("v2.0.0", "v2.0.1").
+			WithFile("v2.0.1", "components.yaml", fakeCRDYAML(crdName, infraGroup, infraKind, newVersions...)).
+			WithMetadata("v2.0.1", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 2, Minor: 0, Contract: currentContractVersion},
+				},
+			})
+	}
+
+	infraPlan := &UpgradePlan{
+		Providers: []UpgradeItem{{
+			Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
+			NextVersion: "v2.0.1",
+		}},
+	}
+
+	reader := test.NewFakeReader().
+		WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com")
+
+	tests := []struct {
+		name     string
+		repo     *repository.MemoryRepository
+		proxy    *test.FakeProxy
+		plan     *UpgradePlan
+		wantErr  bool
+		errorMsg string
+	}{
+		{
+			name: "no versions dropped: no error",
+			repo: infraRepo("v1beta1", "v1beta2"),
+			proxy: test.NewFakeProxy().
+				WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+				WithObjs(fakeCRD(crdName, infraGroup, infraKind, "v1beta1", "v1beta2")),
+			plan:    infraPlan,
+			wantErr: false,
+		},
+		{
+			name: "version dropped, no ClusterClasses: no error",
+			repo: infraRepo("v1beta2"),
+			proxy: test.NewFakeProxy().
+				WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+				WithObjs(fakeCRD(crdName, infraGroup, infraKind, "v1beta1", "v1beta2")),
+			plan:    infraPlan,
+			wantErr: false,
+		},
+		{
+			name: "version dropped, ClusterClass pins dropped version: error",
+			repo: infraRepo("v1beta2"),
+			proxy: test.NewFakeProxy().
+				WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+				WithObjs(
+					fakeCRD(crdName, infraGroup, infraKind, "v1beta1", "v1beta2"),
+					&clusterv1.ClusterClass{
+						ObjectMeta: metav1.ObjectMeta{Name: "cc1", Namespace: "default"},
+						Spec: clusterv1.ClusterClassSpec{
+							Infrastructure: clusterv1.InfrastructureClass{
+								TemplateRef: clusterv1.ClusterClassTemplateReference{
+									APIVersion: infraGroup + "/v1beta1",
+									Kind:       infraKind,
+								},
+							},
+						},
+					},
+				),
+			plan:     infraPlan,
+			wantErr:  true,
+			errorMsg: "default/cc1",
+		},
+		{
+			name: "version dropped, ClusterClass uses newer version: no error",
+			repo: infraRepo("v1beta2"),
+			proxy: test.NewFakeProxy().
+				WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+				WithObjs(
+					fakeCRD(crdName, infraGroup, infraKind, "v1beta1", "v1beta2"),
+					&clusterv1.ClusterClass{
+						ObjectMeta: metav1.ObjectMeta{Name: "cc1", Namespace: "default"},
+						Spec: clusterv1.ClusterClassSpec{
+							Infrastructure: clusterv1.InfrastructureClass{
+								TemplateRef: clusterv1.ClusterClassTemplateReference{
+									APIVersion: infraGroup + "/v1beta2",
+									Kind:       infraKind,
+								},
+							},
+						},
+					},
+				),
+			plan:    infraPlan,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ctx := context.Background()
+
+			configClient, _ := config.New(ctx, "", config.InjectReader(reader))
+
+			u := &providerUpgrader{
+				configClient: configClient,
+				repositoryClientFactory: func(ctx context.Context, provider config.Provider, configClient config.Client, _ ...repository.Option) (repository.Client, error) {
+					return repository.New(ctx, provider, configClient, repository.InjectRepository(tt.repo))
+				},
+				providerInventory:             newInventoryClient(tt.proxy, nil, currentContractVersion),
+				proxy:                         tt.proxy,
+				currentContractVersion:        currentContractVersion,
+				getCompatibleContractVersions: getCompatibleContractVersions,
+			}
+
+			err := u.checkClusterClassRefs(ctx, tt.plan)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).Should(ContainSubstring(tt.errorMsg))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -1150,6 +1150,7 @@ func Test_providerUpgrader_ApplyPlan(t *testing.T) {
 					return repository.New(ctx, provider, configClient, repository.InjectRepository(tt.fields.repository[provider.ManifestLabel()]))
 				},
 				providerInventory:             newInventoryClient(tt.fields.proxy, nil, currentContractVersion),
+				proxy:                         tt.fields.proxy,
 				currentContractVersion:        currentContractVersion,
 				getCompatibleContractVersions: getCompatibleContractVersions,
 			}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Validates that the `apiVersion`s specified in CRDs continue to exist post-upgrade for resources that rely on them. Only done for ClusterClasses right now, and not MachineHealthChecks, since they aren't in the upgrade path.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8566

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->