### PR TITLE
🐛 Lifecycle hooks fix

### DIFF
--- a/core/reconcilers/topology/cluster/reconcile_state.go
+++ b/core/reconcilers/topology/cluster/reconcile_state.go
@@ -422,9 +422,6 @@ func (r *Reconciler) reconcileControlPlane(ctx context.Context, s *scope.Scope) 
 	// to call the lifecycle hooks queued by computeControlPlaneVersion (e.g. AfterControlPlaneUpgrade).
 	// Note: this must happen after the patch above succeeds; otherwise, if the patch fails, a future reconcile
 	// could call e.g. AfterControlPlaneUpgrade even though the ControlPlane never picked up the new version.
-	// Note: this covers the case where the Control Plane is starting a new upgrade step in this very reconcile
-	// (IsStartingUpgrade); the case where the Control Plane is still rolling out a step decided in a previous
-	// reconcile (IsUpgrading) is already handled above, before the early return for IsPendingUpgrade.
 	if len(s.UpgradeTracker.HooksToMarkPending) > 0 {
 		if err := hooks.MarkAsPending(ctx, r.Client, s.Current.Cluster, false, s.UpgradeTracker.HooksToMarkPending...); err != nil {
 			return created, err

--- a/core/reconcilers/topology/cluster/reconcile_state.go
+++ b/core/reconcilers/topology/cluster/reconcile_state.go
@@ -418,6 +418,19 @@ func (r *Reconciler) reconcileControlPlane(ctx context.Context, s *scope.Scope) 
 		return created, err
 	}
 
+	// Only now that the ControlPlane object has been successfully patched to the next version, track the intent
+	// to call the lifecycle hooks queued by computeControlPlaneVersion (e.g. AfterControlPlaneUpgrade).
+	// Note: this must happen after the patch above succeeds; otherwise, if the patch fails, a future reconcile
+	// could call e.g. AfterControlPlaneUpgrade even though the ControlPlane never picked up the new version.
+	// Note: this covers the case where the Control Plane is starting a new upgrade step in this very reconcile
+	// (IsStartingUpgrade); the case where the Control Plane is still rolling out a step decided in a previous
+	// reconcile (IsUpgrading) is already handled above, before the early return for IsPendingUpgrade.
+	if len(s.UpgradeTracker.HooksToMarkPending) > 0 {
+		if err := hooks.MarkAsPending(ctx, r.Client, s.Current.Cluster, false, s.UpgradeTracker.HooksToMarkPending...); err != nil {
+			return created, err
+		}
+	}
+
 	// If the controlPlane has infrastructureMachines and the InfrastructureMachineTemplate has changed on this reconcile
 	// delete the old template.
 	// This is a best effort deletion only and may leak templates if an error occurs during reconciliation.

--- a/core/reconcilers/topology/cluster/reconcile_state_test.go
+++ b/core/reconcilers/topology/cluster/reconcile_state_test.go
@@ -1620,6 +1620,8 @@ func TestReconcileInfrastructureCluster(t *testing.T) {
 }
 
 func TestReconcileControlPlane(t *testing.T) {
+	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
+
 	testReconcileControlPlane(t, "v1beta1")
 	testReconcileControlPlane(t, "v1beta2")
 }
@@ -1708,6 +1710,9 @@ func testReconcileControlPlane(t *testing.T, controlPlaneContractVersion string)
 	upgradeTrackerWithControlPlanePendingUpgrade := scope.NewUpgradeTracker()
 	upgradeTrackerWithControlPlanePendingUpgrade.ControlPlane.IsPendingUpgrade = true
 
+	upgradeTrackerWithHooksToMarkPending := scope.NewUpgradeTracker()
+	upgradeTrackerWithHooksToMarkPending.HooksToMarkPending = []runtimecatalog.Hook{runtimehooksv1.AfterControlPlaneUpgrade}
+
 	tests := []struct {
 		name                                 string
 		class                                *scope.ControlPlaneBlueprint
@@ -1719,6 +1724,7 @@ func testReconcileControlPlane(t *testing.T, controlPlaneContractVersion string)
 		want                                 *scope.ControlPlaneState
 		wantCreated                          bool
 		wantRotation                         bool
+		wantPendingHookAnnotation            string
 		wantErr                              bool
 	}{
 		// Testing reconciliation of a control plane without machines.
@@ -1732,12 +1738,14 @@ func testReconcileControlPlane(t *testing.T, controlPlaneContractVersion string)
 			wantErr:     false,
 		},
 		{
-			name:     "Should update the ControlPlane without machine infrastructure",
-			class:    ccWithoutControlPlaneInfrastructure,
-			original: &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructure.DeepCopy()},
-			desired:  &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructureWithChanges.DeepCopy()},
-			want:     &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructureWithChanges.DeepCopy()},
-			wantErr:  false,
+			name:                      "Should update the ControlPlane without machine infrastructure",
+			class:                     ccWithoutControlPlaneInfrastructure,
+			upgradeTracker:            upgradeTrackerWithHooksToMarkPending,
+			original:                  &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructure.DeepCopy()},
+			desired:                   &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructureWithChanges.DeepCopy()},
+			want:                      &scope.ControlPlaneState{Object: controlPlaneWithoutInfrastructureWithChanges.DeepCopy()},
+			wantPendingHookAnnotation: "AfterControlPlaneUpgrade",
+			wantErr:                   false,
 		},
 		{
 			name:           "Should not update the ControlPlane if ControlPlane is pending upgrade",
@@ -1841,7 +1849,31 @@ func testReconcileControlPlane(t *testing.T, controlPlaneContractVersion string)
 				tt.want = prepareControlPlaneState(g, tt.want, namespace.GetName())
 			}
 
