### PR TITLE
🌱 Use installed CRD refs in patch helper test fixtures

### DIFF
--- a/util/patch/test/patch_test.go
+++ b/util/patch/test/patch_test.go
@@ -65,8 +65,8 @@ func TestPatchHelper(t *testing.T) {
 			},
 			Spec: clusterv1.ClusterSpec{
 				InfrastructureRef: clusterv1.ContractVersionedObjectReference{
-					APIGroup: "foo.cluster.x-k8s.io",
-					Kind:     "TestCluster",
+					APIGroup: builder.InfrastructureGroupVersion.Group,
+					Kind:     builder.TestInfrastructureClusterKind,
 					Name:     "infra-1",
 				},
 			},
@@ -730,7 +730,7 @@ func TestPatchHelper(t *testing.T) {
 			obj.Spec.Paused = ptr.To(true)
 			obj.Spec.InfrastructureRef = clusterv1.ContractVersionedObjectReference{
 				APIGroup: clusterv1.GroupVersionInfrastructure.Group,
-				Kind:     "test-kind",
+				Kind:     builder.TestInfrastructureClusterKind,
 				Name:     "test-ref",
 			}
 
@@ -819,7 +819,7 @@ func TestPatchHelper(t *testing.T) {
 			obj.Spec.Paused = ptr.To(true)
 			obj.Spec.InfrastructureRef = clusterv1.ContractVersionedObjectReference{
 				APIGroup: clusterv1.GroupVersionInfrastructure.Group,
-				Kind:     "test-kind",
+				Kind:     builder.TestInfrastructureClusterKind,
 				Name:     "test-ref",
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it:**

Third of three follow-ups to #8605 — this one fixes the `failed to get labels for CustomResourceDefinition testclusters.foo.cluster.x-k8s.io` errors in test logs. Root cause: three fixtures in `util/patch/test` build a `Cluster` whose `spec.infrastructureRef` points to a group/kind for which no CRD is installed in the envtest cluster. The API server triggers the v1beta1<->v1beta2 conversion while handling the create/patch requests for those Clusters, and the conversion webhook then fails to resolve the fake reference. The tests themselves keep passing (the conversion falls back), so this is log noise only. This switches the fixtures to the `TestInfrastructureCluster` CRD that the test suite already installs, matching how the same file references `TestInfrastructureMachineTemplate` elsewhere.

With this change the errors are gone from `go test -v ./util/patch/test/` (11 occurrences before) and from a full `go test ./... -v` run (34 occurrences before).

**With some help from Claude** (for the log analysis that tracked down the root cause)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8605

/kind cleanup
/area testing
