### PR TITLE
🐛machinepool: Conditionally delegate taint removal

### DIFF
--- a/core/reconcilers/machinepool/machinepool_controller_noderef.go
+++ b/core/reconcilers/machinepool/machinepool_controller_noderef.go
@@ -146,7 +146,7 @@ func (r *Reconciler) reconcileNodeRefs(ctx context.Context, s *scope) (ctrl.Resu
 	r.recorder.Event(mp, corev1.EventTypeNormal, "SuccessfulSetNodeRefs", fmt.Sprintf("%+v", mp.Status.NodeRefs))
 
 	// Reconcile node annotations and taints.
-	err = r.patchNodes(ctx, clusterClient, nodeRefsResult.references, mp)
+	err = r.patchNodes(ctx, clusterClient, nodeRefsResult.references, s)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -231,8 +231,23 @@ func (r *Reconciler) getNodeReferences(ctx context.Context, providerIDList []str
 }
 
 // patchNodes patches the nodes with the cluster name and cluster namespace annotations.
-func (r *Reconciler) patchNodes(ctx context.Context, c client.Client, references []corev1.ObjectReference, mp *clusterv1.MachinePool) error {
+// This also delegates the removal of the NodeUninitializedTaint to the Machine controller if the MachinePool uses
+// MachinePool Machines.
+func (r *Reconciler) patchNodes(ctx context.Context, c client.Client, references []corev1.ObjectReference, s *scope) error {
 	log := ctrl.LoggerFrom(ctx)
+	mp := s.machinePool
+
+	hasMachines, err := s.hasMachinePoolMachines()
+	if err != nil {
+		if s.infraMachinePool == nil {
+			log.V(4).Info("InfraMachinePool not yet set, assuming legacy mode without Machines")
+			hasMachines = false
+		} else {
+			log.Error(err, "Failed to check if MachinePool uses Machines, will not remove uninitialized taint")
+			hasMachines = true
+		}
+	}
+
 	for _, nodeRef := range references {
 		node := &corev1.Node{}
 		if err := c.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
@@ -249,9 +264,14 @@ func (r *Reconciler) patchNodes(ctx context.Context, c client.Client, references
 			clusterv1.OwnerKindAnnotation:        "MachinePool",
 			clusterv1.OwnerNameAnnotation:        mp.Name,
 		}
-		// Add annotations and drop NodeUninitializedTaint.
+		// Add annotations.
 		hasAnnotationChanges := annotations.AddAnnotations(node, desired)
-		hasTaintChanges := taints.RemoveNodeTaint(node, clusterv1.NodeUninitializedTaint)
+
+		var hasTaintChanges bool
+		if !hasMachines {
+			hasTaintChanges = taints.RemoveNodeTaint(node, clusterv1.NodeUninitializedTaint)
+		}
+
 		// Patch the node if needed.
 		if hasAnnotationChanges || hasTaintChanges {
 			if err := patchHelper.Patch(ctx, node); err != nil {

--- a/core/reconcilers/machinepool/machinepool_controller_noderef_test.go
+++ b/core/reconcilers/machinepool/machinepool_controller_noderef_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -382,14 +383,15 @@ func TestMachinePoolPatchNodes(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name          string
-		machinePool   *clusterv1.MachinePool
-		nodeRefs      []corev1.ObjectReference
-		expectedNodes []corev1.Node
-		err           error
+		name             string
+		machinePool      *clusterv1.MachinePool
+		infraMachinePool *unstructured.Unstructured
+		nodeRefs         []corev1.ObjectReference
+		expectedNodes    []corev1.Node
+		err              error
 	}{
 		{
-			name: "Node with uninitialized taint should be patched",
+			name: "Node with uninitialized taint should be patched when MachinePool has no Machines",
 			machinePool: &clusterv1.MachinePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "machinepool-1",
@@ -399,6 +401,9 @@ func TestMachinePoolPatchNodes(t *testing.T) {
 					ClusterName:    "cluster-1",
 					ProviderIDList: []string{"aws://us-east-1/id-node-1"},
 				},
+			},
+			infraMachinePool: &unstructured.Unstructured{
+				Object: map[string]any{},
 			},
 			nodeRefs: []corev1.ObjectReference{
 				{Name: "node-1"},
@@ -416,6 +421,47 @@ func TestMachinePoolPatchNodes(t *testing.T) {
 					},
 					Spec: corev1.NodeSpec{
 						Taints: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "Node with uninitialized taint should not be patched when MachinePool has Machines",
+			machinePool: &clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machinepool-with-machines",
+					Namespace: "my-namespace",
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					ClusterName:    "cluster-1",
+					ProviderIDList: []string{"aws://us-east-1/id-node-1"},
+				},
+			},
+			infraMachinePool: &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"infrastructureMachineKind": "DockerMachine",
+					},
+				},
+			},
+			nodeRefs: []corev1.ObjectReference{
+				{Name: "node-1"},
+			},
+			expectedNodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"cluster.x-k8s.io/cluster-name":      "cluster-1",
+							"cluster.x-k8s.io/cluster-namespace": "my-namespace",
+							"cluster.x-k8s.io/owner-kind":        "MachinePool",
+							"cluster.x-k8s.io/owner-name":        "machinepool-with-machines",
+						},
+					},
+					Spec: corev1.NodeSpec{
+						Taints: []corev1.Taint{
+							clusterv1.NodeUninitializedTaint,
+						},
 					},
 				},
 			},
@@ -506,7 +552,12 @@ func TestMachinePoolPatchNodes(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithObjects(nodeList...).Build()
 
-			err := r.patchNodes(ctx, fakeClient, test.nodeRefs, test.machinePool)
+			s := &scope{
+				machinePool:      test.machinePool,
+				infraMachinePool: test.infraMachinePool,
+			}
+
+			err := r.patchNodes(ctx, fakeClient, test.nodeRefs, s)
 			if test.err == nil {
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: Delegate uninitialized taint removal to the Machine controller when Machines do exist. Unlike earlier, both MachinePool and Machine controllers raced to drop the taint, which was unpredictable and could potentially cause problems with inequality-based selectors (see this comment [1] for more). Also see, [2].

[1]:https://github.com/kubernetes-sigs/cluster-api/issues/8258#issuecomment-5110263260
[2]:https://github.com/kubernetes-sigs/cluster-api/issues/8258#issuecomment-5245418741
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8258 

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area machinepool