### PR TITLE
🌱 fix: correct typos in clusterctl help text and comments

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -73,7 +73,7 @@ type CertManagerClient interface {
 	// older than the version currently suggested by clusterctl, upgrades it.
 	EnsureLatestVersion(ctx context.Context) error
 
-	// PlanUpgrade retruns a CertManagerUpgradePlan with information regarding
+	// PlanUpgrade returns a CertManagerUpgradePlan with information regarding
 	// a cert-manager upgrade if necessary.
 	PlanUpgrade(ctx context.Context) (CertManagerUpgradePlan, error)
 

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -101,7 +101,7 @@ type node struct {
 	restoreObject *unstructured.Unstructured
 
 	// additionalInfo captures any additional information about the object the node represents.
-	// E.g. for the cluster object we capture information to see if the cluster uses a manged topology
+	// E.g. for the cluster object we capture information to see if the cluster uses a managed topology
 	// and the cluster class used.
 	additionalInfo map[string]interface{}
 

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -273,7 +273,7 @@ func (od ObjectTree) IsObjectWithChild(id types.UID) bool {
 	return len(od.ownership[id]) > 0
 }
 
-// GetObjectsByParent returns all the dependant objects for the given uid.
+// GetObjectsByParent returns all the dependent objects for the given uid.
 func (od ObjectTree) GetObjectsByParent(id types.UID) []client.Object {
 	out := make([]client.Object, 0, len(od.ownership[id]))
 	for k := range od.ownership[id] {

--- a/cmd/clusterctl/cmd/rollout/pause.go
+++ b/cmd/clusterctl/cmd/rollout/pause.go
@@ -66,7 +66,7 @@ func NewCmdRolloutPause(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&pauseOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVarP(&pauseOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&pauseOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the default namespace will be used.")
 
 	return cmd
 }

--- a/cmd/clusterctl/cmd/rollout/restart.go
+++ b/cmd/clusterctl/cmd/rollout/restart.go
@@ -65,7 +65,7 @@ func NewCmdRolloutRestart(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&restartOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVarP(&restartOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&restartOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the default namespace will be used.")
 
 	return cmd
 }

--- a/cmd/clusterctl/cmd/rollout/resume.go
+++ b/cmd/clusterctl/cmd/rollout/resume.go
@@ -65,7 +65,7 @@ func NewCmdRolloutResume(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&resumeOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVarP(&resumeOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&resumeOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the default namespace will be used.")
 
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes six typos. Three of them are user-visible: `clusterctl rollout pause`, `restart`, and `resume` all describe their `--namespace` flag as "If unspecified, the defult namespace will be used." The remaining three are in Go comments (`retruns`, `manged`, `dependant`).

No identifiers or behaviour changed, and nothing asserts the old help strings. `go build ./...` passes.

**Which issue(s) this PR fixes**: None

/area clusterctl