### PR TITLE
🐛 Deduplicate KCP preflightchecks

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	pkgerrors "github.com/pkg/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/pkg"
@@ -31,27 +30,9 @@ func (r *Reconciler) tryInPlaceUpdate(
 	controlPlane *pkg.ControlPlane,
 	machineToInPlaceUpdate *clusterv1.Machine,
 	machineUpToDateResult pkg.UpToDateResult,
-) (fallbackToScaleDown bool, _ ctrl.Result, _ error) {
+) (fallbackToScaleDown bool, _ error) {
 	if r.overrideTryInPlaceUpdateFunc != nil {
 		return r.overrideTryInPlaceUpdateFunc(ctx, controlPlane, machineToInPlaceUpdate, machineUpToDateResult)
-	}
-
-	// Run preflight checks to ensure that the control plane is stable before proceeding with in-place update operation.
-	//
-	// Important! preflight checks play an important role in ensuring that KCP performs "one operation at time", by forcing
-	// the system to wait for the previous operation to complete and the control plane to become stable before starting the next one.
-	//
-	// Note: before considering in-place updates, KCP first takes care of completing
-	// ongoing delete operations, completing in-place transitions, remediating unhealthy machines.
-	if resultForAllMachines := r.preflightChecks(ctx, controlPlane, false); !resultForAllMachines.IsZero() {
-		// If the control plane is not stable, check if the issues are only for machineToInPlaceUpdate.
-		if result := r.preflightChecks(ctx, controlPlane, false, machineToInPlaceUpdate); result.IsZero() {
-			// The issues are only for machineToInPlaceUpdate, fallback to scale down.
-			// Note: The consequence of this is that a Machine with issues is scaled down and not in-place updated.
-			return true, ctrl.Result{}, nil
-		}
-
-		return false, resultForAllMachines, nil
 	}
 
 	// Note: Usually canUpdateMachine is only called once for a single Machine rollout.
@@ -62,12 +43,12 @@ func (r *Reconciler) tryInPlaceUpdate(
 	// fails or if we fail to delete the Machine.
 	canUpdate, err := r.canUpdateMachine(ctx, machineToInPlaceUpdate, machineUpToDateResult)
 	if err != nil {
-		return false, ctrl.Result{}, pkgerrors.Wrapf(err, "failed to determine if Machine %s can be updated in-place", machineToInPlaceUpdate.Name)
+		return false, pkgerrors.Wrapf(err, "failed to determine if Machine %s can be updated in-place", machineToInPlaceUpdate.Name)
 	}
 
 	if !canUpdate {
-		return true, ctrl.Result{}, nil
+		return true, nil
 	}
 
-	return false, ctrl.Result{}, r.triggerInPlaceUpdate(ctx, controlPlane, machineToInPlaceUpdate, machineUpToDateResult)
+	return false, r.triggerInPlaceUpdate(ctx, controlPlane, machineToInPlaceUpdate, machineUpToDateResult)
 }

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/inplace_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/gomega"
 	pkgerrors "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/pkg"
@@ -38,37 +37,15 @@ func Test_tryInPlaceUpdate(t *testing.T) {
 
 	tests := []struct {
 		name                           string
-		preflightChecksFunc            func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) ctrl.Result
 		canUpdateMachineFunc           func(ctx context.Context, machine *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error)
 		wantCanUpdateMachineCalled     bool
 		wantTriggerInPlaceUpdateCalled bool
 		wantFallbackToScaleDown        bool
 		wantError                      bool
 		wantErrorMessage               string
-		wantRes                        ctrl.Result
 	}{
 		{
-			name: "Requeue if preflight checks for all Machines failed",
-			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) ctrl.Result {
-				return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}
-			},
-			wantRes: ctrl.Result{RequeueAfter: preflightFailedRequeueAfter},
-		},
-		{
-			name: "Fallback to scale down if checks for all Machines failed, but checks succeed when excluding machineToInPlaceUpdate",
-			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) ctrl.Result {
-				if len(excludeFor) == 1 && excludeFor[0] == machineToInPlaceUpdate {
-					return ctrl.Result{} // If machineToInPlaceUpdate is excluded preflight checks succeed => scale down
-				}
-				return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}
-			},
-			wantFallbackToScaleDown: true,
-		},
-		{
 			name: "Return error if canUpdateMachine returns an error",
-			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) ctrl.Result {
-				return ctrl.Result{}
-			},
 			canUpdateMachineFunc: func(_ context.Context, _ *clusterv1.Machine, _ pkg.UpToDateResult) (bool, error) {
 				return false, pkgerrors.New("canUpdateMachine error")
 			},
@@ -78,9 +55,6 @@ func Test_tryInPlaceUpdate(t *testing.T) {
 		},
 		{
 			name: "Fallback to scale down if canUpdateMachine returns false",
-			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) ctrl.Result {
-				return ctrl.Result{}
-			},
 			canUpdateMachineFunc: func(_ context.Context, _ *clusterv1.Machine, _ pkg.UpToDateResult) (bool, error) {
 				return false, nil
 			},
@@ -89,9 +63,6 @@ func Test_tryInPlaceUpdate(t *testing.T) {
 		},
 		{
 			name: "Trigger in-place update if canUpdateMachine returns true",
-			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) ctrl.Result {
-				return ctrl.Result{}
-			},
 			canUpdateMachineFunc: func(_ context.Context, _ *clusterv1.Machine, _ pkg.UpToDateResult) (bool, error) {
 				return true, nil
 			},
