### PR TITLE
🌱 Remove deprecated MachineWaitForVolumeDetachConsiderVolumeAttachments fg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -315,11 +315,6 @@ linters:
       - zz_generated.*\.go$
       - vendored_openapi\.go$
     rules:
-      # TODO: Excludes that can be removed as part of the Cluster API v1.15 release.
-      - linters:
-          - staticcheck
-        text: 'SA1019: feature.MachineWaitForVolumeDetachConsiderVolumeAttachments is deprecated'
-
       # TODO: Excludes that can be removed once we bumped to controller-runtime v0.25.
       - linters:
           - staticcheck

--- a/core/config/manager/manager.yaml
+++ b/core/config/manager/manager.yaml
@@ -23,7 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
-            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=false}"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=false}"
           image: controller:latest
           name: manager
           env:

--- a/core/reconcilers/machine/machine_controller.go
+++ b/core/reconcilers/machine/machine_controller.go
@@ -1191,19 +1191,17 @@ func getAttachedVolumeInformation(ctx context.Context, remoteClient client.Clien
 		attachedVolumeName.Insert(string(attachedVolume.Name))
 	}
 
-	if feature.Gates.Enabled(feature.MachineWaitForVolumeDetachConsiderVolumeAttachments) {
-		volumeAttachments, err := getVolumeAttachmentForNode(ctx, remoteClient, node.GetName())
-		if err != nil {
-			return nil, nil, pkgerrors.Wrap(err, "failed to list VolumeAttachments")
-		}
+	volumeAttachments, err := getVolumeAttachmentForNode(ctx, remoteClient, node.GetName())
+	if err != nil {
+		return nil, nil, pkgerrors.Wrap(err, "failed to list VolumeAttachments")
+	}
 
-		for _, va := range volumeAttachments {
-			// Return an error if a VolumeAttachments does not refer a PersistentVolume.
-			if va.Spec.Source.PersistentVolumeName == nil {
-				return nil, nil, pkgerrors.Errorf("spec.source.persistentVolumeName for VolumeAttachment %s is not set", va.GetName())
-			}
-			attachedPVNames.Insert(*va.Spec.Source.PersistentVolumeName)
+	for _, va := range volumeAttachments {
+		// Return an error if a VolumeAttachments does not refer a PersistentVolume.
+		if va.Spec.Source.PersistentVolumeName == nil {
+			return nil, nil, pkgerrors.Errorf("spec.source.persistentVolumeName for VolumeAttachment %s is not set", va.GetName())
 		}
+		attachedPVNames.Insert(*va.Spec.Source.PersistentVolumeName)
 	}
 
 	return attachedVolumeName, attachedPVNames, nil

--- a/core/reconcilers/machine/machine_controller_test.go
+++ b/core/reconcilers/machine/machine_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +47,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/core/setup"
-	"sigs.k8s.io/cluster-api/feature"
 	contractapi "sigs.k8s.io/cluster-api/internal/contract/api"
 	contractv1 "sigs.k8s.io/cluster-api/internal/contract/api/v1beta2"
 	"sigs.k8s.io/cluster-api/pkg/dynamiccache"
@@ -2316,7 +2314,6 @@ func TestShouldWaitForNodeVolumes(t *testing.T) {
 		name                     string
 		node                     *corev1.Node
 		remoteObjects            []client.Object
-		featureGateDisabled      bool
 		expected                 ctrl.Result
 		expectedDeletingReason   string
 		expectedDeletingMessage  string
@@ -2472,28 +2469,6 @@ func TestShouldWaitForNodeVolumes(t *testing.T) {
 			expectedDeletingMessage: `Waiting for Node volumes to be detached (started at 2024-10-09T16:13:59Z)
 * PersistentVolumeClaims: default/test-pvc`,
 			expectDeferNextReconcile: waitForVolumeDetachRetryInterval,
-		},
-		{
-			name: "Node has volumes attached according to volumeattachments (but ignored because feature gate is disabled)",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-				},
-				Status: corev1.NodeStatus{
-					Conditions: []corev1.NodeCondition{
-						{
-							Type:   corev1.NodeReady,
-							Status: corev1.ConditionTrue,
-						},
-					},
-				},
-			},
-			remoteObjects: []client.Object{
-				volumeAttachment,
-				persistentVolume,
-			},
-			featureGateDisabled: true,
-			expected:            ctrl.Result{},
 		},
 		{
 			name: "Node has volumes attached according to volumeattachments but without a pv",
@@ -2677,10 +2652,6 @@ func TestShouldWaitForNodeVolumes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-
-			if tt.featureGateDisabled {
-				utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachineWaitForVolumeDetachConsiderVolumeAttachments, false)
-			}
 
 			fakeClient := fake.NewClientBuilder().WithObjects(testCluster).Build()
 

--- a/docs/book/src/developer/providers/migrations/v1.14-to-v1.15.md
+++ b/docs/book/src/developer/providers/migrations/v1.14-to-v1.15.md
@@ -90,6 +90,7 @@ Any feedback or contributions to improve following documentation is welcome!
 
 ## Removals
 
+- The deprecated GA feature gate `MachineWaitForVolumeDetachConsiderVolumeAttachments` has been removed
 - The following functions and types have been removed, please use ClusterCache or inline them instead:
   - `controllers/remote.NewClusterClient`
   - `controllers/remote.RESTConfig`

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -11,11 +11,7 @@ Currently Cluster API has the following experimental features:
 * `KubeadmBootstrapFormatIgnition` (env var: `EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION`): [Ignition](./ignition.md)
 * `MachinePool` (env var: `EXP_MACHINE_POOL`): [MachinePools](./machine-pools.md)
 * `MachineSetPreflightChecks` (env var: `EXP_MACHINE_SET_PREFLIGHT_CHECKS`): [MachineSetPreflightChecks](./machineset-preflight-checks.md)
-* `MachineTaintPropagation` (env var: `EXP_MACHINE_TAINT_PROPAGATION`): [Taint propagation](../../reference/api/taint-propagation.md)
-* `MachineWaitForVolumeDetachConsiderVolumeAttachments` (env var: `EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS`):
-  * During Machine drain the Machine controller waits for volumes to be detached. Per default, the controller considers
-    `Nodes.status.volumesAttached` and `VolumesAttachments`. This feature flag allows to opt-out from considering `VolumeAttachments`.
-    The feature gate was added to allow to opt-out in case unforeseen issues occur with `VolumeAttachments`.
+* `MachineTaintPropagation` (env var: `EXP_MACHINE_TAINT_PROPAGATION`): [Taint propagation](../../reference/api/taint-propagation.md)  
 * `PriorityQueue` (env var: `EXP_PRIORITY_QUEUE`): Enables the usage of the controller-runtime PriorityQueue: https://github.com/kubernetes-sigs/controller-runtime/issues/2374
 * `ReconcilerRateLimiting` (env var: `EXP_RECONCILER_RATE_LIMITING`): Enables reconciler rate-limiting: https://github.com/kubernetes-sigs/cluster-api/issues/13005
   * Note: starting from CAPI v1.12.4 `ReconcilerRateLimiting` also requires `PriorityQueue`

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -57,15 +57,6 @@ const (
 	// beta: v1.9
 	MachineSetPreflightChecks featuregate.Feature = "MachineSetPreflightChecks"
 
-	// MachineWaitForVolumeDetachConsiderVolumeAttachments is a feature gate that controls if the Machine controller
-	// also considers VolumeAttachments in addition to Nodes.status.volumesAttached when waiting for volumes to be detached.
-	//
-	// beta: v1.9
-	// GA: v1.13
-	//
-	// Deprecated: MachineWaitForVolumeDetachConsiderVolumeAttachments feature is now GA and the corresponding feature flag will be removed in the v1.15 release.
-	MachineWaitForVolumeDetachConsiderVolumeAttachments featuregate.Feature = "MachineWaitForVolumeDetachConsiderVolumeAttachments"
-
 	// PriorityQueue is a feature gate that controls if the controller uses the controller-runtime PriorityQueue
 	// instead of the default queue implementation.
 	//
@@ -105,7 +96,6 @@ func init() {
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
-	MachineWaitForVolumeDetachConsiderVolumeAttachments: {Default: true, PreRelease: featuregate.GA},
 	PriorityQueue:                  {Default: true, PreRelease: featuregate.GA},
 	ReconcilerRateLimiting:         {Default: true, PreRelease: featuregate.GA},
 	MachinePool:                    {Default: true, PreRelease: featuregate.Beta},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #12695

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->