### PR TITLE
🐛 Watch webhook certificates directly from Secrets

### DIFF
--- a/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
@@ -12,11 +12,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          secretName: capi-kubeadm-bootstrap-webhook-service-cert

--- a/bootstrap/kubeadm/config/manager/manager.yaml
+++ b/bootstrap/kubeadm/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+            - "--webhook-cert-secret-name=capi-kubeadm-bootstrap-webhook-service-cert"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true}"
             - "--bootstrap-token-ttl=${KUBEADM_BOOTSTRAP_TOKEN_TTL:=15m}"
           image: controller:latest

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
+	"slices"
 	"time"
 
 	"github.com/spf13/pflag"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -52,6 +54,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/crdmigrator"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/feature"
+	secretcertwatcher "sigs.k8s.io/cluster-api/pkg/certwatcher"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
@@ -82,6 +85,7 @@ var (
 	webhookKeyName              string
 	healthAddr                  string
 	managerOptions              = flags.ManagerOptions{}
+	webhookCertificateOptions   = flags.WebhookCertificateOptions{}
 	logOptions                  = logs.NewOptions()
 	// CABPK specific flags.
 	clusterCacheConcurrency  int
@@ -169,6 +173,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"The address the health endpoint binds to.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
+	flags.AddWebhookCertificateOptions(fs, &webhookCertificateOptions)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -220,6 +225,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	webhookTLSOptions := slices.Clone(tlsOptions)
+	var webhookCertificateWatcher *secretcertwatcher.Watcher
+	if webhookCertificateOptions.SecretName != "" {
+		webhookCertificateWatcher, err = secretcertwatcher.New(ctx, restConfig, types.NamespacedName{
+			Namespace: webhookCertificateOptions.SecretNamespace,
+			Name:      webhookCertificateOptions.SecretName,
+		})
+		if err != nil {
+			setupLog.Error(err, "Unable to start manager")
+			os.Exit(1)
+		}
+		webhookTLSOptions = append(webhookTLSOptions, webhookCertificateWatcher.TLSConfig)
+	}
+
 	if enableContentionProfiling {
 		goruntime.SetBlockProfileRate(1)
 	}
@@ -249,7 +271,7 @@ func main() {
 				CertDir:  webhookCertDir,
 				CertName: webhookCertName,
 				KeyName:  webhookKeyName,
-				TLSOpts:  tlsOptions,
+				TLSOpts:  webhookTLSOptions,
 			},
 		),
 	}
@@ -260,8 +282,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup the context that's going to be used in controllers and for the manager.
-	ctx := ctrl.SetupSignalHandler()
+	if webhookCertificateWatcher != nil {
+		if err := mgr.Add(webhookCertificateWatcher); err != nil {
+			setupLog.Error(err, "Unable to add webhook certificate Secret watcher to manager")
+			os.Exit(1)
+		}
+	}
 
 	setupChecks(mgr)
 	setupWebhooks(mgr)

--- a/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
@@ -12,11 +12,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          secretName: capi-kubeadm-control-plane-webhook-service-cert

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -22,6 +22,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+            - "--webhook-cert-secret-name=capi-kubeadm-control-plane-webhook-service-cert"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=false}"
           image: controller:latest
           name: manager

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
+	"slices"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -32,6 +33,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -68,6 +70,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/contract"
 	internalruntimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	secretcertwatcher "sigs.k8s.io/cluster-api/pkg/certwatcher"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/version"
