### PR TITLE
🐛 Use semver version comparison for in-place upgrade

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/util/inplace"
 	"sigs.k8s.io/cluster-api/internal/util/ssa"
+	internalversion "sigs.k8s.io/cluster-api/internal/util/version"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/cache"
 	"sigs.k8s.io/cluster-api/util/collections"
@@ -1146,7 +1147,8 @@ func reconcileMachineUpToDateCondition(_ context.Context, controlPlane *pkg.Cont
 			continue
 		}
 
-		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" && machine.Status.NodeInfo.KubeletVersion != machine.Spec.Version {
+		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" &&
+			!internalversion.KubeletVersionMatches(machine.Status.NodeInfo.KubeletVersion, machine.Spec.Version) {
 			conditions.Set(machine, metav1.Condition{
 				Type:   clusterv1.MachineUpToDateCondition,
 				Status: metav1.ConditionFalse,

--- a/core/reconcilers/machine/machine_controller_status.go
+++ b/core/reconcilers/machine/machine_controller_status.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/cluster-api/core/reconcilers/machinedeployment/mdutil"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/util/inplace"
+	internalversion "sigs.k8s.io/cluster-api/internal/util/version"
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
@@ -723,7 +724,8 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 		return
 	}
 
-	if m.Status.NodeInfo != nil && m.Status.NodeInfo.KubeletVersion != "" && m.Status.NodeInfo.KubeletVersion != m.Spec.Version {
+	if m.Status.NodeInfo != nil && m.Status.NodeInfo.KubeletVersion != "" &&
+		!internalversion.KubeletVersionMatches(m.Status.NodeInfo.KubeletVersion, m.Spec.Version) {
 		conditions.Set(m, metav1.Condition{
 			Type:   clusterv1.MachineUpToDateCondition,
 			Status: metav1.ConditionFalse,

--- a/internal/topology/check/upgrade.go
+++ b/internal/topology/check/upgrade.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	internalversion "sigs.k8s.io/cluster-api/internal/util/version"
 )
 
 // IsMachineDeploymentUpgrading determines if the MachineDeployment is upgrading.
@@ -58,7 +59,9 @@ func IsMachineDeploymentUpgrading(ctx context.Context, c client.Reader, md *clus
 		if machine.Spec.Version != mdVersion {
 			return true, nil
 		}
-		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" && machine.Status.NodeInfo.KubeletVersion != mdVersion {
+
+		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" &&
+			!internalversion.KubeletVersionMatches(machine.Status.NodeInfo.KubeletVersion, mdVersion) {
 			return true, nil
 		}
 	}
@@ -81,7 +84,8 @@ func IsMachinePoolUpgrading(ctx context.Context, c client.Reader, mp *clusterv1.
 		if err := c.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
 			return false, fmt.Errorf("failed to check if MachinePool %s is upgrading: failed to get Node %s", mp.Name, nodeRef.Name)
 		}
-		if mpVersion != node.Status.NodeInfo.KubeletVersion {
+
+		if !internalversion.KubeletVersionMatches(node.Status.NodeInfo.KubeletVersion, mpVersion) {
 			return true, nil
 		}
 	}

--- a/internal/topology/check/upgrade_test.go
+++ b/internal/topology/check/upgrade_test.go
@@ -63,6 +63,56 @@ func TestIsMachineDeploymentUpgrading(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "should return false if kubelet version has a build suffix",
+			md: builder.MachineDeployment("ns", "md1").
+				WithClusterName("cluster1").
+				WithVersion("v1.2.3").
+				Build(),
+			machines: []*clusterv1.Machine{
+				builder.Machine("ns", "machine1").
+					WithClusterName("cluster1").
+					WithVersion("v1.2.3").
+					Build(),
+				func() *clusterv1.Machine {
+					m := builder.Machine("ns", "machine2").
+						WithClusterName("cluster1").
+						WithVersion("v1.2.3").
+						Build()
+					m.Status.NodeInfo = &corev1.NodeSystemInfo{
+						KubeletVersion: "v1.2.3+test",
+					}
+					return m
+				}(),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return true if the kubelet version of one of the machines refers to another Kubernetes version",
+			md: builder.MachineDeployment("ns", "md1").
+				WithClusterName("cluster1").
+				WithVersion("v1.2.3").
+				Build(),
+			machines: []*clusterv1.Machine{
+				builder.Machine("ns", "machine1").
+					WithClusterName("cluster1").
+					WithVersion("v1.2.3").
+					Build(),
+				func() *clusterv1.Machine {
+					m := builder.Machine("ns", "machine2").
+						WithClusterName("cluster1").
+						WithVersion("v1.2.3").
+						Build()
+					m.Status.NodeInfo = &corev1.NodeSystemInfo{
+						KubeletVersion: "v1.2.2+test",
+					}
+					return m
+				}(),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name: "should return true if at least one of the machines of MachineDeployment has a different version",
 			md: builder.MachineDeployment("ns", "md1").
 				WithClusterName("cluster1").
@@ -180,6 +230,64 @@ func TestIsMachinePoolUpgrading(t *testing.T) {
 				},
 			},
 			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return false if all the nodes of MachinePool have a build suffix in the kubelet version",
+			mp: builder.MachinePool("ns", "mp1").
+				WithClusterName("cluster1").
+				WithVersion("v1.2.3").
+				WithStatus(clusterv1.MachinePoolStatus{
+					NodeRefs: []corev1.ObjectReference{
+						{Name: "node1"},
+						{Name: "node2"},
+					},
+				}).
+				Build(),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.3+test"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.3+test"},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "should return true if the kubelet version of one of the nodes refers to another Kubernetes version",
+			mp: builder.MachinePool("ns", "mp1").
+				WithClusterName("cluster1").
+				WithVersion("v1.2.3").
+				WithStatus(clusterv1.MachinePoolStatus{
+					NodeRefs: []corev1.ObjectReference{
+						{Name: "node1"},
+						{Name: "node2"},
+					},
+				}).
+				Build(),
+			nodes: []*corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.3+test"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+					Status: corev1.NodeStatus{
+						NodeInfo: corev1.NodeSystemInfo{KubeletVersion: "v1.2.2+test"},
+					},
+				},
+			},
+			want:    true,
 			wantErr: false,
 		},
 		{

--- a/internal/util/version/version.go
+++ b/internal/util/version/version.go
@@ -31,6 +31,26 @@ type orderedStatusVersion struct {
 	order int
 }
 
+// KubeletVersionMatches returns true if the kubelet version reported by a Node matches the
+// desired Kubernetes version of the corresponding Machine.
+//
+// Note: kubelet reports the version its binary was built with, and this version can carry build
+// metadata that differs from the build metadata of the desired version even though both refer to
+// the same Kubernetes release (e.g. kubelet reports "v1.33.1+test" while the desired version is
+// "v1.33.1"). Both versions are therefore compared as semver versions, which per the semver
+// spec ignores build metadata; otherwise such a Machine would be considered updating forever.
+//
+// Note: If one of the versions cannot be parsed as a semver version we fall back to a string
+// comparison, so an unparsable version never silently matches everything.
+func KubeletVersionMatches(kubeletVersion, desiredVersion string) bool {
+	kubeletSemver, kubeletErr := semver.ParseTolerant(kubeletVersion)
+	desiredSemver, desiredErr := semver.ParseTolerant(desiredVersion)
+	if kubeletErr != nil || desiredErr != nil {
+		return kubeletVersion == desiredVersion
+	}
+	return capiversion.Compare(kubeletSemver, desiredSemver) == 0
+}
+
 // AggregateStatusVersions returns versions aggregated by version.
 func AggregateStatusVersions(versions []clusterv1.StatusVersion) []clusterv1.StatusVersion {
 	if len(versions) == 0 {
@@ -89,7 +109,13 @@ func VersionsFromMachines(machines []*clusterv1.Machine) []clusterv1.StatusVersi
 		}
 
 		version := machine.Spec.Version
-		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" {
+		// Note: We only surface the kubelet version if it actually refers to another Kubernetes
+		// release than the desired version. Otherwise a kubelet reporting only a different build
+		// metadata than the desired version (e.g. "v1.33.1+k0s" vs "v1.33.1+k0s.0") would show up
+		// as an additional status version and make consumers like ControlPlaneContract.IsUpgrading
+		// consider the object upgrading forever.
+		if machine.Status.NodeInfo != nil && machine.Status.NodeInfo.KubeletVersion != "" &&
+			!KubeletVersionMatches(machine.Status.NodeInfo.KubeletVersion, machine.Spec.Version) {
 			version = machine.Status.NodeInfo.KubeletVersion
 		}
 

--- a/internal/util/version/version_test.go
+++ b/internal/util/version/version_test.go
@@ -27,6 +27,71 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
+func TestKubeletVersionMatches(t *testing.T) {
+	tests := []struct {
+		name           string
+		kubeletVersion string
+		desiredVersion string
+		want           bool
+	}{
+		{
+			name:           "matches for equal versions",
+			kubeletVersion: "v1.33.1",
+			desiredVersion: "v1.33.1",
+			want:           true,
+		},
+		{
+			name:           "matches if only the build metadata differs",
+			kubeletVersion: "v1.33.1+test",
+			desiredVersion: "v1.33.1+test.0",
+			want:           true,
+		},
+		{
+			name:           "matches if only one of the versions has build metadata",
+			kubeletVersion: "v1.33.1+test",
+			desiredVersion: "v1.33.1",
+			want:           true,
+		},
+		{
+			name:           "does not match for a different patch version",
+			kubeletVersion: "v1.33.0+test",
+			desiredVersion: "v1.33.1+test.0",
+			want:           false,
+		},
+		{
+			name:           "does not match for a different minor version",
+			kubeletVersion: "v1.32.1",
+			desiredVersion: "v1.33.1",
+			want:           false,
+		},
+		{
+			name:           "does not match if the pre-release differs",
+			kubeletVersion: "v1.33.1-alpha.1",
+			desiredVersion: "v1.33.1",
+			want:           false,
+		},
+		{
+			name:           "falls back to string comparison for unparsable versions",
+			kubeletVersion: "not-a-version",
+			desiredVersion: "v1.33.1",
+			want:           false,
+		},
+		{
+			name:           "falls back to string comparison for equal unparsable versions",
+			kubeletVersion: "not-a-version",
+			desiredVersion: "not-a-version",
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(KubeletVersionMatches(tt.kubeletVersion, tt.desiredVersion)).To(Equal(tt.want))
+		})
+	}
+}
+
 func TestAggregateStatusVersions(t *testing.T) {
 	t.Run("returns nil for empty versions", func(t *testing.T) {
 		g := NewWithT(t)
@@ -105,6 +170,20 @@ func TestVersionsFromMachines(t *testing.T) {
 			{Version: "v1.30.0", Replicas: 1},
 			{Version: "v1.31.1", Replicas: 3},
 			{Version: "v1.32.0", Replicas: 1},
+		}))
+	})
+
+	t.Run("keeps the spec version if the kubelet version only differs in build metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		machines := []*clusterv1.Machine{
+			{Spec: clusterv1.MachineSpec{Version: "v1.33.1+test.0"}, Status: clusterv1.MachineStatus{NodeInfo: &corev1.NodeSystemInfo{KubeletVersion: "v1.33.1+test"}}},
+			{Spec: clusterv1.MachineSpec{Version: "v1.33.1+test.0"}, Status: clusterv1.MachineStatus{NodeInfo: &corev1.NodeSystemInfo{KubeletVersion: "v1.33.0+test"}}},
+		}
+
+		g.Expect(VersionsFromMachines(machines)).To(Equal([]clusterv1.StatusVersion{
+			{Version: "v1.33.0+test", Replicas: 1},
+			{Version: "v1.33.1+test.0", Replicas: 1},
 		}))
 	})
 