@@ -107,9 +78,6 @@ func Test_tryInPlaceUpdate(t *testing.T) {
 			var canUpdateMachineCalled bool
 			var triggerInPlaceUpdateCalled bool
 			r := &Reconciler{
-				overridePreflightChecksFunc: func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) ctrl.Result {
-					return tt.preflightChecksFunc(ctx, controlPlane, excludeFor...)
-				},
 				overrideCanUpdateMachineFunc: func(ctx context.Context, machine *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error) {
 					canUpdateMachineCalled = true
 					return tt.canUpdateMachineFunc(ctx, machine, machineUpToDateResult)
@@ -120,14 +88,13 @@ func Test_tryInPlaceUpdate(t *testing.T) {
 				},
 			}
 
-			fallbackToScaleDown, res, err := r.tryInPlaceUpdate(ctx, nil, machineToInPlaceUpdate, pkg.UpToDateResult{})
+			fallbackToScaleDown, err := r.tryInPlaceUpdate(ctx, nil, machineToInPlaceUpdate, pkg.UpToDateResult{})
 			if tt.wantError {
 				g.Expect(err).To(HaveOccurred())
 				g.Expect(err.Error()).To(Equal(tt.wantErrorMessage))
 			} else {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
-			g.Expect(res).To(Equal(tt.wantRes))
 			g.Expect(fallbackToScaleDown).To(Equal(tt.wantFallbackToScaleDown))
 
 			g.Expect(canUpdateMachineCalled).To(Equal(tt.wantCanUpdateMachineCalled), "canUpdateMachineCalled: actual: %t expected: %t", canUpdateMachineCalled, tt.wantCanUpdateMachineCalled)

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
@@ -116,10 +116,10 @@ type Reconciler struct {
 	ssaCache          ssa.Cache
 
 	// Only used for testing.
-	overrideTryInPlaceUpdateFunc       func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, ctrl.Result, error)
+	overrideTryInPlaceUpdateFunc       func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error)
 	overrideScaleUpControlPlaneFunc    func(ctx context.Context, controlPlane *pkg.ControlPlane) (ctrl.Result, error)
 	overrideScaleDownControlPlaneFunc  func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToDelete *clusterv1.Machine) (ctrl.Result, error)
-	overridePreflightChecksFunc        func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) ctrl.Result
+	overridePreflightChecksFunc        func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) preflightChecksResult
 	overrideCanUpdateMachineFunc       func(ctx context.Context, machine *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error)
 	overrideCanExtensionsUpdateMachine func(ctx context.Context, machine *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult, extensionHandlers []string) (bool, []string, error)
 	overrideTriggerInPlaceUpdate       func(ctx context.Context, machine *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) error
@@ -577,7 +577,7 @@ func (r *Reconciler) reconcile(ctx context.Context, controlPlane *pkg.ControlPla
 		if err != nil {
 			return ctrl.Result{}, pkgerrors.Wrap(err, "failed to select machine for scale down")
 		}
-		return r.scaleDownControlPlane(ctx, controlPlane, machineToDelete)
+		return r.scaleDownControlPlane(ctx, controlPlane, machineToDelete, true)
 	}
 
 	// Get the workload cluster client.

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/preflight.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/preflight.go
@@ -36,6 +36,16 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
+type preflightChecksResult struct {
+	succeeded bool
+	pkg.PreflightCheckResults
+	requeueAfter       time.Duration
+	deferNextReconcile time.Duration
+	logStr             string
+	logKV              []string
+	eventStr           string
+}
+
 // preflightChecks checks if the control plane is stable before proceeding with a in-place update, scale up or scale down operation.
 // Under normal circumstances, a control stable is considered stable when:
 // - There are no machine deletion in progress
