### PR TITLE
🌱 Restore apiVersionGetter after unit tests

### DIFF
--- a/controlplane/kubeadm/webhooks/conversion/common.go
+++ b/controlplane/kubeadm/webhooks/conversion/common.go
@@ -29,6 +29,12 @@ var apiVersionGetter = func(_ context.Context, _ schema.GroupKind) (string, erro
 
 // SetAPIVersionGetter sets an APIVersionGetter that is required during conversion to retrieve
 // the APIVersion when converting from v1beta2 to v1beta1.
-func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) {
+// It returns a function restoring the previously set getter, so tests can avoid
+// leaking a test-specific getter to other tests running in the same process.
+func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
+	previous := apiVersionGetter
 	apiVersionGetter = f
+	return func() {
+		apiVersionGetter = previous
+	}
 }

--- a/controlplane/kubeadm/webhooks/conversion/common.go
+++ b/controlplane/kubeadm/webhooks/conversion/common.go
@@ -29,9 +29,14 @@ var apiVersionGetter = func(_ context.Context, _ schema.GroupKind) (string, erro
 
 // SetAPIVersionGetter sets an APIVersionGetter that is required during conversion to retrieve
 // the APIVersion when converting from v1beta2 to v1beta1.
-// It returns a function restoring the previously set getter, so tests can avoid
-// leaking a test-specific getter to other tests running in the same process.
-func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
+func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) {
+	apiVersionGetter = f
+}
+
+// SwapAPIVersionGetter sets an APIVersionGetter and returns a function restoring the
+// previously set getter, so tests can avoid leaking a test-specific getter to other
+// tests running in the same process.
+func SwapAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
 	previous := apiVersionGetter
 	apiVersionGetter = f
 	return func() {

--- a/controlplane/kubeadm/webhooks/conversion/conversion_test.go
+++ b/controlplane/kubeadm/webhooks/conversion/conversion_test.go
@@ -47,7 +47,7 @@ const (
 // Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
-	SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{
@@ -57,7 +57,7 @@ func TestFuzzyConversion(t *testing.T) {
 			}
 		}
 		return "", fmt.Errorf("failed to map GroupKind %s to version", gk.String())
-	})
+	}))
 
 	t.Run("for KubeadmControlPlane (v1beta1)", conversionutil.SpokeConverterFuzzTestFunc(
 		conversionutil.SpokeConverterFuzzTestFuncInput[*controlplanev1.KubeadmControlPlane, *controlplanev1beta1.KubeadmControlPlane]{

--- a/controlplane/kubeadm/webhooks/conversion/conversion_test.go
+++ b/controlplane/kubeadm/webhooks/conversion/conversion_test.go
@@ -47,7 +47,7 @@ const (
 // Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
-	t.Cleanup(SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(SwapAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{

--- a/core/reconcilers/topology/cluster/reconcile_state_test.go
+++ b/core/reconcilers/topology/cluster/reconcile_state_test.go
@@ -305,7 +305,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 		},
 	}
 
-	conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{
@@ -315,7 +315,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 			}
 		}
 		return "", fmt.Errorf("unknown GroupVersionKind: %v", gk)
-	})
+	}))
 
 	catalog := runtimecatalog.New()
 	_ = runtimehooksv1.AddToCatalog(catalog)

