### PR TITLE
🌱 Framework: Consider restart policy in containerHasTerminated

### DIFF
--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -301,9 +301,9 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 					log.Logf("Error getting pod %s, container %s: %v", klog.KRef(pod.Namespace, pod.Name), container.Name, err)
 					return true, nil
 				}
-				// On retries, stop if the container has terminated (e.g.
-				// completed init container or pod terminated during upgrade).
-				// This also covers pods in Succeeded/Failed phase.
+				// On retries, stop if the container has terminated for good (e.g.
+				// completed init container, or pod terminated/being deleted during
+				// upgrade). This also covers pods in Succeeded/Failed phase.
 				// Skip this check on the first attempt so we still capture
 				// historical logs from already-completed containers.
 				if streamed && containerHasTerminated(actual, container.Name) {
@@ -339,16 +339,40 @@ func (eh *watchPodLogsEventHandler) streamPodLogs(pod *corev1.Pod) {
 }
 
 // containerHasTerminated checks whether a specific container (regular or init)
-// has terminated in the given pod.
+// has terminated for good in the given pod, i.e. it is not expected to produce
+// any more logs.
 func containerHasTerminated(pod *corev1.Pod, containerName string) bool {
 	// Check pod phase first — if the whole pod is done, all containers are done.
 	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 		return true
 	}
-	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+
+	// Init containers only ever run once per pod: the pod does not reach the
+	// Running phase until all init containers have completed successfully, so
+	// observing one here (with the pod Running) always means it is done for
+	// good and won't run again for this pod.
+	for _, cs := range pod.Status.InitContainerStatuses {
 		if cs.Name == containerName {
 			return cs.State.Terminated != nil
 		}
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != containerName {
+			continue
+		}
+		if cs.State.Terminated == nil {
+			return false
+		}
+		// Unlike init containers, a regular container's Terminated state alone
+		// doesn't guarantee it is done for good: with restartPolicy Always or
+		// OnFailure it may be about to be restarted by kubelet (e.g. after a
+		// crash), in which case more logs are still expected. Only with
+		// restartPolicy Never is kubelet guaranteed not to restart it.
+		if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/test/framework/deployment_helpers_test.go
+++ b/test/framework/deployment_helpers_test.go
@@ -74,8 +74,11 @@ func Test_containerHasTerminated(t *testing.T) {
 			want:          true,
 		},
 		{
-			name: "running pod with terminated regular container",
+			name: "terminated regular container in pod with restartPolicy Never",
 			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					ContainerStatuses: []corev1.ContainerStatus{
@@ -92,6 +95,52 @@ func Test_containerHasTerminated(t *testing.T) {
 			},
 			containerName: "sidecar",
 			want:          true,
+		},
+		{
+			name: "terminated regular container in pod with restartPolicy Always may still restart",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyAlways,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "flaky",
+							State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}},
+						},
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "flaky",
+			want:          false,
+		},
+		{
+			name: "terminated regular container in pod with restartPolicy OnFailure may still restart",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:  "flaky",
+							State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1}},
+						},
+						{
+							Name:  "main",
+							State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			containerName: "flaky",
+			want:          false,
 		},
 		{
 			name: "running pod — container still running",


### PR DESCRIPTION
**What this PR does / why we need it**:

Consider restart policies when determining if a container is permanently terminated. Regular containers with restartPolicy Always or OnFailure may restart even when in Terminated state, while init containers always complete permanently once observed in Running pods.

I had missed this in https://github.com/kubernetes-sigs/cluster-api/pull/13410. In reality, capturing the logs *before* a restart would be the most important thing (needed to determine what caused the restart), so this is not that critical. Still wanted to clean it up.

**Background:** (This is just if you really are interested.) I'm investigating duplicated logs in BMO E2E (https://github.com/metal3-io/baremetal-operator/issues/2927). One reason for duplication was the init-container, fixed in #13410. Another is that our Ironic containers don't stop all together (one ignores SIGTERM, see https://github.com/metal3-io/ironic-image/issues/1163). From this I started looking into the CAPI code again and realized my mistake.

Another finding from this is that container status is not updated once the pod goes into terminating (https://github.com/kubernetes/kubernetes/issues/106896). This makes me think we cannot do much better than we already do in CAPI. So I am just fixing the case I missed before, not attempting to detect the state of terminating pod containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->