### PR TITLE
🐛 Don't use cache with CRD migrator

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -315,7 +315,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		// Note: The kubebuilder RBAC markers above has to be kept in sync
 		// with the CRDs that should be migrated by this provider.
 		Config: map[client.Object]crdmigrator.ByObjectConfig{
-			&bootstrapv1.KubeadmConfig{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+			&bootstrapv1.KubeadmConfig{}:         {UseCache: false, UseStatusForStorageVersionMigration: true},
 			&bootstrapv1.KubeadmConfigTemplate{}: {UseCache: false},
 		},
 		// The CRDMigrator is run with only concurrency 1 to ensure we don't overwhelm the apiserver by patching a

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -368,7 +368,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		// Note: The kubebuilder RBAC markers above has to be kept in sync
 		// with the CRDs that should be migrated by this provider.
 		Config: map[client.Object]crdmigrator.ByObjectConfig{
-			&controlplanev1.KubeadmControlPlane{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+			&controlplanev1.KubeadmControlPlane{}:         {UseCache: false, UseStatusForStorageVersionMigration: true},
 			&controlplanev1.KubeadmControlPlaneTemplate{}: {UseCache: false},
 		},
 		// The CRDMigrator is run with only concurrency 1 to ensure we don't overwhelm the apiserver by patching a

--- a/core/main.go
+++ b/core/main.go
@@ -457,25 +457,25 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager, watchNamespace stri
 	// Note: The kubebuilder RBAC markers above has to be kept in sync
 	// with the CRDs that should be migrated by this provider.
 	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
-		&addonsv1.ClusterResourceSetBinding{}: {UseCache: true},
-		&addonsv1.ClusterResourceSet{}:        {UseCache: true, UseStatusForStorageVersionMigration: true},
-		&clusterv1.Cluster{}:                  {UseCache: true, UseStatusForStorageVersionMigration: true},
-		&clusterv1.MachineDeployment{}:        {UseCache: true, UseStatusForStorageVersionMigration: true},
-		&clusterv1.MachineDrainRule{}:         {UseCache: true},
-		&clusterv1.MachineHealthCheck{}:       {UseCache: true, UseStatusForStorageVersionMigration: true},
-		&clusterv1.Machine{}:                  {UseCache: true, UseStatusForStorageVersionMigration: true},
-		&clusterv1.MachineSet{}:               {UseCache: true, UseStatusForStorageVersionMigration: true},
+		&addonsv1.ClusterResourceSetBinding{}: {UseCache: false},
+		&addonsv1.ClusterResourceSet{}:        {UseCache: false, UseStatusForStorageVersionMigration: true},
+		&clusterv1.Cluster{}:                  {UseCache: false, UseStatusForStorageVersionMigration: true},
+		&clusterv1.MachineDeployment{}:        {UseCache: false, UseStatusForStorageVersionMigration: true},
+		&clusterv1.MachineDrainRule{}:         {UseCache: false},
+		&clusterv1.MachineHealthCheck{}:       {UseCache: false, UseStatusForStorageVersionMigration: true},
+		&clusterv1.Machine{}:                  {UseCache: false, UseStatusForStorageVersionMigration: true},
+		&clusterv1.MachineSet{}:               {UseCache: false, UseStatusForStorageVersionMigration: true},
 		&ipamv1.IPAddress{}:                   {UseCache: false},
 		&ipamv1.IPAddressClaim{}:              {UseCache: false, UseStatusForStorageVersionMigration: true},
 	}
 	if feature.Gates.Enabled(feature.ClusterTopology) {
-		crdMigratorConfig[&clusterv1.ClusterClass{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+		crdMigratorConfig[&clusterv1.ClusterClass{}] = crdmigrator.ByObjectConfig{UseCache: false, UseStatusForStorageVersionMigration: true}
 	}
 	if feature.Gates.Enabled(feature.RuntimeSDK) {
-		crdMigratorConfig[&runtimev1.ExtensionConfig{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+		crdMigratorConfig[&runtimev1.ExtensionConfig{}] = crdmigrator.ByObjectConfig{UseCache: false, UseStatusForStorageVersionMigration: true}
 	}
 	if feature.Gates.Enabled(feature.MachinePool) {
-		crdMigratorConfig[&clusterv1.MachinePool{}] = crdmigrator.ByObjectConfig{UseCache: true, UseStatusForStorageVersionMigration: true}
+		crdMigratorConfig[&clusterv1.MachinePool{}] = crdmigrator.ByObjectConfig{UseCache: false, UseStatusForStorageVersionMigration: true}
 	}
 	crdMigratorSkipPhases := make([]crdmigrator.Phase, 0, len(skipCRDMigrationPhases))
 	for _, p := range skipCRDMigrationPhases {

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -395,13 +395,13 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	// Note: The kubebuilder RBAC markers above has to be kept in sync
 	// with the CRDs that should be migrated by this provider.
 	crdMigratorConfig := map[client.Object]crdmigrator.ByObjectConfig{
-		&infrav1.DevCluster{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+		&infrav1.DevCluster{}:         {UseCache: false, UseStatusForStorageVersionMigration: true},
 		&infrav1.DevClusterTemplate{}: {UseCache: false},
-		&infrav1.DevMachine{}:         {UseCache: true, UseStatusForStorageVersionMigration: true},
+		&infrav1.DevMachine{}:         {UseCache: false, UseStatusForStorageVersionMigration: true},
 		&infrav1.DevMachineTemplate{}: {UseCache: false},
 	}
 	if feature.Gates.Enabled(feature.MachinePool) {
-		crdMigratorConfig[&infrav1.DevMachinePool{}] = crdmigrator.ByObjectConfig{UseCache: true}
+		crdMigratorConfig[&infrav1.DevMachinePool{}] = crdmigrator.ByObjectConfig{UseCache: false}
 		crdMigratorConfig[&infrav1.DevMachinePoolTemplate{}] = crdmigrator.ByObjectConfig{UseCache: false}
 	}
 	crdMigratorSkipPhases := make([]crdmigrator.Phase, 0, len(skipCRDMigrationPhases))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
We stopped caching managedFields for various objects. If the CRD migrator is using the cache for an object for which we dropped managedFields it is not able to cleanupManagedFields.

To ensure we don't hit this case this PR changes the CRD migrator configs to stop using the cache for all objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->