### PR TITLE
📖 docs: add Kairos bootstrap and control plane providers to the glossary

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -45,6 +45,12 @@ Cluster API Provider AWS
 ### CABPK
 Cluster API Bootstrap Provider Kubeadm
 
+### CABPKairos
+Cluster API Bootstrap Provider Kairos
+
+### CACPKairos
+Cluster API Control Plane Provider Kairos
+
 ### CAPC
 Cluster API Provider CloudStack
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds glossary entries for `cluster-api-provider-kairos` (`kairos-io`), a released
(v0.1.1) Kairos bootstrap and control-plane provider. The quick-start guide is
infrastructure-provider-centric and has no bootstrap/control-plane tabs, so this
change is limited to the glossary.

**Which issue(s) this PR fixes**:

Part of #14043

```release-note
NONE
```