-			s := scope.New(builder.Cluster(namespace.GetName(), "cluster1").Build())
+			infraTemplate := builder.InfrastructureClusterTemplate(namespace.GetName(), "template1").Build()
+			g.Expect(env.CreateAndWait(ctx, infraTemplate)).To(Succeed())
+
+			cpTemplate := builder.ControlPlaneTemplate(namespace.GetName(), "template1").Build()
+			g.Expect(env.CreateAndWait(ctx, cpTemplate)).To(Succeed())
+
+			clusterclass := builder.ClusterClass(namespace.GetName(), "class1").
+				WithInfrastructureClusterTemplate(infraTemplate).
+				WithControlPlaneTemplate(cpTemplate).
+				Build()
+			g.Expect(env.CreateAndWait(ctx, clusterclass)).To(Succeed())
+
+			cluster := builder.Cluster(namespace.GetName(), "cluster1").
+				WithTopology(&clusterv1.Topology{
+					ClassRef: clusterv1.ClusterClassRef{
+						Name: "class1",
+					},
+					Version: "v1.30.0",
+				}).
+				Build()
+			// Pausing the Cluster so the reconciler running in the background does not reconcile the Cluster for us.
+			cluster.Spec.Paused = ptr.To(true)
+			g.Expect(env.CreateAndWait(ctx, cluster)).To(Succeed())
+
+			s := scope.New(cluster)
 			s.Blueprint = &scope.ClusterBlueprint{
 				ClusterClass: &clusterv1.ClusterClass{},
 			}
@@ -2008,6 +2040,15 @@ func testReconcileControlPlane(t *testing.T, controlPlaneContractVersion string)
 					}, obj)
 					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				}
+			}
+
+			// Check PendingHookAnnotation
+			gotCluster := &clusterv1.Cluster{}
+			g.Expect(env.Get(ctx, client.ObjectKeyFromObject(cluster), gotCluster)).To(Succeed())
+			if tt.wantPendingHookAnnotation != "" {
+				g.Expect(gotCluster.Annotations).To(HaveKeyWithValue(runtimev1.PendingHooksAnnotation, tt.wantPendingHookAnnotation), "Unexpected PendingHookAnnotation")
+			} else {
+				g.Expect(gotCluster.Annotations).ToNot(HaveKey(runtimev1.PendingHooksAnnotation), "Unexpected PendingHookAnnotation")
 			}
 		})
 	}

