### PR TITLE
🐛 Fix CLC rendering for mounts, optional overwrite and indented file content

### DIFF
--- a/bootstrap/kubeadm/pkg/ignition/clc/clc.go
+++ b/bootstrap/kubeadm/pkg/ignition/clc/clc.go
@@ -42,6 +42,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/coreos/go-systemd/v22/unit"
 	clct "github.com/flatcar/container-linux-config-transpiler/config"
 	ignition "github.com/flatcar/ignition/config/v2_3"
 	ignitionTypes "github.com/flatcar/ignition/config/v2_3/types"
@@ -148,7 +149,9 @@ storage:
       mount:
         device: {{ .Device }}
         format: {{ .Filesystem }}
-        wipe_filesystem: {{ .Overwrite }}
+        {{- with .Overwrite }}
+        wipe_filesystem: {{ . }}
+        {{- end }}
         label: {{ .Label }}
         {{- if .ExtraOpts }}
         options:
@@ -201,9 +204,9 @@ storage:
       {{ end -}}
       contents:
         {{ if eq .Encoding "base64" -}}
-        inline: !!binary |
+        inline: !!binary |2
         {{- else -}}
-        inline: |
+        inline: |2
         {{- end }}
           {{ .Content | Indent 10 }}
     {{- end }}
@@ -274,8 +277,13 @@ func defaultTemplateFuncMap() template.FuncMap {
 	}
 }
 
+// mountpointName returns the systemd unit name for a given mount path, without
+// the ".mount" suffix. systemd requires mount units to be named after the
+// escaped mount point, and refuses to load a unit whose name does not match its
+// Where= setting, so the path has to be escaped the same way `systemd-escape
+// --path` does it.
 func mountpointName(name string) string {
-	return strings.TrimPrefix(strings.ReplaceAll(name, "/", "-"), "-")
+	return unit.UnitNamePathEscape(name)
 }
 
 func templateYAMLIndent(i int, input string) string {

--- a/bootstrap/kubeadm/pkg/ignition/clc/clc_test.go
+++ b/bootstrap/kubeadm/pkg/ignition/clc/clc_test.go
@@ -18,6 +18,8 @@ limitations under the License.
 package clc_test
 
 import (
+	"net/url"
+	"strings"
 	"testing"
 
 	ignition "github.com/flatcar/ignition/config/v2_3"
@@ -647,4 +649,158 @@ func TestRender(t *testing.T) {
 			t.Errorf("expected data to be returned on config with warnings")
 		}
 	})