--- a/core/reconcilers/topology/cluster/reconcile_state_test.go
+++ b/core/reconcilers/topology/cluster/reconcile_state_test.go
@@ -305,7 +305,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SwapAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{

--- a/core/webhooks/conversion/common.go
+++ b/core/webhooks/conversion/common.go
@@ -34,8 +34,14 @@ var apiVersionGetter = func(_ context.Context, _ schema.GroupKind) (string, erro
 
 // SetAPIVersionGetter sets an APIVersionGetter that is required during conversion to retrieve
 // the APIVersion when converting from v1beta2 to v1beta1.
-func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) {
+// It returns a function restoring the previously set getter, so tests can avoid
+// leaking a test-specific getter to other tests running in the same process.
+func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
+	previous := apiVersionGetter
 	apiVersionGetter = f
+	return func() {
+		apiVersionGetter = previous
+	}
 }
 
 func convertMachineSpecToContractVersionedObjectReference(src *clusterv1beta1.MachineSpec, dst *clusterv1.MachineSpec) error {

--- a/core/webhooks/conversion/common.go
+++ b/core/webhooks/conversion/common.go
@@ -34,9 +34,14 @@ var apiVersionGetter = func(_ context.Context, _ schema.GroupKind) (string, erro
 
 // SetAPIVersionGetter sets an APIVersionGetter that is required during conversion to retrieve
 // the APIVersion when converting from v1beta2 to v1beta1.
-// It returns a function restoring the previously set getter, so tests can avoid
-// leaking a test-specific getter to other tests running in the same process.
-func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
+func SetAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) {
+	apiVersionGetter = f
+}
+
+// SwapAPIVersionGetter sets an APIVersionGetter and returns a function restoring the
+// previously set getter, so tests can avoid leaking a test-specific getter to other
+// tests running in the same process.
+func SwapAPIVersionGetter(f func(ctx context.Context, gk schema.GroupKind) (string, error)) func() {
 	previous := apiVersionGetter
 	apiVersionGetter = f
 	return func() {

--- a/core/webhooks/conversion/conversion_test.go
+++ b/core/webhooks/conversion/conversion_test.go
@@ -52,7 +52,7 @@ import (
 // Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
-	SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{
@@ -62,7 +62,7 @@ func TestFuzzyConversion(t *testing.T) {
 			}
 		}
 		return "", fmt.Errorf("failed to map GroupKind %s to version", gk.String())
-	})
+	}))
 
 	t.Run("for Cluster (v1beta1)", conversionutil.SpokeConverterFuzzTestFunc(
 		conversionutil.SpokeConverterFuzzTestFuncInput[*clusterv1.Cluster, *clusterv1beta1.Cluster]{

--- a/core/webhooks/conversion/conversion_test.go
+++ b/core/webhooks/conversion/conversion_test.go
@@ -52,7 +52,7 @@ import (
 // Test is disabled when the race detector is enabled (via "//go:build !race" above) because otherwise the fuzz tests would just time out.
 
 func TestFuzzyConversion(t *testing.T) {
-	t.Cleanup(SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(SwapAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -1097,7 +1097,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 		},
 	}
 
-	conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{
@@ -1107,7 +1107,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 			}
 		}
 		return "", fmt.Errorf("unknown GroupVersionKind: %v", gk)
-	})
+	}))
 
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)
 

--- a/exp/topology/desiredstate/desired_state_test.go
+++ b/exp/topology/desiredstate/desired_state_test.go
@@ -1097,7 +1097,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SwapAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{

--- a/exp/topology/desiredstate/lifecycle_hooks_test.go
+++ b/exp/topology/desiredstate/lifecycle_hooks_test.go
@@ -58,7 +58,7 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 		},
 	}
 
-	conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{
@@ -68,7 +68,7 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 			}
 		}
 		return "", pkgerrors.Errorf("unknown GroupVersionKind: %v", gk)
-	})
+	}))
 
 	utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)
 

--- a/exp/topology/desiredstate/lifecycle_hooks_test.go
+++ b/exp/topology/desiredstate/lifecycle_hooks_test.go
@@ -58,7 +58,7 @@ func TestComputeControlPlaneVersion_LifecycleHooksSequences(t *testing.T) {
 		},
 	}
 
-	t.Cleanup(conversion.SetAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
+	t.Cleanup(conversion.SwapAPIVersionGetter(func(_ context.Context, gk schema.GroupKind) (string, error) {
 		for _, gvk := range testGVKs {
 			if gvk.GroupKind() == gk {
 				return schema.GroupVersion{


### PR DESCRIPTION
**What this PR does / why we need it:**

Second of three follow-ups to #8605 — this one fixes the `unknown GroupVersionKind: TestInfrastructure*` errors in unit test logs. Root cause: `conversion.SetAPIVersionGetter` swaps a package-global getter and unit tests that set a fake one never restore it, so the fake leaks into the envtest tests of the same package and the conversion webhook can't resolve the `TestInfrastructure*` GVKs anymore. This makes the setter return a restore func (same pattern as `SetFeatureGateDuringTest` for feature gates) and the tests restore the previous getter via `t.Cleanup`.

With this change `go test -v ./core/reconcilers/...` goes from 449 of those errors to 0.

**With some help from Claude** (for the log analysis that tracked down the root cause)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8605

/kind cleanup
/area testing
