### PR TITLE
🌱 Add contract labels to kubeadm CRDs in envtest

### DIFF
--- a/bootstrap/kubeadm/config/crd/kustomization.yaml
+++ b/bootstrap/kubeadm/config/crd/kustomization.yaml
@@ -2,6 +2,8 @@ labels:
 - pairs:
     # Note: This is needed so the topology reconciler can figure out
     # the contract of v1beta1 when v1beta1 objects are used in ClusterClasses.
+    # Note: internal/test/envtest/environment.go mirrors these labels for
+    # envtest; if they are changed here, they have to be changed there, too.
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
 

--- a/controlplane/kubeadm/config/crd/kustomization.yaml
+++ b/controlplane/kubeadm/config/crd/kustomization.yaml
@@ -2,6 +2,8 @@ labels:
 - pairs:
     # Note: This is needed so the topology reconciler can figure out
     # the contract of v1beta1 when v1beta1 objects are used in ClusterClasses.
+    # Note: internal/test/envtest/environment.go mirrors these labels for
+    # envtest; if they are changed here, they have to be changed there, too.
     cluster.x-k8s.io/v1beta1: v1beta1
     cluster.x-k8s.io/v1beta2: v1beta2
 

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -19,6 +19,7 @@ package envtest
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path"
@@ -291,11 +292,20 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 		crdDirectoryPaths = append(crdDirectoryPaths, filepath.Join(root, path))
 	}
 
+	// Read the CRDs from the raw bases/ manifests into memory, so we can add the
+	// contract labels before they get installed (see addContractLabelsToKubeadmCRDs).
+	crdInstallOptions := envtest.CRDInstallOptions{
+		Paths:              crdDirectoryPaths,
+		ErrorIfPathMissing: true,
+	}
+	if err := envtest.ReadCRDFiles(&crdInstallOptions); err != nil {
+		panic(pkgerrors.Wrapf(err, "failed to read CRD files"))
+	}
+	addContractLabelsToKubeadmCRDs(crdInstallOptions.CRDs)
+
 	// Create the test environment.
 	env := &envtest.Environment{
-		ErrorIfCRDPathMissing: true,
-		CRDDirectoryPaths:     crdDirectoryPaths,
-		CRDs: []*apiextensionsv1.CustomResourceDefinition{
+		CRDs: append(crdInstallOptions.CRDs, []*apiextensionsv1.CustomResourceDefinition{
 			builder.GenericBootstrapConfigCRD.DeepCopy(),
 			builder.GenericBootstrapConfigTemplateCRD.DeepCopy(),
 			builder.GenericControlPlaneCRD.DeepCopy(),
@@ -318,7 +328,7 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 			builder.TestBootstrapConfigCRD.DeepCopy(),
 			builder.TestControlPlaneTemplateCRD.DeepCopy(),
 			builder.TestControlPlaneCRD.DeepCopy(),
-		},
+		}...),
 		// initialize webhook here to be able to test the envtest install via webhookOptions
 		// This should set LocalServingCertDir and LocalServingPort that are used below.
 		WebhookInstallOptions: initWebhookInstallOptions(),
@@ -356,18 +366,6 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 	}
 
 	if _, err := env.Start(); err != nil {
-		err = kerrors.NewAggregate([]error{err, env.Stop()})
-		panic(err)
-	}
-
-	// envtest installs the CRDs from the raw bases/ manifests, which bypasses kustomize and
-	// thus drops the contract labels that are injected in production via
-	// bootstrap/kubeadm/config/crd/kustomization.yaml and
-	// controlplane/kubeadm/config/crd/kustomization.yaml.
-	// Without those labels the conversion webhooks can't resolve the apiVersion of
-	// referenced objects (e.g. a Machine's bootstrapConfigRef pointing to a KubeadmConfig),
-	// which leads to "cannot find any versions matching contract versions" errors in test logs.
-	if err := addContractLabelsToKubeadmCRDs(env.Config, scheme); err != nil {
 		err = kerrors.NewAggregate([]error{err, env.Stop()})
 		panic(err)
 	}
@@ -491,40 +489,24 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 
 // addContractLabelsToKubeadmCRDs adds the contract labels to the kubeadm CRDs, mirroring
 // what kustomize injects in production (see bootstrap/kubeadm/config/crd/kustomization.yaml