@@ -101,6 +104,7 @@ var (
 	runtimeExtensionKeyFile     string
 	healthAddr                  string
 	managerOptions              = flags.ManagerOptions{}
+	webhookCertificateOptions   = flags.WebhookCertificateOptions{}
 	logOptions                  = logs.NewOptions()
 	// KCP specific flags.
 	remoteConditionsGracePeriod    time.Duration
@@ -212,6 +216,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Logging level for etcd client. Possible values are: debug, info, warn, error, dpanic, panic, fatal.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
+	flags.AddWebhookCertificateOptions(fs, &webhookCertificateOptions)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -273,6 +278,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	webhookTLSOptions := slices.Clone(tlsOptions)
+	var webhookCertificateWatcher *secretcertwatcher.Watcher
+	if webhookCertificateOptions.SecretName != "" {
+		webhookCertificateWatcher, err = secretcertwatcher.New(ctx, restConfig, types.NamespacedName{
+			Namespace: webhookCertificateOptions.SecretNamespace,
+			Name:      webhookCertificateOptions.SecretName,
+		})
+		if err != nil {
+			setupLog.Error(err, "Unable to start manager")
+			os.Exit(1)
+		}
+		webhookTLSOptions = append(webhookTLSOptions, webhookCertificateWatcher.TLSConfig)
+	}
+
 	if enableContentionProfiling {
 		goruntime.SetBlockProfileRate(1)
 	}
@@ -302,7 +324,7 @@ func main() {
 				CertDir:  webhookCertDir,
 				CertName: webhookCertName,
 				KeyName:  webhookKeyName,
-				TLSOpts:  tlsOptions,
+				TLSOpts:  webhookTLSOptions,
 			},
 		),
 	}
@@ -313,8 +335,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup the context that's going to be used in controllers and for the manager.
-	ctx := ctrl.SetupSignalHandler()
+	if webhookCertificateWatcher != nil {
+		if err := mgr.Add(webhookCertificateWatcher); err != nil {
+			setupLog.Error(err, "Unable to add webhook certificate Secret watcher to manager")
+			os.Exit(1)
+		}
+	}
 
 	setupChecks(mgr)
 	setupReconcilers(ctx, mgr)

--- a/core/config/default/manager_webhook_patch.yaml
+++ b/core/config/default/manager_webhook_patch.yaml
@@ -12,11 +12,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          secretName: capi-webhook-service-cert

--- a/core/config/manager/manager.yaml
+++ b/core/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
             - "--leader-elect"
             - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
             - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+            - "--webhook-cert-secret-name=capi-webhook-service-cert"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true},InPlaceUpdates=${EXP_IN_PLACE_UPDATES:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=false}"
           image: controller:latest
           name: manager

--- a/core/main.go
+++ b/core/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"regexp"
 	goruntime "runtime"
+	"slices"
 	"time"
 
 	pkgerrors "github.com/pkg/errors"
@@ -34,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -87,6 +89,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/contract"
 	internalruntimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	secretcertwatcher "sigs.k8s.io/cluster-api/pkg/certwatcher"
 	"sigs.k8s.io/cluster-api/util/apiwarnings"
 	"sigs.k8s.io/cluster-api/util/flags"
 	"sigs.k8s.io/cluster-api/util/index"
@@ -121,6 +124,7 @@ var (
 	runtimeExtensionKeyFile     string
 	healthAddr                  string
 	managerOptions              = flags.ManagerOptions{}
+	webhookCertificateOptions   = flags.WebhookCertificateOptions{}
 	logOptions                  = logs.NewOptions()
 	// core Cluster API specific flags.
 	remoteConnectionGracePeriod      time.Duration
@@ -286,6 +290,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"List of regexes to select an additional set of labels to sync from a Machine to its associated Node. An annotation will be synced as long as it matches at least one of the regexes.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
+	flags.AddWebhookCertificateOptions(fs, &webhookCertificateOptions)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -362,6 +367,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	webhookTLSOptions := slices.Clone(tlsOptions)
+	var webhookCertificateWatcher *secretcertwatcher.Watcher
+	if webhookCertificateOptions.SecretName != "" {
+		webhookCertificateWatcher, err = secretcertwatcher.New(ctx, restConfig, types.NamespacedName{
+			Namespace: webhookCertificateOptions.SecretNamespace,
+			Name:      webhookCertificateOptions.SecretName,
+		})
+		if err != nil {
+			setupLog.Error(err, "Unable to start manager")
+			os.Exit(1)
+		}
+		webhookTLSOptions = append(webhookTLSOptions, webhookCertificateWatcher.TLSConfig)
+	}
+
 	if enableContentionProfiling {
 		goruntime.SetBlockProfileRate(1)
 	}
@@ -391,7 +413,7 @@ func main() {
 				CertDir:  webhookCertDir,
 				CertName: webhookCertName,
 				KeyName:  webhookKeyName,
-				TLSOpts:  tlsOptions,
+				TLSOpts:  webhookTLSOptions,
 			},
 		),
 	}
