### PR TITLE
📖 Fix removed migration guide links

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -12,6 +12,8 @@ additional-css = ["theme/css/custom.css"]
 
 [output.html.redirect]
 "/tasks/upgrade.html" = "/tasks/upgrading-cluster-api-versions.html"
+"/developer/providers/migrations/v1.10-to-v1.11.html" = "https://release-1-11.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11"
+"/developer/providers/migrations/v1.11-to-v1.12.html" = "https://release-1-12.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.11-to-v1.12"
 "/agenda.html" = "/agenda/2026.html"
 "/agenda/2026.html" = "https://docs.google.com/document/d/1fKOcbdlRNlpsVViv2cyKNv3HUHxpf-C4EIZVStsfTT0"
 "/agenda/2025.html" = "https://docs.google.com/document/d/1GgFbaYs-H6J5HSQ6a7n4aKpk0nDLE2hgG2NSOM9YIRw"


### PR DESCRIPTION
What this PR does / why we need it:

The v1.11 and v1.12 release notes point at migration guides removed from the main docs site. 
Both return 404 today, it is a dead end for provider authors

This adds redirects to the matching versioned docs

How to reproduce:
```bash
curl -o /dev/null -s -w "%{http_code}\n" https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.10-to-v1.11
curl -o /dev/null -s -w "%{http_code}\n" https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.11-to-v1.12
```

Both currently print 404.

/area documentation