### PR TITLE
🐛 Handle goproxy polling errors

### DIFF
--- a/internal/goproxy/goproxy.go
+++ b/internal/goproxy/goproxy.go
@@ -81,7 +81,7 @@ func (g *Client) GetVersions(ctx context.Context, gomodulePath string) (semver.V
 		var rawResponse []byte
 		var responseStatusCode int
 		var retryError error
-		_ = wait.PollUntilContextTimeout(ctx, retryableOperationInterval, retryableOperationTimeout, true, func(context.Context) (bool, error) {
+		pollErr := wait.PollUntilContextTimeout(ctx, retryableOperationInterval, retryableOperationTimeout, true, func(context.Context) (bool, error) {
 			retryError = nil
 
 			resp, err := http.DefaultClient.Do(req)
@@ -111,8 +111,14 @@ func (g *Client) GetVersions(ctx context.Context, gomodulePath string) (semver.V
 			}
 			return true, nil
 		})
+		if pollErr != nil && ctx.Err() != nil {
+			return nil, pollErr
+		}
 		if retryError != nil {
 			return nil, retryError
+		}
+		if pollErr != nil {
+			return nil, pollErr
 		}
 
 		// Don't try to read the versions if status was not found.

--- a/internal/goproxy/goproxy_test.go
+++ b/internal/goproxy/goproxy_test.go
@@ -29,6 +29,16 @@ import (
 	goproxytest "sigs.k8s.io/cluster-api/internal/goproxy/test"
 )
 
+func TestClient_GetVersionsHonorsCanceledContext(t *testing.T) {
+	g := NewWithT(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := NewClient("https", "proxy.golang.org").GetVersions(ctx, "github.com/o/r")
+	g.Expect(err).To(MatchError(context.Canceled))
+}
+
 func TestClient_GetVersions(t *testing.T) {
 	retryableOperationInterval = 200 * time.Millisecond
 	retryableOperationTimeout = 1 * time.Second


### PR DESCRIPTION
**What this PR does / why we need it**:

`internal/goproxy.Client.GetVersions` used `wait.PollUntilContextTimeout` for retrying goproxy requests, but discarded the poll error. This PR returns poll errors so caller cancellation and poll timeouts are not hidden by the retry loop, while preserving the existing retry error behavior for HTTP/read failures.

A regression test covers an already-canceled context and expects `context.Canceled`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterctl