### PR TITLE
📖 revert autoscaler documentation changes

### DIFF
--- a/api/core/v1beta1/common_types.go
+++ b/api/core/v1beta1/common_types.go
@@ -180,7 +180,7 @@ const (
 	// AutoscalerMinSizeAnnotation defines the minimum node group size.
 	// The annotation is used by autoscaler.
 	// The annotation is copied from kubernetes/autoscaler.
-	// Ref:https://github.com/kubernetes-sigs/cluster-autoscaler/blob/562c02c17afedc1a1699b6c772018c009e790e41/pkg/cloudprovider/clusterapi/clusterapi_utils.go#L329-L332
+	// Ref:https://github.com/kubernetes/autoscaler/blob/d8336cca37dbfa5d1cb7b7e453bd511172d6e5e7/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go#L256-L259
 	// Note: With the Kubernetes autoscaler it is possible to use different annotations by configuring a different
 	// "Cluster API group" than "cluster.x-k8s.io" via the "CAPI_GROUP" environment variable.
 	// We only handle the default group in our implementation.
@@ -190,7 +190,7 @@ const (
 	// AutoscalerMaxSizeAnnotation defines the maximum node group size.
 	// The annotations is used by the autoscaler.
 	// The annotation definition is copied from kubernetes/autoscaler.
-	// Ref:https://github.com/kubernetes-sigs/cluster-autoscaler/blob/562c02c17afedc1a1699b6c772018c009e790e41/pkg/cloudprovider/clusterapi/clusterapi_utils.go#L337-L340
+	// Ref:https://github.com/kubernetes/autoscaler/blob/d8336cca37dbfa5d1cb7b7e453bd511172d6e5e7/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go#L264-L267
 	// Note: With the Kubernetes autoscaler it is possible to use different annotations by configuring a different
 	// "Cluster API group" than "cluster.x-k8s.io" via the "CAPI_GROUP" environment variable.
 	// We only handle the default group in our implementation.

--- a/api/core/v1beta2/common_types.go
+++ b/api/core/v1beta2/common_types.go
@@ -187,7 +187,7 @@ const (
 	// AutoscalerMinSizeAnnotation defines the minimum node group size.
 	// The annotation is used by autoscaler.
 	// The annotation is copied from kubernetes/autoscaler.
-	// Ref:https://github.com/kubernetes-sigs/cluster-autoscaler/blob/562c02c17afedc1a1699b6c772018c009e790e41/pkg/cloudprovider/clusterapi/clusterapi_utils.go#L329-L332
+	// Ref:https://github.com/kubernetes/autoscaler/blob/d8336cca37dbfa5d1cb7b7e453bd511172d6e5e7/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go#L256-L259
 	// Note: With the Kubernetes autoscaler it is possible to use different annotations by configuring a different
 	// "Cluster API group" than "cluster.x-k8s.io" via the "CAPI_GROUP" environment variable.
 	// We only handle the default group in our implementation.
@@ -197,7 +197,7 @@ const (
 	// AutoscalerMaxSizeAnnotation defines the maximum node group size.
 	// The annotations is used by the autoscaler.
 	// The annotation definition is copied from kubernetes/autoscaler.
-	// Ref:https://github.com/kubernetes-sigs/cluster-autoscaler/blob/562c02c17afedc1a1699b6c772018c009e790e41/pkg/cloudprovider/clusterapi/clusterapi_utils.go#L337-L340
+	// Ref:https://github.com/kubernetes/autoscaler/blob/d8336cca37dbfa5d1cb7b7e453bd511172d6e5e7/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_utils.go#L264-L267
 	// Note: With the Kubernetes autoscaler it is possible to use different annotations by configuring a different
 	// "Cluster API group" than "cluster.x-k8s.io" via the "CAPI_GROUP" environment variable.
 	// We only handle the default group in our implementation.

--- a/docs/book/src/tasks/automated-machine-management/autoscaling.md
+++ b/docs/book/src/tasks/automated-machine-management/autoscaling.md
@@ -3,12 +3,12 @@
 This section applies only to worker Machines. Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster based
 on the utilization of Pods and Nodes in your cluster. For more general information about the
 Cluster Autoscaler, please see the
-[project documentation](https://github.com/kubernetes-sigs/cluster-autoscaler/).
+[project documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
 
 The following instructions are a reproduction of the Cluster API provider specific documentation
-from the [Autoscaler project documentation](https://github.com/kubernetes-sigs/cluster-autoscaler/tree/main/pkg/cloudprovider/clusterapi).
+from the [Autoscaler project documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/clusterapi).
 
-{{#embed-github repo:"kubernetes-sigs/cluster-autoscaler" path:"pkg/cloudprovider/clusterapi/README.md" }}
+{{#embed-github repo:"kubernetes/autoscaler" path:"cluster-autoscaler/cloudprovider/clusterapi/README.md" }}
 
 <aside class="note warning">
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This change reverts the autoscaler documentation links to their previous location due to a miscommunication in the repository migration.

reverting #14038

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->