### PR TITLE
📖 Fix MetalLB subnet detection on dual-stack nets

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -673,7 +673,7 @@ kubectl wait pods -n metallb-system -l app=metallb,component=speaker --for=condi
 Now, we'll create the `IPAddressPool` and the `L2Advertisement` custom resources. For that, we'll need to set the IP
 range. First, we'll read the `kind` network in order to find its subnet:
 ```bash
-SUBNET=$(docker network inspect -f '{{range .IPAM.Config}}{{if .Gateway}}{{.Subnet}}{{end}}{{end}}' kind)
+SUBNET=$(docker network inspect kind | jq -r 'first(.[0].IPAM.Config[].Subnet | select(test("^[0-9]+\\.")))')
 PREFIX=$(echo $SUBNET | sed -E 's|^([0-9]+\.[0-9]+)\..*$|\1|g')
 
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
On dual-stack networks where both IPv4 and IPv6 networks have a gateway, the current detection fails. It tries to detect the IPv4 network by detecting the network that has a gateway.

This patch uses jq to detect the IPv4 network, by testing for only numbers and ".". And although it seems to work fine in the current template if there are several IPv4 networks (the first is used and the rest are ignored), I also added to select the first one. This way, we are sure this only refers to one subnet and we can't introduce bug so easily due to in some cases having several new-line separated networks.

Please note that jq is already used in this guide (it is used just above to resolve the MetalLB release tag), this is not adding a new dependency.

The previous command on my system generated:
```bash
	$ docker network inspect -f '{{range .IPAM.Config}}{{if .Gateway}}{{.Subnet}}{{end}}{{end}}' kind
	fc00:f853:ccd:e793::/64172.18.0.0/16
```
Which is broken, mixing IPv6 and IPv4.

The new command here gives me:
```bash
	$ docker network inspect kind | jq -r 'first(.[0].IPAM.Config[].Subnet | select(test("^[0-9]+\\.")))'
	172.18.0.0/16
```
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Fixes the subnet calculation for dual networks on kind. It's just a documentation bug.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area documentation
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->