### PR TITLE
📖 Add KubeSwift to the quick-start guide and glossary

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -90,6 +90,9 @@ Cluster API Provider Nutanix
 ### CAPKK
 Cluster API Provider KubeKey
 
+### CAPKS
+Cluster API Provider KubeSwift
+
 ### CAPK
 Cluster API Provider Kubevirt
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -273,7 +273,7 @@ Additional documentation about experimental features can be found in [Experiment
 Depending on the infrastructure provider you are planning to use, some additional prerequisites should be satisfied
 before getting started with Cluster API. See below for the expected settings for common providers.
 
-{{#tabs name:"tab-installation-infrastructure" tabs:"Akamai (Linode),AWS,Azure,cloudscale,CloudStack,DigitalOcean,Docker,GCP,Harvester,Hetzner,Hivelocity,Huawei,IBM Cloud,IONOS Cloud,K0smotron,KubeKey,KubeVirt,Metal3,metal-stack,Nutanix,OCI,OpenNebula,OpenStack,Outscale,Oxide,Proxmox,Scaleway,VCD,vcluster,Virtink,vSphere,Vultr"}}
+{{#tabs name:"tab-installation-infrastructure" tabs:"Akamai (Linode),AWS,Azure,cloudscale,CloudStack,DigitalOcean,Docker,GCP,Harvester,Hetzner,Hivelocity,Huawei,IBM Cloud,IONOS Cloud,K0smotron,KubeKey,KubeSwift,KubeVirt,Metal3,metal-stack,Nutanix,OCI,OpenNebula,OpenStack,Outscale,Oxide,Proxmox,Scaleway,VCD,vcluster,Virtink,vSphere,Vultr"}}
 {{#tab Akamai (Linode)}}
 
 ```bash
@@ -641,6 +641,18 @@ clusterctl init --infrastructure kubekey
 ```
 
 {{#/tab }}
+{{#tab KubeSwift}}
+
+KubeSwift runs the workload machines on the management cluster, so no cloud credentials
+are required. Ensure [KubeSwift](https://github.com/kubeswift-io/kubeswift) is installed
+on the management cluster first.
+
+```bash
+# Initialize the management cluster
+clusterctl init --infrastructure kubeswift-io
+```
+
+{{#/tab }}
 {{#tab KubeVirt}}
 
 Please visit the [KubeVirt project][KubeVirt provider] for more information.
@@ -943,7 +955,7 @@ before configuring a cluster with Cluster API. Instructions are provided for com
 Otherwise, you can look at the `clusterctl generate cluster` [command][clusterctl generate cluster] documentation for details about how to
 discover the list of variables required by a cluster templates.
 
-{{#tabs name:"tab-configuration-infrastructure" tabs:"Akamai (Linode),AWS,Azure,cloudscale,CloudStack,DigitalOcean,Docker,GCP,Harvester,Huawei,IBM Cloud,IONOS Cloud,K0smotron,KubeKey,KubeVirt,Metal3,metal-stack,Nutanix,OpenNebula,OpenStack,Outscale,Oxide,Proxmox,Scaleway,Tinkerbell,VCD,vcluster,Virtink,vSphere,Vultr"}}
+{{#tabs name:"tab-configuration-infrastructure" tabs:"Akamai (Linode),AWS,Azure,cloudscale,CloudStack,DigitalOcean,Docker,GCP,Harvester,Huawei,IBM Cloud,IONOS Cloud,K0smotron,KubeKey,KubeSwift,KubeVirt,Metal3,metal-stack,Nutanix,OpenNebula,OpenStack,Outscale,Oxide,Proxmox,Scaleway,Tinkerbell,VCD,vcluster,Virtink,vSphere,Vultr"}}
 {{#tab Akamai (Linode)}}
 
 ```bash
@@ -1265,6 +1277,23 @@ export CONTROL_PLANE_ENDPOINT_IP=<your-control-plane-virtual-ip>
 ```
 
 Please visit the [KubeKey provider] for more information.
+
+{{#/tab }}
+{{#tab KubeSwift}}
+
+KubeSwift runs the workload machines as VMs on the management cluster, so no cloud
+credentials are required. Ensure the management cluster has a Ready `SwiftImage` (for
+example `ubuntu-noble`) and the cluster-scoped `SwiftGuestClass`es referenced by the
+template (`capi-controlplane`, `capi-worker`).
+
+The template variables all have defaults; override them only if your names differ:
+```bash
+export KUBESWIFT_IMAGE="ubuntu-noble"
+export KUBESWIFT_CONTROL_PLANE_CLASS="capi-controlplane"
+export KUBESWIFT_WORKER_CLASS="capi-worker"
+```
+
+Please visit the [cluster-api-provider-kubeswift](https://github.com/kubeswift-io/cluster-api-provider-kubeswift) repository for more information.
 
 {{#/tab }}
 {{#tab KubeVirt}}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Documents KubeSwift in the getting-started book, mirroring how other infrastructure
providers document themselves:
- `user/quick-start.md`: a **KubeSwift** tab in the infrastructure *installation* group
  (`clusterctl init --infrastructure kubeswift-io`) and the *configuration* group
  (SwiftImage + SwiftGuestClass prerequisites, optional template variables).
- `reference/glossary.md`: the **CAPKS** entry (Cluster API Provider KubeSwift).
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Follow-up to the provider-list additions in #13946 and #13947.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->