### PR TITLE
✨ Add CAPD_DOCKER_NETWORK environment variable

### DIFF
--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -42,6 +42,8 @@ spec:
               fieldPath: status.podIP
         - name: DOCKER_HOST
           value: ${CAPD_DOCKER_HOST:=""}
+        - name: DOCKER_NETWORK
+          value: ${CAPD_DOCKER_NETWORK:=""}
         ports:
         - containerPort: 9440
           name: healthz

--- a/test/infrastructure/docker/internal/docker/manager.go
+++ b/test/infrastructure/docker/internal/docker/manager.go
@@ -19,6 +19,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"os"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
@@ -40,6 +41,13 @@ const HAProxyPort = 8404
 
 // DefaultNetwork is the default network name to use in kind.
 const DefaultNetwork = "kind"
+
+func getDockerNetwork() string {
+	if network := os.Getenv("DOCKER_NETWORK"); network != "" {
+		return network
+	}
+	return DefaultNetwork
+}
 
 // haproxyEntrypoint is the entrypoint used to start the haproxy load balancer container.
 var haproxyEntrypoint = []string{"haproxy", "-W", "-db", "-f", "/usr/local/etc/haproxy/haproxy.cfg"}
@@ -168,7 +176,7 @@ func createNode(ctx context.Context, opts *nodeCreateOpts) (*types.Node, error) 
 		Volumes:      map[string]string{"/var": ""},
 		Mounts:       generateMountInfo(opts.Mounts),
 		PortMappings: generatePortMappings(opts.PortMappings),
-		Network:      DefaultNetwork,
+		Network:      getDockerNetwork(),
 		Tmpfs: map[string]string{
 			"/tmp": "", // various things depend on working /tmp
 			"/run": "", // systemd wants a writable /run

--- a/test/infrastructure/docker/internal/docker/manager_test.go
+++ b/test/infrastructure/docker/internal/docker/manager_test.go
@@ -71,6 +71,33 @@ func TestCreateNode(t *testing.T) {
 	g.Expect(runConfig.Labels["io.x-k8s.kind.cluster"]).To(Equal("TestClusterName"))
 }
 
+func TestCreateNodeWithConfiguredDockerNetwork(t *testing.T) {
+	t.Setenv("DOCKER_NETWORK", "custom-network")
+
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+	containerRuntime.ResetRunContainerCallLogs()
+
+	createOpts := &nodeCreateOpts{
+		Name:        "TestName",
+		ClusterName: "TestClusterName",
+		Role:        constants.ControlPlaneNodeRoleValue,
+		Mounts:      []v1alpha4.Mount{},
+		IPFamily:    container.IPv4IPFamily,
+		KindMapping: kind.Mapping{
+			Image: "TestImage",
+			Mode:  kind.ModeNone,
+		},
+	}
+	_, err := createNode(ctx, createOpts)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	callLog := containerRuntime.RunContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].RunConfig.Network).To(Equal("custom-network"))
+}
+
 func TestCreateControlPlaneNode(t *testing.T) {
 	g := NewWithT(t)
 	containerRuntime := &container.FakeRuntime{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Adds an optional  `CAPD_DOCKER_NETWORK`  installation variable. The CAPD controller receives it as  `DOCKER_NETWORK`  and uses it when creating Docker workload nodes and load-balancer containers. CAPD continues to use  the "kind" docker network name  when no network is configured.

CAPD currently hard-codes the  `kind`  Docker network. This prevents CAPD from working in local environments where the management cluster and supporting services use a deliberately named Docker network. Allowing an explicit network keeps CAPD workload containers on the same reachable network without requiring users to rename or recreate existing local infrastructure.

This is intended to support kind cluster installations that use `KIND_EXPERIMENTAL_DOCKER_NETWORK`

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->