### PR TITLE
🐛 clustercache: apply Options.ClusterFilter in SetupWithManager

### DIFF
--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -332,6 +332,7 @@ func SetupWithManager(ctx context.Context, mgr manager.Manager, options Options,
 		client:                mgr.GetClient(),
 		clusterAccessorConfig: buildClusterAccessorConfig(mgr.GetScheme(), options, controllerPodMetadata),
 		clusterAccessors:      make(map[client.ObjectKey]*clusterAccessor),
+		clusterFilter:         options.ClusterFilter,
 		cacheCtx:              cacheCtx,
 		cacheCtxCancel:        cacheCtxCancel,
 	}

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -864,3 +864,37 @@ func getCounterMetric(metricFamilyName, controllerName string) (float64, error) 
 
 	return 0, fmt.Errorf("failed to find %q metric", metricFamilyName)
 }
+
+func TestSetupWithManagerAppliesClusterFilter(t *testing.T) {
+	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	filter := func(cluster *clusterv1.Cluster) bool {
+		return cluster.Labels["cluster.x-k8s.io/included-in-clustercache-tests"] == "true"
+	}
+	cc, err := SetupWithManager(ctx, env.Manager, Options{
+		SecretClient: env.GetClient(),
+		Cache: CacheOptions{
+			Indexes: []CacheOptionsIndex{NodeProviderIDIndex},
+		},
+		Client: ClientOptions{
+			UserAgent: remote.DefaultClusterAPIUserAgent("test-controller-manager"),
+		},
+		ClusterFilter: filter,
+	}, controller.Options{
+		MaxConcurrentReconciles: 1,
+		// Has to be skipped as other tests in this package also register a "clustercache" controller
+		// with the same manager.
+		SkipNameValidation: ptr.To(true),
+	})
+	g.Expect(err).ToNot(HaveOccurred())
+	internalCC, ok := cc.(*clusterCache)
+	g.Expect(ok).To(BeTrue())
+	defer internalCC.Shutdown()
+	g.Expect(internalCC.clusterFilter).ToNot(BeNil(), "Options.ClusterFilter must be wired into the ClusterCache")
+	g.Expect(internalCC.clusterFilter(&clusterv1.Cluster{})).To(BeFalse())
+	g.Expect(internalCC.clusterFilter(&clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{"cluster.x-k8s.io/included-in-clustercache-tests": "true"},
+	}})).To(BeTrue())
+}


### PR DESCRIPTION
## What happened
`clustercache.Options.ClusterFilter` (added in #12665, milestone v1.13) has no effect: `SetupWithManager`
builds the `clusterCache` struct without copying `options.ClusterFilter` into the private `clusterFilter`
field, so the check in `Reconcile` (`if cc.clusterFilter != nil && !cc.clusterFilter(cluster)`) is always
skipped and the cache connects to every provisioned Cluster.

Observed in an infrastructure provider running on a management cluster shared with other providers:
with `clustercache.Options{ClusterFilter: <only our InfraCluster kind>}` the log still shows
`Connected … Cluster <cluster of another provider>` — the provider read a foreign kubeconfig Secret and
health-probed a foreign workload API server.

## Evidence
- `controllers/clustercache/cluster_cache.go` (v1.13.0, v1.14.0, main): the only occurrences of
  `clusterFilter` are the field declaration and the `Reconcile` check; the `cc := &clusterCache{…}` literal
  in `SetupWithManager` does not set it.
- #12665 adds `Options.ClusterFilter`, the type, the private field and the check, but no assignment; its test
  constructs `&clusterCache{clusterFilter: …}` directly, so the public `Options` path is never exercised.

## What you expected
Clusters for which the filter returns false are never connected, as the `Options.ClusterFilter` godoc state


/area clustercache