### PR TITLE
🌱 Increase MD/MS topology reconciler concurrency to 25

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -578,7 +578,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespace stri
 			Client:           mgr.GetClient(),
 			APIReader:        mgr.GetAPIReader(),
 			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
+			// Concurrency 25 should work in all cases, not adding a command-line arg as this
+			// Reconciler will be merged into the regular MachineDeployment reconciler.
+		}).SetupWithManager(ctx, mgr, concurrency(25)); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MachineDeploymentTopology")
 			os.Exit(1)
 		}
@@ -587,7 +589,9 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespace stri
 			Client:           mgr.GetClient(),
 			APIReader:        mgr.GetAPIReader(),
 			WatchFilterValue: watchFilterValue,
-		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
+			// Concurrency 25 should work in all cases, not adding a command-line arg as this
+			// Reconciler will be merged into the regular MachineSet reconciler.
+		}).SetupWithManager(ctx, mgr, concurrency(25)); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MachineSetTopology")
 			os.Exit(1)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->