### PR TITLE
🌱 Avoid unnecessary memory allocation in ssa.Patch after cache hit

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers.go
@@ -293,7 +293,7 @@ func (r *Reconciler) updateLabelsAndAnnotations(ctx context.Context, obj client.
 	updatedObject.SetLabels(desiredstate.ControlPlaneMachineLabels(kcp, cluster.Name))
 	updatedObject.SetAnnotations(desiredstate.ControlPlaneMachineAnnotations(kcp))
 
-	return ssa.Patch(ctx, r.Client, kcpMetadataManagerName, updatedObject, ssa.WithCachingProxy{Cache: r.ssaCache, Original: obj})
+	return ssa.Patch(ctx, r.Client, kcpMetadataManagerName, updatedObject, ssa.WithCachingProxy{Cache: r.ssaCache, Original: obj, SkipUpdateModifiedOnCacheHit: true})
 }
 
 func (r *Reconciler) createMachine(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, machine *clusterv1.Machine) error {

--- a/core/reconcilers/machineset/machineset_controller.go
+++ b/core/reconcilers/machineset/machineset_controller.go
@@ -1344,7 +1344,7 @@ func (r *Reconciler) updateLabelsAndAnnotations(ctx context.Context, c ssa.Write
 	updatedObject.SetLabels(machineLabelsFromMachineSet(machineSet))
 	updatedObject.SetAnnotations(machineAnnotationsFromMachineSet(machineSet))
 
-	return ssa.Patch(ctx, c, machineSetMetadataManagerName, updatedObject, ssa.WithCachingProxy{Cache: r.ssaCache, Original: obj})
+	return ssa.Patch(ctx, c, machineSetMetadataManagerName, updatedObject, ssa.WithCachingProxy{Cache: r.ssaCache, Original: obj, SkipUpdateModifiedOnCacheHit: true})
 }
 
 func (r *Reconciler) getOwnerMachineDeployment(ctx context.Context, machineSet *clusterv1.MachineSet) (*clusterv1.MachineDeployment, error) {

--- a/internal/util/ssa/patch.go
+++ b/internal/util/ssa/patch.go
@@ -47,9 +47,12 @@ func (w WithDryRun) ApplyToOptions(in *Options) {
 // The original and modified object will be used to generate an
 // identifier for the request.
 // The cache will be used to cache the result of the request.
+// In some cases we never read the modified object after ssa.Patch, so
+// SkipUpdateModifiedOnCacheHit allows to avoid unnecessary memory allocations.
 type WithCachingProxy struct {
-	Cache    Cache
-	Original client.Object
+	Cache                        Cache
+	Original                     client.Object
+	SkipUpdateModifiedOnCacheHit bool
 }
 
 // ApplyToOptions applies WithCachingProxy to the given Options.
@@ -57,14 +60,16 @@ func (w WithCachingProxy) ApplyToOptions(in *Options) {
 	in.WithCachingProxy = true
 	in.Cache = w.Cache
 	in.Original = w.Original
+	in.SkipUpdateModifiedOnCacheHit = w.SkipUpdateModifiedOnCacheHit
 }
 
 // Options contains the options for the Patch func.
 type Options struct {
-	WithDryRun       bool
-	WithCachingProxy bool
-	Cache            Cache
-	Original         client.Object
+	WithDryRun                   bool
+	WithCachingProxy             bool
+	Cache                        Cache
+	SkipUpdateModifiedOnCacheHit bool
+	Original                     client.Object
 }
 
 // Patch executes an SSA patch.
@@ -101,6 +106,11 @@ func Patch(ctx context.Context, c WriterWithScheme, fieldManager string, modifie
 		if options.Cache.Has(requestIdentifier, gvk.Kind) {
 			// Refresh the cache entry so we don't have to execute the Apply again after the cache TTL.
 			options.Cache.Add(requestIdentifier)
+
+			// In some cases we never read the modified object after ssa.Patch, so let's avoid unnecessary memory allocations.
+			if options.SkipUpdateModifiedOnCacheHit {
+				return nil
+			}
 
 			// If the request is cached return the original object.
 			if err := c.Scheme().Convert(options.Original, modified, ctx); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Around 4-5% of our memory allocation in core CAPI at stable state is just updating modified after a cache hit in ssa.Patch. We don't need that as we never read the updatedObject after ssa.Patch

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13305

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->