### PR TITLE
🌱 Improve metrics config

### DIFF
--- a/core/config/metrics/crd-metrics-config.yaml
+++ b/core/config/metrics/crd-metrics-config.yaml
@@ -110,23 +110,6 @@ spec:
       help: Information about a kubeadmconfig.
       name: info
     - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
-    - each:
         stateSet:
           labelName: status
           labelsFromPath:
@@ -358,23 +341,6 @@ spec:
       help: Information about a clusterclass.
       name: info
     - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
-    - each:
         stateSet:
           labelName: status
           labelsFromPath:
@@ -522,23 +488,6 @@ spec:
         type: Info
       help: Information about a machine.
       name: info
-    - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
     - each:
         gauge:
           nilIsZero: true
@@ -695,23 +644,6 @@ spec:
         type: Info
       help: Information about a machinedeployment.
       name: info
-    - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
     - each:
         gauge:
           nilIsZero: true
@@ -896,6 +828,11 @@ spec:
     - each:
         info:
           labelsFromPath:
+            # This label is already configured for MHC above, but without this label MHC objects
+            # without triggerIf don't show up because they don't have any labels (see below).
+            cluster_name:
+              - spec
+              - clusterName
             remediation_triggerif_unhealthyinrange:
             - spec
             - remediation
@@ -910,23 +847,6 @@ spec:
         type: Info
       help: Information about a machinehealthcheck.
       name: info
-    - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
     - each:
         stateSet:
           labelName: status
@@ -1077,23 +997,6 @@ spec:
         type: Info
       help: Information about a machinepool.
       name: info
-    - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
     - each:
         gauge:
           nilIsZero: false
@@ -1276,23 +1179,6 @@ spec:
       help: Information about a machineset.
       name: info
     - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
-    - each:
         gauge:
           nilIsZero: true
           path:
@@ -1431,23 +1317,6 @@ spec:
         type: Info
       help: Information about a kubeadmcontrolplane.
       name: info
-    - each:
-        info:
-          labelsFromPath:
-            owner_is_controller:
-            - controller
-            owner_kind:
-            - kind
-            owner_name:
-            - name
-            owner_uid:
-            - uid
-          path:
-          - metadata
-          - ownerReferences
-        type: Info
-      help: Owner references.
-      name: owner
     - each:
         gauge:
           nilIsZero: false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
At high scale we were running into issues with too many metrics. Dropping the _owner metrics now because they are not used in our dashboards.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->