### PR TITLE
🌱 Install the minimum required kind version for e2e test 

### DIFF
--- a/hack/scripts/ensure/ensure-kind.sh
+++ b/hack/scripts/ensure/ensure-kind.sh
@@ -51,6 +51,16 @@ install_kind() {
   fi
 }
 
+# verify_kind_installed checks that the kind binary resolved via PATH meets MINIMUM_KIND_VERSION.
+verify_kind_installed() {
+  local kind_version
+  kind_version="v$(kind version -q)"
+  if [[ "${MINIMUM_KIND_VERSION}" != $(echo -e "${MINIMUM_KIND_VERSION}\n${kind_version}" | sort -s -t. -k 1,1n -k 2,2n -k 3,3n | head -n1) ]]; then
+    echo "error: 'kind' in PATH resolved to ${kind_version} after install; expected >= ${MINIMUM_KIND_VERSION}"
+    return 2
+  fi
+}
+
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
 
@@ -58,6 +68,7 @@ verify_kind_version() {
   if ! [ -x "$(command -v kind)" ]; then
     echo 'kind not found, installing'
     install_kind
+    verify_kind_installed
     return
   fi
 
@@ -70,6 +81,7 @@ Requires ${MINIMUM_KIND_VERSION} or greater.
 Installing ${MINIMUM_KIND_VERSION}.
 EOF
     install_kind
+    verify_kind_installed
   fi
 }
 

--- a/hack/scripts/ensure/ensure-kind.sh
+++ b/hack/scripts/ensure/ensure-kind.sh
@@ -35,23 +35,30 @@ goos="$(go env GOOS)"
 MINIMUM_KIND_VERSION=v0.33.0
 
 
+# install_kind downloads and installs the required kind version into GOPATH_BIN.
+install_kind() {
+  if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
+    echo "Installing kind ${MINIMUM_KIND_VERSION}"
+    if ! [ -d "${GOPATH_BIN}" ]; then
+      mkdir -p "${GOPATH_BIN}"
+    fi
+    curl --retry 5 --retry-all-errors -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
+    chmod +x "${GOPATH_BIN}/kind"
+    verify_gopath_bin
+  else
+    echo "Unsupported OS: cannot install kind on ${goos}"
+    return 2
+  fi
+}
+
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {
 
   # If kind is not available on the path, get it
   if ! [ -x "$(command -v kind)" ]; then
-    if [ "$goos" == "linux" ] || [ "$goos" == "darwin" ]; then
-      echo 'kind not found, installing'
-      if ! [ -d "${GOPATH_BIN}" ]; then
-        mkdir -p "${GOPATH_BIN}"
-      fi
-      curl --retry 5 --retry-all-errors -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
-      chmod +x "${GOPATH_BIN}/kind"
-      verify_gopath_bin
-    else
-      echo "Missing required binary in path: kind"
-      return 2
-    fi
+    echo 'kind not found, installing'
+    install_kind
+    return
   fi
 
   local kind_version
@@ -60,9 +67,9 @@ verify_kind_version() {
     cat <<EOF
 Detected kind version: ${kind_version}.
 Requires ${MINIMUM_KIND_VERSION} or greater.
-Please install ${MINIMUM_KIND_VERSION} or later.
+Installing ${MINIMUM_KIND_VERSION}.
 EOF
-    return 2
+    install_kind
   fi
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

Background:
Added an optional periodic and presubmit job to main branch to use the new kubekins-e2e-v2 image via [PR](https://github.com/kubernetes/test-infra/pull/37632) but they started failing with below error, [Testgrid Ref](https://testgrid.k8s.io/cluster-api-core-main#capi-e2e-main-v2)
```
 + ./hack/scripts/ci/ci-e2e.sh
Detected kind version: v0.32.0.
Requires v0.33.0 or greater.
Please install v0.33.0 or later.
```

This PR updates the script to override the kind image with the minimum required version by downloading it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->