### PR TITLE
🌱 Optimize memory usage of conversion by only setting required fields in annotation

### DIFF
--- a/bootstrap/kubeadm/webhooks/conversion/kubeadmconfig.go
+++ b/bootstrap/kubeadm/webhooks/conversion/kubeadmconfig.go
@@ -226,8 +226,89 @@ func ConvertKubeadmConfigHubToV1Beta1(ctx context.Context, src *bootstrapv1.Kube
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec)
 	dropEmptyStringsKubeadmConfigStatus(&dst.Status)
 
-	// Preserve Hub data on down-conversion except for metadata.
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertKubeadmConfigV1Beta1ToHub to reduce memory usage.
+	src = &bootstrapv1.KubeadmConfig{
+		Spec: KubeadmConfigSpecForRestore(&src.Spec),
+		Status: bootstrapv1.KubeadmConfigStatus{
+			Initialization: src.Status.Initialization,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
+}
+
+// KubeadmConfigSpecForRestore returns a KubeadmConfigSpec that only contains the fields that
+// are actually read back from the conversion annotation by RestoreBoolIntentKubeadmConfigSpec and
+// RestoreKubeadmConfigSpec. This is used to reduce the amount of data stored in the conversion annotation.
+func KubeadmConfigSpecForRestore(src *bootstrapv1.KubeadmConfigSpec) bootstrapv1.KubeadmConfigSpec {
+	return bootstrapv1.KubeadmConfigSpec{
+		ClusterConfiguration: bootstrapv1.ClusterConfiguration{
+			APIServer: bootstrapv1.APIServer{
+				ExtraVolumes: hostPathMountsForRestore(src.ClusterConfiguration.APIServer.ExtraVolumes),
+			},
+			ControllerManager: bootstrapv1.ControllerManager{
+				ExtraVolumes: hostPathMountsForRestore(src.ClusterConfiguration.ControllerManager.ExtraVolumes),
+			},
+			Scheduler: bootstrapv1.Scheduler{
+				ExtraVolumes: hostPathMountsForRestore(src.ClusterConfiguration.Scheduler.ExtraVolumes),
+			},
+		},
+		InitConfiguration: bootstrapv1.InitConfiguration{
+			Timeouts: src.InitConfiguration.Timeouts,
+		},
+		JoinConfiguration: bootstrapv1.JoinConfiguration{
+			Timeouts: src.JoinConfiguration.Timeouts,
+			Discovery: bootstrapv1.Discovery{
+				BootstrapToken: bootstrapv1.BootstrapTokenDiscovery{
+					UnsafeSkipCAVerification: src.JoinConfiguration.Discovery.BootstrapToken.UnsafeSkipCAVerification,
+				},
+				File: bootstrapv1.FileDiscovery{
+					KubeConfig: bootstrapv1.FileDiscoveryKubeConfig{
+						Cluster: bootstrapv1.KubeConfigCluster{
+							InsecureSkipTLSVerify: src.JoinConfiguration.Discovery.File.KubeConfig.Cluster.InsecureSkipTLSVerify,
+						},
+						User: bootstrapv1.KubeConfigUser{
+							Exec: bootstrapv1.KubeConfigAuthExec{
+								ProvideClusterInfo: src.JoinConfiguration.Discovery.File.KubeConfig.User.Exec.ProvideClusterInfo,
+							},
+						},
+					},
+				},
+			},
+		},
+		Files: filesForRestore(src.Files),
+		Ignition: bootstrapv1.IgnitionSpec{
+			ContainerLinuxConfig: bootstrapv1.ContainerLinuxConfig{
+				Strict: src.Ignition.ContainerLinuxConfig.Strict,
+			},
+		},
+	}
+}
+
+// hostPathMountsForRestore returns a slice of HostPathMount that only contains the fields
+// needed to restore the ReadOnly bool intent (HostPath is used to find the matching entry).
+func hostPathMountsForRestore(volumes []bootstrapv1.HostPathMount) []bootstrapv1.HostPathMount {
+	if volumes == nil {
+		return nil
+	}
+	out := make([]bootstrapv1.HostPathMount, len(volumes))
+	for i, v := range volumes {
+		out[i] = bootstrapv1.HostPathMount{HostPath: v.HostPath, ReadOnly: v.ReadOnly}
+	}
+	return out
+}
+
+// filesForRestore returns a slice of File that only contains the fields needed to restore
+// the Append bool intent (Path is used to find the matching entry).
+func filesForRestore(files []bootstrapv1.File) []bootstrapv1.File {
+	if files == nil {
+		return nil
+	}
+	out := make([]bootstrapv1.File, len(files))
+	for i, f := range files {
+		out[i] = bootstrapv1.File{Path: f.Path, Append: f.Append}
+	}
+	return out
 }
 
 // ConvertKubeadmConfigSpecHubToV1Beta1 converts a hub KubeadmConfigSpec to a v1beta1 KubeadmConfigSpec.

--- a/bootstrap/kubeadm/webhooks/conversion/kubeadmconfigtemplate.go
+++ b/bootstrap/kubeadm/webhooks/conversion/kubeadmconfigtemplate.go
@@ -69,6 +69,14 @@ func ConvertKubeadmConfigTemplateHubToV1Beta1(ctx context.Context, src *bootstra
 
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec.Template.Spec)
 
-	// Preserve Hub data on down-conversion except for metadata.
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertKubeadmConfigTemplateV1Beta1ToHub to reduce memory usage.
+	src = &bootstrapv1.KubeadmConfigTemplate{
+		Spec: bootstrapv1.KubeadmConfigTemplateSpec{
+			Template: bootstrapv1.KubeadmConfigTemplateResource{
+				Spec: KubeadmConfigSpecForRestore(&src.Spec.Template.Spec),
+			},
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }

--- a/controlplane/kubeadm/webhooks/conversion/kubeadmcontrolplane.go
+++ b/controlplane/kubeadm/webhooks/conversion/kubeadmcontrolplane.go
@@ -103,7 +103,19 @@ func ConvertKubeadmControlPlaneHubToV1Beta1(ctx context.Context, src *controlpla
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec.KubeadmConfigSpec)
 	dropEmptyStringsKubeadmControlPlaneStatus(&dst.Status)
 
-	// Preserve Hub data on down-conversion except for metadata.
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertKubeadmControlPlaneV1Beta1ToHub to reduce memory usage.
+	src = &controlplanev1.KubeadmControlPlane{
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			KubeadmConfigSpec: bootstrapconversion.KubeadmConfigSpecForRestore(&src.Spec.KubeadmConfigSpec),
+			Remediation: controlplanev1.KubeadmControlPlaneRemediationSpec{
+				RetryPeriodSeconds: src.Spec.Remediation.RetryPeriodSeconds,
+			},
+		},
+		Status: controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: src.Status.Initialization,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }
 

--- a/controlplane/kubeadm/webhooks/conversion/kubeadmcontrolplanetemplate.go
+++ b/controlplane/kubeadm/webhooks/conversion/kubeadmcontrolplanetemplate.go
@@ -76,6 +76,19 @@ func ConvertKubeadmControlPlaneTemplateHubToV1Beta1(ctx context.Context, src *co
 
 	dropEmptyStringsKubeadmConfigSpec(&dst.Spec.Template.Spec.KubeadmConfigSpec)
 
-	// Preserve Hub data on down-conversion except for metadata.
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertKubeadmControlPlaneTemplateV1Beta1ToHub to reduce memory usage.
+	src = &controlplanev1.KubeadmControlPlaneTemplate{
+		Spec: controlplanev1.KubeadmControlPlaneTemplateSpec{
+			Template: controlplanev1.KubeadmControlPlaneTemplateResource{
+				Spec: controlplanev1.KubeadmControlPlaneTemplateResourceSpec{
+					KubeadmConfigSpec: bootstrapconversion.KubeadmConfigSpecForRestore(&src.Spec.Template.Spec.KubeadmConfigSpec),
+					Remediation: controlplanev1.KubeadmControlPlaneRemediationSpec{
+						RetryPeriodSeconds: src.Spec.Template.Spec.Remediation.RetryPeriodSeconds,
+					},
+				},
+			},
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }

--- a/core/webhooks/conversion/cluster.go
+++ b/core/webhooks/conversion/cluster.go
@@ -116,6 +116,16 @@ func ConvertClusterHubToV1Beta1(ctx context.Context, src *clusterv1.Cluster, dst
 
 	dropEmptyStringsCluster(dst)
 
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertClusterV1Beta1ToHub to reduce memory usage.
+	src = &clusterv1.Cluster{
+		Spec: clusterv1.ClusterSpec{
+			Paused: src.Spec.Paused,
+		},
+		Status: clusterv1.ClusterStatus{
+			Initialization: src.Status.Initialization,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }
 

--- a/core/webhooks/conversion/ipaddressclaim.go
+++ b/core/webhooks/conversion/ipaddressclaim.go
@@ -106,7 +106,13 @@ func ConvertIPAddressClaimHubToV1Alpha1(_ context.Context, src *ipamv1.IPAddress
 		dst.Labels[clusterv1.ClusterNameLabel] = src.Spec.ClusterName
 	}
 
-	// Preserve Hub data on down-conversion except for metadata
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertIPAddressClaimV1Alpha1ToHub to reduce memory usage.
+	src = &ipamv1.IPAddressClaim{
+		Status: ipamv1.IPAddressClaimStatus{
+			Conditions: src.Status.Conditions,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }
 

--- a/core/webhooks/conversion/machine.go
+++ b/core/webhooks/conversion/machine.go
@@ -85,5 +85,17 @@ func ConvertMachineHubToV1Beta1(ctx context.Context, src *clusterv1.Machine, dst
 
 	dropEmptyStringsMachineSpec(&dst.Spec)
 
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertMachineV1Beta1ToHub to reduce memory usage.
+	src = &clusterv1.Machine{
+		Spec: clusterv1.MachineSpec{
+			MinReadySeconds: src.Spec.MinReadySeconds,
+		},
+		Status: clusterv1.MachineStatus{
+			Phase:          src.Status.Phase,
+			FailureDomain:  src.Status.FailureDomain,
+			Initialization: src.Status.Initialization,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }

--- a/core/webhooks/conversion/machinedeployment.go
+++ b/core/webhooks/conversion/machinedeployment.go
@@ -69,5 +69,12 @@ func ConvertMachineDeploymentHubToV1Beta1(ctx context.Context, src *clusterv1.Ma
 
 	dropEmptyStringsMachineSpec(&dst.Spec.Template.Spec)
 
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertMachineDeploymentV1Beta1ToHub to reduce memory usage.
+	src = &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			Paused: src.Spec.Paused,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }

--- a/core/webhooks/conversion/machinehealthcheck.go
+++ b/core/webhooks/conversion/machinehealthcheck.go
@@ -61,5 +61,14 @@ func ConvertMachineHealthCheckHubToV1Beta1(_ context.Context, src *clusterv1.Mac
 		dst.Spec.RemediationTemplate.Namespace = src.Namespace
 	}
 
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertMachineHealthCheckV1Beta1ToHub to reduce memory usage.
+	src = &clusterv1.MachineHealthCheck{
+		Status: clusterv1.MachineHealthCheckStatus{
+			ExpectedMachines:    src.Status.ExpectedMachines,
+			CurrentHealthy:      src.Status.CurrentHealthy,
+			RemediationsAllowed: src.Status.RemediationsAllowed,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }

--- a/core/webhooks/conversion/machinepool.go
+++ b/core/webhooks/conversion/machinepool.go
@@ -77,5 +77,12 @@ func ConvertMachinePoolHubToV1Beta1(ctx context.Context, src *clusterv1.MachineP
 
 	dropEmptyStringsMachineSpec(&dst.Spec.Template.Spec)
 
+	// Note: Only put the fields into the conversion annotation that are actually restored in
+	// ConvertMachinePoolV1Beta1ToHub to reduce memory usage.
+	src = &clusterv1.MachinePool{
+		Status: clusterv1.MachinePoolStatus{
+			Initialization: src.Status.Initialization,
+		},
+	}
 	return conversionutil.MarshalDataUnsafeNoCopy(src, dst)
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR optimizes the memory usage of conversion by avoiding to send the entire objects around when we only need a few fields.

Skipped ClusterClass as it's not worth the effort/complexity

**With some help from Claude**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->