### PR TITLE
🐛 Fix a panic in CAPDev cache.Get()

### DIFF
--- a/test/infrastructure/inmemory/pkg/runtime/cache/client.go
+++ b/test/infrastructure/inmemory/pkg/runtime/cache/client.go
@@ -73,7 +73,11 @@ func (c *cache) Get(resourceGroup string, objKey client.ObjectKey, obj client.Ob
 		return apierrors.NewNotFound(unsafeGuessGroupVersionResource(objGVK).GroupResource(), objKey.String())
 	}
 
-	if err := c.scheme.Convert(trackedObj, obj, nil); err != nil {
+	// Note: We have to deep copy trackedObj otherwise the returned obj will point to data
+	// in the tracker (for Unstructured Convert just points obj to the content of trackedObj).
+	// Without deep copy we can get `fatal error: concurrent map iteration and map write` if the
+	// object in the tracker is modified while `Get` is called.
+	if err := c.scheme.Convert(trackedObj.DeepCopyObject(), obj, nil); err != nil {
 		return apierrors.NewInternalError(err)
 	}
 	obj.GetObjectKind().SetGroupVersionKind(trackedObj.GetObjectKind().GroupVersionKind())
@@ -154,6 +158,10 @@ func (c *cache) List(resourceGroup string, list client.ObjectList, opts ...clien
 				}
 			}
 
+			// Note: We have to deep copy obj otherwise the returned unstructuredObj will point to data
+			// in the tracker (for Unstructured Convert just points unstructuredObj to the content of obj).
+			// Without deep copy we can get `fatal error: concurrent map iteration and map write` if the
+			// object in the tracker is modified while `Get` is called.
 			obj := obj.DeepCopyObject().(client.Object)
 			switch list.(type) {
 			case *unstructured.UnstructuredList:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->