### PR TITLE
🌱 Increase clusterctl and e2e test dry-run cluster-template timeouts

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -259,13 +259,12 @@ func retryWithExponentialBackoff(ctx context.Context, opts wait.Backoff, operati
 
 // newWriteBackoff creates a new API Machinery backoff parameter set suitable for use with clusterctl write operations.
 func newWriteBackoff() wait.Backoff {
-	// Return a exponential backoff configuration which returns durations for a total time of ~40s.
-	// Example: 0, .5s, 1.2s, 2.3s, 4s, 6s, 10s, 16s, 24s, 37s
+	// Return a exponential backoff configuration which returns durations for a total time of ~159s.
 	// Jitter is added as a random fraction of the duration multiplied by the jitter factor.
 	return wait.Backoff{
 		Duration: 500 * time.Millisecond,
 		Factor:   1.5,
-		Steps:    10,
+		Steps:    13,
 		Jitter:   0.4,
 	}
 }

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -474,7 +474,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		log.Logf("Applying the cluster template yaml to the cluster in dry-run")
 		Eventually(func() error {
 			return managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate, framework.WithCreateOpts([]client.CreateOption{client.DryRunAll}...), framework.WithUpdateOpts([]client.UpdateOption{client.DryRunAll}...))
-		}, "1m", "10s").ShouldNot(HaveOccurred())
+		}, "2m", "10s").ShouldNot(HaveOccurred())
 
 		log.Logf("Applying the cluster template yaml to the cluster")
 		Expect(managementClusterProxy.CreateOrUpdate(ctx, workloadClusterTemplate)).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Trying to address
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-latestk8s-main/2082327038047293440
* https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-e2e-main/2078550540647665664

Based on the new data we collect:
* there was no cert rotation
* serving cert and caBundle in webhook configuration objects are in sync

I don't think there is anything wrong in Cluster API. kube-apiserver code for cert loading/refresh also seems correct: https://github.com/kubernetes/kubernetes/blob/v1.37.0-beta.0/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go

So to be honest, no idea why this sometimes fails. I assume if we increase timeouts towards 2min it might go away, because the kubelet secret sync takes about 60-90s. Let's see if that theory is correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Trying to address #13300

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->