--- a/exp/topology/desiredstate/desired_state.go
+++ b/exp/topology/desiredstate/desired_state.go
@@ -582,6 +582,16 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 	// after the control plane is stable.
 	if cpUpgrading {
 		s.UpgradeTracker.ControlPlane.IsUpgrading = true
+
+		// Recovery code in case control plane version was changed, but it failed to apply the list of pending hooks.
+		if feature.Gates.Enabled(feature.RuntimeSDK) {
+			if !hooks.IsPending(runtimehooksv1.AfterControlPlaneUpgrade, s.Current.Cluster) {
+				hooksToMarkPending := getHooksToMarkPending(s, *currentVersion)
+				if err := hooks.MarkAsPending(ctx, g.Client, s.Current.Cluster, false, hooksToMarkPending...); err != nil {
+					return "", err
+				}
+			}
+		}
 		return *currentVersion, nil
 	}
 
@@ -698,21 +708,15 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 			return *currentVersion, nil
 		}
 
-		// After BeforeControlPlaneUpgrade unblocked the upgrade step, consider the upgrade step start started,
-		// As a consequence, the system start tracking the intent of calling other hooks for this upgrade step:
+		// After BeforeControlPlaneUpgrade unblocked the upgrade step, consider the upgrade step starting,
+		// As a consequence, the system should also start tracking the intent of calling other hooks for this upgrade step:
 		// - AfterControlPlaneUpgrade hook to be called after the control plane completes the upgrade step.
 		// - If workers are required to upgrade to the current control plane version:
 		//   - BeforeWorkersUpgrade hook to be called before workers start the upgrade step.
 		//   - AfterWorkersUpgrade hook to be called after workers completes the upgrade step.
-		hooksToBeCalled := []runtimecatalog.Hook{runtimehooksv1.AfterControlPlaneUpgrade}
-		machineDeploymentPendingUpgrade := len(s.UpgradeTracker.MachineDeployments.UpgradePlan) > 0 && s.UpgradeTracker.MachineDeployments.UpgradePlan[0] == nextVersion
-		machinePoolPendingUpgrade := len(s.UpgradeTracker.MachinePools.UpgradePlan) > 0 && s.UpgradeTracker.MachinePools.UpgradePlan[0] == nextVersion
-		if machineDeploymentPendingUpgrade || machinePoolPendingUpgrade {
-			hooksToBeCalled = append(hooksToBeCalled, runtimehooksv1.BeforeWorkersUpgrade, runtimehooksv1.AfterWorkersUpgrade)
-		}
-		if err := hooks.MarkAsPending(ctx, g.Client, s.Current.Cluster, false, hooksToBeCalled...); err != nil {
-			return "", err
-		}
+		// Note: the intent must surface on the Cluster object only after the control plane version is actually set
+		// in reconcileControlPlane.
+		s.UpgradeTracker.HooksToMarkPending = getHooksToMarkPending(s, nextVersion)
 	}
 
 	// The upgrade is now starting in this reconcile and not pending anymore.
@@ -726,6 +730,16 @@ func (g *generator) computeControlPlaneVersion(ctx context.Context, s *scope.Sco
 		s.Current.ControlPlane.Object.GetKind(), klog.KObj(s.Current.ControlPlane.Object),
 	)
 	return nextVersion, nil
