### PR TITLE
[release-1.13] 🐛 Fix Machine taint propagation in the Cluster topology controller for the v1beta1 contract

### DIFF
--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -457,12 +457,12 @@ func (g *generator) computeControlPlane(ctx context.Context, s *scope.Scope, inf
 	// NOTE: If taints value from both Cluster and ClusterClass is nil, it is assumed that the control plane controller
 	// does not implement support for this field and the ControlPlane object is generated without taints.
 	if s.Blueprint.Topology.ControlPlane.Taints != nil {
-		if err := contract.ControlPlane().MachineTemplate().Taints().Set(controlPlane, s.Blueprint.Topology.ControlPlane.Taints); err != nil {
-			return nil, errors.Wrapf(err, "failed to set %s in the ControlPlane object", contract.ControlPlane().MachineTemplate().Taints().Path())
+		if err := contract.ControlPlane().MachineTemplate().Taints(contractVersion).Set(controlPlane, s.Blueprint.Topology.ControlPlane.Taints); err != nil {
+			return nil, errors.Wrapf(err, "failed to set %s in the ControlPlane object", contract.ControlPlane().MachineTemplate().Taints(contractVersion).Path())
 		}
 	} else if s.Blueprint.ClusterClass.Spec.ControlPlane.Taints != nil {
-		if err := contract.ControlPlane().MachineTemplate().Taints().Set(controlPlane, s.Blueprint.ClusterClass.Spec.ControlPlane.Taints); err != nil {
-			return nil, errors.Wrapf(err, "failed to set %s in the ControlPlane object", contract.ControlPlane().MachineTemplate().Taints().Path())
+		if err := contract.ControlPlane().MachineTemplate().Taints(contractVersion).Set(controlPlane, s.Blueprint.ClusterClass.Spec.ControlPlane.Taints); err != nil {
+			return nil, errors.Wrapf(err, "failed to set %s in the ControlPlane object", contract.ControlPlane().MachineTemplate().Taints(contractVersion).Path())
 		}
 	}
 

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -505,6 +505,7 @@ func TestComputeControlPlane(t *testing.T) {
 		assertNestedField(g, obj, int64(replicas), contract.ControlPlane().Replicas().Path()...)
 		assertNestedField(g, obj, rolloutAfter.ToUnstructured(), contract.ControlPlane().RolloutAfter().Path()...)
 		assertNestedField(g, obj, expectedReadinessGates, contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta1").Path()...)
+		assertNestedField(g, obj, expectedTaints, contract.ControlPlane().MachineTemplate().Taints("v1beta1").Path()...)
 		assertNestedField(g, obj, (time.Duration(topologyDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path()...)
 		assertNestedField(g, obj, (time.Duration(topologyDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Path()...)
 		assertNestedField(g, obj, (time.Duration(topologyDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeDeletionTimeout().Path()...)
@@ -546,7 +547,7 @@ func TestComputeControlPlane(t *testing.T) {
 		assertNestedField(g, obj, int64(replicas), contract.ControlPlane().Replicas().Path()...)
 		assertNestedField(g, obj, rolloutAfter.ToUnstructured(), contract.ControlPlane().RolloutAfter().Path()...)
 		assertNestedField(g, obj, expectedReadinessGates, contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta2").Path()...)
-		assertNestedField(g, obj, expectedTaints, contract.ControlPlane().MachineTemplate().Taints().Path()...)
+		assertNestedField(g, obj, expectedTaints, contract.ControlPlane().MachineTemplate().Taints("v1beta2").Path()...)
 		assertNestedField(g, obj, int64(topologyDuration), contract.ControlPlane().MachineTemplate().NodeDrainTimeoutSeconds().Path()...)
 		assertNestedField(g, obj, int64(topologyDuration), contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeoutSeconds().Path()...)
 		assertNestedField(g, obj, int64(topologyDuration), contract.ControlPlane().MachineTemplate().NodeDeletionTimeoutSeconds().Path()...)
@@ -596,6 +597,7 @@ func TestComputeControlPlane(t *testing.T) {
 
 		// checking only values from CC defaults
 		assertNestedField(g, obj, expectedClusterClassReadinessGates, contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta1").Path()...)
+		assertNestedField(g, obj, expectedClusterClassTaints, contract.ControlPlane().MachineTemplate().Taints("v1beta1").Path()...)
 		assertNestedField(g, obj, (time.Duration(clusterClassDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path()...)
 		assertNestedField(g, obj, (time.Duration(clusterClassDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Path()...)
 		assertNestedField(g, obj, (time.Duration(clusterClassDuration) * time.Second).String(), contract.ControlPlane().MachineTemplate().NodeDeletionTimeout().Path()...)
@@ -641,7 +643,7 @@ func TestComputeControlPlane(t *testing.T) {
 
 		// checking only values from CC defaults
 		assertNestedField(g, obj, expectedClusterClassReadinessGates, contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta2").Path()...)
-		assertNestedField(g, obj, expectedClusterClassTaints, contract.ControlPlane().MachineTemplate().Taints().Path()...)
+		assertNestedField(g, obj, expectedClusterClassTaints, contract.ControlPlane().MachineTemplate().Taints("v1beta2").Path()...)
 		assertNestedField(g, obj, int64(clusterClassDuration), contract.ControlPlane().MachineTemplate().NodeDrainTimeoutSeconds().Path()...)
 		assertNestedField(g, obj, int64(clusterClassDuration), contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeoutSeconds().Path()...)
 		assertNestedField(g, obj, int64(clusterClassDuration), contract.ControlPlane().MachineTemplate().NodeDeletionTimeoutSeconds().Path()...)
@@ -736,7 +738,8 @@ func TestComputeControlPlane(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
-		assertNestedFieldUnset(g, obj, contract.ControlPlane().MachineTemplate().Taints().Path()...)
+		assertNestedFieldUnset(g, obj, contract.ControlPlane().MachineTemplate().Taints("v1beta1").Path()...)
+		assertNestedFieldUnset(g, obj, contract.ControlPlane().MachineTemplate().Taints("v1beta2").Path()...)
 	})
 	t.Run("Generates the ControlPlane from the template and adds the infrastructure machine template if required (v1beta1 contract)", func(t *testing.T) {
 		g := NewWithT(t)

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -549,7 +549,13 @@ func (m *ReadinessGates) Set(obj *unstructured.Unstructured, readinessGates []cl
 }
 
 // Taints provides access to control plane's Taints.
-func (c *ControlPlaneMachineTemplate) Taints() *Taints {
+func (c *ControlPlaneMachineTemplate) Taints(contractVersion string) *Taints {
+	if contractVersion == "v1beta1" {
+		return &Taints{
+			path: []string{"spec", "machineTemplate", "taints"},
+		}
+	}
+
 	return &Taints{
 		path: []string{"spec", "machineTemplate", "spec", "taints"},
 	}

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -503,7 +503,7 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(got).To(BeComparableTo(readinessGates))
 	})
 
-	t.Run("Manages spec.machineTemplate.taints (v1beta2 contract)", func(t *testing.T) {
+	t.Run("Manages spec.machineTemplate.taints (v1beta1 contract)", func(t *testing.T) {
 		g := NewWithT(t)
 
 		taints := []clusterv1.MachineTaint{
@@ -511,12 +511,12 @@ func TestControlPlane(t *testing.T) {
 			{Key: "bar", Effect: "NoExecute", Propagation: clusterv1.MachineTaintPropagationOnInitialization},
 		}
 
-		g.Expect(ControlPlane().MachineTemplate().Taints().Path()).To(Equal(Path{"spec", "machineTemplate", "spec", "taints"}))
+		g.Expect(ControlPlane().MachineTemplate().Taints("v1beta1").Path()).To(Equal(Path{"spec", "machineTemplate", "taints"}))
 
-		err := ControlPlane().MachineTemplate().Taints().Set(obj, taints)
+		err := ControlPlane().MachineTemplate().Taints("v1beta1").Set(obj, taints)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err := ControlPlane().MachineTemplate().Taints().Get(obj)
+		got, err := ControlPlane().MachineTemplate().Taints("v1beta1").Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got).To(BeComparableTo(taints))
@@ -525,24 +525,69 @@ func TestControlPlane(t *testing.T) {
 		obj2 := &unstructured.Unstructured{Object: map[string]interface{}{}}
 		taints = nil
 
-		err = ControlPlane().MachineTemplate().Taints().Set(obj2, taints)
+		err = ControlPlane().MachineTemplate().Taints("v1beta1").Set(obj2, taints)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		_, ok, err := unstructured.NestedSlice(obj2.UnstructuredContent(), ControlPlane().MachineTemplate().Taints().Path()...)
+		_, ok, err := unstructured.NestedSlice(obj2.UnstructuredContent(), ControlPlane().MachineTemplate().Taints("v1beta1").Path()...)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(ok).To(BeFalse())
 
-		_, err = ControlPlane().MachineTemplate().Taints().Get(obj2)
+		_, err = ControlPlane().MachineTemplate().Taints("v1beta1").Get(obj2)
 		g.Expect(err).To(HaveOccurred())
 
 		// Empty taints are set.
 		obj3 := &unstructured.Unstructured{Object: map[string]interface{}{}}
 		taints = []clusterv1.MachineTaint{}
 
-		err = ControlPlane().MachineTemplate().Taints().Set(obj3, taints)
+		err = ControlPlane().MachineTemplate().Taints("v1beta1").Set(obj3, taints)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err = ControlPlane().MachineTemplate().Taints().Get(obj3)
+		got, err = ControlPlane().MachineTemplate().Taints("v1beta1").Get(obj3)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got).To(BeComparableTo(taints))
+	})
+
+	t.Run("Manages spec.machineTemplate.taints (v1beta2 contract)", func(t *testing.T) {
+		g := NewWithT(t)
+
+		taints := []clusterv1.MachineTaint{
+			{Key: "foo", Effect: "NoSchedule", Propagation: clusterv1.MachineTaintPropagationAlways},
+			{Key: "bar", Effect: "NoExecute", Propagation: clusterv1.MachineTaintPropagationOnInitialization},
+		}
+
+		g.Expect(ControlPlane().MachineTemplate().Taints("v1beta2").Path()).To(Equal(Path{"spec", "machineTemplate", "spec", "taints"}))
+
+		err := ControlPlane().MachineTemplate().Taints("v1beta2").Set(obj, taints)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().MachineTemplate().Taints("v1beta2").Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got).To(BeComparableTo(taints))
+
+		// Nil taints are not set.
+		obj2 := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		taints = nil
+
+		err = ControlPlane().MachineTemplate().Taints("v1beta2").Set(obj2, taints)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		_, ok, err := unstructured.NestedSlice(obj2.UnstructuredContent(), ControlPlane().MachineTemplate().Taints("v1beta2").Path()...)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ok).To(BeFalse())
+
+		_, err = ControlPlane().MachineTemplate().Taints("v1beta2").Get(obj2)
+		g.Expect(err).To(HaveOccurred())
+
+		// Empty taints are set.
+		obj3 := &unstructured.Unstructured{Object: map[string]interface{}{}}
+		taints = []clusterv1.MachineTaint{}
+
+		err = ControlPlane().MachineTemplate().Taints("v1beta2").Set(obj3, taints)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err = ControlPlane().MachineTemplate().Taints("v1beta2").Get(obj3)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got).To(BeComparableTo(taints))

--- a/internal/controllers/topology/cluster/patches/engine.go
+++ b/internal/controllers/topology/cluster/patches/engine.go
@@ -556,7 +556,8 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		// requiring a client here to retrieve the contract version of the ControlPlane object.
 		contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta1").Path(),
 		contract.ControlPlane().MachineTemplate().ReadinessGates("v1beta2").Path(),
-		contract.ControlPlane().MachineTemplate().Taints().Path(),
+		contract.ControlPlane().MachineTemplate().Taints("v1beta1").Path(),
+		contract.ControlPlane().MachineTemplate().Taints("v1beta2").Path(),
 		contract.ControlPlane().MachineTemplate().InfrastructureV1Beta1Ref().Path(),
 		contract.ControlPlane().MachineTemplate().InfrastructureRef().Path(),
 		contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path(),


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Cherry-pick of #13984

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->