### PR TITLE
[release-1.13] 🌱 KCP enforce context deadline on connection stream

### DIFF
--- a/controlplane/kubeadm/internal/proxy/conn.go
+++ b/controlplane/kubeadm/internal/proxy/conn.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -26,10 +27,14 @@ import (
 
 // Conn is a Kubernetes API server proxied type of net/conn.
 type Conn struct {
-	connection    httpstream.Connection
-	stream        httpstream.Stream
+	connection httpstream.Connection
+	stream     httpstream.Stream
+
 	readDeadline  time.Time
 	writeDeadline time.Time
+
+	deadlineTimerLock sync.Mutex
+	deadlineTimer     *time.Timer
 }
 
 // Read from the connection.
@@ -39,6 +44,13 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 
 // Close the underlying proxied connection.
 func (c *Conn) Close() error {
+	c.deadlineTimerLock.Lock()
+	if c.deadlineTimer != nil {
+		c.deadlineTimer.Stop()
+		c.deadlineTimer = nil
+	}
+	c.deadlineTimerLock.Unlock()
+
 	return kerrors.NewAggregate([]error{c.stream.Close(), c.connection.Close()})
 }
 
@@ -59,22 +71,73 @@ func (c *Conn) RemoteAddr() net.Addr {
 
 // SetDeadline sets the read and write deadlines to the specified interval.
 func (c *Conn) SetDeadline(t time.Time) error {
-	// TODO: Handle deadlines
+	c.deadlineTimerLock.Lock()
+	defer c.deadlineTimerLock.Unlock()
 	c.readDeadline = t
 	c.writeDeadline = t
+	c.armDeadlineTimerLocked()
 	return nil
 }
 
-// SetWriteDeadline sets the read and write deadlines to the specified interval.
+// SetWriteDeadline sets the write deadline to the specified time.
 func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.deadlineTimerLock.Lock()
+	defer c.deadlineTimerLock.Unlock()
 	c.writeDeadline = t
+	c.armDeadlineTimerLocked()
 	return nil
 }
 
-// SetReadDeadline sets the read and write deadlines to the specified interval.
+// SetReadDeadline sets the read deadline to the specified time.
 func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.deadlineTimerLock.Lock()
+	defer c.deadlineTimerLock.Unlock()
 	c.readDeadline = t
+	c.armDeadlineTimerLocked()
 	return nil
+}
+
+// armDeadlineTimerLocked (re)arms the timer that enforces the earliest of the
+// configured read/write deadlines by closing the underlying connection when
+// it elapses. httpstream.Connection has no concept of an absolute deadline
+// (only SetIdleTimeout, a rolling duration), so closing on expiry is the only
+// way to unblock a stream.Read/Write call that ignores context cancellation,
+// which is required for callers like tls.HandshakeContext and the gRPC
+// transport that rely on net.Conn deadlines to interrupt blocked I/O.
+// c.mu must be held by the caller.
+func (c *Conn) armDeadlineTimerLocked() {
+	if c.deadlineTimer != nil {
+		c.deadlineTimer.Stop()
+		c.deadlineTimer = nil
+	}
+
+	deadline := earliestDeadline(c.readDeadline, c.writeDeadline)
+	if deadline.IsZero() {
+		return
+	}
+
+	d := time.Until(deadline)
+	if d < 0 {
+		d = 0
+	}
+	c.deadlineTimer = time.AfterFunc(d, func() {
+		_ = c.Close()
+	})
+}
+
+// earliestDeadline returns the earlier of a and b, treating the zero value
+// (no deadline) as later than any set deadline.
+func earliestDeadline(a, b time.Time) time.Time {
+	switch {
+	case a.IsZero():
+		return b
+	case b.IsZero():
+		return a
+	case a.Before(b):
+		return a
+	default:
+		return b
+	}
 }
 
 // NewConn creates a new net/conn interface based on an underlying Kubernetes