+}
+
+func TestRenderMountUnitNames(t *testing.T) {
+	tests := []struct {
+		mountPoint string
+		wantUnit   string
+	}{
+		{
+			mountPoint: "/var/lib/testdir",
+			wantUnit:   "var-lib-testdir.mount",
+		},
+		{
+			mountPoint: "/var/lib/etcd-data",
+			wantUnit:   `var-lib-etcd\x2ddata.mount`,
+		},
+		{
+			mountPoint: "/mnt/data-disk",
+			wantUnit:   `mnt-data\x2ddisk.mount`,
+		},
+		{
+			mountPoint: "/var/lib/containerd/",
+			wantUnit:   "var-lib-containerd.mount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mountPoint, func(t *testing.T) {
+			input := &cloudinit.BaseUserData{
+				KubeadmCommand: "kubeadm join",
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: []bootstrapv1.Filesystem{
+						{
+							Device:     "/dev/disk/azure/scsi1/lun0",
+							Filesystem: "ext4",
+							Label:      "test_disk",
+							Overwrite:  ptr.To(true),
+						},
+					},
+				},
+				Mounts: []bootstrapv1.MountPoints{{"test_disk", tt.mountPoint}},
+			}
+
+			ignitionBytes, _, err := clc.Render(input, &bootstrapv1.ContainerLinuxConfig{}, "foo")
+			if err != nil {
+				t.Fatalf("rendering: %v", err)
+			}
+
+			ign, reports, err := ignition.Parse(ignitionBytes)
+			if err != nil {
+				t.Fatalf("Parsing generated Ignition: %v", err)
+			}
+
+			if reports.IsFatal() {
+				t.Fatalf("Generated Ignition has fatal reports: %s", reports)
+			}
+
+			var got []string
+			for _, unit := range ign.Systemd.Units {
+				if unit.Name == "kubeadm.service" {
+					continue
+				}
+				got = append(got, unit.Name)
+			}
+
+			if diff := cmp.Diff([]string{tt.wantUnit}, got); diff != "" {
+				t.Fatalf("Mount unit name mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRenderOptionalFilesystemOverwrite(t *testing.T) {
+	tests := []struct {
+		name      string
+		overwrite *bool
+	}{
+		{name: "overwrite set to true", overwrite: ptr.To(true)},
+		{name: "overwrite set to false", overwrite: ptr.To(false)},
+		{name: "overwrite not set", overwrite: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &cloudinit.BaseUserData{
+				KubeadmCommand: "kubeadm join",
+				DiskSetup: &bootstrapv1.DiskSetup{
+					Filesystems: []bootstrapv1.Filesystem{
+						{
+							Device:     "/dev/disk/azure/scsi1/lun0",
+							Filesystem: "ext4",
+							Label:      "test_disk",
+							Overwrite:  tt.overwrite,
+						},
+					},
+				},
+			}
+
+			if _, _, err := clc.Render(input, &bootstrapv1.ContainerLinuxConfig{}, "foo"); err != nil {
+				t.Fatalf("rendering: %v", err)
+			}
+		})
+	}
+}
+
+func TestRenderIndentedFileContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "first line indented with spaces", content: "  foo: bar\nbaz: qux\n"},
+		{name: "first line indented with a tab", content: "\tfoo: bar\nbaz: qux\n"},
+		{name: "content indented deeper than the following lines", content: "    foo: bar\n  baz: qux\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &cloudinit.BaseUserData{
+				KubeadmCommand: "kubeadm join",
+				WriteFiles: []bootstrapv1.File{
+					{
+						Path:        "/etc/testfile.yaml",
+						Content:     tt.content,
+						Permissions: "0644",
+					},
+				},
+			}
+
+			ignitionBytes, _, err := clc.Render(input, &bootstrapv1.ContainerLinuxConfig{}, "foo")
+			if err != nil {
+				t.Fatalf("rendering: %v", err)
+			}
+
+			ign, _, err := ignition.Parse(ignitionBytes)
+			if err != nil {
+				t.Fatalf("Parsing generated Ignition: %v", err)
+			}
+
+			var source string
+			for _, file := range ign.Storage.Files {
+				if file.Path == "/etc/testfile.yaml" {
+					source = file.Contents.Source
+				}
+			}
+
+			got, err := url.PathUnescape(strings.TrimPrefix(source, "data:,"))
+			if err != nil {
+				t.Fatalf("Decoding file contents: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.content, got); diff != "" {
+				t.Fatalf("File contents mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coredns/corefile-migration v1.0.34
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
@@ -78,7 +79,6 @@ require (
 	github.com/coredns/caddy v1.1.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/coredns/corefile-migration v1.0.35
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/distribution/reference v0.6.0
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
@@ -78,7 +79,6 @@ require (
 	github.com/coredns/caddy v1.1.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
-	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:

Three inputs that are valid in `KubeadmConfig` render broken Ignition for Flatcar nodes.

**1. `diskSetup.filesystems[].overwrite` is optional, but was always rendered.**

Leaving it out writes `wipe_filesystem: <nil>` and the render fails:

```
error parsing Container Linux Config: error: yaml: unmarshal errors:
line 37: cannot unmarshal !!str `<nil>` into bool
```

The machine then gets no bootstrap data. `wipe_table` a few lines above already guards this with
`{{- with .Overwrite }}`; `wipe_filesystem` now does the same.

**2. Mount unit names were not escaped for systemd.**

`mountpointName` only replaced `/` with `-`. systemd also needs a `-` inside a path escaped as
`\x2d`, otherwise it refuses to load the unit because the name does not match `Where=`.

| mount point | before | after (matches `systemd-escape -p`) |
|---|---|---|
| `/var/lib/testdir` | `var-lib-testdir` | `var-lib-testdir` |
| `/mnt/data-disk` | `mnt-data-disk` | `mnt-data\x2ddisk` |
| `/var/lib/etcd-data` | `var-lib-etcd-data` | `var-lib-etcd\x2ddata` |
| `/var/lib/containerd/` | `var-lib-containerd-` | `var-lib-containerd` |

This one is silent: Ignition applies, the node boots and joins, the disk is just never mounted. Now
uses `unit.UnitNamePathEscape`.

**3. `writeFiles` content starting with a space or a tab failed the render.**

The `inline:` block scalar had no indentation indicator, so YAML took the indentation from the first
line of the content:

```
"  foo: bar\nbaz: qux\n"  ->  yaml: line 25: did not find expected key
"\tfoo: bar\nbaz: qux\n"  ->  yaml: line 26: found a tab character where an indentation space is expected
```

It is now `|2`, so the indentation comes from the template instead of the data.

`github.com/coreos/go-systemd/v22` was already an indirect dependency and is only promoted to direct.

One test per case, each fails without the change. The existing `TestRender` cases are untouched and
still pass, so configs that already worked render exactly the same.

**Which issue(s) this PR fixes**:

None.

/area bootstrap

```release-note
Fix Ignition bootstrap rendering for mount paths that need systemd escaping, for `diskSetup.filesystems[].overwrite` when it is not set, and for `writeFiles` content whose first line is indented.
```
