### PR TITLE
🌱 Remove CRB clusterName migration logic

### DIFF
--- a/core/reconcilers/clusterresourcesetbinding/clusterresourcesetbinding_controller.go
+++ b/core/reconcilers/clusterresourcesetbinding/clusterresourcesetbinding_controller.go
@@ -21,8 +21,6 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -84,9 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
-	if err := r.updateClusterReference(ctx, binding); err != nil {
-		return ctrl.Result{}, err
-	}
+
 	cluster, err := util.GetClusterByName(ctx, r.Client, req.Namespace, binding.Spec.ClusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -121,57 +117,4 @@ func (r *Reconciler) clusterToClusterResourceSetBinding(_ context.Context, o cli
 			},
 		},
 	}
-}
-
-// updateClusterReference updates how the ClusterResourceSetBinding references the Cluster.
-// Before 1.4 cluster name was stored as an ownerReference. This function migrates the cluster name to the spec.clusterName and removes the Cluster OwnerReference.
-// Ref: https://github.com/kubernetes-sigs/cluster-api/issues/7669.
-func (r *Reconciler) updateClusterReference(ctx context.Context, binding *addonsv1.ClusterResourceSetBinding) error {
-	original := binding.DeepCopy()
-
-	// If the `.spec.clusterName` is not set, take the value from the ownerReference.
-	if binding.Spec.ClusterName == "" {
-		// Update the clusterName field of the existing ClusterResourceSetBindings with ownerReferences.
-		// More details please refer to: https://github.com/kubernetes-sigs/cluster-api/issues/7669.
-		clusterName, err := getClusterNameFromOwnerRef(binding.ObjectMeta)
-		if err != nil {
-			return err
-		}
-		binding.Spec.ClusterName = clusterName
-	}
-
-	// Remove the Cluster OwnerReference if it exists. This is a no-op if the OwnerReference does not exist.
-	// TODO: (killianmuldoon) This can be removed in CAPI v1beta2.
-	binding.OwnerReferences = util.RemoveOwnerRef(binding.OwnerReferences, metav1.OwnerReference{
-		APIVersion: clusterv1.GroupVersion.String(),
-		Kind:       "Cluster",
-		Name:       binding.Spec.ClusterName,
-	})
-
-	if binding.Spec.ClusterName == original.Spec.ClusterName && len(binding.OwnerReferences) == len(original.OwnerReferences) {
-		return nil
-	}
-
-	return r.Client.Patch(ctx, binding, client.MergeFrom(original))
-}
-
-func getClusterNameFromOwnerRef(obj metav1.ObjectMeta) (string, error) {
-	for _, ref := range obj.GetOwnerReferences() {
-		if ref.Kind != "Cluster" {
-			continue
-		}
-		gv, err := schema.ParseGroupVersion(ref.APIVersion)
-		if err != nil {
-			return "", pkgerrors.Wrap(err, "failed to find cluster name in ownerRefs")
-		}
-
-		if gv.Group != clusterv1.GroupVersion.Group {
-			continue
-		}
-		if ref.Name == "" {
-			return "", pkgerrors.New("failed to find cluster name in ownerRefs: ref name is empty")
-		}
-		return ref.Name, nil
-	}
-	return "", pkgerrors.New("failed to find cluster name in ownerRefs: no cluster ownerRef")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8190

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->