--- a/controlplane/kubeadm/internal/proxy/conn_test.go
+++ b/controlplane/kubeadm/internal/proxy/conn_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// fakeStream is an httpstream.Stream backed by an io.Pipe, so Read blocks
+// until data is written or the stream is closed.
+type fakeStream struct {
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+func newFakeStream() *fakeStream {
+	r, w := io.Pipe()
+	return &fakeStream{PipeReader: r, PipeWriter: w}
+}
+
+func (s *fakeStream) Close() error {
+	_ = s.PipeWriter.Close()
+	return s.PipeReader.Close()
+}
+
+func (s *fakeStream) Reset() error         { return s.Close() }
+func (s *fakeStream) Headers() http.Header { return nil }
+func (s *fakeStream) Identifier() uint32   { return 0 }
+
+// fakeConnection is an httpstream.Connection that records whether Close was called.
+type fakeConnection struct {
+	closed chan struct{}
+}
+
+func newFakeConnection() *fakeConnection {
+	return &fakeConnection{closed: make(chan struct{})}
+}
+
+func (f *fakeConnection) CreateStream(_ http.Header) (httpstream.Stream, error) { return nil, nil }
+func (f *fakeConnection) CloseChan() <-chan bool                                { return nil }
+func (f *fakeConnection) SetIdleTimeout(_ time.Duration)                        {}
+func (f *fakeConnection) RemoveStreams(_ ...httpstream.Stream)                  {}
+
+func (f *fakeConnection) Close() error {
+	select {
+	case <-f.closed:
+		// already closed
+	default:
+		close(f.closed)
+	}
+	return nil
+}
+
+func TestConn_SetReadDeadline_UnblocksPendingRead(t *testing.T) {
+	g := NewWithT(t)
+
+	stream := newFakeStream()
+	connection := newFakeConnection()
+	conn := NewConn(connection, stream)
+
+	g.Expect(conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))).To(Succeed())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := conn.Read(make([]byte, 1))
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		g.Expect(err).To(HaveOccurred())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read did not unblock after read deadline expired")
+	}
+
+	// The underlying connection must have been closed to unblock the read.
+	select {
+	case <-connection.closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("underlying connection was not closed on deadline expiry")
+	}
+}
+
+func TestConn_SetDeadline_InThePast_ClosesImmediately(t *testing.T) {
+	g := NewWithT(t)
+
+	stream := newFakeStream()
+	connection := newFakeConnection()
+	conn := NewConn(connection, stream)
+
+	g.Expect(conn.SetDeadline(time.Now().Add(-time.Second))).To(Succeed())
+
+	select {
+	case <-connection.closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connection was not closed for a deadline already in the past")
+	}
+}
+
+func TestConn_SetDeadline_Zero_CancelsTimer(t *testing.T) {
+	g := NewWithT(t)
+
+	stream := newFakeStream()
+	connection := newFakeConnection()
+	conn := NewConn(connection, stream)
+
+	g.Expect(conn.SetDeadline(time.Now().Add(50 * time.Millisecond))).To(Succeed())
+	g.Expect(conn.SetDeadline(time.Time{})).To(Succeed())
+
+	select {
+	case <-connection.closed:
+		t.Fatal("connection was closed even though the deadline was cleared")
+	case <-time.After(5 * time.Second):
+		// Expected: no close happened.
+	}
+}
+
+func TestConn_Close_StopsPendingDeadlineTimer(t *testing.T) {
+	g := NewWithT(t)
+
+	stream := newFakeStream()
+	connection := newFakeConnection()
+	conn := NewConn(connection, stream)
+
+	g.Expect(conn.SetDeadline(time.Now().Add(time.Hour))).To(Succeed())
+	g.Expect(conn.Close()).To(Succeed())
+
+	g.Expect(conn.deadlineTimer).To(BeNil())
+}

--- a/controlplane/kubeadm/internal/proxy/dial.go
+++ b/controlplane/kubeadm/internal/proxy/dial.go
@@ -167,5 +167,15 @@ func (d *Dialer) DialContext(ctx context.Context, _ string, addr string) (net.Co
 	}
 
 	// Create the net.Conn and return.
-	return NewConn(connection, dataStream), nil
+	// If there is context deadline, also apply it to the stream inside the connection.
+	conn := NewConn(connection, dataStream)
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return nil, kerrors.NewAggregate([]error{
+				err,
+				connection.Close(),
+			})
+		}
+	}
+	return conn, nil
 }

--- a/test/infrastructure/inmemory/pkg/server/proxy/conn.go
+++ b/test/infrastructure/inmemory/pkg/server/proxy/conn.go
@@ -59,7 +59,6 @@ func (c *Conn) RemoteAddr() net.Addr {
 
 // SetDeadline sets the read and write deadlines to the specified interval.
 func (c *Conn) SetDeadline(t time.Time) error {
-	// TODO: Handle deadlines
 	c.readDeadline = t
 	c.writeDeadline = t
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Manual backport of https://github.com/kubernetes-sigs/cluster-api/pull/13939

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->