### PR TITLE
🐛 Fix parallel build of binaries in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -251,6 +251,7 @@ def build_go_binary(context, reload_deps, debug, go_main, binary_name, label):
         ),
         deps = live_reload_deps,
         labels = [label],
+        allow_parallel = True,
     )
 
 def build_docker_image(image, context, binary_name, additional_docker_build_commands, additional_docker_helper_commands, port_forwards):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
At the moment controllers wait for all binaries to be build. Even if they are not used in the controller (e.g. CAPI waits for the CAPD binary).

Claude's diagnosis:
```
  Root cause: Tilt runs local_resource updates through a single global serial queue by default (one at a time across all local   
  resources), unlike docker_build/k8s deploys which can build concurrently. Since build_go_binary() in the Tiltfile never set    
  allow_parallel, every provider's manager-binary build (capi_binary, cabpk_binary, kcp_binary, capd_binary,                     
  test-extension_binary) competed for that one slot. A controller image can't start building until its own binary's turn comes up
  in that shared queue — so triggering, say, capi_controller effectively had to wait for unrelated binaries ahead of it to       
  finish first, which looks like "the image depends on all binaries."                                                            
                                                                                                                                 
  The actual file-level Deps/ResourceDependencies for each binary and image were already correctly scoped per-provider (verified 
  via tilt alpha tiltfile-result), so no other change was needed.                                                                
                                                                                                                                 
  Fix: added allow_parallel = True to the local_resource(...) call in build_go_binary() (Tiltfile:246-255), letting all provider 
  binaries build concurrently. Each image build now only waits on its own binary.                                                
                                                                                                   
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->