### PR TITLE
📖 Fix variable name in Pod Security Standards patch example

### DIFF
--- a/docs/book/src/security/pod-security-standards.md
+++ b/docs/book/src/security/pod-security-standards.md
@@ -101,11 +101,11 @@ spec:
                   apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
                   kind: PodSecurityConfiguration
                   defaults:
-                    enforce: "{{ .podSecurity.enforce }}"
+                    enforce: "{{ .podSecurityStandard.enforce }}"
                     enforce-version: "latest"
-                    audit: "{{ .podSecurity.audit }}"
+                    audit: "{{ .podSecurityStandard.audit }}"
                     audit-version: "latest"
-                    warn: "{{ .podSecurity.warn }}"
+                    warn: "{{ .podSecurityStandard.warn }}"
                     warn-version: "latest"
                   exemptions:
                     usernames: []
@@ -167,11 +167,11 @@ spec:
                     apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
                     kind: PodSecurityConfiguration
                     defaults:
-                      enforce: "{{ .podSecurity.enforce }}"
+                      enforce: "{{ .podSecurityStandard.enforce }}"
                       enforce-version: "latest"
-                      audit: "{{ .podSecurity.audit }}"
+                      audit: "{{ .podSecurityStandard.audit }}"
                       audit-version: "latest"
-                      warn: "{{ .podSecurity.warn }}"
+                      warn: "{{ .podSecurityStandard.warn }}"
                       warn-version: "latest"
                     exemptions:
                       usernames: []


### PR DESCRIPTION
**What this PR does / why we need it**:

The patch examples in the "Pod Security Standards" docs page reference `.podSecurity`, but the variable is named `podSecurityStandard` (as `enabledIf` already uses). Fixes those references so examples work.

**Which issue(s) this PR fixes**
None

/area documentation