### PR DESCRIPTION
## What this PR does / why we need it

Compare `Node.status.nodeInfo.kubeletVersion` against the desired Kubernetes version as semver instead of as raw strings.                                          

kubelet reports the version its binary was built with, which can carry build metadata that differs from the build metadata of the desired version even though both refer to the same Kubernetes release — e.g. a distribution builds kubelet as `v1.33.1+k0s` while `spec.version` is set to `v1.33.1`. With the raw string comparison introduced for in-place upgrade detection, such a Machine is considered updating forever, which blocks ClusterClass-driven upgrades.

This adds `internal/util/version.KubeletVersionMatches`, which parses both versions with `semver.ParseTolerant` and compares them ignoring build metadata (per semver spec §10), falling back to a string comparison when either version is unparsable. It is used in:   
- `IsMachineDeploymentUpgrading` / `IsMachinePoolUpgrading` (`internal/topology/check`)   
- the `MachineUpToDate` condition in the Machine and KubeadmControlPlane controllers 
- `VersionsFromMachines`, which now only surfaces the kubelet version in `status.versions` when it refers to a different Kubernetes release. Otherwise a build-metadata-only difference leaks into `status.versions` and makes `ControlPlaneContract.IsUpgrading` (which compares `WithBuildTags()`) report the control plane as upgrading forever.                                                                                                                                              

Note: build metadata is intentionally ignored, so a change that only bumps build metadata is no longer detected as an upgrade by these checks. 

/area machinedeployment                