### PR TITLE
🐛 Return errors from HasKubeadmConfig instead of swallowing them

### DIFF
--- a/controlplane/kubeadm/pkg/workload_cluster.go
+++ b/controlplane/kubeadm/pkg/workload_cluster.go
@@ -224,10 +224,13 @@ func (w *Workload) HasKubeadmConfig(ctx context.Context) (bool, error) {
 		Name:      kubeadmConfigKey,
 		Namespace: metav1.NamespaceSystem,
 	}
-	err := w.Client.Get(ctx, key, &corev1.ConfigMap{})
-	// TODO: Consider if this should only return false if the error is IsNotFound.
-	// TODO: Consider adding a third state of 'unknown' when there is an error retrieving the config map.
-	return err == nil, nil
+	if err := w.Client.Get(ctx, key, &corev1.ConfigMap{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, pkgerrors.Wrap(err, "failed to check if the kubeadm-config ConfigMap exists")
+	}
+	return true, nil
 }
 
 // GetAPIServerCertificateExpiry returns the certificate expiry of the apiserver on the given node.

--- a/controlplane/kubeadm/pkg/workload_cluster_test.go
+++ b/controlplane/kubeadm/pkg/workload_cluster_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/yaml"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
@@ -814,6 +815,7 @@ func TestHasKubeadmConfig(t *testing.T) {
 	tests := []struct {
 		name                   string
 		objs                   []client.Object
+		getErr                 error
 		expectErr              bool
 		expectHasKubeadmConfig bool
 	}{
@@ -829,12 +831,27 @@ func TestHasKubeadmConfig(t *testing.T) {
 			expectErr:              false,
 			expectHasKubeadmConfig: true,
 		},
+		{
+			// Note: an error other than NotFound must be surfaced instead of being
+			// reported as "the cluster does not have a kubeadm config".
+			name:      "Returns an error if getting the kubeadm config fails",
+			objs:      []client.Object{kconf},
+			getErr:    apierrors.NewInternalError(errors.New("internal error")),
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			fakeClient := fake.NewClientBuilder().WithObjects(tt.objs...).Build()
+			if tt.getErr != nil {
+				fakeClient = interceptor.NewClient(fakeClient, interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return tt.getErr
+					},
+				})
+			}
 			w := &Workload{
 				Client: fakeClient,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

`HasKubeadmConfig` discarded every error returned by the API server and reported it as "the cluster does not have a kubeadm-config ConfigMap":

```go
err := w.Client.Get(ctx, key, &corev1.ConfigMap{})
// TODO: Consider if this should only return false if the error is IsNotFound.
// TODO: Consider adding a third state of 'unknown' when there is an error retrieving the config map.
return err == nil, nil
```

A request timeout, an RBAC denial or a transient workload cluster apiserver outage was therefore indistinguishable from the ConfigMap genuinely being absent.

Both callers, in `controlplane/kubeadm/reconcilers/kubeadmcontrolplane/status.go` (in `updateV1Beta1Status` and `updateStatus`), do check the returned error:

```go
hasKubeadmConfig, err := workloadCluster.HasKubeadmConfig(ctx)
if err != nil {
    return err
}
```

Since the error was always `nil`, those checks could never fire.

The practical effect is that a transient failure to reach the workload cluster made KCP conclude the control plane was not initialized, so it left `status.initialization.controlPlaneInitialized` and the `Available` condition unset and waited for the next resync instead of surfacing the failure and retrying. The error was also invisible to operators, since it was neither returned nor logged.

This addresses the first of the two pre-existing TODOs on that function. The second one, about introducing a third "unknown" state, is intentionally left alone as it would be an API change for `WorkloadCluster`.

**Changes**:

- `HasKubeadmConfig` now maps only `NotFound` to `false`; any other error is returned to the caller, which makes the existing error handling in both callers effective.
- Adds a test case covering a non-`NotFound` error, injected with `interceptor.NewClient`. The `expectErr` field already present in the test table was previously unused, so no case exercised the error path.

**Which issue(s) this PR fixes**:

**Additional context**:

Verified that the new test case fails against the current implementation on `main` and passes with the change, so it genuinely covers the fixed behaviour. `make lint` and the full `./controlplane/kubeadm/...` suite pass.

/area control-plane
