### PR TITLE
🐛 cloudbuild: Bump timeout to 1hr

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 2700s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 2700s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**: The current 45m timeout limit for post-cluster-api-push-images [1] is been causing it to permafail since yesterday. Increase that limit to an hour.

[1]:https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-cluster-api-push-images

See this [Slack thread](https://kubernetes.slack.com/archives/C08AA0FFWG3/p1788516151904459) for more info.

/area ci
<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->