### PR TITLE
📖 docs: add Kairos Fleet to the infrastructure provider list

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -54,6 +54,7 @@ source of inspiration and ideas for others.
 - [Huawei Cloud](https://github.com/HuaweiCloudDeveloper/cluster-api-provider-huawei)
 - [IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud)
 - [IONOS Cloud](https://github.com/ionos-cloud/cluster-api-provider-ionoscloud)
+- [Kairos Fleet](https://github.com/kairos-io/cluster-api-provider-kairos-fleet)
 - [KubeKey](https://github.com/kubesphere/kubekey)
 - [k0smotron RemoteMachine (SSH)](https://github.com/k0sproject/k0smotron)
 - [KubeSwift](https://github.com/kubeswift-io/cluster-api-provider-kubeswift)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds [`cluster-api-provider-kairos-fleet`](https://github.com/kairos-io/cluster-api-provider-kairos-fleet)
to the Infrastructure provider list in the Cluster API Book. It is a released
(v0.1.1) Cluster API infrastructure provider that claims already-enrolled Kairos
nodes from an AuroraBoot fleet.

**Which issue(s) this PR fixes**:

Part of #14044

```release-note
NONE
```