### PR TITLE
🐛 Sync kubeconfig secret changes in ClusterCache and refresh rotated bearer tokens in place

### DIFF
--- a/controllers/clustercache/cluster_accessor.go
+++ b/controllers/clustercache/cluster_accessor.go
@@ -17,18 +17,22 @@ limitations under the License.
 package clustercache
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -177,6 +181,24 @@ type clusterAccessorLockedConnectionState struct {
 	// restConfig to communicate with the workload cluster.
 	restConfig *rest.Config
 
+	// kubeconfigResourceVersion is the ResourceVersion of the kubeconfig Secret
+	// as of the last successful load.
+	kubeconfigResourceVersion string
+
+	// kubeconfig is the raw kubeconfig as of the last successful load.
+	kubeconfig []byte
+
+	// lastKubeconfigSyncTime is the time when the kubeconfig Secret was last read, either at
+	// connection creation or by SyncKubeconfig. The ClusterCache reconciler uses it to rate-limit syncs.
+	lastKubeconfigSyncTime time.Time
+
+	// tokenHolder holds the dynamic bearer token for static bearer-token kubeconfigs.
+	tokenHolder *tokenHolder
+
+	// runningOnCluster is true if the controller is running on the workload cluster.
+	// In this case the server and CA from the kubeconfig are replaced with in-cluster values.
+	runningOnCluster bool
+
 	// restClient to communicate with the workload cluster.
 	restClient RESTClient
 
@@ -286,12 +308,17 @@ func (ca *clusterAccessor) Connect(ctx context.Context) (retErr error) {
 		consecutiveFailures:  0,
 	}
 	ca.lockedState.connection = &clusterAccessorLockedConnectionState{
-		restConfig:     connection.RESTConfig,
-		restClient:     connection.RESTClient,
-		cachedClient:   connection.CachedClient,
-		uncachedClient: connection.UncachedClient,
-		cache:          connection.Cache,
-		watches:        sets.Set[string]{},
+		restConfig:                connection.RESTConfig,
+		kubeconfigResourceVersion: connection.KubeconfigResourceVersion,
+		kubeconfig:                connection.Kubeconfig,
+		lastKubeconfigSyncTime:    now,
+		tokenHolder:               connection.TokenHolder,
+		runningOnCluster:          connection.RunningOnCluster,
+		restClient:                connection.RESTClient,
+		cachedClient:              connection.CachedClient,
+		uncachedClient:            connection.UncachedClient,
+		cache:                     connection.Cache,
+		watches:                   sets.Set[string]{},
 	}
 
 	return nil
@@ -373,6 +400,209 @@ func (ca *clusterAccessor) HealthCheck(ctx context.Context) (bool, bool) {
 
 	tooManyConsecutiveFailures := ca.lockedState.healthChecking.consecutiveFailures >= ca.config.HealthProbe.FailureThreshold
 	return tooManyConsecutiveFailures, unauthorizedErrorOccurred
+}
+
+// SyncKubeconfig checks if the kubeconfig Secret changed and updates the connection accordingly:
+//   - If only the bearer token changed, the token is updated in place, i.e. without re-creating the
+//     connection (client, cache, etc.): all transports created for the connection get the current
+//     token from the tokenHolder on every request.
+//   - If the controller is running on the workload cluster, changes to the server URL and CA are ignored
+//     because those fields are replaced with in-cluster values when the connection is created.
+//   - For all other changes, true is returned and the caller is expected to re-create the connection
+//     (i.e. call Disconnect and Connect).
+//
+// Note: Errors when reading or parsing the kubeconfig Secret intentionally never lead to a reconnect,
+// a working connection should not be torn down because of them (the health probe remains the fallback).
+func (ca *clusterAccessor) SyncKubeconfig(ctx context.Context) bool {
+	log := ctrl.LoggerFrom(ctx)
+
+	ca.lock(ctx)
+	if ca.lockedState.connection == nil {
+		ca.unlock(ctx)
+		log.V(6).Info("Skipping kubeconfig sync, not connected")
+		return false
+	}
+	// Record the sync independent of its outcome, also failed Secret reads should not be
+	// retried on every Reconcile.
+	ca.lockedState.connection.lastKubeconfigSyncTime = time.Now()
+	oldKubeconfigResourceVersion := ca.lockedState.connection.kubeconfigResourceVersion
+	oldKubeconfig := ca.lockedState.connection.kubeconfig
+	runningOnCluster := ca.lockedState.connection.runningOnCluster
+	ca.unlock(ctx)
+
+	kubeconfigSecret, kubeconfig, err := getKubeconfigSecret(ctx, ca.config.SecretClient, ca.cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(6).Info("Skipping kubeconfig sync, kubeconfig Secret does not exist")
+		} else {
+			log.Error(err, "Failed to sync kubeconfig, keeping current connection")
+		}
+		return false
+	}
+
+	if kubeconfigSecret.ResourceVersion == oldKubeconfigResourceVersion {
+		return false
+	}
+
+	// Only store the new resourceVersion if the kubeconfig itself didn't change,
+	// e.g. because another entry of the kubeconfig Secret changed.
+	if bytes.Equal(kubeconfig, oldKubeconfig) {
+		ca.storeKubeconfig(ctx, oldKubeconfigResourceVersion, kubeconfigSecret.ResourceVersion, kubeconfig)
+		return false
+	}
+
+	onlyTokenOrIgnoredChanges, oldToken, newToken, err := kubeconfigChangesOnlyInTokensAndIgnoredFields(oldKubeconfig, kubeconfig, runningOnCluster)
+	if err != nil {
+		log.Error(err, "Failed to sync kubeconfig, keeping current connection")
+		return false
+	}
+
+	// If the effective kubeconfig did not change, only store the new kubeconfig state.
+	// This avoids reporting a token rotation for e.g. changes to tokens of unused AuthInfos.
+	if onlyTokenOrIgnoredChanges && oldToken == newToken {
+		ca.storeKubeconfig(ctx, oldKubeconfigResourceVersion, kubeconfigSecret.ResourceVersion, kubeconfig)
+		return false
+	}
+
+	if onlyTokenOrIgnoredChanges && newToken != "" {
+		switch ca.refreshToken(ctx, oldKubeconfigResourceVersion, kubeconfigSecret.ResourceVersion, kubeconfig, newToken) {
+		case tokenRefreshed:
+			log.Info("Bearer token in kubeconfig Secret was rotated, updated token in existing connection")
+			kubeconfigSyncTotal.WithLabelValues(ca.cluster.Name, ca.cluster.Namespace, "token_refreshed").Inc()
+			return false
+		case tokenRefreshOutdated:
+			return false
+		case tokenRefreshNeedsReconnect:
+			// Re-create the connection below.
+		}
+	}
+
+	log.Info("Kubeconfig Secret was updated, re-creating the connection")
+	kubeconfigSyncTotal.WithLabelValues(ca.cluster.Name, ca.cluster.Namespace, "reconnect").Inc()
+	return true
+}
+
+func (ca *clusterAccessor) storeKubeconfig(ctx context.Context, oldKubeconfigResourceVersion, kubeconfigResourceVersion string, kubeconfig []byte) {
+	ca.lock(ctx)
+	defer ca.unlock(ctx)
+
+	// Return early if the connection or the kubeconfig state changed in the meantime.
+	if ca.lockedState.connection == nil || ca.lockedState.connection.kubeconfigResourceVersion != oldKubeconfigResourceVersion {
+		return
+	}
+
+	ca.lockedState.connection.kubeconfigResourceVersion = kubeconfigResourceVersion
+	ca.lockedState.connection.kubeconfig = kubeconfig
+}
+
+type tokenRefreshResult int
+
+const (
+	// tokenRefreshed means the bearer token of the connection was updated in place.
+	tokenRefreshed tokenRefreshResult = iota
+
+	// tokenRefreshNeedsReconnect means the connection doesn't use a static bearer token and
+	// accordingly a reconnect is required to pick up the new kubeconfig.
+	tokenRefreshNeedsReconnect
+
+	// tokenRefreshOutdated means the connection or the kubeconfig state changed since the
+	// kubeconfig was read, so the refresh was skipped as it was based on outdated state.
+	tokenRefreshOutdated
+)
+
+// refreshToken updates the bearer token of the connection in place.
+func (ca *clusterAccessor) refreshToken(ctx context.Context, oldKubeconfigResourceVersion, kubeconfigResourceVersion string, kubeconfig []byte, token string) tokenRefreshResult {
+	ca.lock(ctx)
+	defer ca.unlock(ctx)
+
+	// Return early if the connection or the kubeconfig state changed in the meantime.
+	if ca.lockedState.connection == nil || ca.lockedState.connection.kubeconfigResourceVersion != oldKubeconfigResourceVersion {
+		return tokenRefreshOutdated
+	}
+
+	// The connection doesn't use a static bearer token, e.g. because a token was added to a
+	// kubeconfig that previously used another authentication method.
+	if ca.lockedState.connection.tokenHolder == nil {
+		return tokenRefreshNeedsReconnect
+	}
+
+	ca.lockedState.connection.tokenHolder.store(token)
+
+	// Replace restConfig with a copy that contains the new token instead of modifying it in place,
+	// as the restConfig is shared with consumers of the ClusterCache via GetRESTConfig.
+	restConfig := rest.CopyConfig(ca.lockedState.connection.restConfig)
+	restConfig.BearerToken = token
+	ca.lockedState.connection.tokenHolder.setConfigWrapTransport(restConfig)
+	ca.lockedState.connection.restConfig = restConfig
+	ca.lockedState.connection.kubeconfigResourceVersion = kubeconfigResourceVersion
+	ca.lockedState.connection.kubeconfig = kubeconfig
+	return tokenRefreshed
+}
+
+// kubeconfigChangesOnlyInTokensAndIgnoredFields returns true if the two kubeconfigs are identical except for
+// the bearer tokens of their AuthInfos. If runningOnCluster is true, changes to the server and CA of the current
+// cluster are also ignored because those fields are replaced with in-cluster values.
+// The current bearer tokens from both kubeconfigs are returned as well.
+func kubeconfigChangesOnlyInTokensAndIgnoredFields(oldKubeconfig, newKubeconfig []byte, runningOnCluster bool) (bool, string, string, error) {
+	oldConfig, err := clientcmd.Load(oldKubeconfig)
+	if err != nil {
+		return false, "", "", pkgerrors.WithMessage(err, "error parsing previous kubeconfig")
+	}
+
+	newConfig, err := clientcmd.Load(newKubeconfig)
+	if err != nil {
+		return false, "", "", pkgerrors.WithMessage(err, "error parsing new kubeconfig")
+	}
+
+	oldToken := currentAuthInfoToken(oldConfig)
+	newToken := currentAuthInfoToken(newConfig)
+
+	oldConfigWithoutTokens := oldConfig.DeepCopy()
+	newConfigWithoutTokens := newConfig.DeepCopy()
+	clearAuthInfoTokens(oldConfigWithoutTokens)
+	clearAuthInfoTokens(newConfigWithoutTokens)
+	if runningOnCluster {
+		clearCurrentClusterServerAndCA(oldConfigWithoutTokens)
+		clearCurrentClusterServerAndCA(newConfigWithoutTokens)
+	}
+
+	return apiequality.Semantic.DeepEqual(oldConfigWithoutTokens, newConfigWithoutTokens), oldToken, newToken, nil
+}
+
+func clearAuthInfoTokens(config *clientcmdapi.Config) {
+	for _, authInfo := range config.AuthInfos {
+		authInfo.Token = ""
+	}
+}
+
+func clearCurrentClusterServerAndCA(config *clientcmdapi.Config) {
+	currentContext, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return
+	}
+
+	cluster, ok := config.Clusters[currentContext.Cluster]
+	if !ok {
+		return
+	}
+
+	cluster.Server = ""
+	cluster.CertificateAuthority = ""
+	cluster.CertificateAuthorityData = nil
+}
+
+func currentAuthInfoToken(config *clientcmdapi.Config) string {
+	currentContext := config.Contexts[config.CurrentContext]
+	if currentContext == nil {
+		return ""
+	}
+
+	authInfo := config.AuthInfos[currentContext.AuthInfo]
+	if authInfo == nil {
+		return ""
+	}
+
+	return authInfo.Token
 }
 
 func (ca *clusterAccessor) GetClient(ctx context.Context) (client.Client, error) {
@@ -477,6 +707,18 @@ func (ca *clusterAccessor) GetLastConnectionCreationErrorTime(ctx context.Contex
 	defer ca.rUnlock(ctx)
 
 	return ca.lockedState.lastConnectionCreationErrorTime
+}
+
+// GetLastKubeconfigSyncTime returns the time when the kubeconfig Secret was last read for the
+// current connection, or the zero time if there is no connection.
+func (ca *clusterAccessor) GetLastKubeconfigSyncTime(ctx context.Context) time.Time {
+	ca.rLock(ctx)
+	defer ca.rUnlock(ctx)
+
+	if ca.lockedState.connection == nil {
+		return time.Time{}
+	}
+	return ca.lockedState.connection.lastKubeconfigSyncTime
 }
 
 func (ca *clusterAccessor) rLock(ctx context.Context) {

--- a/controllers/clustercache/cluster_accessor_client.go
+++ b/controllers/clustercache/cluster_accessor_client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -30,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -38,15 +40,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 type createConnectionResult struct {
-	RESTConfig     *rest.Config
-	RESTClient     *rest.RESTClient
-	CachedClient   client.Client
-	UncachedClient client.Client
-	Cache          *stoppableCache
+	RESTConfig                *rest.Config
+	KubeconfigResourceVersion string
+	Kubeconfig                []byte
+	TokenHolder               *tokenHolder
+	RunningOnCluster          bool
+	RESTClient                *rest.RESTClient
+	CachedClient              client.Client
+	UncachedClient            client.Client
+	Cache                     *stoppableCache
 }
 
 func (ca *clusterAccessor) createConnection(ctx context.Context) (*createConnectionResult, error) {
@@ -54,7 +60,7 @@ func (ca *clusterAccessor) createConnection(ctx context.Context) (*createConnect
 	log.V(6).Info("Creating connection")
 
 	log.V(6).Info("Creating REST config")
-	restConfig, err := createRESTConfig(ctx, ca.config.Client, ca.config.SecretClient, ca.cluster)
+	restConfig, kubeconfigResourceVersion, kubeconfig, tokenHolder, err := createRESTConfig(ctx, ca.config.Client, ca.config.SecretClient, ca.cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -113,33 +119,44 @@ func (ca *clusterAccessor) createConnection(ctx context.Context) (*createConnect
 	}
 
 	return &createConnectionResult{
-		RESTConfig:     restConfig,
-		RESTClient:     restClient,
-		CachedClient:   cachedClient,
-		UncachedClient: uncachedClient,
-		Cache:          cache,
+		RESTConfig:                restConfig,
+		KubeconfigResourceVersion: kubeconfigResourceVersion,
+		Kubeconfig:                kubeconfig,
+		TokenHolder:               tokenHolder,
+		RunningOnCluster:          runningOnCluster,
+		RESTClient:                restClient,
+		CachedClient:              cachedClient,
+		UncachedClient:            uncachedClient,
+		Cache:                     cache,
 	}, nil
 }
 
 // createRESTConfig returns a REST config created based on the kubeconfig Secret.
-func createRESTConfig(ctx context.Context, clientConfig *clusterAccessorClientConfig, c client.Reader, cluster client.ObjectKey) (*rest.Config, error) {
-	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
+func createRESTConfig(ctx context.Context, clientConfig *clusterAccessorClientConfig, c client.Reader, cluster client.ObjectKey) (*rest.Config, string, []byte, *tokenHolder, error) {
+	kubeconfigSecret, kubeConfig, err := getKubeconfigSecret(ctx, c, cluster)
 	if err != nil {
-		return nil, pkgerrors.WithMessage(err, "error creating REST config: error getting kubeconfig secret")
+		return nil, "", nil, nil, pkgerrors.WithMessage(err, "error creating REST config: error getting kubeconfig secret")
 	}
 
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
 	if err != nil {
-		return nil, pkgerrors.WithMessage(err, "error creating REST config: error parsing kubeconfig")
+		return nil, "", nil, nil, pkgerrors.WithMessage(err, "error creating REST config: error parsing kubeconfig")
+	}
+
+	var holder *tokenHolder
+	if usesStaticBearerToken(restConfig) {
+		holder = newTokenHolder(restConfig.BearerToken)
+		holder.originalWrapTransport = restConfig.WrapTransport
+		holder.setConfigWrapTransport(restConfig)
 	}
 
 	// Note: Using ExecProvider is not supported in ClusterCache as we don't want our controllers to exec.
 	if restConfig.ExecProvider != nil {
-		return nil, pkgerrors.New("ExecProvider is not supported in ClusterCache")
+		return nil, "", nil, nil, pkgerrors.New("ExecProvider is not supported in ClusterCache")
 	}
 	// Note: Using AuthProvider is not supported as we are not registering plugins like e.g. oidc in Cluster API.
 	if restConfig.AuthProvider != nil {
-		return nil, pkgerrors.New("AuthProvider is not supported in ClusterCache")
+		return nil, "", nil, nil, pkgerrors.New("AuthProvider is not supported in ClusterCache")
 	}
 
 	restConfig.UserAgent = clientConfig.UserAgent
@@ -147,7 +164,107 @@ func createRESTConfig(ctx context.Context, clientConfig *clusterAccessorClientCo
 	restConfig.QPS = clientConfig.QPS
 	restConfig.Burst = clientConfig.Burst
 
-	return restConfig, nil
+	return restConfig, kubeconfigSecret.ResourceVersion, kubeConfig, holder, nil
+}
+
+func getKubeconfigSecret(ctx context.Context, c client.Reader, cluster client.ObjectKey) (*corev1.Secret, []byte, error) {
+	kubeconfigSecret, err := secret.Get(ctx, c, cluster, secret.Kubeconfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kubeConfig, ok := kubeconfigSecret.Data[secret.KubeconfigDataName]
+	if !ok {
+		return nil, nil, pkgerrors.Errorf("missing key %q in secret data", secret.KubeconfigDataName)
+	}
+
+	return kubeconfigSecret, kubeConfig, nil
+}
+
+// usesStaticBearerToken returns true if the rest.Config authenticates via a static bearer token,
+// i.e. a token that client-go cannot refresh on its own (as opposed to e.g. a token file or exec plugin).
+func usesStaticBearerToken(config *rest.Config) bool {
+	return config.BearerToken != "" &&
+		config.BearerTokenFile == "" &&
+		config.ExecProvider == nil &&
+		config.AuthProvider == nil
+}
+
+// tokenHolder holds the current bearer token and the original transport wrapper so the
+// rest.Config wrapper can be rebuilt after a token rotation without stacking wrappers.
+type tokenHolder struct {
+	// value is the current bearer token used by all transports created for the connection.
+	value atomic.Pointer[string]
+
+	// originalWrapTransport is preserved when rebuilding the dynamic bearer-token wrapper after a token rotation.
+	originalWrapTransport func(http.RoundTripper) http.RoundTripper
+}
+
+func newTokenHolder(token string) *tokenHolder {
+	holder := &tokenHolder{}
+	holder.store(token)
+	return holder
+}
+
+func (h *tokenHolder) store(token string) {
+	h.value.Store(&token)
+}
+
+func (h *tokenHolder) token() string {
+	token := h.value.Load()
+	if token == nil {
+		return ""
+	}
+	return *token
+}
+
+// setConfigWrapTransport configures the rest.Config to replace its static bearer token with the current
+// token from the tokenHolder while preserving request-specific Authorization headers.
+func (h *tokenHolder) setConfigWrapTransport(config *rest.Config) {
+	configuredToken := config.BearerToken
+	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		if h.originalWrapTransport != nil {
+			rt = h.originalWrapTransport(rt)
+		}
+		return &dynamicBearerTokenRoundTripper{
+			holder:          h,
+			configuredToken: configuredToken,
+			rt:              rt,
+		}
+	}
+}
+
+// dynamicBearerTokenRoundTripper replaces the static bearer token configured for the transport
+// with the current token from the tokenHolder, so a rotated token is picked up without re-creating
+// transports. Request-specific Authorization headers are preserved.
+type dynamicBearerTokenRoundTripper struct {
+	holder *tokenHolder
+
+	// configuredToken is the static token client-go adds to requests for this transport.
+	// Only this token is replaced so request-specific Authorization headers are preserved.
+	configuredToken string
+
+	rt http.RoundTripper
+}
+
+var _ utilnet.RoundTripperWrapper = &dynamicBearerTokenRoundTripper{}
+
+func (rt *dynamicBearerTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	authorizationHeader := req.Header.Get("Authorization")
+	if authorizationHeader != "" && authorizationHeader != "Bearer "+rt.configuredToken {
+		return rt.rt.RoundTrip(req)
+	}
+
+	token := rt.holder.token()
+	if token != "" {
+		req = utilnet.CloneRequest(req)
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return rt.rt.RoundTrip(req)
+}
+
+func (rt *dynamicBearerTokenRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return rt.rt
 }
 
 // runningOnWorkloadCluster detects if the current controller runs on the workload cluster.

--- a/controllers/clustercache/cluster_accessor_client_test.go
+++ b/controllers/clustercache/cluster_accessor_client_test.go
@@ -17,15 +17,69 @@ limitations under the License.
 package clustercache
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestDynamicBearerTokenRoundTripper(t *testing.T) {
+	g := NewWithT(t)
+
+	var authorizationHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizationHeaders = append(authorizationHeaders, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	holder := newTokenHolder("stale-token")
+	config := &rest.Config{
+		Host:        server.URL,
+		BearerToken: "stale-token",
+	}
+	holder.originalWrapTransport = config.WrapTransport
+	holder.setConfigWrapTransport(config)
+
+	httpClient, err := rest.HTTPClientFor(config)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+	g.Expect(err).ToNot(HaveOccurred())
+	resp, err := httpClient.Do(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.Body.Close()).To(Succeed())
+	g.Expect(authorizationHeaders).To(Equal([]string{"Bearer stale-token"}))
+
+	holder.store("rotated-token")
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+	g.Expect(err).ToNot(HaveOccurred())
+	resp, err = httpClient.Do(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	body, err := io.ReadAll(resp.Body)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.Body.Close()).To(Succeed())
+	g.Expect(body).To(BeEmpty())
+	g.Expect(authorizationHeaders).To(Equal([]string{"Bearer stale-token", "Bearer rotated-token"}))
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+	g.Expect(err).ToNot(HaveOccurred())
+	req.Header.Set("Authorization", "Bearer request-token")
+	resp, err = httpClient.Do(req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(resp.Body.Close()).To(Succeed())
+	g.Expect(authorizationHeaders).To(Equal([]string{"Bearer stale-token", "Bearer rotated-token", "Bearer request-token"}))
+}
 
 func TestRunningOnWorkloadCluster(t *testing.T) {
 	tests := []struct {

--- a/controllers/clustercache/cluster_accessor_test.go
+++ b/controllers/clustercache/cluster_accessor_test.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -342,6 +344,239 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
+func TestSyncKubeconfig(t *testing.T) {
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+	clusterKey := client.ObjectKeyFromObject(testCluster)
+	oldKubeconfig := newTokenKubeconfig("test-cluster", "https://old.example.com", "old-token", []byte("old-ca"))
+	rotatedTokenKubeconfig := newTokenKubeconfig("test-cluster", "https://old.example.com", "new-token", []byte("old-ca"))
+	newServerKubeconfig := newTokenKubeconfig("test-cluster", "https://new.example.com", "old-token", []byte("new-ca"))
+	newServerAndRotatedTokenKubeconfig := newTokenKubeconfig("test-cluster", "https://new.example.com", "new-token", []byte("new-ca"))
+	oldKubeconfigWithInactiveToken := withAuthInfoToken(oldKubeconfig, "inactive-user", "old-inactive-token")
+	newKubeconfigWithInactiveToken := withAuthInfoToken(oldKubeconfig, "inactive-user", "new-inactive-token")
+	oldClientCertificateKubeconfig := withClientCertificateAuth(oldKubeconfig)
+	newClientCertificateKubeconfig := withClientCertificateAuth(newServerKubeconfig)
+	newTLSServerNameKubeconfig := withClusterTLSServerName(oldKubeconfig, "test-cluster", "new.example.com")
+
+	tests := []struct {
+		name                       string
+		initialResourceVersion     string
+		initialKubeconfig          []byte
+		initialToken               string
+		initialTokenHolder         *tokenHolder
+		runningOnCluster           bool
+		secret                     *corev1.Secret
+		secretReaderError          error
+		wantNeedsReconnect         bool
+		wantResourceVersion        string
+		wantKubeconfig             []byte
+		wantToken                  string
+		wantRESTConfigBearerToken  string
+		wantRESTConfigPointerEqual bool
+	}{
+		{
+			name:                       "resourceVersion unchanged returns no-op",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "1", rotatedTokenKubeconfig),
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "same kubeconfig bytes with new resourceVersion only updates resourceVersion",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "2", oldKubeconfig),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "token-only change refreshes connection in place",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "2", rotatedTokenKubeconfig),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             rotatedTokenKubeconfig,
+			wantToken:                  "new-token",
+			wantRESTConfigBearerToken:  "new-token",
+			wantRESTConfigPointerEqual: false,
+		},
+		{
+			name:                       "token-only change without token holder needs reconnect",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			secret:                     newKubeconfigSecret(testCluster, "2", rotatedTokenKubeconfig),
+			wantNeedsReconnect:         true,
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "server change needs reconnect",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "2", newServerKubeconfig),
+			wantNeedsReconnect:         true,
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "server change while running on cluster does not need reconnect",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			runningOnCluster:           true,
+			secret:                     newKubeconfigSecret(testCluster, "2", newServerKubeconfig),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             newServerKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "server and token change while running on cluster refreshes token in place",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			runningOnCluster:           true,
+			secret:                     newKubeconfigSecret(testCluster, "2", newServerAndRotatedTokenKubeconfig),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             newServerAndRotatedTokenKubeconfig,
+			wantToken:                  "new-token",
+			wantRESTConfigBearerToken:  "new-token",
+			wantRESTConfigPointerEqual: false,
+		},
+		{
+			name:                       "server and CA change with client certificate while running on cluster only updates kubeconfig state",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldClientCertificateKubeconfig,
+			runningOnCluster:           true,
+			secret:                     newKubeconfigSecret(testCluster, "2", newClientCertificateKubeconfig),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             newClientCertificateKubeconfig,
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "TLS server name change while running on cluster needs reconnect",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			runningOnCluster:           true,
+			secret:                     newKubeconfigSecret(testCluster, "2", newTLSServerNameKubeconfig),
+			wantNeedsReconnect:         true,
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "inactive AuthInfo token change only updates kubeconfig state",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfigWithInactiveToken,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "2", newKubeconfigWithInactiveToken),
+			wantResourceVersion:        "2",
+			wantKubeconfig:             newKubeconfigWithInactiveToken,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "secret missing keeps connection",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secretReaderError:          apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "test-cluster-kubeconfig"),
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+		{
+			name:                       "unparsable new kubeconfig keeps connection",
+			initialResourceVersion:     "1",
+			initialKubeconfig:          oldKubeconfig,
+			initialToken:               "old-token",
+			initialTokenHolder:         newTokenHolder("old-token"),
+			secret:                     newKubeconfigSecret(testCluster, "2", []byte("not a kubeconfig")),
+			wantResourceVersion:        "1",
+			wantKubeconfig:             oldKubeconfig,
+			wantToken:                  "old-token",
+			wantRESTConfigBearerToken:  "old-token",
+			wantRESTConfigPointerEqual: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			accessor := newClusterAccessor(context.Background(), clusterKey, &clusterAccessorConfig{
+				SecretClient: &testSecretReader{
+					secret: tt.secret,
+					err:    tt.secretReaderError,
+				},
+			})
+			restConfig := &rest.Config{
+				Host:        "https://old.example.com",
+				BearerToken: tt.initialToken,
+			}
+			accessor.lockedState.connection = &clusterAccessorLockedConnectionState{
+				restConfig:                restConfig,
+				kubeconfigResourceVersion: tt.initialResourceVersion,
+				kubeconfig:                tt.initialKubeconfig,
+				tokenHolder:               tt.initialTokenHolder,
+				runningOnCluster:          tt.runningOnCluster,
+			}
+
+			needsReconnect := accessor.SyncKubeconfig(ctx)
+
+			g.Expect(needsReconnect).To(Equal(tt.wantNeedsReconnect))
+			g.Expect(accessor.lockedState.connection.kubeconfigResourceVersion).To(Equal(tt.wantResourceVersion))
+			g.Expect(accessor.lockedState.connection.kubeconfig).To(Equal(tt.wantKubeconfig))
+			g.Expect(accessor.lockedState.connection.restConfig.BearerToken).To(Equal(tt.wantRESTConfigBearerToken))
+			if tt.wantRESTConfigPointerEqual {
+				g.Expect(accessor.lockedState.connection.restConfig).To(BeIdenticalTo(restConfig))
+			} else {
+				g.Expect(accessor.lockedState.connection.restConfig).ToNot(BeIdenticalTo(restConfig))
+			}
+			if tt.initialTokenHolder != nil {
+				g.Expect(tt.initialTokenHolder.token()).To(Equal(tt.wantToken))
+			}
+		})
+	}
+}
+
 func TestWatch(t *testing.T) {
 	g := NewWithT(t)
 
@@ -489,4 +724,104 @@ func objBody(obj runtime.Object) io.ReadCloser {
 	corev1GV := schema.GroupVersion{Version: "v1"}
 	corev1Codec := scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(corev1GV), scheme.Codecs.UniversalDecoder(corev1GV), corev1GV, corev1GV)
 	return io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(corev1Codec, obj))))
+}
+
+type testSecretReader struct {
+	secret *corev1.Secret
+	err    error
+}
+
+var _ client.Reader = &testSecretReader{}
+
+func (r *testSecretReader) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	r.secret.DeepCopyInto(obj.(*corev1.Secret))
+	return nil
+}
+
+func (r *testSecretReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return errors.New("List is not implemented")
+}
+
+func newKubeconfigSecret(cluster *clusterv1.Cluster, resourceVersion string, data []byte) *corev1.Secret {
+	kubeconfigSecret := kubeconfig.GenerateSecret(cluster, data)
+	kubeconfigSecret.ResourceVersion = resourceVersion
+	return kubeconfigSecret
+}
+
+func newTokenKubeconfig(clusterName, server, token string, certificateAuthorityData []byte) []byte {
+	const authInfoName = "test-user"
+
+	data, err := clientcmd.Write(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                   server,
+				CertificateAuthorityData: certificateAuthorityData,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			clusterName: {
+				Cluster:  clusterName,
+				AuthInfo: authInfoName,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			authInfoName: {
+				Token: token,
+			},
+		},
+		CurrentContext: clusterName,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func withAuthInfoToken(kubeconfig []byte, name, token string) []byte {
+	config, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	config.AuthInfos[name] = &clientcmdapi.AuthInfo{Token: token}
+
+	data, err := clientcmd.Write(*config)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func withClientCertificateAuth(kubeconfig []byte) []byte {
+	config, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	authInfo := config.AuthInfos[config.Contexts[config.CurrentContext].AuthInfo]
+	authInfo.Token = ""
+	authInfo.ClientCertificateData = []byte("client-certificate")
+	authInfo.ClientKeyData = []byte("client-key")
+
+	data, err := clientcmd.Write(*config)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func withClusterTLSServerName(kubeconfig []byte, clusterName, tlsServerName string) []byte {
+	config, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	config.Clusters[clusterName].TLSServerName = tlsServerName
+
+	data, err := clientcmd.Write(*config)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -54,6 +54,8 @@ type Options struct {
 	// with the following name format: "<cluster-name>-kubeconfig".
 	// Ideally this is a client that caches only kubeconfig secrets, it is highly recommended to avoid caching all secrets.
 	// An example on how to create an ideal secret caching client can be found in the core Cluster API controller main.go file.
+	// Note: The kubeconfig Secret is not only read when connecting, it is also read periodically
+	// (at most once per health probe interval per Cluster) to detect kubeconfig changes, e.g. token rotations.
 	SecretClient client.Reader
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
@@ -516,6 +518,27 @@ func (cc *clusterCache) Reconcile(ctx context.Context, req reconcile.Request) (r
 		}
 	}
 
+	// Sync the kubeconfig Secret before running the health probe. This allows token-only
+	// changes to be applied in place so the probe uses the refreshed token.
+	if connected {
+		lastKubeconfigSyncTime := accessor.GetLastKubeconfigSyncTime(ctx)
+
+		// Requeue, if the kubeconfig was already synced within the HealthProbe.Interval.
+		// This rate-limits kubeconfig Secret reads, which is important if the SecretClient is not cached.
+		if requeueAfter, requeue := shouldRequeue(time.Now(), lastKubeconfigSyncTime, accessor.config.HealthProbe.Interval); requeue {
+			log.V(6).Info(fmt.Sprintf("Requeuing after %s as kubeconfig was already synced within the last %s",
+				requeueAfter.Truncate(time.Second/10), accessor.config.HealthProbe.Interval))
+			requeueAfterDurations = append(requeueAfterDurations, requeueAfter)
+		} else if accessor.SyncKubeconfig(ctx) {
+			accessor.Disconnect(ctx)
+			didDisconnect = true
+			connected = false
+
+			log.V(6).Info("Requeuing immediately (disconnected after kubeconfig changed)")
+			requeueAfterDurations = append(requeueAfterDurations, 1*time.Millisecond)
+		}
+	}
+
 	// Run the health probe, if connected.
 	if connected {
 		healthCheckingState := accessor.GetHealthCheckingState(ctx)
@@ -642,6 +665,8 @@ func (cc *clusterCache) cleanupMetricsForCluster(cluster client.ObjectKey) {
 	connectionUp.DeleteLabelValues(cluster.Name, cluster.Namespace)
 	healthChecksTotal.DeleteLabelValues(cluster.Name, cluster.Namespace, "success")
 	healthChecksTotal.DeleteLabelValues(cluster.Name, cluster.Namespace, "error")
+	kubeconfigSyncTotal.DeleteLabelValues(cluster.Name, cluster.Namespace, "token_refreshed")
+	kubeconfigSyncTotal.DeleteLabelValues(cluster.Name, cluster.Namespace, "reconnect")
 }
 
 func (cc *clusterCache) cleanupForCluster(ctx context.Context, cluster client.ObjectKey) {

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -22,17 +22,24 @@ import (
 	"math"
 	"math/rand/v2"
 	"net/http"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	pkgerrors "github.com/pkg/errors"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
@@ -49,6 +56,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/cluster-api/util/test/builder"
 )
 
@@ -242,6 +250,208 @@ func TestReconcile(t *testing.T) {
 	// Verify Cluster queue.
 	g.Expect(clusterQueue.Len()).To(Equal(1))
 	g.Expect(clusterQueue.Get()).To(Equal(reconcile.Request{NamespacedName: clusterKey}))
+}
+
+func TestReconcileSyncKubeconfigServerChange(t *testing.T) {
+	g := NewWithT(t)
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-kubeconfig-sync",
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				"cluster.x-k8s.io/included-in-clustercache-tests": "true",
+			},
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
+			},
+		},
+	}
+	clusterKey := client.ObjectKeyFromObject(testCluster)
+	g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
+	defer func() { g.Expect(client.IgnoreNotFound(env.CleanupAndWait(ctx, testCluster))).To(Succeed()) }()
+
+	patch := client.MergeFrom(testCluster.DeepCopy())
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
+	g.Expect(env.Status().Patch(ctx, testCluster, patch)).To(Succeed())
+
+	kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, kubeconfig.FromEnvTestConfig(env.Config, testCluster))
+	g.Expect(env.CreateAndWait(ctx, kubeconfigSecret)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, kubeconfigSecret)).To(Succeed()) }()
+
+	accessorConfig := buildClusterAccessorConfig(env.GetScheme(), Options{
+		SecretClient: env.GetClient(),
+		Client: ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("test-controller-manager"),
+			Timeout:   10 * time.Second,
+		},
+	}, nil)
+	cc := &clusterCache{
+		client:                env.GetAPIReader(),
+		clusterAccessorConfig: accessorConfig,
+		clusterAccessors:      make(map[client.ObjectKey]*clusterAccessor),
+		cacheCtx:              context.Background(),
+		clusterFilter: func(cluster *clusterv1.Cluster) bool {
+			return cluster.ObjectMeta.Labels["cluster.x-k8s.io/included-in-clustercache-tests"] == "true"
+		},
+	}
+
+	res, err := cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.RequeueAfter >= accessorConfig.HealthProbe.Interval-2*time.Second).To(BeTrue())
+	g.Expect(res.RequeueAfter <= accessorConfig.HealthProbe.Interval).To(BeTrue())
+	accessor := cc.getClusterAccessor(clusterKey)
+	g.Expect(accessor.Connected(ctx)).To(BeTrue())
+	oldCache := accessor.lockedState.connection.cache
+
+	updateKubeconfigSecretServer(g, testCluster)
+
+	// The kubeconfig sync is rate-limited, so a Reconcile right after the connect
+	// doesn't pick up the change yet.
+	res, err = cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.RequeueAfter).To(BeNumerically(">", 0))
+	g.Expect(accessor.Connected(ctx)).To(BeTrue())
+	g.Expect(accessor.lockedState.connection.cache).To(BeIdenticalTo(oldCache))
+
+	rewindLastKubeconfigSyncTime(accessor, accessorConfig)
+
+	res, err = cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res).To(Equal(reconcile.Result{RequeueAfter: 1 * time.Millisecond}))
+	g.Expect(accessor.Connected(ctx)).To(BeFalse())
+	g.Expect(oldCache.stopped).To(BeTrue())
+
+	res, err = cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(res.RequeueAfter >= accessorConfig.HealthProbe.Interval-2*time.Second).To(BeTrue())
+	g.Expect(res.RequeueAfter <= accessorConfig.HealthProbe.Interval).To(BeTrue())
+	g.Expect(accessor.Connected(ctx)).To(BeTrue())
+	g.Expect(accessor.lockedState.connection.cache).ToNot(BeIdenticalTo(oldCache))
+}
+
+func TestReconcileSyncKubeconfigTokenRotation(t *testing.T) {
+	g := NewWithT(t)
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-token-rotation",
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				"cluster.x-k8s.io/included-in-clustercache-tests": "true",
+			},
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: builder.ControlPlaneGroupVersion.Group,
+				Kind:     builder.GenericControlPlaneKind,
+				Name:     "cp1",
+			},
+		},
+	}
+	clusterKey := client.ObjectKeyFromObject(testCluster)
+	g.Expect(env.CreateAndWait(ctx, testCluster)).To(Succeed())
+	defer func() { g.Expect(client.IgnoreNotFound(env.CleanupAndWait(ctx, testCluster))).To(Succeed()) }()
+
+	patch := client.MergeFrom(testCluster.DeepCopy())
+	testCluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
+	g.Expect(env.Status().Patch(ctx, testCluster, patch)).To(Succeed())
+
+	// ServiceAccount the kubeconfig tokens are requested for, with the permission required
+	// for connection creation and the health probe (GET "/").
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "token-rotation", Namespace: metav1.NamespaceDefault},
+	}
+	g.Expect(env.CreateAndWait(ctx, serviceAccount)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, serviceAccount)).To(Succeed()) }()
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "token-rotation-health-probe"},
+		Rules: []rbacv1.PolicyRule{{
+			NonResourceURLs: []string{"/"},
+			Verbs:           []string{"get"},
+		}},
+	}
+	g.Expect(env.CreateAndWait(ctx, clusterRole)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, clusterRole)).To(Succeed()) }()
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "token-rotation-health-probe"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: clusterRole.Name},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccount.Name,
+			Namespace: serviceAccount.Namespace,
+		}},
+	}
+	g.Expect(env.CreateAndWait(ctx, clusterRoleBinding)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, clusterRoleBinding)).To(Succeed()) }()
+
+	oldToken := requestServiceAccountToken(g, serviceAccount)
+	kubeconfigSecret := kubeconfig.GenerateSecret(testCluster, newTokenKubeconfig(testCluster.Name, env.Config.Host, oldToken, env.Config.CAData))
+	g.Expect(env.CreateAndWait(ctx, kubeconfigSecret)).To(Succeed())
+	defer func() { g.Expect(env.CleanupAndWait(ctx, kubeconfigSecret)).To(Succeed()) }()
+
+	accessorConfig := buildClusterAccessorConfig(env.GetScheme(), Options{
+		SecretClient: env.GetClient(),
+		Client: ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("test-controller-manager"),
+			Timeout:   10 * time.Second,
+		},
+	}, nil)
+	cc := &clusterCache{
+		client:                env.GetAPIReader(),
+		clusterAccessorConfig: accessorConfig,
+		clusterAccessors:      make(map[client.ObjectKey]*clusterAccessor),
+		cacheCtx:              context.Background(),
+		clusterFilter: func(cluster *clusterv1.Cluster) bool {
+			return cluster.ObjectMeta.Labels["cluster.x-k8s.io/included-in-clustercache-tests"] == "true"
+		},
+	}
+
+	// Connection creation already exercises the token against the apiserver (it probes "/").
+	_, err := cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	accessor := cc.getClusterAccessor(clusterKey)
+	g.Expect(accessor.Connected(ctx)).To(BeTrue())
+	oldCache := accessor.lockedState.connection.cache
+
+	// Invalidate the old token by re-creating the ServiceAccount (tokens are bound to the
+	// ServiceAccount UID) and rotate the kubeconfig Secret to a token of the new ServiceAccount.
+	g.Expect(env.CleanupAndWait(ctx, serviceAccount)).To(Succeed())
+	serviceAccount = &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace},
+	}
+	g.Expect(env.CreateAndWait(ctx, serviceAccount)).To(Succeed())
+	newToken := requestServiceAccountToken(g, serviceAccount)
+	updateKubeconfigSecret(g, testCluster, newTokenKubeconfig(testCluster.Name, env.Config.Host, newToken, env.Config.CAData))
+
+	// Wait until the apiserver rejects the old token, so the health probe below can only
+	// succeed with the rotated token.
+	// Note: This can take a bit because the apiserver caches successful token authentications.
+	g.Eventually(func(g Gomega) {
+		g.Expect(apierrors.IsUnauthorized(probeWithToken(oldToken))).To(BeTrue())
+	}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
+
+	rewindLastKubeconfigSyncTime(accessor, accessorConfig)
+
+	res, err := cc.Reconcile(ctx, reconcile.Request{NamespacedName: clusterKey})
+	g.Expect(err).ToNot(HaveOccurred())
+	// The token-only change is applied in place, the connection is not re-created.
+	g.Expect(res.RequeueAfter).ToNot(Equal(1 * time.Millisecond))
+	g.Expect(accessor.Connected(ctx)).To(BeTrue())
+	g.Expect(accessor.lockedState.connection.cache).To(BeIdenticalTo(oldCache))
+	g.Expect(accessor.lockedState.connection.tokenHolder.token()).To(Equal(newToken))
+	g.Expect(accessor.lockedState.connection.restConfig.BearerToken).To(Equal(newToken))
+
+	// The existing connection uses the rotated token, so the health probe succeeds.
+	tooManyConsecutiveFailures, unauthorizedErrorOccurred := accessor.HealthCheck(ctx)
+	g.Expect(tooManyConsecutiveFailures).To(BeFalse())
+	g.Expect(unauthorizedErrorOccurred).To(BeFalse())
 }
 
 func TestShouldRequeue(t *testing.T) {
@@ -834,6 +1044,98 @@ func createCluster(g Gomega, testCluster testCluster) {
 	patch := client.MergeFrom(cluster.DeepCopy())
 	cluster.Status.Initialization.InfrastructureProvisioned = ptr.To(true)
 	g.Expect(env.Status().Patch(ctx, cluster, patch)).To(Succeed())
+}
+
+func updateKubeconfigSecretServer(g Gomega, cluster *clusterv1.Cluster) {
+	secretKey := client.ObjectKey{
+		Name:      secret.Name(cluster.Name, secret.Kubeconfig),
+		Namespace: cluster.Namespace,
+	}
+	kubeconfigSecret := &corev1.Secret{}
+	g.Expect(env.GetAPIReader().Get(ctx, secretKey, kubeconfigSecret)).To(Succeed())
+	oldResourceVersion := kubeconfigSecret.ResourceVersion
+
+	cmdConfig, err := clientcmd.Load(kubeconfigSecret.Data[secret.KubeconfigDataName])
+	g.Expect(err).ToNot(HaveOccurred())
+	parsedServer, err := url.Parse(cmdConfig.Clusters[cluster.Name].Server)
+	g.Expect(err).ToNot(HaveOccurred())
+	cmdConfig.Clusters[cluster.Name].Server = "https://localhost:" + parsedServer.Port()
+	cmdConfig.Clusters[cluster.Name].TLSServerName = parsedServer.Hostname()
+	kubeconfigBytes, err := clientcmd.Write(*cmdConfig)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	patch := client.MergeFrom(kubeconfigSecret.DeepCopy())
+	kubeconfigSecret.Data[secret.KubeconfigDataName] = kubeconfigBytes
+	g.Expect(env.Patch(ctx, kubeconfigSecret, patch)).To(Succeed())
+
+	g.Eventually(func(g Gomega) {
+		cachedSecret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, cachedSecret)).To(Succeed())
+		g.Expect(cachedSecret.ResourceVersion).ToNot(Equal(oldResourceVersion))
+		g.Expect(cachedSecret.Data[secret.KubeconfigDataName]).To(Equal(kubeconfigBytes))
+	}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+}
+
+func updateKubeconfigSecret(g Gomega, cluster *clusterv1.Cluster, kubeconfigBytes []byte) {
+	secretKey := client.ObjectKey{
+		Name:      secret.Name(cluster.Name, secret.Kubeconfig),
+		Namespace: cluster.Namespace,
+	}
+	kubeconfigSecret := &corev1.Secret{}
+	g.Expect(env.GetAPIReader().Get(ctx, secretKey, kubeconfigSecret)).To(Succeed())
+
+	patch := client.MergeFrom(kubeconfigSecret.DeepCopy())
+	kubeconfigSecret.Data[secret.KubeconfigDataName] = kubeconfigBytes
+	g.Expect(env.Patch(ctx, kubeconfigSecret, patch)).To(Succeed())
+
+	g.Eventually(func(g Gomega) {
+		cachedSecret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, cachedSecret)).To(Succeed())
+		g.Expect(cachedSecret.Data[secret.KubeconfigDataName]).To(Equal(kubeconfigBytes))
+	}, 10*time.Second, 100*time.Millisecond).Should(Succeed())
+}
+
+// rewindLastKubeconfigSyncTime makes the rate-limited kubeconfig sync run again on the next Reconcile.
+func rewindLastKubeconfigSyncTime(accessor *clusterAccessor, accessorConfig *clusterAccessorConfig) {
+	accessor.lock(ctx)
+	defer accessor.unlock(ctx)
+	accessor.lockedState.connection.lastKubeconfigSyncTime = time.Now().Add(-(accessorConfig.HealthProbe.Interval + time.Second))
+}
+
+func requestServiceAccountToken(g Gomega, serviceAccount *corev1.ServiceAccount) string {
+	clientSet, err := kubernetes.NewForConfig(env.Config)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	tokenRequest := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			// 10 minutes is the minimum the TokenRequest API allows.
+			ExpirationSeconds: ptr.To[int64](10 * 60),
+		},
+	}
+	tokenRequest, err = clientSet.CoreV1().ServiceAccounts(serviceAccount.Namespace).
+		CreateToken(ctx, serviceAccount.Name, tokenRequest, metav1.CreateOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(tokenRequest.Status.Token).ToNot(BeEmpty())
+	return tokenRequest.Status.Token
+}
+
+func probeWithToken(token string) error {
+	restClientConfig := &rest.Config{
+		Host: env.Config.Host,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: env.Config.CAData,
+		},
+		BearerToken: token,
+	}
+	restClientConfig.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
+		Serializer: runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()},
+	})
+	restClient, err := rest.UnversionedRESTClientFor(restClientConfig)
+	if err != nil {
+		return err
+	}
+	_, err = restClient.Get().AbsPath("/").DoRaw(ctx)
+	return err
 }
 
 func getCounterMetric(metricFamilyName, controllerName string) (float64, error) {

--- a/controllers/clustercache/metrics.go
+++ b/controllers/clustercache/metrics.go
@@ -26,6 +26,7 @@ func init() {
 	ctrlmetrics.Registry.MustRegister(healthCheck)
 	ctrlmetrics.Registry.MustRegister(connectionUp)
 	ctrlmetrics.Registry.MustRegister(healthChecksTotal)
+	ctrlmetrics.Registry.MustRegister(kubeconfigSyncTotal)
 }
 
 var (
@@ -43,6 +44,14 @@ var (
 			Help: "Results of all clustercache healthchecks.",
 		}, []string{
 			"cluster_name", "cluster_namespace", "status",
+		},
+	)
+	kubeconfigSyncTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "capi_cluster_cache_kubeconfig_sync_total",
+			Help: "Results of clustercache kubeconfig syncs.",
+		}, []string{
+			"cluster_name", "cluster_namespace", "result",
 		},
 	)
 	connectionUp = prometheus.NewGaugeVec(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Today the ClusterCache only picks up a changed kubeconfig Secret after the health
probe fails (consecutive failures or unauthorized). This has two problems:

1. If the old credentials keep working (e.g. a relay proxy address change where
   existing connections survive but new connections fail), the change is never
   picked up. Consumers of `GetRESTConfig` (e.g. the KCP etcd client) keep getting
   a stale server address (#12399).
2. If credentials are rotated frequently (e.g. the EKS token in the CAPA kubeconfig
   Secret rotates every ~15m), the connection is torn down and all informers for the
   workload cluster are recreated on every rotation, with "connection to the workload
   cluster is down" error spam in between (#12363).

This PR makes the ClusterCache sync the kubeconfig Secret on every reconcile of a
connected cluster, before the health probe runs:

* The connection tracks the kubeconfig Secret's `resourceVersion` and raw kubeconfig,
  so an unchanged Secret is a cheap no-op (single read via the (ideally caching)
  SecretClient, per-field comparison only when the resourceVersion changed). No watch
  on Secrets is added.
* If only the bearer token of the current AuthInfo changed, the token is refreshed
  in place: connections use a dynamic bearer token RoundTripper that reads the
  current token from a shared holder on every request, so the existing client, cache
  and informers keep working across rotations. `GetRESTConfig` consumers get a copied
  `rest.Config` with the new token (previously handed out configs also pick up the new
  token). Request-specific Authorization headers are preserved. This only applies to
  static bearer tokens; token file / exec plugin credentials are already refreshed by
  client-go.
* For any other effective change (server, CA, certs, auth method, ...), the accessor
  is disconnected and the reconcile requeues immediately to reconnect with the new
  kubeconfig.
* Irrelevant changes are ignored: other Secret keys, tokens of unused AuthInfos, and,
  when the controller runs on the workload cluster, server/CA changes (those fields
  are replaced with in-cluster values anyway; runningOnCluster is captured at connect
  time and not re-checked).
* Errors reading or parsing the Secret never tear down a working connection; the
  health probe remains the fallback.
* Adds a `capi_cluster_cache_kubeconfig_sync_total` metric (results: `token_refreshed`,
  `reconnect`), cleaned up on Cluster deletion like the existing metrics.

I followed the approach discussed in
https://github.com/kubernetes-sigs/cluster-api/issues/12363#issuecomment-3232583426
and supersedes #12400.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #12399
Fixes #12363 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area clustercache
-->