### PR TITLE
:seedling: Bump cert-manager to v1.21.1

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -30,7 +30,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.21.0"
+	CertManagerDefaultVersion = "v1.21.1"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -194,7 +194,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.21.0). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.21.1). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/developer/getting-started.md
+++ b/docs/book/src/developer/getting-started.md
@@ -80,7 +80,7 @@ go install github.com/drone/envsubst/v2/cmd/envsubst@latest
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.0/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.1/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.

--- a/hack/scripts/ci/ci-e2e-lib.sh
+++ b/hack/scripts/ci/ci-e2e-lib.sh
@@ -260,9 +260,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.21.0"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.21.0"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.21.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.21.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.21.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.21.1"
 
   # Pull all images defined in DOCKER_PRELOAD_IMAGES.
   for IMAGE in $(grep DOCKER_PRELOAD_IMAGES: < "$E2E_CONF_FILE" | sed -E 's/.*\[(.*)\].*/\1/' | tr ',' ' '); do

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -21,11 +21,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/test-extension-{ARCH}:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.21.0
+- name: quay.io/jetstack/cert-manager-cainjector:v1.21.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.21.0
+- name: quay.io/jetstack/cert-manager-webhook:v1.21.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.21.0
+- name: quay.io/jetstack/cert-manager-controller:v1.21.1
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump cert-manager to [v1.21.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.21.1).

Prior-art: https://github.com/kubernetes-sigs/cluster-api/pull/13900

**Which issue(s) this PR fixes** :
Fixes # n/a

/area clusterctl