### PR TITLE
🐛 bootstrap/kubeadm: execute /etc/kubeadm.sh via /bin/bash for /etc noexec compatibility

### DIFF
--- a/bootstrap/kubeadm/pkg/ignition/clc/clc.go
+++ b/bootstrap/kubeadm/pkg/ignition/clc/clc.go
@@ -101,7 +101,7 @@ systemd:
         [Service]
         # To not restart the unit when it exits, as it is expected.
         Type=oneshot
-        ExecStart=/etc/kubeadm.sh
+        ExecStart=/bin/bash /etc/kubeadm.sh
         [Install]
         WantedBy=multi-user.target
     {{- if .NTP }}{{ if .NTP.Enabled }}

--- a/bootstrap/kubeadm/pkg/ignition/clc/clc_test.go
+++ b/bootstrap/kubeadm/pkg/ignition/clc/clc_test.go
@@ -248,7 +248,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/bin/bash /etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  ptr.To(true),
 							Name:     "kubeadm.service",
 						},
@@ -339,7 +339,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/bin/bash /etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  ptr.To(true),
 							Name:     "kubeadm.service",
 						},
@@ -422,7 +422,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/bin/bash /etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  ptr.To(true),
 							Name:     "kubeadm.service",
 						},
@@ -549,7 +549,7 @@ func TestRender(t *testing.T) {
 				Systemd: types.Systemd{
 					Units: []types.Unit{
 						{
-							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+							Contents: "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\nAfter=network.target\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/bin/bash /etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
 							Enabled:  ptr.To(true),
 							Name:     "kubeadm.service",
 						},

--- a/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
+++ b/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 
@@ -94,7 +94,7 @@ func getActions(userData []byte) ([]provisioning.Cmd, error) {
 
 		commands = append(commands, []provisioning.Cmd{
 			// Idempotently create the directory.
-			{Cmd: "mkdir", Args: []string{"-p", filepath.Dir(f.Path)}, Retry: 5},
+			{Cmd: "mkdir", Args: []string{"-p", path.Dir(f.Path)}, Retry: 5},
 			// Write the file.
 			{Cmd: "/bin/sh", Args: []string{"-c", fmt.Sprintf("cat > %s /dev/stdin", f.Path)}, Stdin: contents, Retry: 5},
 			// Set file permissions.

--- a/test/infrastructure/docker/internal/provisioning/ignition/kindadapter_test.go
+++ b/test/infrastructure/docker/internal/provisioning/ignition/kindadapter_test.go
@@ -53,7 +53,7 @@ func TestRealUseCase(t *testing.T) {
     "systemd": {
       "units": [
         {
-          "contents": "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
+          "contents": "[Unit]\nDescription=kubeadm\n# Run only once. After successful run, this file is moved to /tmp/.\nConditionPathExists=/etc/kubeadm.yml\n[Service]\n# To not restart the unit when it exits, as it is expected.\nType=oneshot\nExecStart=/bin/bash /etc/kubeadm.sh\n[Install]\nWantedBy=multi-user.target\n",
           "enabled": true,
           "name": "kubeadm.service"
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
Starting with Flatcar `4628+`, Flatcar mounts `/etc` as a `systemd-confext` overlay with the `noexec` flag for security hardening. As `kubeadm.service` was executing `ExecStart=/etc/kubeadm.sh` directly as a binary, systemd fails with `Permission denied` on boot, breaking node bootstrapping.

In this PR we update `kubeadm.service` generation to execute the script via `/bin/bash` (`ExecStart=/bin/bash /etc/kubeadm.sh`). 

**Why this fix works:**
* `/bin/bash` lives on the executable `/bin` filesystem. Passing `/etc/kubeadm.sh` as an argument to `bash` executes the script without triggering the `noexec` mount restriction on `/etc`.
* Keeps script and config file locations unchanged, avoiding breaking changes for downstream tools.
* Updates `kindadapter.go` to use Go's `path` package instead of `filepath` for cross-platform test compatibility on Windows hosts.

**Verification / Test Output**:
* Unit tests in `bootstrap/kubeadm/pkg/ignition/clc` pass (`go test ./bootstrap/kubeadm/pkg/ignition/clc/...`).
<img width="669" height="59" alt="image" src="https://github.com/user-attachments/assets/4116ea6c-b267-4143-9677-827a38259f91" />

* Unit tests in `test/infrastructure/docker` pass (`go test ./internal/provisioning/ignition/...`).
<img width="763" height="54" alt="image" src="https://github.com/user-attachments/assets/bc667b2b-c347-4a21-94e5-99844088c5d2" />

**Which issue(s) this PR fixes**:
Related to [flatcar/Flatcar#2166](https://github.com/flatcar/Flatcar/issues/2166)

/area bootstrap