@@ -402,8 +424,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup the context that's going to be used in controllers and for the manager.
-	ctx := ctrl.SetupSignalHandler()
+	if webhookCertificateWatcher != nil {
+		if err := mgr.Add(webhookCertificateWatcher); err != nil {
+			setupLog.Error(err, "Unable to add webhook certificate Secret watcher to manager")
+			os.Exit(1)
+		}
+	}
 
 	setupChecks(mgr)
 	setupIndexes(ctx, mgr)

--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package certwatcher provides a Secret-backed TLS certificate watcher.
+package certwatcher
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Watcher watches a single Secret and exposes its current TLS certificate.
+// Invalid updates do not replace the last valid certificate.
+type Watcher struct {
+	secretKey   types.NamespacedName
+	informer    toolscache.SharedIndexInformer
+	currentCert atomic.Pointer[tls.Certificate]
+}
+
+// New creates a Watcher for a TLS Secret. It reads and validates the current
+// certificate before returning so GetCertificate is ready before the webhook
+// server starts.
+func New(ctx context.Context, config *rest.Config, secretKey types.NamespacedName) (*Watcher, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client for webhook certificate Secret: %w", err)
+	}
+	return newWithClient(ctx, client, secretKey)
+}
+
+func newWithClient(ctx context.Context, client kubernetes.Interface, secretKey types.NamespacedName) (*Watcher, error) {
+	if secretKey.Namespace == "" || secretKey.Name == "" {
+		return nil, fmt.Errorf("webhook certificate Secret namespace and name must be set")
+	}
+
+	secret, err := client.CoreV1().Secrets(secretKey.Namespace).Get(ctx, secretKey.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get webhook certificate Secret %s: %w", secretKey, err)
+	}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		0,
+		informers.WithNamespace(secretKey.Namespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", secretKey.Name).String()
+		}),
+	)
+	w := &Watcher{
+		secretKey: secretKey,
+		informer:  factory.Core().V1().Secrets().Informer(),
+	}
+	if err := w.updateCertificate(secret); err != nil {
+		return nil, err
+	}
+
+	if _, err := w.informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			w.handleUpdate(obj)
+		},
+		UpdateFunc: func(_, newObj any) {
+			w.handleUpdate(newObj)
+		},
+		DeleteFunc: func(obj any) {
+			w.handleDelete(obj)
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add event handler for webhook certificate Secret %s: %w", secretKey, err)
+	}
+
+	return w, nil
+}
+
+// GetCertificate returns the latest valid certificate loaded from the Secret.
+func (w *Watcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	certificate := w.currentCert.Load()
+	if certificate == nil {
+		return nil, fmt.Errorf("webhook certificate Secret %s has not been loaded", w.secretKey)
+	}
+	return certificate, nil
+}
+
+// TLSConfig sets GetCertificate on a TLS config.
+func (w *Watcher) TLSConfig(config *tls.Config) {
+	config.GetCertificate = w.GetCertificate
+}
+
+// Start starts watching the Secret until the context is canceled.
+func (w *Watcher) Start(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx).WithValues("Secret", klog.KRef(w.secretKey.Namespace, w.secretKey.Name))
+	log.Info("Starting webhook certificate Secret watcher")
+	w.informer.RunWithContext(ctx)
+	return nil
+}
+
+// NeedLeaderElection indicates that the Watcher should run on every replica.
+func (*Watcher) NeedLeaderElection() bool {
+	return false
+}
+
+func (w *Watcher) handleUpdate(obj any) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret.Namespace != w.secretKey.Namespace || secret.Name != w.secretKey.Name {
+		return
+	}
+
+	if err := w.updateCertificate(secret); err != nil {
+		ctrl.Log.WithName("certwatcher").Error(err, "Failed to update webhook certificate; continuing to use the last valid certificate",
+			"Secret", klog.KRef(w.secretKey.Namespace, w.secretKey.Name))
+	}
+}
+
+func (w *Watcher) handleDelete(obj any) {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		if tombstone, tombstoneOK := obj.(toolscache.DeletedFinalStateUnknown); tombstoneOK {
+			secret, ok = tombstone.Obj.(*corev1.Secret)
+		}
+	}
+	if !ok || secret.Namespace != w.secretKey.Namespace || secret.Name != w.secretKey.Name {
+		return
+	}
+
+	ctrl.Log.WithName("certwatcher").Info("Webhook certificate Secret was deleted; continuing to use the last valid certificate",
+		"Secret", klog.KRef(w.secretKey.Namespace, w.secretKey.Name))
+}
+
+func (w *Watcher) updateCertificate(secret *corev1.Secret) error {
+	certPEM, ok := secret.Data[corev1.TLSCertKey]
+	if !ok {
+		return fmt.Errorf("webhook certificate Secret %s does not contain %q", w.secretKey, corev1.TLSCertKey)
+	}
+	keyPEM, ok := secret.Data[corev1.TLSPrivateKeyKey]
+	if !ok {
+		return fmt.Errorf("webhook certificate Secret %s does not contain %q", w.secretKey, corev1.TLSPrivateKeyKey)
+	}
+
+	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return fmt.Errorf("failed to load certificate from webhook certificate Secret %s: %w", w.secretKey, err)
+	}
+	w.currentCert.Store(&certificate)
+	return nil
+}
+
+var _ manager.LeaderElectionRunnable = &Watcher{}

