### PR TITLE
✨ Add --tls-curve-preferences flag to manager options

### DIFF
--- a/util/flags/manager.go
+++ b/util/flags/manager.go
@@ -43,6 +43,9 @@ type ManagerOptions struct {
 	// TLSCipherSuites is the field that stores the value of the --tls-cipher-suites flag.
 	// For further details, please see the description of the flag.
 	TLSCipherSuites []string
+	// TLSCurvePreferences is the field that stores the value of the --tls-curve-preferences flag.
+	// For further details, please see the description of the flag.
+	TLSCurvePreferences []int32
 
 	// Metrics Options
 	// These are used to configure the metrics server
@@ -69,6 +72,14 @@ func AddManagerOptions(fs *pflag.FlagSet, options *ManagerOptions) {
 			"If omitted, the default Go cipher suites will be used. \n"+
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+
+	fs.Int32SliceVar(&options.TLSCurvePreferences, "tls-curve-preferences", []int32{},
+		"Comma-separated list of numeric Go crypto/tls CurveID values, as the allowed key exchange mechanisms "+
+			"for the webhook server and metrics server (the latter only if --insecure-diagnostics is not set to true). "+
+			"The supported values depend on the Go version used. "+
+			"See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. "+
+			"The order of the list is ignored, and key exchange mechanisms are chosen by Go from this list "+
+			"using an internal preference order. If omitted, the default Go curves will be used.")
 
 	fs.StringVar(&options.DiagnosticsAddress, "diagnostics-address", ":8443",
 		"The address the diagnostics endpoint binds to. Per default metrics are served via https and with"+
@@ -100,6 +111,16 @@ func GetManagerOptions(options ManagerOptions) ([]func(config *tls.Config), *met
 		}
 		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
 			cfg.CipherSuites = suites
+		})
+	}
+
+	if len(options.TLSCurvePreferences) != 0 {
+		curvePreferences, err := cliflag.TLSCurvePreferences(options.TLSCurvePreferences)
+		if err != nil {
+			return nil, nil, err
+		}
+		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
+			cfg.CurvePreferences = curvePreferences
 		})
 	}
 

--- a/util/flags/manager_test.go
+++ b/util/flags/manager_test.go
@@ -53,16 +53,25 @@ func TestGetManagerOptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid tls curve preferences",
+			managerOptions: ManagerOptions{
+				TLSCurvePreferences: []int32{-1},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid tls + insecure diagnostics + diagnostics address",
 			managerOptions: ManagerOptions{
 				TLSMinVersion:       "VersionTLS13",
 				TLSCipherSuites:     []string{"TLS_AES_256_GCM_SHA384"},
+				TLSCurvePreferences: []int32{int32(tls.X25519MLKEM768)},
 				InsecureDiagnostics: true,
 				DiagnosticsAddress:  ":8443",
 			},
 			wantTLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS13,
-				CipherSuites: []uint16{tls.TLS_AES_256_GCM_SHA384},
+				MinVersion:       tls.VersionTLS13,
+				CipherSuites:     []uint16{tls.TLS_AES_256_GCM_SHA384},
+				CurvePreferences: []tls.CurveID{tls.X25519MLKEM768},
 			},
 			wantMetricsOptions: &metricsserver.Options{
 				BindAddress: ":8443",
@@ -72,13 +81,15 @@ func TestGetManagerOptions(t *testing.T) {
 		{
 			name: "valid tls + diagnostics address",
 			managerOptions: ManagerOptions{
-				TLSMinVersion:      "VersionTLS13",
-				TLSCipherSuites:    []string{"TLS_AES_256_GCM_SHA384"},
-				DiagnosticsAddress: ":8443",
+				TLSMinVersion:       "VersionTLS13",
+				TLSCipherSuites:     []string{"TLS_AES_256_GCM_SHA384"},
+				TLSCurvePreferences: []int32{int32(tls.X25519MLKEM768)},
+				DiagnosticsAddress:  ":8443",
 			},
 			wantTLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS13,
-				CipherSuites: []uint16{tls.TLS_AES_256_GCM_SHA384},
+				MinVersion:       tls.VersionTLS13,
+				CipherSuites:     []uint16{tls.TLS_AES_256_GCM_SHA384},
+				CurvePreferences: []tls.CurveID{tls.X25519MLKEM768},
 			},
 			wantMetricsOptions: &metricsserver.Options{
 				BindAddress:    ":8443",
@@ -96,8 +107,9 @@ func TestGetManagerOptions(t *testing.T) {
 				},
 			},
 			wantMetricsOptionsTLSConfig: &tls.Config{
-				MinVersion:   tls.VersionTLS13,
-				CipherSuites: []uint16{tls.TLS_AES_256_GCM_SHA384},
+				MinVersion:       tls.VersionTLS13,
+				CipherSuites:     []uint16{tls.TLS_AES_256_GCM_SHA384},
+				CurvePreferences: []tls.CurveID{tls.X25519MLKEM768},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `--tls-curve-preferences` flag to `util/flags.ManagerOptions`, following the same pattern as the existing `--tls-min-version` and `--tls-cipher-suites` flags. This lets users configure the allowed TLS key exchange mechanisms (curves) for the webhook server and metrics server.

This mirrors the equivalent `--tls-curve-preferences` flag added to `k8s.io/apiserver`'s `SecureServingOptions` in kubernetes/kubernetes#137115, which is already available in the `k8s.io/component-base` v0.37.0 dependency vendored by Cluster API (`cliflag.TLSCurvePreferences`), so no dependency bump is required.

/area security