### PR TITLE
🐛 KCP: tolerate unnamed etcd learner during Node registration race

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/consts.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/consts.go
@@ -30,4 +30,10 @@ const (
 	// dependentCertRequeueAfter is how long to wait before checking again to see if
 	// dependent certificates have been created.
 	dependentCertRequeueAfter = 30 * time.Second
+
+	// unnamedEtcdMemberGracePeriod is how long an etcd member without a name is tolerated after
+	// a control plane Machine's Node has been registered. This accounts for the delay between
+	// kubelet registering the Node and the local etcd Pod completing the join as a named member,
+	// and avoids removing a learner that is still in the process of joining.
+	unnamedEtcdMemberGracePeriod = 2 * time.Minute
 )

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
@@ -1335,6 +1335,27 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 		return ctrl.Result{}, nil
 	}
 
+	// If one of the unexpected members doesn't have a name yet, there is a chance it is a learner hosted on a
+	// Machine whose Node was registered only recently: kubelet can register the Node (and KCP set the Machine's
+	// NodeRef) before the local etcd Pod starts and the member completes the join with a name.
+	// Tolerate this for a bounded grace period after the Node was created, to avoid removing a learner that is
+	// still in the process of joining.
+	for _, member := range unexpectedMembers.UnsortedList() {
+		if member.Name != "" {
+			continue
+		}
+		for _, node := range controlPlane.Nodes {
+			if !expectedMembers.Has(node.Name) {
+				continue
+			}
+			if time.Since(node.CreationTimestamp.Time) < unnamedEtcdMemberGracePeriod {
+				log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, waiting because Node %s was registered recently and might still be joining etcd as a learner", strings.Join(unexpectedMembersMsg, ", "), node.Name))
+				return ctrl.Result{}, nil
+			}
+		}
+		break
+	}
+
 	// If there are unexpected members, KCP must remove them (it removes one, then re-queue).
 	//
 	// Before deleting any etcd member, KCP should assess the potential effects of this operation.

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
@@ -3743,6 +3743,58 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			wantRemoveEtcdMemberCalled: 0,
 		},
 		{
+			name: "Do not remove additional etcd members without name when the corresponding Node was registered recently",
+			controlPlane: &pkg.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+				Nodes: []*pkg.Node{
+					{
+						ObjectMeta: pkg.ObjectMeta{
+							Name:              "m1-node",
+							CreationTimestamp: metav1.Now(),
+						},
+					},
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: ""},
+			},
+			wantResult:                 ctrl.Result{},
+			wantRemoveEtcdMemberCalled: 0,
+		},
+		{
+			name: "Remove additional etcd members without name when the corresponding Node was registered a long time ago",
+			controlPlane: &pkg.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+				},
+				Nodes: []*pkg.Node{
+					{
+						ObjectMeta: pkg.ObjectMeta{
+							Name:              "m1-node",
+							CreationTimestamp: metav1.NewTime(time.Now().Add(-unnamedEtcdMemberGracePeriod - time.Minute)),
+						},
+					},
+				},
+			},
+			additionalEtcdMembers: []*etcd.Member{
+				{Name: ""},
+			},
+			wantResult:                 ctrl.Result{RequeueAfter: 1 * time.Second},
+			wantRemoveEtcdMemberCalled: 1,
+		},
+		{
 			name: "Do not remove additional etcd members when the target etcd cluster is not healthy",
 			controlPlane: &pkg.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{},


### PR DESCRIPTION
**What this PR does / why we need it**:

During a KubeadmControlPlane (KCP) rollout, kubelet can register the new control-plane Node
before kubeadm's local etcd static Pod has finished joining the etcd cluster as a learner. In
that window, `reconcileEtcdMembers` sees the Machine's `NodeRef` is set (so it's no longer
"provisioning") and the etcd member has no name yet, so it treats the unnamed learner as an
orphaned/unexpected member and removes it. The subsequent kubeadm etcd join then fails because
its member was removed, leaving the Machine `NotReady` and the rollout blocked.

This PR adds a bounded 2-minute grace period: if there is an unnamed etcd member and any
control-plane Machine's corresponding Node was registered less than 2 minutes ago, KCP waits
instead of removing the member, giving the local etcd Pod time to finish joining. After the
grace period (or when no recently-registered Node exists), the existing cleanup behavior for
orphaned members is unchanged. Note the grace period cannot pin an unnamed member to one exact
Machine (it has no name to key on) - it only checks whether *any* expected Node was recently
registered, which is a reasonable approximation given the information available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Validation**:
- Added a regression test to `TestKubeadmControlPlaneReconciler_reconcileEtcdMembers` that
  reproduces the race (Machine with `NodeRef` set, corresponding Node created moments ago, an
  unnamed etcd member present) and asserts `RemoveEtcdMember` is NOT called. Confirmed this test
  fails on the code prior to this change and passes after it - i.e. a real fail-to-pass
  reproduction of the defect, not just a new assertion on unrelated code. A second new test case
  confirms the old removal behavior is preserved once the grace period has elapsed.
- Ran `go build ./controlplane/...` - passes.
- Ran `go vet ./controlplane/kubeadm/...` - clean.
- Ran `golangci-lint run ./controlplane/kubeadm/reconcilers/kubeadmcontrolplane/...` - 0 issues.
- Ran the full package suite: `KUBEBUILDER_ASSETS=<envtest assets> go test ./controlplane/kubeadm/reconcilers/kubeadmcontrolplane/...` - all tests pass.
- Did not run a live e2e/dev-stack reproduction of the timing race against a real cluster; the
  unit test above exercises the exact same code path (`reconcileEtcdMembers`) and inputs that
  trigger the bug in production, so it stands in for a live reproduction for this class of fix.

<!--
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+
-->
/area control-plane-kubeadm

Fixes #14197

```release-note
🐛 KCP: tolerate unnamed etcd learner during Node registration race
```