--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certwatcher
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/admission/plugin/webhook/testcerts"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNew(t *testing.T) {
+	secretKey := types.NamespacedName{Namespace: "test", Name: "webhook-cert"}
+
+	t.Run("loads the initial certificate", func(t *testing.T) {
+		g := NewWithT(t)
+		client := fake.NewSimpleClientset(newTLSSecret(secretKey, testcerts.ServerCert, testcerts.ServerKey))
+
+		watcher, err := newWithClient(t.Context(), client, secretKey)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		certificate, err := watcher.GetCertificate(nil)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(certificate.Certificate).ToNot(BeEmpty())
+
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		watcher.TLSConfig(tlsConfig)
+		g.Expect(tlsConfig.GetCertificate).ToNot(BeNil())
+		certificate, err = tlsConfig.GetCertificate(nil)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(certificate.Certificate).ToNot(BeEmpty())
+	})
+
+	for name, key := range map[string]types.NamespacedName{
+		"requires a Secret name":      {Namespace: "test"},
+		"requires a Secret namespace": {Name: "webhook-cert"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := newWithClient(t.Context(), fake.NewSimpleClientset(), key)
+			g.Expect(err).To(MatchError("webhook certificate Secret namespace and name must be set"))
+		})
+	}
+
+	t.Run("fails if the Secret does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		_, err := newWithClient(t.Context(), fake.NewSimpleClientset(), secretKey)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("fails if the initial certificate is invalid", func(t *testing.T) {
+		g := NewWithT(t)
+		client := fake.NewSimpleClientset(newTLSSecret(secretKey, []byte("invalid"), []byte("invalid")))
+		_, err := newWithClient(t.Context(), client, secretKey)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	for name, secret := range map[string]*corev1.Secret{
+		"fails if the Secret has no certificate": {
+			ObjectMeta: metav1.ObjectMeta{Namespace: secretKey.Namespace, Name: secretKey.Name},
+			Data:       map[string][]byte{corev1.TLSPrivateKeyKey: testcerts.ServerKey},
+		},
+		"fails if the Secret has no private key": {
+			ObjectMeta: metav1.ObjectMeta{Namespace: secretKey.Namespace, Name: secretKey.Name},
+			Data:       map[string][]byte{corev1.TLSCertKey: testcerts.ServerCert},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := newWithClient(t.Context(), fake.NewSimpleClientset(secret), secretKey)
+			g.Expect(err).To(HaveOccurred())
+		})
+	}
+}
+
+func TestWatcher(t *testing.T) {
+	g := NewWithT(t)
+	secretKey := types.NamespacedName{Namespace: "test", Name: "webhook-cert"}
+	client := fake.NewSimpleClientset(newTLSSecret(secretKey, testcerts.ServerCert, testcerts.ServerKey))
+	watcher, err := newWithClient(t.Context(), client, secretKey)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = watcher.Start(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		g.Eventually(done, 5*time.Second).Should(BeClosed())
+	})
+
+	initialCertificate, err := watcher.GetCertificate(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	updatedSecret := newTLSSecret(secretKey, testcerts.ClientCert, testcerts.ClientKey)
+	_, err = client.CoreV1().Secrets(secretKey.Namespace).Update(t.Context(), updatedSecret, metav1.UpdateOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Eventually(func() bool {
+		certificate, err := watcher.GetCertificate(nil)
+		return err == nil && !bytes.Equal(certificate.Certificate[0], initialCertificate.Certificate[0])
+	}, 5*time.Second).Should(BeTrue())
+
+	validCertificate, err := watcher.GetCertificate(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+	invalidSecret := newTLSSecret(secretKey, []byte("invalid"), []byte("invalid"))
+	_, err = client.CoreV1().Secrets(secretKey.Namespace).Update(t.Context(), invalidSecret, metav1.UpdateOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Consistently(func() bool {
+		certificate, err := watcher.GetCertificate(nil)
+		return err == nil && bytes.Equal(certificate.Certificate[0], validCertificate.Certificate[0])
+	}, time.Second).Should(BeTrue())
+
+	restoredSecret := newTLSSecret(secretKey, testcerts.ServerCert, testcerts.ServerKey)
+	_, err = client.CoreV1().Secrets(secretKey.Namespace).Update(t.Context(), restoredSecret, metav1.UpdateOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Eventually(func() bool {
+		certificate, err := watcher.GetCertificate(nil)
+		return err == nil && bytes.Equal(certificate.Certificate[0], initialCertificate.Certificate[0])
+	}, 5*time.Second).Should(BeTrue())
+
+	restoredCertificate, err := watcher.GetCertificate(nil)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(client.CoreV1().Secrets(secretKey.Namespace).Delete(t.Context(), secretKey.Name, metav1.DeleteOptions{})).To(Succeed())
+	g.Consistently(func() bool {
+		certificate, err := watcher.GetCertificate(nil)
+		return err == nil && bytes.Equal(certificate.Certificate[0], restoredCertificate.Certificate[0])
+	}, time.Second).Should(BeTrue())
+}
+
+func newTLSSecret(secretKey types.NamespacedName, cert, key []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretKey.Namespace,
+			Name:      secretKey.Name,
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       cert,
+			corev1.TLSPrivateKeyKey: key,
+		},
+	}
+}
+
+var _ func(*tls.ClientHelloInfo) (*tls.Certificate, error) = (&Watcher{}).GetCertificate

--- a/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
@@ -12,12 +12,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      volumes:
-      - name: cert
-        secret:
-          secretName: capd-webhook-service-cert # this secret will not be prefixed, since it's not managed by kustomize
-

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
         - "--leader-elect"
         - "--diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}"
         - "--insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}"
+        - "--webhook-cert-secret-name=capd-webhook-service-cert"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},PriorityQueue=${EXP_PRIORITY_QUEUE:=true},ReconcilerRateLimiting=${EXP_RECONCILER_RATE_LIMITING:=true}"
         image: controller:latest
         name: manager

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
+	"slices"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -56,6 +58,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/crdmigrator"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/feature"
+	secretcertwatcher "sigs.k8s.io/cluster-api/pkg/certwatcher"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	infrav1beta1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta2"
@@ -94,6 +97,7 @@ var (
 	webhookKeyName              string
 	healthAddr                  string
 	managerOptions              = flags.ManagerOptions{}
+	webhookCertificateOptions   = flags.WebhookCertificateOptions{}
 	logOptions                  = logs.NewOptions()
 	// CAPD specific flags.
 	devMachineConcurrency         int
@@ -198,6 +202,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"The address the health endpoint binds to.")
 
 	flags.AddManagerOptions(fs, &managerOptions)
+	flags.AddWebhookCertificateOptions(fs, &webhookCertificateOptions)
 
 	feature.MutableGates.AddFlag(fs)
 }
