### PR TITLE
📖 Add warnings for in-place updates of Machines created with CAPI v1.11

### DIFF
--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-in-place-update-hooks.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-in-place-update-hooks.md
@@ -8,6 +8,18 @@ Please note Runtime SDK is an advanced feature. If implemented incorrectly, a fa
 
 </aside>
 
+<aside class="note warning">
+
+<h1>Caution</h1>
+
+For Clusters that have been created with CAPI <= v1.11 it will only be possible to unset fields during in-place updates after:
+* a regular rollout that replaces all Machines
+* an in-place update that updates all Machines
+
+For details see the PR description of [CAPI-12890](https://github.com/kubernetes-sigs/cluster-api/pull/12890) section "Migration from managedFields v1.11 => v1.12".
+
+</aside>
+
 ## Introduction
 
 The proposal for [in-place updates in Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240807-in-place-updates.md)

--- a/docs/proposals/20240807-in-place-updates-implementation-notes.md
+++ b/docs/proposals/20240807-in-place-updates-implementation-notes.md
@@ -256,3 +256,11 @@ When triggering in-place updates:
    - labels and annotations are owned by the metadata manager
    - spec is owned by the spec manager
    - in-progress and cloned-from annotations are owned by the spec manager
+
+### Limitation for Machines created with CAPI v1.11
+
+For Clusters that have been created with CAPI <= v1.11 it will only be possible to unset fields during in-place updates after:
+* a regular rollout that replaces all Machines
+* an in-place update that updates all Machines
+
+For details see the PR description of [CAPI-12890](https://github.com/kubernetes-sigs/cluster-api/pull/12890) section "Migration from managedFields v1.11 => v1.12".

--- a/docs/proposals/20240807-in-place-updates.md
+++ b/docs/proposals/20240807-in-place-updates.md
@@ -158,6 +158,7 @@ The responsibility to determine which Machine/MachineSet should be updated, the 
 
 - To provide rollbacks in case of an in-place update failure. Failed updates need to be fixed manually by the user on the machine or by replacing the machine.
 - Introduce any API changes both in core Cluster API or in KCP (or any other control plane provider).
+- Support unsetting fields of Machines created with CAPI v1.11 during the first in-place update. For details see the PR description of [CAPI-12890](https://github.com/kubernetes-sigs/cluster-api/pull/12890) section "Migration from managedFields v1.11 => v1.12".
 - Support more than one pluggable update extensions (future goal).
 - Allow in-place updates for single-node clusters without the requirement to reprovision hosts (future goal).
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:
Adding the disclaimer from https://github.com/kubernetes-sigs/cluster-api/pull/12890 to the docs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/issues/14023

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->