### PR TITLE
🐛 Fix ParseSecretName round-trip for purposes containing hyphens

### DIFF
--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -56,15 +56,13 @@ func Name(cluster string, suffix Purpose) string {
 // ParseSecretName return the cluster name and the suffix Purpose in name is a valid cluster secret,
 // otherwise it return error.
 func ParseSecretName(name string) (string, Purpose, error) {
-	separatorPos := strings.LastIndex(name, "-")
-	if separatorPos == -1 {
+	if !strings.Contains(name, "-") {
 		return "", "", pkgerrors.Errorf("%q is not a valid cluster secret name. The purpose suffix is missing", name)
 	}
-	clusterName := name[:separatorPos]
-	purposeSuffix := Purpose(name[separatorPos+1:])
 	for _, purpose := range allSecretPurposes {
-		if purpose == purposeSuffix {
-			return clusterName, purposeSuffix, nil
+		suffix := "-" + string(purpose)
+		if strings.HasSuffix(name, suffix) {
+			return strings.TrimSuffix(name, suffix), purpose, nil
 		}
 	}
 	return "", "", pkgerrors.Errorf("%q is not a valid cluster secret name. Invalid purpose suffix", name)

--- a/util/secret/secret_test.go
+++ b/util/secret/secret_test.go
@@ -52,6 +52,24 @@ func TestParseSecretName(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "A secret for the test cluster (purpose with - in the middle)",
+			args: args{
+				name: "test-apiserver-etcd-client",
+			},
+			want:    "test",
+			want1:   APIServerEtcdClient,
+			wantErr: false,
+		},
+		{
+			name: "A secret for the test-capa cluster (cluster name and purpose with - in the middle)",
+			args: args{
+				name: "test-capa-apiserver-etcd-client",
+			},
+			want:    "test-capa",
+			want1:   APIServerEtcdClient,
+			wantErr: false,
+		},
+		{
 			name: "Not a Cluster API secret",
 			args: args{
 				name: "foo",


### PR DESCRIPTION
/kind bug
/area bootstrap
/sig cluster-lifecycle

**What this PR does / why we need it**:

Some Cluster API secrets were being silently dropped during `clusterctl move`, causing the move graph to miss real resources. The cause is `ParseSecretName` failing on the `APIServerEtcdClient` purpose because it splits the secret name at the last hyphen and the trailing segment is not a valid purpose.

The fix replaces the `LastIndex` split with suffix-based matching against `allSecretPurposes`, mirroring `HasPurposeSuffix` in `consts.go`.

**Which issue(s) this PR fixes**:
-

**Suggested Release Note**"

```release-note
Fix `ParseSecretName` round-trip for purposes containing hyphens by using suffix-based matching instead of `LastIndex` splitting.
```

**Reviewer notes**:

- `ParseSecretName` is also called from `util/kubeconfig/kubeconfig.go:193`, but that path only handles `Kubeconfig` secrets, so it never hit the bug.
- Required test also added for future regressions :) Before the fix, `TestParseSecretName_RoundTrip`'s two `APIServerEtcdClient` cases (`"cluster-apiserver-etcd-client"` and `"my-cluster-apiserver-etcd-client"`) returned an error because the last-hyphen split extracted `"client"` instead of `"apiserver-etcd-client"`. After the fix, both parse correctly as `(cluster_name, APIServerEtcdClient)`.
