### PR TITLE
:book: add weekly-* workflow cleanup to post-release steps

### DIFF
--- a/docs/release/role-handbooks/ci-signal/README.md
+++ b/docs/release/role-handbooks/ci-signal/README.md
@@ -91,7 +91,13 @@ To reduce the amount of flakes please periodically:
 ### Post-release cleanup
 Once the new minor release (e.g., `v1.8.0`) has been officially cut, perform the following cleanup:
 
-- Remove old release branches and unused versions from the `cluster-api-prowjob-gen.yaml` file in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/) according to our policy documented in [Support and guarantees](https://cluster-api.sigs.k8s.io/reference/versions#cluster-api-release-support)
+1. In [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api/), remove old release branches and unused versions from the `cluster-api-prowjob-gen.yaml` file according to our policy documented in [Support and guarantees](https://cluster-api.sigs.k8s.io/reference/versions#cluster-api-release-support).
 
-We can now drop test coverage for branches out of support (e.g. `release-1.5`).
+   We can now drop test coverage for branches out of support (e.g. `release-1.5`).
+
+2. Drop the oldest release branch from the `matrix.branch` list in each of the three `weekly-.*` GitHub Actions workflow files, keeping only `main` and the two most-recent supported release branches:
+
+   - `.github/workflows/weekly-md-link-check.yaml`
+   - `.github/workflows/weekly-security-scan.yaml`
+   - `.github/workflows/weekly-test-release.yaml`
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

The post-release cleanup section only mentioned updating ProwJobs in test-infra. Add a second step to drop the oldest release branch `weekly-.*` GitHub Actions workflows in this repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->