-// and controlplane/kubeadm/config/crd/kustomization.yaml).
-func addContractLabelsToKubeadmCRDs(config *rest.Config, scheme *runtime.Scheme) error {
-	c, err := client.New(config, client.Options{Scheme: scheme})
-	if err != nil {
-		return fmt.Errorf("failed to create client: %w", err)
-	}
-
+// and controlplane/kubeadm/config/crd/kustomization.yaml). Without those labels the
+// conversion webhooks can't resolve the apiVersion of referenced objects (e.g. a Machine's
+// bootstrapConfigRef pointing to a KubeadmConfig), which leads to "cannot find any versions
+// matching contract versions" errors in test logs.
+func addContractLabelsToKubeadmCRDs(crds []*apiextensionsv1.CustomResourceDefinition) {
 	contractLabels := map[string]string{
 		clusterv1beta1.GroupVersion.String(): clusterv1beta1.GroupVersion.Version,
 		clusterv1.GroupVersion.String():      clusterv1.GroupVersion.Version,
 	}
-
-	ctx := context.Background()
-	for _, crdName := range []string{
-		"kubeadmconfigs.bootstrap.cluster.x-k8s.io",
-		"kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io",
-		"kubeadmcontrolplanes.controlplane.cluster.x-k8s.io",
-		"kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io",
-	} {
-		crd := &apiextensionsv1.CustomResourceDefinition{
-			ObjectMeta: metav1.ObjectMeta{Name: crdName},
+	for _, crd := range crds {
+		if crd.Spec.Group != bootstrapv1.GroupVersion.Group && crd.Spec.Group != controlplanev1.GroupVersion.Group {
+			continue
 		}
-		patch := client.MergeFrom(crd.DeepCopy())
 		if crd.Labels == nil {
 			crd.Labels = map[string]string{}
 		}
-		for key, value := range contractLabels {
-			crd.Labels[key] = value
-		}
-		if err := c.Patch(ctx, crd, patch); err != nil {
-			return fmt.Errorf("failed to add contract labels to CRD %s: %w", crdName, err)
-		}
+		maps.Copy(crd.Labels, contractLabels)
 	}
-	return nil
 }
 
 func writeAuditPolicy(dir string) (string, error) {

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -360,6 +360,18 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 		panic(err)
 	}
 
+	// envtest installs the CRDs from the raw bases/ manifests, which bypasses kustomize and
+	// thus drops the contract labels that are injected in production via
+	// bootstrap/kubeadm/config/crd/kustomization.yaml and
+	// controlplane/kubeadm/config/crd/kustomization.yaml.
+	// Without those labels the conversion webhooks can't resolve the apiVersion of
+	// referenced objects (e.g. a Machine's bootstrapConfigRef pointing to a KubeadmConfig),
+	// which leads to "cannot find any versions matching contract versions" errors in test logs.
+	if err := addContractLabelsToKubeadmCRDs(env.Config, scheme); err != nil {
+		err = kerrors.NewAggregate([]error{err, env.Stop()})
+		panic(err)
+	}
+
 	// Localhost is used on MacOS to avoid Firewall warning popups.
 	host := "localhost"
 	if strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
@@ -475,6 +487,44 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 		Config:  mgr.GetConfig(),
 		env:     env,
 	}
+}
+
+// addContractLabelsToKubeadmCRDs adds the contract labels to the kubeadm CRDs, mirroring
+// what kustomize injects in production (see bootstrap/kubeadm/config/crd/kustomization.yaml
+// and controlplane/kubeadm/config/crd/kustomization.yaml).
+func addContractLabelsToKubeadmCRDs(config *rest.Config, scheme *runtime.Scheme) error {
+	c, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	contractLabels := map[string]string{
+		clusterv1beta1.GroupVersion.String(): clusterv1beta1.GroupVersion.Version,
+		clusterv1.GroupVersion.String():      clusterv1.GroupVersion.Version,
+	}
+
+	ctx := context.Background()
+	for _, crdName := range []string{
+		"kubeadmconfigs.bootstrap.cluster.x-k8s.io",
+		"kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io",
+		"kubeadmcontrolplanes.controlplane.cluster.x-k8s.io",
+		"kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io",
+	} {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: crdName},
+		}
+		patch := client.MergeFrom(crd.DeepCopy())
+		if crd.Labels == nil {
+			crd.Labels = map[string]string{}
+		}
+		for key, value := range contractLabels {
+			crd.Labels[key] = value
+		}
+		if err := c.Patch(ctx, crd, patch); err != nil {
+			return fmt.Errorf("failed to add contract labels to CRD %s: %w", crdName, err)
+		}
+	}
+	return nil
 }
 
 func writeAuditPolicy(dir string) (string, error) {

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -299,7 +299,7 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 		ErrorIfPathMissing: true,
 	}
 	if err := envtest.ReadCRDFiles(&crdInstallOptions); err != nil {
-		panic(pkgerrors.Wrapf(err, "failed to read CRD files"))
+		klog.Fatalf("failed to read CRD files: %v", err)
 	}
 	addContractLabelsToKubeadmCRDs(crdInstallOptions.CRDs)
 
@@ -494,9 +494,11 @@ func newEnvironment(_ context.Context, scheme *runtime.Scheme, additionalCRDDire
 // bootstrapConfigRef pointing to a KubeadmConfig), which leads to "cannot find any versions
 // matching contract versions" errors in test logs.
 func addContractLabelsToKubeadmCRDs(crds []*apiextensionsv1.CustomResourceDefinition) {
+	// The label keys and values are hard-coded on purpose: this must not silently
+	// change when clusterv1 is bumped to a newer version (e.g. v1beta3 or v1).
 	contractLabels := map[string]string{
-		clusterv1beta1.GroupVersion.String(): clusterv1beta1.GroupVersion.Version,
-		clusterv1.GroupVersion.String():      clusterv1.GroupVersion.Version,
+		"cluster.x-k8s.io/v1beta1": "v1beta1",
+		"cluster.x-k8s.io/v1beta2": "v1beta2",
 	}
 	for _, crd := range crds {
 		if crd.Spec.Group != bootstrapv1.GroupVersion.Group && crd.Spec.Group != controlplanev1.GroupVersion.Group {


### PR DESCRIPTION
**What this PR does / why we need it:**

First of three follow-ups to #8605 — this one fixes the `cannot find any versions matching contract versions` errors for the kubeadm CRDs in unit test logs.

Root cause: in production the contract labels on those CRDs are added by kustomize; envtest loads the raw bases/ manifests and skips that step, so the conversion webhooks can't resolve the apiVersion of referenced objects. This adds the labels right after the test env starts, same approach as `addOrReplaceContractLabels` in internal/topology/upgrade/clusterctl_upgrade_test.go.

With this change `go test -v ./bootstrap/kubeadm/reconcilers/kubeadmconfig/...` goes from 48 of those errors to 0. The other two signatures from the issue (TestInfrastructure GVKs, testclusters.foo.example.com) will be addressed in follow-up PRs.

**With some help from Claude** (for the log analysis that tracked down the root cause)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8605

/kind cleanup
/area testing