@@ -48,21 +58,17 @@ import (
 //
 // Note: This check leverage the information collected in reconcileControlPlaneAndMachinesConditions at the beginning of reconcile;
 // the info are also used to compute status.Conditions.
-func (r *Reconciler) preflightChecks(ctx context.Context, controlPlane *pkg.ControlPlane, isScaleUp bool, excludeFor ...*clusterv1.Machine) ctrl.Result {
+func (r *Reconciler) preflightChecks(ctx context.Context, controlPlane *pkg.ControlPlane, isScaleUp bool, excludeFor ...*clusterv1.Machine) preflightChecksResult {
 	if r.overridePreflightChecksFunc != nil {
 		return r.overridePreflightChecksFunc(ctx, controlPlane, excludeFor...)
 	}
-
-	// Reset PreflightCheckResults in case this function is called multiple times (e.g. for in-place update code paths)
-	// Note: The PreflightCheckResults field is only written by this func, so this is safe.
-	controlPlane.PreflightCheckResults = pkg.PreflightCheckResults{}
 
 	log := ctrl.LoggerFrom(ctx)
 
 	// If there is no KCP-owned control-plane machines, then control-plane has not been initialized yet,
 	// so it is considered ok to proceed.
 	if controlPlane.Machines.Len() == 0 {
-		return ctrl.Result{}
+		return preflightChecksResult{succeeded: true}
 	}
 
 	if feature.Gates.Enabled(feature.ClusterTopology) && controlPlane.Cluster.Spec.Topology.IsDefined() {
@@ -78,31 +84,41 @@ func (r *Reconciler) preflightChecks(ctx context.Context, controlPlane *pkg.Cont
 			if version, ok := controlPlane.Cluster.GetAnnotations()[clusterv1.ClusterTopologyUpgradeStepAnnotation]; ok && version != "" {
 				v = version
 			}
-			log.Info(fmt.Sprintf("Waiting for a version upgrade to %s to be propagated", v))
-			controlPlane.PreflightCheckResults.TopologyVersionMismatch = true
 			// Slow down reconcile frequency, as deferring a version upgrade waits for slow processes,
 			// e.g. workers are completing a previous upgrade step.
-			r.controller.DeferNextReconcileForObject(controlPlane.KCP, time.Now().Add(5*time.Second))
-			return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}
+			return preflightChecksResult{
+				succeeded:             false,
+				PreflightCheckResults: pkg.PreflightCheckResults{TopologyVersionMismatch: true},
+				requeueAfter:          preflightFailedRequeueAfter,
+				deferNextReconcile:    5 * time.Second,
+				logStr:                fmt.Sprintf("Waiting for a version upgrade to %s to be propagated", v),
+			}
 		}
 	}
 
 	// If certificates are missing, can't join a new machine
 	if isScaleUp && !conditions.IsTrue(controlPlane.KCP, controlplanev1.KubeadmControlPlaneCertificatesAvailableCondition) {
-		controlPlane.PreflightCheckResults.CertificateMissing = true
-		log.Info("Certificates are missing or unknown, can't join a new machine")
 		// Slow down reconcile frequency, user intervention is required to fix the problem.
-		r.controller.DeferNextReconcileForObject(controlPlane.KCP, time.Now().Add(5*time.Second))
-		return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}
+		return preflightChecksResult{
+			succeeded:             false,
+			PreflightCheckResults: pkg.PreflightCheckResults{CertificateMissing: true},
+			requeueAfter:          preflightFailedRequeueAfter,
+			deferNextReconcile:    5 * time.Second,
+			logStr:                "Certificates are missing or unknown, can't join a new machine",
+		}
 	}
 
 	// If there are deleting machines, wait for the operation to complete.
 	if controlPlane.HasDeletingMachine() {
-		controlPlane.PreflightCheckResults.HasDeletingMachine = true
-		log.Info("Waiting for machines to be deleted", "machines", strings.Join(controlPlane.Machines.Filter(collections.HasDeletionTimestamp).Names(), ", "))
 		// Slow down reconcile frequency, deletion is a slow process.
-		r.controller.DeferNextReconcileForObject(controlPlane.KCP, time.Now().Add(5*time.Second))
-		return ctrl.Result{RequeueAfter: deleteRequeueAfter}
+		return preflightChecksResult{
+			succeeded:             false,
+			PreflightCheckResults: pkg.PreflightCheckResults{HasDeletingMachine: true},
+			requeueAfter:          deleteRequeueAfter,
+			deferNextReconcile:    5 * time.Second,
+			logStr:                "Waiting for machines to be deleted",
+			logKV:                 []string{"machines", strings.Join(controlPlane.Machines.Filter(collections.HasDeletionTimestamp).Names(), ", ")},
+		}
 	}
 
 	// At this point we can assume that:
@@ -114,33 +130,42 @@ func (r *Reconciler) preflightChecks(ctx context.Context, controlPlane *pkg.Cont
 	// Most specifically, KCP should determine if this operation is going to leave the Kubernetes control plane components
 	// and the etcd cluster in operational state or not.
 	// This check will return false if there are machines not yet fully provisioned or if there are etcd members still in learner mode.
-	err := r.checkHealthiness(ctx, controlPlane, excludeFor)
+	controlPlaneComponentsNotHealthy, etcdClusterNotHealthy, err := r.checkHealthiness(ctx, controlPlane, excludeFor)
 
 	// If the control plane doesn't meet the "fully stable" criteria, and the control plane is trying to perform a scale up after
 	// a machine deletion due to remediation, perform a more precise check on Kubernetes control plane components and etcd members,
 	// thus allowing the system to recover also when there are multiple failures.
 	if _, ok := controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation]; ok && isScaleUp && err != nil {
 		log.Info("Performing checks to allow creation of a replacement machine while remediation is in progress")
-		err = r.checkHealthinessWhileRemediationInProgress(ctx, controlPlane)
+		controlPlaneComponentsNotHealthy, etcdClusterNotHealthy, err = r.checkHealthinessWhileRemediationInProgress(ctx, controlPlane)
 	}
 
 	if err != nil {
-		r.recorder.Eventf(controlPlane.KCP, corev1.EventTypeWarning, "ControlPlaneUnhealthy",
-			"Waiting for control plane to pass preflight checks to continue reconciliation: %v", err)
-		log.Info("Waiting for control plane to pass preflight checks", "failures", err.Error())
 		// Slow down reconcile frequency, it takes some time before control plane components stabilize
 		// after a new Machine is created. Similarly, if there are issues on running Machines, it
 		// usually takes some time to get back to normal state.
-		r.controller.DeferNextReconcileForObject(controlPlane.KCP, time.Now().Add(5*time.Second))
-		return ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}
+		return preflightChecksResult{
+			succeeded: false,
+			PreflightCheckResults: pkg.PreflightCheckResults{
+				ControlPlaneComponentsNotHealthy: controlPlaneComponentsNotHealthy,
+				EtcdClusterNotHealthy:            etcdClusterNotHealthy,
+			},
+			requeueAfter:       preflightFailedRequeueAfter,
+			deferNextReconcile: 5 * time.Second,
+			logStr:             "Waiting for control plane to pass preflight checks",
+			logKV:              []string{"failures", err.Error()},
+			eventStr:           fmt.Sprintf("Waiting for control plane to pass preflight checks to continue reconciliation: %v", err),
+		}
 	}
 
-	return ctrl.Result{}
+	return preflightChecksResult{succeeded: true}
 }
 
 // checkHealthiness verifies if the control plane is fully stable checking that all Kubernetes control plane components and etcd members are ok.
 // When performing a scale down operation, the deleting machine is ignored.
-func (r *Reconciler) checkHealthiness(_ context.Context, controlPlane *pkg.ControlPlane, excludeFor []*clusterv1.Machine) error {
+func (r *Reconciler) checkHealthiness(_ context.Context, controlPlane *pkg.ControlPlane, excludeFor []*clusterv1.Machine) (bool, bool, error) {
+	var controlPlaneComponentsNotHealthy, etcdClusterNotHealthy bool
+
 	// Check machine health conditions; if there are conditions with False or Unknown, then wait.
 	allMachineHealthConditions := []string{
 		controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition,
@@ -172,24 +197,24 @@ loopmachines:
 			// towards the unset nodeRef (which is the root cause of the conditions not being there).
 			machineErrors = append(machineErrors, pkgerrors.Errorf("Machine %s does not have a corresponding Node yet (Machine.status.nodeRef not set)", machine.Name))
 
-			controlPlane.PreflightCheckResults.ControlPlaneComponentsNotHealthy = true
+			controlPlaneComponentsNotHealthy = true
 			if controlPlane.IsEtcdManaged() {
-				controlPlane.PreflightCheckResults.EtcdClusterNotHealthy = true
+				etcdClusterNotHealthy = true
 			}
 		} else {
 			for _, condition := range allMachineHealthConditions {
 				if err := preflightCheckCondition("Machine", machine, condition); err != nil {
 					if condition == controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition {
-						controlPlane.PreflightCheckResults.EtcdClusterNotHealthy = true
+						etcdClusterNotHealthy = true
 					} else {
-						controlPlane.PreflightCheckResults.ControlPlaneComponentsNotHealthy = true
+						controlPlaneComponentsNotHealthy = true
 					}
 					machineErrors = append(machineErrors, err)
 				}
 			}
 		}
 	}
-	return kerrors.NewAggregate(machineErrors)
+	return controlPlaneComponentsNotHealthy, etcdClusterNotHealthy, kerrors.NewAggregate(machineErrors)
 }
 
 // checkHealthinessWhileRemediationInProgress verifies if the Kubernetes control plane components and etcd members are healthy enough
