### PR TITLE
[release-1.13] 🐛 Fix KCP rollout issue after upgrade from CAPI v1.11

### DIFF
--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -322,6 +322,19 @@ func PrepareKubeadmConfigsForDiff(desiredKubeadmConfig, currentKubeadmConfig *bo
 		currentKubeadmConfig.Spec.JoinConfiguration.CACertPath = desiredKubeadmConfig.Spec.JoinConfiguration.CACertPath
 	}
 
+	// Note: On KubeadmConfigs created by CAPI v1.11 KCP did not set JoinConfiguration.ControlPlane.
+	// CABPK was setting it, but because of a reentrancy issue in CABPK it is not guaranteed that
+	// this field is actually set. If the current KubeadmConfig is missing this field, it should not
+	// be considered a diff.
+	// The reentrancy issue in CABPK was that if the status write succeeds and the spec write fails CABPK
+	// does not try to write JoinConfiguration.ControlPlane again.
+	// As CAPI v1.11 supported up to Kubernetes v1.34. We assume the Machine has to be rolled out before CAPI
+	// drops support for Kubernetes v1.34. So this code can be removed once CAPI doesn't support Kubernetes
+	// v1.34 anymore.
+	if isKubeadmConfigForJoin(currentKubeadmConfig) && currentKubeadmConfig.Spec.JoinConfiguration.ControlPlane == nil {
+		currentKubeadmConfig.Spec.JoinConfiguration.ControlPlane = &bootstrapv1.JoinControlPlane{}
+	}
+
 	// Ignore ControlPlaneEndpoint which is added on the Machine KubeadmConfig by CABPK.
 	// Note: ControlPlaneEndpoint should also never change for a Cluster, so no reason to trigger a rollout because of that.
 	currentKubeadmConfig.Spec.ClusterConfiguration.ControlPlaneEndpoint = desiredKubeadmConfig.Spec.ClusterConfiguration.ControlPlaneEndpoint
@@ -543,8 +556,17 @@ func dropOmittableFields(spec *bootstrapv1.KubeadmConfigSpec) {
 // is not safe because apiServer.timeoutForControlPlane in v1beta1 is also converted to
 // joinConfiguration.timeouts.controlPlaneComponentHealthCheckSeconds in v1beta2 and
 // accordingly we would also detect init KubeadmConfigs as join.
+// Note: On KubeadmConfigs created by CAPI v1.11 KCP did not set JoinConfiguration.ControlPlane.
+// CABPK was setting it, but because of a reentrancy issue in CABPK it is not guaranteed that
+// this field is actually set. We're making up for that by additionally checking kubeletExtraArgs
+// which is usually always set (because of the --cloud-provider=external extra arg).
+// The reentrancy issue in CABPK was that if the status write succeeds and the spec write fails CABPK
+// does not try to write JoinConfiguration.ControlPlane again.
+// As CAPI v1.11 supported up to Kubernetes v1.34. We assume the Machine has to be either rolled out
+// or in-place updated before CAPI drops support for Kubernetes v1.34. So this code (the KubeletExtraArgs check)
+// can be removed once CAPI doesn't support Kubernetes v1.34 anymore.
 func isKubeadmConfigForJoin(c *bootstrapv1.KubeadmConfig) bool {
-	return c.Spec.JoinConfiguration.ControlPlane != nil
+	return c.Spec.JoinConfiguration.ControlPlane != nil || len(c.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs) > 0
 }
 
 // isKubeadmConfigForInit returns true if the KubeadmConfig is for the first control plane

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -738,6 +738,86 @@ func TestMatchesKubeadmConfig(t *testing.T) {
 		g.Expect(match).To(BeTrue())
 		g.Expect(reason).To(BeEmpty())
 	})
+	t.Run("returns true if JoinConfiguration is equal apart from JoinControlPlane not set on current KubeadmConfig (v1.11 case)", func(t *testing.T) {
+		g := NewWithT(t)
+		kcp := &controlplanev1.KubeadmControlPlane{
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+					ClusterConfiguration: bootstrapv1.ClusterConfiguration{},
+					InitConfiguration: bootstrapv1.InitConfiguration{
+						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+							Name: "A new name",
+							KubeletExtraArgs: []bootstrapv1.Arg{
+								{
+									Name:  "cloud-provider",
+									Value: ptr.To("external"),
+								},
+							},
+						},
+					},
+					JoinConfiguration: bootstrapv1.JoinConfiguration{
+						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+							Name: "A new name",
+							KubeletExtraArgs: []bootstrapv1.Arg{
+								{
+									Name:  "cloud-provider",
+									Value: ptr.To("external"),
+								},
+							},
+						},
+						ControlPlane: nil, // Control plane configuration missing in KCP
+					},
+				},
+				Version: "v1.30.0",
+			},
+		}
+		m := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test",
+			},
+			Spec: clusterv1.MachineSpec{
+				Bootstrap: clusterv1.Bootstrap{
+					ConfigRef: clusterv1.ContractVersionedObjectReference{
+						Kind:     "KubeadmConfig",
+						Name:     "test",
+						APIGroup: bootstrapv1.GroupVersion.Group,
+					},
+				},
+			},
+		}
+		machineConfigs := map[string]*bootstrapv1.KubeadmConfig{
+			m.Name: {
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					JoinConfiguration: bootstrapv1.JoinConfiguration{
+						NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+							Name: "A new name",
+							// KubeletExtraArgs is used by isKubeadmConfigForJoin to detect that this is a Join
+							// even if JoinConfiguration.ControlPlane is not set.
+							KubeletExtraArgs: []bootstrapv1.Arg{
+								{
+									Name:  "cloud-provider",
+									Value: ptr.To("external"),
+								},
+							},
+						},
+						// Machine does not get JoinConfiguration.ControlPlane set by CABPK because of reentrancy issue.
+					},
+				},
+			},
+		}
+		reason, currentKubeadmConfig, desiredKubeadmConfig, match, err := matchesKubeadmConfig(machineConfigs, kcp, &clusterv1.Cluster{}, m)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(currentKubeadmConfig).ToNot(BeNil())
+		g.Expect(desiredKubeadmConfig).ToNot(BeNil())
+		g.Expect(isKubeadmConfigForJoin(desiredKubeadmConfig)).To(BeTrue())
+		g.Expect(match).To(BeTrue())
+		g.Expect(reason).To(BeEmpty())
+	})
 	t.Run("returns false if JoinConfiguration is not equal, and InitConfiguration is also not equal", func(t *testing.T) {
 		g := NewWithT(t)
 		kcp := &controlplanev1.KubeadmControlPlane{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/14167

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->