@@ -251,6 +256,23 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "Unable to start manager: invalid flags")
 		os.Exit(1)
+	}
+
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	webhookTLSOptions := slices.Clone(tlsOptions)
+	var webhookCertificateWatcher *secretcertwatcher.Watcher
+	if webhookCertificateOptions.SecretName != "" {
+		webhookCertificateWatcher, err = secretcertwatcher.New(ctx, restConfig, types.NamespacedName{
+			Namespace: webhookCertificateOptions.SecretNamespace,
+			Name:      webhookCertificateOptions.SecretName,
+		})
+		if err != nil {
+			setupLog.Error(err, "Unable to start manager")
+			os.Exit(1)
+		}
+		webhookTLSOptions = append(webhookTLSOptions, webhookCertificateWatcher.TLSConfig)
 	}
 
 	var watchNamespaces map[string]ctrlcache.Config
@@ -312,7 +334,7 @@ func main() {
 				CertDir:  webhookCertDir,
 				CertName: webhookCertName,
 				KeyName:  webhookKeyName,
-				TLSOpts:  tlsOptions,
+				TLSOpts:  webhookTLSOptions,
 			},
 		),
 	}
@@ -323,8 +345,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup the context that's going to be used in controllers and for the manager.
-	ctx := ctrl.SetupSignalHandler()
+	if webhookCertificateWatcher != nil {
+		if err := mgr.Add(webhookCertificateWatcher); err != nil {
+			setupLog.Error(err, "Unable to add webhook certificate Secret watcher to manager")
+			os.Exit(1)
+		}
+	}
 
 	setupChecks(mgr)
 	setupReconcilers(ctx, mgr)

