### PR TITLE
🐛 Propagate kubeadm config read errors

### DIFF
--- a/controlplane/kubeadm/pkg/workload_cluster.go
+++ b/controlplane/kubeadm/pkg/workload_cluster.go
@@ -225,9 +225,13 @@ func (w *Workload) HasKubeadmConfig(ctx context.Context) (bool, error) {
 		Namespace: metav1.NamespaceSystem,
 	}
 	err := w.Client.Get(ctx, key, &corev1.ConfigMap{})
-	// TODO: Consider if this should only return false if the error is IsNotFound.
-	// TODO: Consider adding a third state of 'unknown' when there is an error retrieving the config map.
-	return err == nil, nil
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "failed to get kubeadm-config ConfigMap")
+	}
+	return true, nil
 }
 
 // GetAPIServerCertificateExpiry returns the certificate expiry of the apiserver on the given node.

--- a/controlplane/kubeadm/pkg/workload_cluster_test.go
+++ b/controlplane/kubeadm/pkg/workload_cluster_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/yaml"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
@@ -847,6 +848,19 @@ func TestHasKubeadmConfig(t *testing.T) {
 			g.Expect(got).To(Equal(tt.expectHasKubeadmConfig))
 		})
 	}
+}
+
+func TestHasKubeadmConfigReturnsGetErrors(t *testing.T) {
+	g := NewWithT(t)
+	w := &Workload{Client: fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return apierrors.NewServiceUnavailable("workload API unavailable")
+		},
+	}).Build()}
+
+	hasKubeadmConfig, err := w.HasKubeadmConfig(ctx)
+	g.Expect(hasKubeadmConfig).To(BeFalse())
+	g.Expect(err).To(MatchError(ContainSubstring("workload API unavailable")))
 }
 
 func TestUpdateFeatureGatesInKubeadmConfigMap(t *testing.T) {


### PR DESCRIPTION
What this PR does / why we need it:

Return non-NotFound errors from the kubeadm-config read. Before, a workload API failure became `false, nil`, so KCP skipped its retry path

How to reproduce:

Make the workload client `Get` return `ServiceUnavailable`. 
Before: `false, nil`. Now: `false` plus the read error

Testing:

`go test -c -o /tmp/capi-kubeadm-pkg.test ./controlplane/kubeadm/pkg`