### PR TITLE
🌱 fix: trivyignore CVE-2026-56852

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,3 +31,6 @@ CVE-2026-42506
 # GHSA-hrxh-6v49-42gf: gRPC-Go xDS RBAC and HTTP/2 vulnerabilities
 # This issue is only exploitable if workload cluster etcd is taken over, otherwise it is only used in test code
 GHSA-hrxh-6v49-42gf
+# CVE-2026-56852: x/text norm.Iter infinite loop, only reached via cases.Title() on
+# hardcoded strings in util/record and exp/runtime/catalog, not attacker input.
+CVE-2026-56852


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up to #13978 for the weekly Trivy scan on release-1.12: `CVE-2026-56852` (x/text `norm.Iter` infinite loop, fixed in v0.39.0) wasn't covered by the `.govuln_exclude` entries added in #13978, since those only feed govulncheck, not Trivy.

`golang.org/x/text/unicode/norm` is only reached via `cases.Title()` in `util/record` (hardcoded event reason strings) and `exp/runtime/catalog` (internal GVK/hook names) — never attacker-controlled input — so it's not exploitable here. Added to `.trivyignore`.

## Test plan

- [x] Weekly security scan / Trivy job passes