@@ -197,12 +222,9 @@ loopmachines:
 // Note: In this case it is not required to check if there are machines not yet fully provisioned, because remediation
 // can start only when all the machines are provisioned (already checked before setting remediation in progress, and
 // after that only machine deletion could happen).
-func (r *Reconciler) checkHealthinessWhileRemediationInProgress(ctx context.Context, controlPlane *pkg.ControlPlane) error {
+func (r *Reconciler) checkHealthinessWhileRemediationInProgress(ctx context.Context, controlPlane *pkg.ControlPlane) (bool, bool, error) {
+	var controlPlaneComponentsNotHealthy, etcdClusterNotHealthy bool
 	allErrors := []error{}
-
-	// make sure we reset the flags for surfacing prefligh checks in conditions from scratch.
-	controlPlane.PreflightCheckResults.ControlPlaneComponentsNotHealthy = false
-	controlPlane.PreflightCheckResults.EtcdClusterNotHealthy = false
 
 	// Considering this func is only called before scaling up after one has been deleted due to remediation,
 	// we can assume that the target cluster will have current Machines +1 new Machine (the replacement machine).
@@ -217,7 +239,7 @@ func (r *Reconciler) checkHealthinessWhileRemediationInProgress(ctx context.Cont
 
 	// Check id the target Kubernetes control plane will have at least one set of operational Kubernetes control plane components.
 	if !r.targetKubernetesControlPlaneComponentsHealthy(ctx, controlPlane, addKubernetesControlPlane, kubernetesControlPlaneToBeDeleted) {
-		controlPlane.PreflightCheckResults.ControlPlaneComponentsNotHealthy = true
+		controlPlaneComponentsNotHealthy = true
 		allErrors = append(allErrors, pkgerrors.New("cannot add a new control plane Machine when there are no control plane Machines with all Kubernetes control plane components in healthy state. Please check Kubernetes control plane component status"))
 	}
 
@@ -227,11 +249,11 @@ func (r *Reconciler) checkHealthinessWhileRemediationInProgress(ctx context.Cont
 			allErrors = append(allErrors, pkgerrors.New("cannot check etcd cluster health before scale up, etcd member list is empty"))
 		} else if !r.targetEtcdClusterHealthy(ctx, controlPlane, addEtcdMember, etcdMemberToBeDeleted) {
 			allErrors = append(allErrors, pkgerrors.New("adding a new control plane Machine can lead to etcd quorum loss. Please check the etcd status"))
-			controlPlane.PreflightCheckResults.EtcdClusterNotHealthy = true
+			etcdClusterNotHealthy = true
 		}
 	}
 
-	return kerrors.NewAggregate(allErrors)
+	return controlPlaneComponentsNotHealthy, etcdClusterNotHealthy, kerrors.NewAggregate(allErrors)
 }
 
 func preflightCheckCondition(kind string, obj *clusterv1.Machine, conditionType string) error {
@@ -246,4 +268,30 @@ func preflightCheckCondition(kind string, obj *clusterv1.Machine, conditionType 
 		return pkgerrors.Errorf("%s %s reports %s condition is unknown (%s)", kind, obj.GetName(), conditionType, c.Message)
 	}
 	return nil
+}
+
+func (r *Reconciler) handlePreflightCheckResults(ctx context.Context, controlPlane *pkg.ControlPlane, res preflightChecksResult) ctrl.Result {
+	controlPlane.PreflightCheckResults = res.PreflightCheckResults
+	if res.succeeded {
+		return ctrl.Result{}
+	}
+	if res.deferNextReconcile > 0 {
+		r.controller.DeferNextReconcileForObject(controlPlane.KCP, time.Now().Add(res.deferNextReconcile))
+	}
+	if res.logStr != "" {
+		log := ctrl.LoggerFrom(ctx)
+		var args []any
+		for _, s := range res.logKV {
+			args = append(args, s)
+		}
+		log.Info(res.logStr, args...)
+	}
+	if res.eventStr != "" {
+		r.recorder.Event(controlPlane.KCP, corev1.EventTypeWarning, "ControlPlaneUnhealthy", res.eventStr)
+	}
+	if res.requeueAfter == 0 {
+		// Default requeueAfter to ensure we always requeue if the preflight checks failed.
+		res.requeueAfter = preflightFailedRequeueAfter
+	}
+	return ctrl.Result{RequeueAfter: res.requeueAfter}
 }

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/preflight_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/preflight_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubeadmcontrolplane
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -48,6 +47,9 @@ func TestPreflightChecks(t *testing.T) {
 		expectResult             ctrl.Result
 		expectPreflight          pkg.PreflightCheckResults
 		expectDeferNextReconcile time.Duration
+		expectLogStr             string
+		expectLogKV              []string
+		expectEventStr           string
 	}{
 		{
 			name:         "control plane without machines (not initialized) should pass",
@@ -88,6 +90,7 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          true,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for a version upgrade to v1.33.0 to be propagated",
 		},
 		{
 			name: "control plane with a pending upgrade, but not yet at the current step of the upgrade plan, should requeue",
@@ -121,6 +124,7 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          true,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for a version upgrade to v1.32.0 to be propagated",
 		},
 		{
 			name: "control plane with a deleting machine should requeue",
@@ -134,6 +138,7 @@ func TestPreflightChecks(t *testing.T) {
 			machines: []*clusterv1.Machine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:              "deleting-machine",
 						DeletionTimestamp: &metav1.Time{Time: time.Now()},
 					},
 				},
@@ -147,6 +152,8 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for machines to be deleted",
+			expectLogKV:              []string{"machines", "deleting-machine"},
 		},
 		{
 			name: "control plane without certificates should requeue if scale up",
@@ -174,6 +181,7 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Certificates are missing or unknown, can't join a new machine",
 		},
 		{
 			name: "control plane without certificates should pass if not scale up",
@@ -250,6 +258,9 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for control plane to pass preflight checks",
+			expectLogKV:              []string{"failures", "Machine machine-1 does not have a corresponding Node yet (Machine.status.nodeRef not set)"},
+			expectEventStr:           "Waiting for control plane to pass preflight checks to continue reconciliation: Machine machine-1 does not have a corresponding Node yet (Machine.status.nodeRef not set)",
 		},
 		{
 			name: "control plane with an unhealthy machine condition should requeue",
@@ -270,7 +281,7 @@ func TestPreflightChecks(t *testing.T) {
 							Name: "node-1",
 						},
 						Conditions: []metav1.Condition{
-							{Type: controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition, Status: metav1.ConditionFalse},
+							{Type: controlplanev1.KubeadmControlPlaneMachineAPIServerPodHealthyCondition, Status: metav1.ConditionFalse, Message: "message"},
 							{Type: controlplanev1.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition, Status: metav1.ConditionTrue},
 							{Type: controlplanev1.KubeadmControlPlaneMachineSchedulerPodHealthyCondition, Status: metav1.ConditionTrue},
 							{Type: controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, Status: metav1.ConditionTrue},
@@ -288,6 +299,9 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for control plane to pass preflight checks",
+			expectLogKV:              []string{"failures", "Machine machine-1 reports APIServerPodHealthy condition is false (message)"},
+			expectEventStr:           "Waiting for control plane to pass preflight checks to continue reconciliation: Machine machine-1 reports APIServerPodHealthy condition is false (message)",
 		},
 		{
 			name: "control plane with an unhealthy machine condition should requeue",
@@ -312,7 +326,7 @@ func TestPreflightChecks(t *testing.T) {
 							{Type: controlplanev1.KubeadmControlPlaneMachineControllerManagerPodHealthyCondition, Status: metav1.ConditionTrue},
 							{Type: controlplanev1.KubeadmControlPlaneMachineSchedulerPodHealthyCondition, Status: metav1.ConditionTrue},
 							{Type: controlplanev1.KubeadmControlPlaneMachineEtcdPodHealthyCondition, Status: metav1.ConditionTrue},
-							{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionFalse},
+							{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionFalse, Message: "message"},
 						},
 					},
 				},
@@ -326,6 +340,9 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for control plane to pass preflight checks",
+			expectLogKV:              []string{"failures", "Machine machine-1 reports EtcdMemberHealthy condition is false (message)"},
+			expectEventStr:           "Waiting for control plane to pass preflight checks to continue reconciliation: Machine machine-1 reports EtcdMemberHealthy condition is false (message)",
 		},
 		{
 			name: "control plane where target etcd cluster and k8s control plane will be healthy state should pass when scaling up after remediation, no matter of failures on other machines",
@@ -447,6 +464,10 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for control plane to pass preflight checks",
+			expectLogKV: []string{"failures", "cannot add a new control plane Machine when there are no control plane Machines " +
+				"with all Kubernetes control plane components in healthy state. Please check Kubernetes control plane component status"},
+			expectEventStr: "Waiting for control plane to pass preflight checks to continue reconciliation: cannot add a new control plane Machine when there are no control plane Machines with all Kubernetes control plane components in healthy state. Please check Kubernetes control plane component status",
 		},
 		{
 			name: "requeue control plane where target etcd cluster will be unhealthy when scaling up after remediation",
@@ -525,6 +546,9 @@ func TestPreflightChecks(t *testing.T) {
 				TopologyVersionMismatch:          false,
 			},
 			expectDeferNextReconcile: 5 * time.Second,
+			expectLogStr:             "Waiting for control plane to pass preflight checks",
+			expectLogKV:              []string{"failures", "adding a new control plane Machine can lead to etcd quorum loss. Please check the etcd status"},
+			expectEventStr:           "Waiting for control plane to pass preflight checks to continue reconciliation: adding a new control plane Machine can lead to etcd quorum loss. Please check the etcd status",
 		},
 		{
 			name: "control plane with an healthy machine and an healthy kcp condition should pass",
@@ -641,7 +665,16 @@ func TestPreflightChecks(t *testing.T) {
 				Machines:    collections.FromMachines(tt.machines...),
 				EtcdMembers: etcdMembers(collections.FromMachines(tt.machines...)),
 			}
-			result := r.preflightChecks(context.TODO(), controlPlane, tt.isScaleUp)
+			preflightChecksResult := r.preflightChecks(t.Context(), controlPlane, tt.isScaleUp)
+			g.Expect(preflightChecksResult.succeeded).To(Equal(tt.expectResult.IsZero()))
+			g.Expect(preflightChecksResult.PreflightCheckResults).To(Equal(tt.expectPreflight))
+			g.Expect(preflightChecksResult.requeueAfter).To(Equal(tt.expectResult.RequeueAfter))
+			g.Expect(preflightChecksResult.deferNextReconcile).To(Equal(tt.expectDeferNextReconcile))
+			g.Expect(preflightChecksResult.logStr).To(Equal(tt.expectLogStr))
+			g.Expect(preflightChecksResult.logKV).To(Equal(tt.expectLogKV))
+			g.Expect(preflightChecksResult.eventStr).To(Equal(tt.expectEventStr))
+
+			result := r.handlePreflightCheckResults(t.Context(), controlPlane, preflightChecksResult)
 			g.Expect(result).To(BeComparableTo(tt.expectResult))
 			g.Expect(controlPlane.PreflightCheckResults).To(Equal(tt.expectPreflight))
 			if tt.expectDeferNextReconcile == 0 {

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale.go
@@ -71,7 +71,7 @@ func (r *Reconciler) scaleUpControlPlane(ctx context.Context, controlPlane *pkg.
 	//
 	// Note: before considering scale up/scale up in the context of a rollout/scale up after a remediation, KCP first takes care of completing
 	// ongoing delete operations, completing in-place transitions, remediating unhealthy machines and completing on going in-place updates.
-	if result := r.preflightChecks(ctx, controlPlane, true); !result.IsZero() {
+	if result := r.handlePreflightCheckResults(ctx, controlPlane, r.preflightChecks(ctx, controlPlane, true)); !result.IsZero() {
 		return result, nil
 	}
 
@@ -100,6 +100,7 @@ func (r *Reconciler) scaleDownControlPlane(
 	ctx context.Context,
 	controlPlane *pkg.ControlPlane,
 	machineToDelete *clusterv1.Machine,
+	runPreflightChecks bool,
 ) (ctrl.Result, error) {
 	if r.overrideScaleDownControlPlaneFunc != nil {
 		return r.overrideScaleDownControlPlaneFunc(ctx, controlPlane, machineToDelete)
@@ -107,17 +108,19 @@ func (r *Reconciler) scaleDownControlPlane(
 
 	log := ctrl.LoggerFrom(ctx)
 
-	// Run preflight checks ensuring the control plane is stable before proceeding with a scale up/scale down operation; if not, wait.
-	//
-	// Important! preflight checks play an important role in ensuring that KCP performs "one operation at time", by forcing
-	// the system to wait for the previous operation to complete and the control plane to become stable before starting the next one.
-	//
-	// Note: before considering scale down/scale down in the context of a rollout, KCP first takes care of completing
-	// ongoing delete operations, completing in-place transitions, remediating unhealthy machines and completing on going in-place updates.
-	//
-	// Given that we're scaling down, we can exclude the machineToDelete from the preflight checks.
-	if result := r.preflightChecks(ctx, controlPlane, false, machineToDelete); !result.IsZero() {
-		return result, nil
+	if runPreflightChecks {
+		// Run preflight checks ensuring the control plane is stable before proceeding with a scale up/scale down operation; if not, wait.
+		//
+		// Important! preflight checks play an important role in ensuring that KCP performs "one operation at time", by forcing
+		// the system to wait for the previous operation to complete and the control plane to become stable before starting the next one.
+		//
+		// Note: before considering scale down/scale down in the context of a rollout, KCP first takes care of completing
+		// ongoing delete operations, completing in-place transitions, remediating unhealthy machines and completing on going in-place updates.
+		//
+		// Given that we're scaling down, we can exclude the machineToDelete from the preflight checks.
+		if result := r.handlePreflightCheckResults(ctx, controlPlane, r.preflightChecks(ctx, controlPlane, false, machineToDelete)); !result.IsZero() {
+			return result, nil
+		}
 	}
 
 	workloadCluster, err := controlPlane.GetWorkloadCluster(ctx)

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale_test.go
@@ -309,7 +309,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		machineToDelete, err := selectMachineForInPlaceUpdateOrScaleDown(ctx, controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
-		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete, true)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result.IsZero()).To(BeTrue())
 
@@ -363,7 +363,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		machineToDelete, err := selectMachineForInPlaceUpdateOrScaleDown(ctx, controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
-		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete, true)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result.IsZero()).To(BeTrue())
 
@@ -406,7 +406,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 
 		machineToDelete, err := selectMachineForInPlaceUpdateOrScaleDown(ctx, controlPlane, controlPlane.Machines)
 		g.Expect(err).ToNot(HaveOccurred())
-		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete)
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete, true)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(result).To(BeComparableTo(ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}))
 		g.Expect(fc.Deferrals).To(HaveKeyWithValue(
@@ -417,6 +417,51 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 		controlPlaneMachines := clusterv1.MachineList{}
 		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())
 		g.Expect(controlPlaneMachines.Items).To(HaveLen(3))
+	})
+
+	t.Run("scale down if preflight checks would fail but are not executed", func(t *testing.T) {
+		g := NewWithT(t)
+
+		machines := map[string]*clusterv1.Machine{
+			"one":   machine("one", withTimestamp(time.Now().Add(-1*time.Minute))),
+			"two":   machine("two", withTimestamp(time.Now())),
+			"three": machine("three", withTimestamp(time.Now())),
+		}
+		setMachineHealthy(machines["three"])
+		fakeClient := newFakeClient(machines["one"], machines["two"], machines["three"])
+
+		fc := capicontrollerutil.NewFakeController()
+
+		r := &Reconciler{
+			recorder:                        record.NewFakeRecorder(32),
+			Client:                          fakeClient,
+			controller:                      fc,
+			SecretCachingClient:             fakeClient,
+			machineClientWithDeleteResponse: capicontrollerutil.NewClientWithDeleteResponseFromClient(fakeClient),
+			managementCluster: &fakeManagementCluster{
+				Workload: &fakeWorkloadCluster{},
+			},
+		}
+
+		cluster := &clusterv1.Cluster{}
+		kcp := &controlplanev1.KubeadmControlPlane{}
+		controlPlane := &pkg.ControlPlane{
+			KCP:        kcp,
+			Cluster:    cluster,
+			Machines:   machines,
+			EtcdLeader: &etcd.Member{Name: "one"},
+		}
+		controlPlane.InjectTestManagementCluster(r.managementCluster)
+
+		machineToDelete, err := selectMachineForInPlaceUpdateOrScaleDown(ctx, controlPlane, controlPlane.Machines)
+		g.Expect(err).ToNot(HaveOccurred())
+		result, err := r.scaleDownControlPlane(context.Background(), controlPlane, machineToDelete, false)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(result.IsZero()).To(BeTrue())
+
+		controlPlaneMachines := clusterv1.MachineList{}
+		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())
+		g.Expect(controlPlaneMachines.Items).To(HaveLen(2))
 	})
 }
 

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update.go
@@ -142,18 +142,33 @@ func (r *Reconciler) rollingUpdate(
 	if feature.Gates.Enabled(feature.InPlaceUpdates) &&
 		machineUpToDateResult.EligibleForInPlaceUpdate &&
 		currentUpToDateReplicas < desiredReplicas {
-		fallbackToScaleDown, res, err := r.tryInPlaceUpdate(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown, machineUpToDateResult)
+		// Run preflight checks to ensure that the control plane is stable before proceeding with in-place update operation.
+		//
+		// Important! preflight checks play an important role in ensuring that KCP performs "one operation at time", by forcing
+		// the system to wait for the previous operation to complete and the control plane to become stable before starting the next one.
+		//
+		// Note: before considering in-place updates, KCP first takes care of completing
+		// ongoing delete operations, completing in-place transitions, remediating unhealthy machines.
+		if resultForAllMachines := r.preflightChecks(ctx, controlPlane, false); !resultForAllMachines.succeeded {
+			// If the control plane is not stable, check if the issues are only for machineToInPlaceUpdateOrScaleDown.
+			if result := r.preflightChecks(ctx, controlPlane, false, machineToInPlaceUpdateOrScaleDown); result.succeeded {
+				// The issues are only for machineToInPlaceUpdate, fallback to scale down.
+				// Note: The consequence of this is that a Machine with issues is scaled down and not in-place updated.
+				return r.scaleDownControlPlane(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown, false) // No need to run preflightChecks again, already passed above.
+			}
+
+			return r.handlePreflightCheckResults(ctx, controlPlane, resultForAllMachines), nil
+		}
+
+		fallbackToScaleDown, err := r.tryInPlaceUpdate(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown, machineUpToDateResult)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if !res.IsZero() {
-			return res, nil
-		}
 		if fallbackToScaleDown {
-			return r.scaleDownControlPlane(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown)
+			return r.scaleDownControlPlane(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown, false) // No need to run preflightChecks again, already passed above.
 		}
 		// In-place update triggered
 		return ctrl.Result{}, nil // Note: Requeue is not needed, changes to Machines trigger another reconcile.
 	}
-	return r.scaleDownControlPlane(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown)
+	return r.scaleDownControlPlane(ctx, controlPlane, machineToInPlaceUpdateOrScaleDown, true)
 }

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
@@ -308,7 +308,9 @@ func Test_rollingUpdate(t *testing.T) {
 		desiredReplicas                 int32
 		enableInPlaceUpdatesFeatureGate bool
 		machineEligibleForInPlaceUpdate bool
-		tryInPlaceUpdateFunc            func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, ctrl.Result, error)
+		preflightChecksFunc             func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) preflightChecksResult
+		tryInPlaceUpdateFunc            func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error)
+		wantPreflightChecksFuncCalled   bool
 		wantTryInPlaceUpdateCalled      bool
 		wantScaleDownCalled             bool
 		wantScaleUpCalled               bool
