### PR TITLE
🐛 Support slash branch names in GitHub template URLs

### DIFF
--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -220,7 +220,16 @@ func (t *templateClient) getGitHubFileContent(ctx context.Context, rURL *url.URL
 }
 
 func getGithubFileContentFromCode(ctx context.Context, ghClient *github.Client, fullPath string, owner string, repo string, path string, branch string) ([]byte, error) {
-	fileContent, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: branch})
+	fileContent, _, response, err := ghClient.Repositories.GetContents(ctx, owner, repo, path, &github.RepositoryContentGetOptions{Ref: branch})
+	if err != nil && response != nil && response.StatusCode == http.StatusNotFound {
+		resolvedBranch, resolvedPath, resolveErr := resolveGitHubBranchAndPath(ctx, ghClient, owner, repo, branch, path)
+		if resolveErr != nil {
+			return nil, handleGithubErr(resolveErr, "failed to resolve branch for %q", fullPath)
+		}
+		if resolvedBranch != "" {
+			fileContent, _, _, err = ghClient.Repositories.GetContents(ctx, owner, repo, resolvedPath, &github.RepositoryContentGetOptions{Ref: resolvedBranch})
+		}
+	}
 	if err != nil {
 		return nil, handleGithubErr(err, "failed to get %q", fullPath)
 	}
@@ -235,6 +244,32 @@ func getGithubFileContentFromCode(ctx context.Context, ghClient *github.Client, 
 		return nil, pkgerrors.Wrapf(err, "failed to decode file %q", fullPath)
 	}
 	return content, nil
+}
+
+func resolveGitHubBranchAndPath(ctx context.Context, ghClient *github.Client, owner, repo, branch, path string) (string, string, error) {
+	pathParts := strings.Split(path, "/")
+	if len(pathParts) < 2 {
+		return "", "", nil
+	}
+
+	refs, _, err := ghClient.Git.ListMatchingRefs(ctx, owner, repo, fmt.Sprintf("heads/%s/%s", branch, pathParts[0]))
+	if err != nil {
+		return "", "", err
+	}
+
+	branchAndPath := branch + "/" + path
+	resolvedBranch := ""
+	for _, ref := range refs {
+		refName := strings.TrimPrefix(ref.GetRef(), "refs/heads/")
+		if strings.HasPrefix(branchAndPath, refName+"/") && len(refName) > len(resolvedBranch) {
+			resolvedBranch = refName
+		}
+	}
+	if resolvedBranch == "" {
+		return "", "", nil
+	}
+
+	return resolvedBranch, strings.TrimPrefix(branchAndPath, resolvedBranch+"/"), nil
 }
 
 func (t *templateClient) getRawURLFileContent(ctx context.Context, rURL string) ([]byte, error) {

--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -169,7 +169,8 @@ func Test_templateClient_getGitHubFileContent(t *testing.T) {
 	configClient, err := config.New(context.Background(), "", config.InjectReader(test.NewFakeReader()))
 	g.Expect(err).ToNot(HaveOccurred())
 
-	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/config/default/cluster-template.yaml", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/config/default/cluster-template.yaml", func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.Query().Get("ref")).To(Equal("main"))
 		fmt.Fprint(w, `{
 		  "type": "file",
 		  "encoding": "base64",
@@ -178,6 +179,32 @@ func Test_templateClient_getGitHubFileContent(t *testing.T) {
 		  "size": 12,
 		  "name": "cluster-template.yaml",
 		  "path": "config/default/cluster-template.yaml"
+		}`)
+	})
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/templates/config/default/cluster-template.yaml", func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.Query().Get("ref")).To(Equal("feature"))
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"message":"No commit found for the ref feature"}`)
+	})
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/git/matching-refs/heads/feature/templates", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[
+		  {"ref":"refs/heads/feature/templates"},
+		  {"ref":"refs/heads/feature/templates/config"}
+		]`)
+	})
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/git/matching-refs/heads/main/config", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `[]`)
+	})
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/default/cluster-template.yaml", func(w http.ResponseWriter, r *http.Request) {
+		g.Expect(r.URL.Query().Get("ref")).To(Equal("feature/templates/config"))
+		fmt.Fprint(w, `{
+		  "type": "file",
+		  "encoding": "base64",
+		  "content": "`+base64.StdEncoding.EncodeToString([]byte(template))+`",
+		  "sha": "f5f369044773ff9c6383c087466d12adb6fa0828",
+		  "size": 12,
+		  "name": "cluster-template.yaml",
+		  "path": "default/cluster-template.yaml"
 		}`)
 	})
 
@@ -194,6 +221,14 @@ func Test_templateClient_getGitHubFileContent(t *testing.T) {
 			name: "Return custom template",
 			args: args{
 				rURL: mustParseURL("https://github.com/kubernetes-sigs/cluster-api/blob/main/config/default/cluster-template.yaml"),
+			},
+			want:    []byte(template),
+			wantErr: false,
+		},
+		{
+			name: "Return custom template from branch with slashes",
+			args: args{
+				rURL: mustParseURL("https://github.com/kubernetes-sigs/cluster-api/blob/feature/templates/config/default/cluster-template.yaml"),
 			},
 			want:    []byte(template),
 			wantErr: false,


### PR DESCRIPTION
What this PR does / why we need it:

GitHub blob URLs with slash branch names, like `dependabot/go_modules/...`, are parsed as if the branch was just `dependabot`
Valid templates then fail with a 404

This retries 404s by resolving matching branch refs and picks the longest match. 
Simple refs keep the current fast path, so theres no extra API call there

Repro:

```sh
clusterctl generate yaml \
  --from "https://github.com/kubernetes-sigs/cluster-api/blob/dependabot/go_modules/all-go-mod-patch-and-minor-3a2e2cb45c/test/e2e/config/docker.yaml" \
  --list-variables
```

Before: `No commit found for the ref dependabot`
After: exits 0 and loads the template

Which issue(s) this PR fixes:

None.

/kind bug
/area clusterctl