+}
+
+func getHooksToMarkPending(s *scope.Scope, nextVersion string) []runtimecatalog.Hook {
+	hooksToMarkPending := []runtimecatalog.Hook{runtimehooksv1.AfterControlPlaneUpgrade}
+	machineDeploymentPendingUpgrade := len(s.UpgradeTracker.MachineDeployments.UpgradePlan) > 0 && s.UpgradeTracker.MachineDeployments.UpgradePlan[0] == nextVersion
+	machinePoolPendingUpgrade := len(s.UpgradeTracker.MachinePools.UpgradePlan) > 0 && s.UpgradeTracker.MachinePools.UpgradePlan[0] == nextVersion
+	if machineDeploymentPendingUpgrade || machinePoolPendingUpgrade {
+		hooksToMarkPending = append(hooksToMarkPending, runtimehooksv1.BeforeWorkersUpgrade, runtimehooksv1.AfterWorkersUpgrade)
+	}
+	return hooksToMarkPending
 }
 
 // computeCluster computes the desired state for the Cluster object.

--- a/exp/topology/desiredstate/lifecycle_hooks_test.go
+++ b/exp/topology/desiredstate/lifecycle_hooks_test.go
@@ -1338,15 +1338,15 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			g.Expect(hooksCalled.Has("AfterWorkersUpgrade")).To(Equal(tt.wantAfterWorkersUpgradeRequest != nil), "Unexpected call/missing call to AfterWorkersUpgrade")
 
 			// check intent to call hooks
-			hookNames := make([]string, 0, len(s.UpgradeTracker.HooksToMarkPending))
+			var hookNames []string
 			for _, hook := range s.UpgradeTracker.HooksToMarkPending {
 				hookNames = append(hookNames, runtimecatalog.HookName(hook))
 			}
-			g.Expect(hookNames).To(HaveLen(len(tt.wantHooksToMarkPending)), "Unexpected list of hooksToMarkPending")
+			g.Expect(hookNames).To(ConsistOf(tt.wantHooksToMarkPending))
 			if tt.wantPendingHookAnnotation != "" {
-				g.Expect(s.Current.Cluster.Annotations).To(HaveKeyWithValue(runtimev1.PendingHooksAnnotation, tt.wantPendingHookAnnotation), "Unexpected PendingHookAnnotation")
+				g.Expect(s.Current.Cluster.Annotations).To(HaveKeyWithValue(runtimev1.PendingHooksAnnotation, tt.wantPendingHookAnnotation))
 			} else {
-				g.Expect(s.Current.Cluster.Annotations).ToNot(HaveKey(runtimev1.PendingHooksAnnotation), "Unexpected PendingHookAnnotation")
+				g.Expect(s.Current.Cluster.Annotations).ToNot(HaveKey(runtimev1.PendingHooksAnnotation))
 			}
 
 			if tt.wantHookCacheEntry != nil {

--- a/exp/topology/desiredstate/lifecycle_hooks_test.go
+++ b/exp/topology/desiredstate/lifecycle_hooks_test.go
@@ -194,6 +194,7 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 		wantVersion                          string
 		wantIsPendingUpgrade                 bool
 		wantIsStartingUpgrade                bool
+		wantHooksToMarkPending               []string
 		wantIsWaitingForWorkersUpgrade       bool
 		wantPendingHookAnnotation            string
 		wantHookCacheEntry                   *cache.HookEntry
@@ -300,12 +301,13 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			beforeControlPlaneUpgradeResponse: nonBlockingBeforeControlPlaneUpgradeResponse,
 			wantVersion:                       "v1.2.3", // changed from previous step
 			wantIsStartingUpgrade:             true,
-			wantPendingHookAnnotation:         "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade", // changed from previous step
+			wantHooksToMarkPending:            []string{"AfterControlPlaneUpgrade", "AfterWorkersUpgrade", "BeforeWorkersUpgrade"},
+			wantPendingHookAnnotation:         "AfterClusterUpgrade",
 		},
 		{
 			name:                  "when control plane is upgrading: do not call hooks",
 			topologyVersion:       "v1.2.3",
-			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade",
+			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade", // Changed from a previous step by reconcileControlPlane
 			controlPlaneObj: builder.ControlPlane("test1", "cp1").
 				WithSpecFields(map[string]interface{}{
 					"spec.version": "v1.2.3",
@@ -320,6 +322,25 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			machinePoolsUpgradePlan:       []string{"v1.2.3"},
 			wantVersion:                   "v1.2.3",
 			wantPendingHookAnnotation:     "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade",
+		},
+		{
+			name:                  "when control plane is upgrading: add intent to call hooks if missing", // Note: this is a variant of the step above (in case reconcileControlPlane fails to apply the HooksToMarkPending)
+			topologyVersion:       "v1.2.3",
+			pendingHookAnnotation: "AfterClusterUpgrade",
+			controlPlaneObj: builder.ControlPlane("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version": "v1.2.3",
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version": "v1.2.2",
+				}).
+				Build(),
+			minWorkersVersion:             "v1.2.2",
+			controlPlaneUpgradePlan:       []string{"v1.2.3"},
+			machineDeploymentsUpgradePlan: []string{"v1.2.3"},
+			machinePoolsUpgradePlan:       []string{"v1.2.3"},
+			wantVersion:                   "v1.2.3",
+			wantPendingHookAnnotation:     "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade", // Fixed up
 		},
 		{
 			name:                  "after control plane is upgraded: call the AfterControlPlaneUpgrade hook, blocking answer",
@@ -605,12 +626,13 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			beforeControlPlaneUpgradeResponse: nonBlockingBeforeControlPlaneUpgradeResponse,
 			wantVersion:                       "v1.3.3", // changed from previous step
 			wantIsStartingUpgrade:             true,
-			wantPendingHookAnnotation:         "AfterClusterUpgrade,AfterControlPlaneUpgrade", // changed from previous step
+			wantHooksToMarkPending:            []string{"AfterControlPlaneUpgrade"},
+			wantPendingHookAnnotation:         "AfterClusterUpgrade",
 		},
 		{
 			name:                  "when control plane is upgrading to the first minor: do not call hooks",
 			topologyVersion:       "v1.4.4",
-			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade",
+			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade", // Changed from a previous step by reconcileControlPlane
 			controlPlaneObj: builder.ControlPlane("test1", "cp1").
 				WithSpecFields(map[string]interface{}{
 					"spec.version": "v1.3.3",
@@ -714,12 +736,13 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			beforeControlPlaneUpgradeResponse: nonBlockingBeforeControlPlaneUpgradeResponse,
 			wantVersion:                       "v1.4.4", // changed from previous step
 			wantIsStartingUpgrade:             true,
-			wantPendingHookAnnotation:         "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade", // changed from previous step
+			wantHooksToMarkPending:            []string{"AfterControlPlaneUpgrade", "AfterWorkersUpgrade", "BeforeWorkersUpgrade"},
+			wantPendingHookAnnotation:         "AfterClusterUpgrade",
 		},
 		{
 			name:                  "when control plane is upgrading to the second minor: do not call hooks",
 			topologyVersion:       "v1.4.4",
-			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade",
+			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade,AfterWorkersUpgrade,BeforeWorkersUpgrade", // Changed from a previous step by reconcileControlPlane
 			controlPlaneObj: builder.ControlPlane("test1", "cp1").
 				WithSpecFields(map[string]interface{}{
 					"spec.version": "v1.4.4",
@@ -996,7 +1019,8 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			beforeControlPlaneUpgradeResponse: nonBlockingBeforeControlPlaneUpgradeResponse,
 			wantVersion:                       "v1.3.3", // changed from previous step
 			wantIsStartingUpgrade:             true,
-			wantPendingHookAnnotation:         "AfterClusterUpgrade,AfterControlPlaneUpgrade", // changed from previous step
+			wantHooksToMarkPending:            []string{"AfterControlPlaneUpgrade"},
+			wantPendingHookAnnotation:         "AfterClusterUpgrade",
 		},
 		{
 			name:                  "when control plane is upgrading to the first minor: do not call hooks",
@@ -1102,12 +1126,13 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			beforeControlPlaneUpgradeResponse: nonBlockingBeforeControlPlaneUpgradeResponse,
 			wantVersion:                       "v1.4.4", // changed from previous step
 			wantIsStartingUpgrade:             true,
-			wantPendingHookAnnotation:         "AfterClusterUpgrade,AfterControlPlaneUpgrade", // changed from previous step
+			wantHooksToMarkPending:            []string{"AfterControlPlaneUpgrade"},
+			wantPendingHookAnnotation:         "AfterClusterUpgrade",
 		},
 		{
 			name:                  "when control plane is upgrading to the second minor: do not call hooks",
 			topologyVersion:       "v1.4.4",
-			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade",
+			pendingHookAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade", // Changed from a previous step by reconcileControlPlane
 			controlPlaneObj: builder.ControlPlane("test1", "cp1").
 				WithSpecFields(map[string]interface{}{
 					"spec.version": "v1.4.4",
@@ -1313,6 +1338,11 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			g.Expect(hooksCalled.Has("AfterWorkersUpgrade")).To(Equal(tt.wantAfterWorkersUpgradeRequest != nil), "Unexpected call/missing call to AfterWorkersUpgrade")
 
 			// check intent to call hooks
+			hookNames := make([]string, 0, len(s.UpgradeTracker.HooksToMarkPending))
+			for _, hook := range s.UpgradeTracker.HooksToMarkPending {
+				hookNames = append(hookNames, runtimecatalog.HookName(hook))
+			}
+			g.Expect(hookNames).To(HaveLen(len(tt.wantHooksToMarkPending)), "Unexpected list of hooksToMarkPending")
 			if tt.wantPendingHookAnnotation != "" {
 				g.Expect(s.Current.Cluster.Annotations).To(HaveKeyWithValue(runtimev1.PendingHooksAnnotation, tt.wantPendingHookAnnotation), "Unexpected PendingHookAnnotation")
 			} else {

--- a/exp/topology/scope/upgradetracker.go
+++ b/exp/topology/scope/upgradetracker.go
@@ -33,7 +33,7 @@ type UpgradeTracker struct {
 	// Note: when there are no upgrade in progress, ComputeUpgradePlan succeeds and it returns an empty upgrade plan.
 	ComputeUpgradePlanSucceeded bool
 
-	// HooksToMarkPending is the list of lifecycle hooks for which the intent to be called
+	// HooksToMarkPending is the list of lifecycle hooks that must be market as pending
 	// after the control plane is updated to the next version.
 	HooksToMarkPending []runtimecatalog.Hook
 }

--- a/exp/topology/scope/upgradetracker.go
+++ b/exp/topology/scope/upgradetracker.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package scope
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	runtimecatalog "sigs.k8s.io/cluster-api/api/runtime/catalog"
+)
 
 // UpgradeTracker is a helper to capture the upgrade status and make upgrade decisions.
 type UpgradeTracker struct {
@@ -28,6 +32,10 @@ type UpgradeTracker struct {
 	// ComputeUpgradePlanSucceeded reports when an upgrade plan has been successfully computed
 	// Note: when there are no upgrade in progress, ComputeUpgradePlan succeeds and it returns an empty upgrade plan.
 	ComputeUpgradePlanSucceeded bool
+
+	// HooksToMarkPending is the list of lifecycle hooks for which the intent to be called
+	// after the control plane is updated to the next version.
+	HooksToMarkPending []runtimecatalog.Hook
 }
 
 // ControlPlaneUpgradeTracker holds the current upgrade status of the Control Plane.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
This PR fixes race conditions when topology controller updates the control plane version and sets the intent to track lifecycle hooks and one of the two operations fails

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/area clusterclass