### PR TITLE
📖 Document coredns upgrade

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -435,6 +435,11 @@ To look up the max supported CoreDNS version of a specific Cluster API version:
 * Look up the `corefile-migration` version in the CAPI top-level go.mod file, e.g. `github.com/coredns/corefile-migration v1.0.31`
 * Look up the highest supported CoreDNS version, e.g. in https://github.com/coredns/corefile-migration/blob/v1.0.31/migration/versions.go#L32
 
+Note: unlike `kubeadm upgrade`, the Kubeadm Control Plane provider does not automatically upgrade CoreDNS to a new
+default version as part of a Kubernetes upgrade. CoreDNS is only reconciled when the target version is explicitly
+set in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`. See
+[How to upgrade CoreDNS](../tasks/upgrading-clusters.md#how-to-upgrade-coredns) for more details.
+
 ### Other providers
 
 Cluster API has a vibrant ecosystem of awesome providers maintained by independent teams and hosted outside of

--- a/docs/book/src/tasks/control-plane/kubeadm-control-plane.md
+++ b/docs/book/src/tasks/control-plane/kubeadm-control-plane.md
@@ -10,6 +10,16 @@ KubeadmControlPlane is solely supporting CoreDNS as a DNS server at this time.
 
 </aside>
 
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+KubeadmControlPlane does not automatically upgrade CoreDNS when the Kubernetes version is upgraded, unlike
+`kubeadm upgrade`. CoreDNS is only upgraded if you explicitly set the target version, see
+[How to upgrade CoreDNS][upgrade-coredns].
+
+</aside>
+
 ### Kubeconfig management
 
 KCP will generate and manage the admin Kubeconfig for clusters. The client certificate for the admin user is created
@@ -53,3 +63,4 @@ Note: Changes to these fields will not be propagated to Machines, InfraMachines 
 
 <!-- links -->
 [upgrades]: ../upgrading-clusters.md#how-to-upgrade-the-kubernetes-control-plane-version
+[upgrade-coredns]: ../upgrading-clusters.md#how-to-upgrade-coredns

--- a/docs/book/src/tasks/upgrading-clusters.md
+++ b/docs/book/src/tasks/upgrading-clusters.md
@@ -47,6 +47,36 @@ that if a specific machine image is specified, it has to match the Kubernetes ve
 `KubeadmControlPlane` spec. In order to only trigger a single upgrade, the new `MachineTemplate` should be created first
 and then both the `Version` and `InfrastructureTemplate` should be modified in a single transaction.
 
+#### How to upgrade CoreDNS
+
+Unlike a plain `kubeadm upgrade`, the Kubeadm Control Plane provider does
+**not** automatically upgrade CoreDNS to a new default version as part of a
+Kubernetes upgrade. CoreDNS is only reconciled by KCP when the `imageTag` (and
+optionally `imageRepository`) fields are explicitly set under
+`KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns`. If left
+unset, KCP leaves the currently deployed CoreDNS version untouched, even while
+the rest of the control plane is upgraded.
+
+To upgrade CoreDNS, explicitly set the desired version, e.g.:
+
+```yaml
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      dns:
+        imageTag: v1.14.6
+```
+
+See [CoreDNS Support](../reference/versions.md#coredns-support) for how to
+determine the maximum CoreDNS version supported by a given Cluster API release.
+If you'd rather manage CoreDNS yourself, or with another tool, you can have KCP
+skip reconciling it entirely by adding the
+[`controlplane.cluster.x-k8s.io/skip-coredns`](../reference/api/labels-and-annotations.md)
+annotation to the `KubeadmControlPlane` resource.
+
+For more context and discussion about this behavior, see
+[kubernetes-sigs/cluster-api#6429](https://github.com/kubernetes-sigs/cluster-api/issues/6429).
+
 #### How to schedule a machine rollout
 
 The  `KubeadmControlPlane` and `MachineDepoyment` resources have a `spec.rollout.after` field that can be 


### PR DESCRIPTION
**What this PR does / why we need it**:

Unlike plain kubeadm, CAPI with the kubeadm control-plane provider does NOT upgrade coredns automatically. The user has to explicitly specify the version they want, or no reconciliation will happen.

This commit adds notes in the documentation about the behavior to avoid surprises for users accustomed to plain kubeadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #6429

AI disclosure: I used generative AI to assist me in making this PR.

/area documentation