--- a/util/flags/manager.go
+++ b/util/flags/manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -55,6 +56,15 @@ type ManagerOptions struct {
 	InsecureDiagnostics bool
 }
 
+// WebhookCertificateOptions provides command line flags for loading a webhook certificate from a Secret.
+type WebhookCertificateOptions struct {
+	// SecretName is the name of the Secret containing the webhook certificate.
+	// If it is empty, the webhook server reads its certificate from the configured files.
+	SecretName string
+	// SecretNamespace is the namespace of the Secret containing the webhook certificate.
+	SecretNamespace string
+}
+
 // AddManagerOptions adds the manager options flags to the flag set.
 func AddManagerOptions(fs *pflag.FlagSet, options *ManagerOptions) {
 	fs.StringVar(&options.TLSMinVersion, "tls-min-version", "VersionTLS12",
@@ -77,6 +87,14 @@ func AddManagerOptions(fs *pflag.FlagSet, options *ManagerOptions) {
 
 	fs.BoolVar(&options.InsecureDiagnostics, "insecure-diagnostics", false,
 		"Enable insecure diagnostics serving. For more details see the description of --diagnostics-address.")
+}
+
+// AddWebhookCertificateOptions adds webhook certificate Secret flags to the flag set.
+func AddWebhookCertificateOptions(fs *pflag.FlagSet, options *WebhookCertificateOptions) {
+	fs.StringVar(&options.SecretName, "webhook-cert-secret-name", "",
+		"Name of the Secret containing the webhook server certificate. If set, the Secret is watched directly instead of reading the certificate from files.")
+	fs.StringVar(&options.SecretNamespace, "webhook-cert-secret-namespace", os.Getenv("POD_NAMESPACE"),
+		"Namespace of the Secret containing the webhook server certificate. Defaults to the POD_NAMESPACE environment variable.")
 }
 
 // GetManagerOptions returns options which can be used to configure a Manager.

--- a/util/flags/manager_test.go
+++ b/util/flags/manager_test.go
@@ -23,11 +23,25 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 	"k8s.io/apiserver/pkg/server/routes"
 	"k8s.io/component-base/logs"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
+
+func TestAddWebhookCertificateOptions(t *testing.T) {
+	g := NewWithT(t)
+	t.Setenv("POD_NAMESPACE", "capi-system")
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	options := WebhookCertificateOptions{}
+	AddWebhookCertificateOptions(fs, &options)
+
+	g.Expect(fs.Parse([]string{"--webhook-cert-secret-name=webhook-cert"})).To(Succeed())
+	g.Expect(options.SecretName).To(Equal("webhook-cert"))
+	g.Expect(options.SecretNamespace).To(Equal("capi-system"))
+}
 
 func TestGetManagerOptions(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Watches webhook serving certificates directly from their Secrets in the core, kubeadm bootstrap, kubeadm control plane, and Docker infrastructure managers. This removes the projected-volume refresh delay during certificate rotation. Invalid updates and Secret deletion keep the last valid certificate available, while the existing file-based path remains available when the Secret flags are not set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10522
