### PR TITLE
🐛 Convert CAPI resources in generic Lists

### DIFF
--- a/cmd/clusterctl/client/convert/convert.go
+++ b/cmd/clusterctl/client/convert/convert.go
@@ -19,8 +19,10 @@ package convert
 
 import (
 	pkgerrors "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
 )
@@ -73,6 +75,16 @@ func (c *Converter) Convert(input []byte, toVersion string) (Result, error) {
 	var converted, passedThrough int
 	for i := range docs {
 		doc := &docs[i]
+		if isGenericList(doc.gvk) {
+			docConverted, docPassedThrough, err := c.convertGenericList(doc, targetGV)
+			if err != nil {
+				return Result{}, err
+			}
+			converted += docConverted
+			passedThrough += docPassedThrough
+			continue
+		}
+
 		if !doc.convertible {
 			passedThrough++
 			continue
@@ -96,4 +108,55 @@ func (c *Converter) Convert(input []byte, toVersion string) (Result, error) {
 		Converted:     converted,
 		PassedThrough: passedThrough,
 	}, nil
+}
+
+func (c *Converter) convertGenericList(doc *document, targetGV schema.GroupVersion) (int, int, error) {
+	obj, ok := doc.object.(*unstructured.Unstructured)
+	if !ok {
+		return 0, 0, pkgerrors.Errorf("failed to convert List at index %d: expected unstructured object, got %T", doc.index, doc.object)
+	}
+	list, err := obj.ToList()
+	if err != nil {
+		return 0, 0, pkgerrors.Wrapf(err, "failed to decode List at index %d", doc.index)
+	}
+
+	typedDecoder := serializer.NewCodecFactory(c.scheme).UniversalDeserializer()
+	items := make([]interface{}, len(list.Items))
+	var converted, passedThrough int
+	for i := range list.Items {
+		gvk := list.Items[i].GroupVersionKind()
+		if !c.sourceGVs[gvk.GroupVersion()] {
+			items[i] = list.Items[i].Object
+			passedThrough++
+			continue
+		}
+
+		rawItem, err := list.Items[i].MarshalJSON()
+		if err != nil {
+			return 0, 0, pkgerrors.Wrapf(err, "failed to marshal List item at index %d", i)
+		}
+		item := runtime.Object(&list.Items[i])
+		if typedItem, _, decodeErr := typedDecoder.Decode(rawItem, &gvk, nil); decodeErr == nil {
+			item = typedItem
+		}
+		convertedItem, err := convertResource(item, targetGV, c.scheme)
+		if err != nil {
+			return 0, 0, pkgerrors.Wrapf(err, "failed to convert List item %s at index %d", gvk.String(), i)
+		}
+		items[i], err = runtime.DefaultUnstructuredConverter.ToUnstructured(convertedItem)
+		if err != nil {
+			return 0, 0, pkgerrors.Wrapf(err, "failed to serialize List item at index %d", i)
+		}
+		converted++
+	}
+
+	if converted == 0 {
+		return 0, 1, nil
+	}
+	obj.Object["items"] = items
+	return converted, passedThrough, nil
+}
+
+func isGenericList(gvk schema.GroupVersionKind) bool {
+	return gvk.Group == "" && gvk.Version == "v1" && gvk.Kind == "List"
 }

--- a/cmd/clusterctl/client/convert/convert_test.go
+++ b/cmd/clusterctl/client/convert/convert_test.go
@@ -27,11 +27,14 @@ import (
 
 func TestConverter_Convert(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		toVersion   string
-		wantErr     bool
-		wantV1Beta2 bool
+		name          string
+		input         string
+		toVersion     string
+		wantErr       bool
+		wantV1Beta2   bool
+		wantConverted int
+		wantPassed    int
+		wantList      bool
 	}{
 		{
 			name: "convert v1beta1 cluster to v1beta2",
@@ -46,8 +49,10 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
 `,
-			toVersion:   "v1beta2",
-			wantV1Beta2: true,
+			toVersion:     "v1beta2",
+			wantV1Beta2:   true,
+			wantConverted: 1,
+			wantPassed:    0,
 		},
 		{
 			name: "pass through v1beta2 cluster unchanged",
@@ -62,7 +67,9 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
 `,
-			toVersion: "v1beta2",
+			toVersion:     "v1beta2",
+			wantConverted: 0,
+			wantPassed:    1,
 		},
 		{
 			name: "pass through non-CAPI resource",
@@ -74,7 +81,9 @@ metadata:
 data:
   key: value
 `,
-			toVersion: "v1beta2",
+			toVersion:     "v1beta2",
+			wantConverted: 0,
+			wantPassed:    1,
 		},
 		{
 			name: "convert multi-document YAML",
@@ -90,8 +99,30 @@ metadata:
   name: test-machine
   namespace: default
 `,
-			toVersion:   "v1beta2",
-			wantV1Beta2: true,
+			toVersion:     "v1beta2",
+			wantV1Beta2:   true,
+			wantConverted: 2,
+			wantPassed:    0,
+		},
+		{
+			name: "convert resources in generic List",
+			input: `apiVersion: v1
+kind: List
+items:
+- apiVersion: cluster.x-k8s.io/v1beta1
+  kind: Cluster
+  metadata:
+    name: test-cluster
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: test-config
+`,
+			toVersion:     "v1beta2",
+			wantV1Beta2:   true,
+			wantConverted: 1,
+			wantPassed:    1,
+			wantList:      true,
 		},
 		{
 			name: "invalid YAML",
@@ -117,10 +148,14 @@ kind: Cluster
 			}
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(result.Output).ToNot(BeEmpty())
+			g.Expect(result.Converted).To(Equal(tt.wantConverted))
+			g.Expect(result.PassedThrough).To(Equal(tt.wantPassed))
 
 			if tt.wantV1Beta2 {
 				g.Expect(string(result.Output)).To(ContainSubstring("cluster.x-k8s.io/v1beta2"))
-				g.Expect(result.Converted).To(BeNumerically(">", 0))
+			}
+			if tt.wantList {
+				g.Expect(string(result.Output)).To(ContainSubstring("kind: List"))
 			}
 		})
 	}


### PR DESCRIPTION
What this PR does / why we need it:

`clusterctl convert` treated a generic `v1/List` as one non CAPI object. CAPI resources under `items` stayed on `v1beta1`

This sends List items through the existing converter and keeps the List wrapper and metadata

Repro:

```sh
kubectl get clusters,machines -A -o yaml | clusterctl convert
```

Before this reports `Converted 0 resource(s)`. Now nested resources are converted and counted

Which issue(s) this PR fixes:

None. Related to #12716.

/area clusterctl