@@ -386,65 +388,97 @@ func Test_rollingUpdate(t *testing.T) {
 			wantTryInPlaceUpdateCalled:      false,
 			wantScaleDownCalled:             true,
 		},
+		// In-place updates: preflightCheck failures
+		{
+			name:                            "In-place updates: preflightChecks failed",
+			maxSurge:                        0,
+			currentReplicas:                 3,
+			currentUpToDateReplicas:         0,
+			desiredReplicas:                 3,
+			enableInPlaceUpdatesFeatureGate: true,
+			machineEligibleForInPlaceUpdate: true,
+			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) preflightChecksResult {
+				return preflightChecksResult{succeeded: false, requeueAfter: 3 * time.Second}
+			},
+			wantPreflightChecksFuncCalled: true,
+			wantTryInPlaceUpdateCalled:    false,
+			wantScaleDownCalled:           false,
+			wantRes:                       ctrl.Result{RequeueAfter: 3 * time.Second},
+		},
+		{
+			name:                            "In-place updates: preflightChecks failed only for specific Machine, fallback to scale down",
+			maxSurge:                        0,
+			currentReplicas:                 3,
+			currentUpToDateReplicas:         0,
+			desiredReplicas:                 3,
+			enableInPlaceUpdatesFeatureGate: true,
+			machineEligibleForInPlaceUpdate: true,
+			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) preflightChecksResult {
+				if len(excludeFor) > 0 {
+					return preflightChecksResult{succeeded: true}
+				}
+				return preflightChecksResult{succeeded: false, requeueAfter: 3 * time.Second}
+			},
+			wantPreflightChecksFuncCalled: true,
+			wantTryInPlaceUpdateCalled:    false,
+			wantScaleDownCalled:           true,
+		},
 		// In-place updates: tryInPlaceUpdate called
 		{
-			name:                            "In-place updates: tryInPlaceUpdate returns error",
+			name:                            "In-place updates: preflightChecks succeeded, tryInPlaceUpdate returns error",
 			maxSurge:                        0,
 			currentReplicas:                 3,
 			currentUpToDateReplicas:         0,
 			desiredReplicas:                 3,
 			enableInPlaceUpdatesFeatureGate: true,
 			machineEligibleForInPlaceUpdate: true,
-			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (bool, ctrl.Result, error) {
-				return false, ctrl.Result{}, pkgerrors.New("in-place update error")
+			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) preflightChecksResult {
+				return preflightChecksResult{succeeded: true}
 			},
-			wantTryInPlaceUpdateCalled: true,
-			wantScaleDownCalled:        false,
-			wantError:                  true,
-			wantErrorMessage:           "in-place update error",
+			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (bool, error) {
+				return false, pkgerrors.New("in-place update error")
+			},
+			wantPreflightChecksFuncCalled: true,
+			wantTryInPlaceUpdateCalled:    true,
+			wantScaleDownCalled:           false,
+			wantError:                     true,
+			wantErrorMessage:              "in-place update error",
 		},
 		{
-			name:                            "In-place updates: tryInPlaceUpdate returns Requeue",
+			name:                            "In-place updates: preflightChecks succeeded, tryInPlaceUpdate returns fallback to scale down",
 			maxSurge:                        0,
 			currentReplicas:                 3,
 			currentUpToDateReplicas:         0,
 			desiredReplicas:                 3,
 			enableInPlaceUpdatesFeatureGate: true,
 			machineEligibleForInPlaceUpdate: true,
-			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (fallbackToScaleDown bool, _ ctrl.Result, _ error) {
-				return false, ctrl.Result{RequeueAfter: preflightFailedRequeueAfter}, nil
+			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) preflightChecksResult {
+				return preflightChecksResult{succeeded: true}
 			},
-			wantTryInPlaceUpdateCalled: true,
-			wantScaleDownCalled:        false,
-			wantRes:                    ctrl.Result{RequeueAfter: preflightFailedRequeueAfter},
+			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (fallbackToScaleDown bool, _ error) {
+				return true, nil
+			},
+			wantPreflightChecksFuncCalled: true,
+			wantTryInPlaceUpdateCalled:    true,
+			wantScaleDownCalled:           true,
 		},
 		{
-			name:                            "In-place updates: tryInPlaceUpdate returns fallback to scale down",
+			name:                            "In-place updates: preflightChecks succeeded, tryInPlaceUpdate returns nothing (in-place update triggered)",
 			maxSurge:                        0,
 			currentReplicas:                 3,
 			currentUpToDateReplicas:         0,
 			desiredReplicas:                 3,
 			enableInPlaceUpdatesFeatureGate: true,
 			machineEligibleForInPlaceUpdate: true,
-			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (fallbackToScaleDown bool, _ ctrl.Result, _ error) {
-				return true, ctrl.Result{}, nil
+			preflightChecksFunc: func(_ context.Context, _ *pkg.ControlPlane, _ ...*clusterv1.Machine) preflightChecksResult {
+				return preflightChecksResult{succeeded: true}
 			},
-			wantTryInPlaceUpdateCalled: true,
-			wantScaleDownCalled:        true,
-		},
-		{
-			name:                            "In-place updates: tryInPlaceUpdate returns nothing (in-place update triggered)",
-			maxSurge:                        0,
-			currentReplicas:                 3,
-			currentUpToDateReplicas:         0,
-			desiredReplicas:                 3,
-			enableInPlaceUpdatesFeatureGate: true,
-			machineEligibleForInPlaceUpdate: true,
-			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (fallbackToScaleDown bool, _ ctrl.Result, _ error) {
-				return false, ctrl.Result{}, nil
+			tryInPlaceUpdateFunc: func(_ context.Context, _ *pkg.ControlPlane, _ *clusterv1.Machine, _ pkg.UpToDateResult) (fallbackToScaleDown bool, _ error) {
+				return false, nil
 			},
-			wantTryInPlaceUpdateCalled: true,
-			wantScaleDownCalled:        false,
+			wantPreflightChecksFuncCalled: true,
+			wantTryInPlaceUpdateCalled:    true,
+			wantScaleDownCalled:           false,
 		},
 	}
 	for _, tt := range tests {
@@ -455,11 +489,16 @@ func Test_rollingUpdate(t *testing.T) {
 				utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.InPlaceUpdates, true)
 			}
 
+			var preflightChecksFuncCalled bool
 			var inPlaceUpdateCalled bool
 			var scaleDownCalled bool
 			var scaleUpCalled bool
 			r := &Reconciler{
-				overrideTryInPlaceUpdateFunc: func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, ctrl.Result, error) {
+				overridePreflightChecksFunc: func(ctx context.Context, controlPlane *pkg.ControlPlane, excludeFor ...*clusterv1.Machine) preflightChecksResult {
+					preflightChecksFuncCalled = true
+					return tt.preflightChecksFunc(ctx, controlPlane, excludeFor...)
+				},
+				overrideTryInPlaceUpdateFunc: func(ctx context.Context, controlPlane *pkg.ControlPlane, machineToInPlaceUpdate *clusterv1.Machine, machineUpToDateResult pkg.UpToDateResult) (bool, error) {
 					inPlaceUpdateCalled = true
 					return tt.tryInPlaceUpdateFunc(ctx, controlPlane, machineToInPlaceUpdate, machineUpToDateResult)
 				},
@@ -471,6 +510,8 @@ func Test_rollingUpdate(t *testing.T) {
 					scaleUpCalled = true
 					return ctrl.Result{}, nil
 				},
+				controller: capicontrollerutil.NewFakeController(),
+				recorder:   record.NewFakeRecorder(32),
 			}
 
 			machines := collections.Machines{}
@@ -513,6 +554,7 @@ func Test_rollingUpdate(t *testing.T) {
 			}
 			g.Expect(res).To(Equal(tt.wantRes))
 
+			g.Expect(preflightChecksFuncCalled).To(Equal(tt.wantPreflightChecksFuncCalled), "preflightChecksFuncCalled: actual: %t expected: %t", preflightChecksFuncCalled, tt.wantPreflightChecksFuncCalled)
 			g.Expect(inPlaceUpdateCalled).To(Equal(tt.wantTryInPlaceUpdateCalled), "inPlaceUpdateCalled: actual: %t expected: %t", inPlaceUpdateCalled, tt.wantTryInPlaceUpdateCalled)
 			g.Expect(scaleDownCalled).To(Equal(tt.wantScaleDownCalled), "scaleDownCalled: actual: %t expected: %t", scaleDownCalled, tt.wantScaleDownCalled)
 			g.Expect(scaleUpCalled).To(Equal(tt.wantScaleUpCalled), "scaleUpCalled: actual: %t expected: %t", scaleUpCalled, tt.wantScaleUpCalled)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Today there are a few code paths in KCP where we are running preflight checks multiple times.
The problem is primarily that we defer / log and produce events multiple times as well which might be misleading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #13285

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->