### PR TITLE
🐛 ClusterResourceSet: Patch increased memory consumption 

### DIFF
--- a/core/reconcilers/clusterresourceset/clusterresourceset_scope.go
+++ b/core/reconcilers/clusterresourceset/clusterresourceset_scope.go
@@ -73,7 +73,6 @@ func newResourceReconcileScope(
 		clusterResourceSet: clusterResourceSet,
 		resourceRef:        resourceRef,
 		resourceSetBinding: resourceSetBinding,
-		data:               normalizedData,
 		normalizedObjs:     objs,
 		computedHash:       computeHash(normalizedData),
 	}
@@ -93,7 +92,6 @@ type baseResourceReconcileScope struct {
 	resourceRef        addonsv1.ResourceRef
 	resourceSetBinding *addonsv1.ResourceSetBinding
 	normalizedObjs     []unstructured.Unstructured
-	data               [][]byte
 	computedHash       string
 }
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Patch increased memory consumption in ClusterResourceSet by dropping the redundant `data` field from newResourceReconcileScope, in favor of the already used `normalizedData` in computedHash. The dropped field was not used anywhere, and gave rise to memory increments during deepcopies, marshals, as seen from the pprof comparison below (also notice the 1.4G savings for 10 clusters deployed in a CAPD environment setup on kind):
```
$ go tool pprof -sample_index=alloc_space -base=pre-patch.pb.gz post-patch.pb.gz
File: manager
Build ID: 12353c25392746204f7dc8ffc80a77f3c21f5f3f
Type: alloc_space
Time: 2026-08-04 20:22:12 IST
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top5
Showing nodes accounting for -222.10MB, 15.86% of 1400.21MB total
Dropped 1132 nodes (cum <= 7MB)
Showing top 5 nodes out of 345
      flat  flat%   sum%        cum   cum%
  -86.02MB  6.14%  6.14%   -86.02MB  6.14%  k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue
  -54.51MB  3.89% 10.04%   -81.52MB  5.82%  github.com/evanphx/json-patch/v5/internal/json.(*decodeState).objectInterface
  -32.73MB  2.34% 12.37%   -64.27MB  4.59%  encoding/json.Marshal
  -24.70MB  1.76% 14.14%   -24.70MB  1.76%  text/template.addValueFuncs
  -24.13MB  1.72% 15.86%   -23.11MB  1.65%  io.ReadAll
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #9843

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area clusterresourceset