### PR TITLE
🐛 Fix deprecate condition utils

### DIFF
--- a/util/conditions/deprecated/v1beta1/unstructured.go
+++ b/util/conditions/deprecated/v1beta1/unstructured.go
@@ -43,6 +43,15 @@ type unstructuredWrapper struct {
 
 // GetConditions returns the list of conditions from an Unstructured object.
 //
+// NOTE: GetConditions supports retrieving conditions from objects at different stages of the transition from
+// clusterv1.conditions to the metav1.Condition type:
+//   - Objects with clusterv1.Condition in status.deprecated.v1beta1.conditions
+//   - Objects with clusterv1.Condition in status.conditions
+//   - Objects with metav1.Conditions in status.conditions; in this case a best effort conversion
+//     to metav1.Condition is performed, just enough to allow surfacing a condition from a provider object with Mirror
+//
+// NOTE: GetConditions supports retrieving conditions from non-CAPI objects like Pods, Nodes.
+//
 // NOTE: Due to the constraints of JSON-unmarshal, this operation is to be considered best effort.
 // In more details:
 //   - Errors during JSON-unmarshal are ignored and a empty collection list is returned.
@@ -52,10 +61,17 @@ type unstructuredWrapper struct {
 //     JSON-unmarshal matches incoming object keys to the keys; this can lead to conditions values partially set.
 func (c *unstructuredWrapper) GetV1Beta1Conditions() clusterv1.Conditions {
 	conditions := clusterv1.Conditions{}
-	if err := util.UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "conditions"); err != nil {
-		return nil
+	if err := util.UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "deprecated", "v1beta1", "conditions"); err == nil {
+		return conditions
 	}
-	return conditions
+
+	if err := util.UnstructuredUnmarshalField(c.Unstructured, &conditions, "status", "conditions"); err == nil {
+		return conditions
+	}
+
+	// With unstructured, it is not possible to detect if conditions are not set if the type is wrongly defined.
+	// This methods assume condition are not set.
+	return nil
 }
 
 // SetConditions set the conditions into an Unstructured object.
@@ -77,7 +93,7 @@ func (c *unstructuredWrapper) SetV1Beta1Conditions(conditions clusterv1.Conditio
 	}
 	// unstructured.SetNestedField returns an error only if value cannot be set because one of
 	// the nesting levels is not a map[string]interface{}; this is not the case so the error should never happen here.
-	err := unstructured.SetNestedField(c.Object, v, "status", "conditions")
+	err := unstructured.SetNestedField(c.Object, v, "status", "deprecated", "v1beta1", "conditions")
 	if err != nil {
 		log.Log.Error(err, "Failed to set Conditions on unstructured object. This error shouldn't have occurred, please file an issue.", "groupVersionKind", c.GroupVersionKind(), "name", c.GetName(), "namespace", c.GetNamespace())
 	}

--- a/util/conditions/deprecated/v1beta1/unstructured_test.go
+++ b/util/conditions/deprecated/v1beta1/unstructured_test.go
@@ -31,8 +31,28 @@ import (
 func TestUnstructuredGetConditions(t *testing.T) {
 	g := NewWithT(t)
 
+	// GetV1Beta1Conditions should return conditions from an unstructured object (conditions in status.deprecated.v1beta1.conditions)
+	u1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"deprecated": map[string]interface{}{
+					"v1beta1": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":   "true1",
+								"status": "True",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(UnstructuredGetter(u1).GetV1Beta1Conditions()).To(haveSameConditionsOf(conditionList(true1)))
+
 	// GetV1Beta1Conditions should return conditions from an unstructured object
-	u := &unstructured.Unstructured{
+	u2 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"status": map[string]interface{}{
 				"conditions": []interface{}{
@@ -45,19 +65,19 @@ func TestUnstructuredGetConditions(t *testing.T) {
 		},
 	}
 
-	g.Expect(UnstructuredGetter(u).GetV1Beta1Conditions()).To(haveSameConditionsOf(conditionList(true1)))
+	g.Expect(UnstructuredGetter(u2).GetV1Beta1Conditions()).To(haveSameConditionsOf(conditionList(true1)))
 
 	// GetV1Beta1Conditions should return nil for an unstructured object with empty conditions
-	u = &unstructured.Unstructured{}
+	u3 := &unstructured.Unstructured{}
 
-	g.Expect(UnstructuredGetter(u).GetV1Beta1Conditions()).To(BeNil())
+	g.Expect(UnstructuredGetter(u3).GetV1Beta1Conditions()).To(BeNil())
 
 	// GetV1Beta1Conditions should return nil for an unstructured object without conditions
 	e := &corev1.Pod{}
-	u = &unstructured.Unstructured{}
-	g.Expect(scheme.Scheme.Convert(e, u, nil)).To(Succeed())
+	u4 := &unstructured.Unstructured{}
+	g.Expect(scheme.Scheme.Convert(e, u4, nil)).To(Succeed())
 
-	g.Expect(UnstructuredGetter(u).GetV1Beta1Conditions()).To(BeNil())
+	g.Expect(UnstructuredGetter(u4).GetV1Beta1Conditions()).To(BeNil())
 
 	// GetV1Beta1Conditions should return conditions from an unstructured object with a different type of conditions.
 	p := &corev1.Pod{Status: corev1.PodStatus{
@@ -72,10 +92,10 @@ func TestUnstructuredGetConditions(t *testing.T) {
 			},
 		},
 	}}
-	u = &unstructured.Unstructured{}
-	g.Expect(scheme.Scheme.Convert(p, u, nil)).To(Succeed())
+	u5 := &unstructured.Unstructured{}
+	g.Expect(scheme.Scheme.Convert(p, u5, nil)).To(Succeed())
 
-	g.Expect(UnstructuredGetter(u).GetV1Beta1Conditions()).To(HaveLen(1))
+	g.Expect(UnstructuredGetter(u5).GetV1Beta1Conditions()).To(HaveLen(1))
 }
 
 func TestUnstructuredSetConditions(t *testing.T) {
@@ -90,5 +110,13 @@ func TestUnstructuredSetConditions(t *testing.T) {
 
 	s := UnstructuredSetter(u)
 	s.SetV1Beta1Conditions(conditions)
+	g.Expect(u.Object).To(HaveKey("status"))
+	status := u.Object["status"].(map[string]any)
+	g.Expect(status).To(HaveKey("deprecated"))
+	deprecated := status["deprecated"].(map[string]any)
+	g.Expect(deprecated).To(HaveKey("v1beta1"))
+	v1beta1 := deprecated["v1beta1"].(map[string]any)
+	g.Expect(v1beta1).To(HaveKey("conditions"))
+
 	g.Expect(s.GetV1Beta1Conditions()).To(BeComparableTo(conditions))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
The deprecated condition util (used by CAPI to retrieve conditions from external objects) was wrongly using status.conditions as a target path, while instead status.deprecated.v1beta1.conditions must be used.

Also, adding a fallback handling to ensure that the deprecated condition util can handle external objects at different state of the transition to metav1.conditions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area conditions