### PR TITLE
🌱 Stop applying kubeadm:cluster-admins CRB in KCP

### DIFF
--- a/controlplane/kubeadm/pkg/workload_cluster_rbac.go
+++ b/controlplane/kubeadm/pkg/workload_cluster_rbac.go
@@ -30,11 +30,6 @@ import (
 )
 
 const (
-	// ClusterAdminsGroupAndClusterRoleBinding is the name of the Group used for kubeadm generated cluster
-	// admin credentials and the name of the ClusterRoleBinding that binds the same Group to the "cluster-admin"
-	// built-in ClusterRole.
-	ClusterAdminsGroupAndClusterRoleBinding = "kubeadm:cluster-admins"
-
 	// KubeletAPIAdminClusterRoleBindingName is the name of the ClusterRoleBinding for the apiserver kubelet client.
 	KubeletAPIAdminClusterRoleBindingName = "kubeadm:apiserver-kubelet-client"
 
@@ -72,30 +67,6 @@ func (w *Workload) EnsureKubeadmPermissions(ctx context.Context, targetVersion s
 	// have been introduced to kubeadm, so upgrade will keep working also in case the changes are backported to older versions.
 	if version.Compare(targetVersion, semver.Version{Major: 1, Minor: 38, Patch: 0}, version.WithoutPreReleases()) >= 0 {
 		return nil
-	}
-
-	// Kubeadm added this role with K8s 1.29 when introducing
-	// a cleaner split between kubeadm:cluster-admins and system:masters.
-	// Rif https://github.com/kubernetes/kubernetes/pull/121305
-	// This change can be dropped when the min supported Kubernetes version in Cluster API >= 1.30.
-	err := w.EnsureResource(ctx, &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: ClusterAdminsGroupAndClusterRoleBinding,
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
-			Name:     "cluster-admin",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind: rbacv1.GroupKind,
-				Name: ClusterAdminsGroupAndClusterRoleBinding,
-			},
-		},
-	})
-	if err != nil {
-		return err
 	}
 
 	// Kubeadm introduced this role with K8s 1.37 when reducing

--- a/controlplane/kubeadm/pkg/workload_cluster_rbac_test.go
+++ b/controlplane/kubeadm/pkg/workload_cluster_rbac_test.go
@@ -36,28 +36,12 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 		wantObjs      []client.Object
 	}{
 		{
-			name:          "Add kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s <= 1.37",
+			name:          "Add kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s <= 1.37",
 			objs:          nil,
 			targetVersion: semver.MustParse("1.37.5"),
 			wantObjs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     "cluster-admin",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							Kind: rbacv1.GroupKind,
-							Name: ClusterAdminsGroupAndClusterRoleBinding,
-						},
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
 					},
 					RoleRef: rbacv1.RoleRef{
@@ -75,14 +59,8 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s <= 1.37 (kubeadm started adding those roles in patch versions)",
+			name: "Ignore kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s <= 1.37 (kubeadm started adding those roles in patch versions)",
 			objs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
-				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
@@ -94,25 +72,14 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			wantObjs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
 					},
 				},
 			},
 		},
 		{
-			name: "Ignore kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s >= 1.38 (kubeadm should add those roles or KCP in a previous update)",
+			name: "Ignore kubeadm:apiserver-kubelet-client ClusterRoleBinding if they already exist for K8s >= 1.38 (kubeadm should add those roles or KCP in a previous update)",
 			objs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
-				},
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
@@ -124,45 +91,24 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			wantObjs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
 					},
 				},
 			},
 		},
 		{
-			name:          "Do not add kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s >= 1.38 (this should never happen, kubeadm should add those roles or KCP in a previous update)",
+			name:          "Do not add kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s >= 1.38 (this should never happen, kubeadm should add those roles or KCP in a previous update)",
 			objs:          nil,
 			targetVersion: semver.MustParse("1.38.0"),
 			wantObjs:      nil,
 		},
 		{
-			name:          "Add both ClusterRoleBindings for K8s < 1.29 (no lower bound, applied even before kubeadm introduced them)",
+			name:          "Add kubeadm:apiserver-kubelet-client ClusterRoleBindings for K8s < 1.29 (no lower bound, applied even before kubeadm introduced them)",
 			objs:          nil,
 			targetVersion: semver.MustParse("1.28.0"),
 			wantObjs: []client.Object{
 				&rbacv1.ClusterRoleBinding{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     "cluster-admin",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							Kind: rbacv1.GroupKind,
-							Name: ClusterAdminsGroupAndClusterRoleBinding,
-						},
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: KubeletAPIAdminClusterRoleBindingName,
 					},
 					RoleRef: rbacv1.RoleRef{
@@ -180,80 +126,10 @@ func TestEnsureKubeadmPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:          "Do not add kubeadm:cluster-admins and kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s 1.38 pre-release (pre-releases are treated as >= 1.38 via WithoutPreReleases)",
+			name:          "Do not add kubeadm:apiserver-kubelet-client ClusterRoleBinding for K8s 1.38 pre-release (pre-releases are treated as >= 1.38 via WithoutPreReleases)",
 			objs:          nil,
 			targetVersion: semver.MustParse("1.38.0-beta.0"),
 			wantObjs:      nil,
-		},
-		{
-			name: "Add only kubeadm:apiserver-kubelet-client when kubeadm:cluster-admins already exists for K8s <= 1.37",
-			objs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
-				},
-			},
-			targetVersion: semver.MustParse("1.37.0"),
-			wantObjs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: KubeletAPIAdminClusterRoleBindingName,
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     KubeletAPIAdminClusterRoleName,
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							Kind: rbacv1.UserKind,
-							Name: APIServerKubeletClientCertCommonName,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Add only kubeadm:cluster-admins when kubeadm:apiserver-kubelet-client already exists for K8s <= 1.37",
-			objs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: KubeletAPIAdminClusterRoleBindingName,
-					},
-					// Intentionally using a different ClusterRoleBinding to check that it is not changed.
-				},
-			},
-			targetVersion: semver.MustParse("1.37.0"),
-			wantObjs: []client.Object{
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: KubeletAPIAdminClusterRoleBindingName,
-					},
-				},
-				&rbacv1.ClusterRoleBinding{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: ClusterAdminsGroupAndClusterRoleBinding,
-					},
-					RoleRef: rbacv1.RoleRef{
-						APIGroup: rbacv1.GroupName,
-						Kind:     "ClusterRole",
-						Name:     "cluster-admin",
-					},
-					Subjects: []rbacv1.Subject{
-						{
-							Kind: rbacv1.GroupKind,
-							Name: ClusterAdminsGroupAndClusterRoleBinding,
-						},
-					},
-				},
-			},
 		},
 	}
 

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/fakes_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/fakes_test.go
@@ -99,10 +99,6 @@ func (f *fakeWorkloadCluster) GetAPIServerCertificateExpiry(_ context.Context, _
 	return f.APIServerCertificateExpiry, nil
 }
 
-func (f *fakeWorkloadCluster) AllowClusterAdminPermissions(_ context.Context, _ semver.Version) error {
-	return nil
-}
-
 func (f *fakeWorkloadCluster) UpdateEtcdLocalInKubeadmConfigMap(bootstrapv1.LocalEtcd) func(*bootstrapv1.ClusterConfiguration) {
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Minimum supported wl cluster version in CAPI v1.15 will be v1.32

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubernetes-sigs/cluster-api/issues/8190

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->