### PR TITLE
🐛KCP: avoid deleting learners after Node registration

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
@@ -74,6 +74,10 @@ const (
 	kcpManagerName          = "capi-kubeadmcontrolplane"
 	kcpMetadataManagerName  = "capi-kubeadmcontrolplane-metadata"
 	kubeadmControlPlaneKind = "KubeadmControlPlane"
+
+	// etcdMemberStartupGracePeriod is the maximum time KCP waits for an etcd
+	// member to get its name after the kubelet registers a new Node.
+	etcdMemberStartupGracePeriod = 20 * time.Second
 )
 
 var (
@@ -1294,6 +1298,7 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 	// Loop trough machines and collect the list of expected etcd members, which can be inferred because etcd members name is equal to the node name.
 	// Also keep track if there are machines still pending for the node name being reported (provisioning machines).
 	provisioningMachines := sets.New[string]()
+	machinesWithNewlyRegisteredNodes := sets.New[string]()
 	expectedMembers := sets.New[string]()
 	for _, machine := range controlPlane.Machines {
 		if !machine.Status.NodeRef.IsDefined() {
@@ -1301,6 +1306,18 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 			continue
 		}
 		expectedMembers.Insert(machine.Status.NodeRef.Name)
+
+		// A NodeRef is set as soon as the kubelet registers the Node. It does not imply
+		// that the local etcd static Pod is started or that its learner has a name yet.
+		// So keep track of machines with newly registered nodes.
+		if machine.DeletionTimestamp.IsZero() {
+			for _, node := range controlPlane.Nodes {
+				if node.Name == machine.Status.NodeRef.Name && time.Since(node.CreationTimestamp.Time) < etcdMemberStartupGracePeriod {
+					machinesWithNewlyRegisteredNodes.Insert(machine.Name)
+					break
+				}
+			}
+		}
 	}
 
 	// Loop trough etcd members and identify unexpected members.
@@ -1319,8 +1336,10 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 	}
 
 	unexpectedMembersMsg := []string{}
+	hasUnnamedUnexpectedMember := false
 	for _, m := range unexpectedMembers.UnsortedList() {
 		if m.Name == "" {
+			hasUnnamedUnexpectedMember = true
 			unexpectedMembersMsg = append(unexpectedMembersMsg, "(Name not yet assigned)")
 			continue
 		}
@@ -1331,7 +1350,14 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 	// If there are unexpected members, but there is a machine not yet reporting the node name,
 	// there is chance that the unexpected member is the one hosted on the provisioning machine, so wait.
 	if len(provisioningMachines) > 0 {
-		log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, potential match with provisioning machines %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(provisioningMachines.UnsortedList(), ", ")))
+		log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, potential match with machines with newly provisioned nodes %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(provisioningMachines.UnsortedList(), ", ")))
+		return ctrl.Result{}, nil
+	}
+	// An unnamed member is normally a learner added by kubeadm before the local
+	// etcd static Pod starts. Keep it while a Node was recently registered (grace period) so
+	// we prevent that a NodeRef-before-etcd-name race leads the code below to remove the etcd member too aggressively.
+	if hasUnnamedUnexpectedMember && len(machinesWithNewlyRegisteredNodes) > 0 {
+		log.Info(fmt.Sprintf("Etcd members %s without corresponding Machines, potential match with machines with newly provisioned nodes %s", strings.Join(unexpectedMembersMsg, ", "), strings.Join(machinesWithNewlyRegisteredNodes.UnsortedList(), ", ")))
 		return ctrl.Result{}, nil
 	}
 

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
@@ -3563,6 +3563,7 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 	tests := []struct {
 		name                       string
 		controlPlane               *pkg.ControlPlane
+		etcdMembers                []*etcd.Member // If not set, etcdMembers are inferred from machines with a NodeRef.
 		additionalEtcdMembers      []*etcd.Member
 		wantErr                    bool
 		wantResult                 ctrl.Result
@@ -3743,6 +3744,69 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			wantRemoveEtcdMemberCalled: 0,
 		},
 		{
+			name: "Do not remove unnamed etcd member when a NodeRef was recently registered",
+			controlPlane: &pkg.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+					"m2": func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						m.Name = "m2"
+						m.Status.NodeRef.Name = "m2-node"
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionFalse, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberNotHealthyReason})
+						return m
+					}(),
+				},
+				Nodes: []*pkg.Node{
+					pkg.TransformNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+						Name:              "m2-node",
+						CreationTimestamp: metav1.Now(),
+					}}),
+				},
+			},
+			etcdMembers: []*etcd.Member{
+				{Name: "m1-node"},
+				{Name: ""}, // Member on m2 machine does not have the name yet, even if NodeRef is already set.
+			},
+			wantResult:                 ctrl.Result{},
+			wantRemoveEtcdMemberCalled: 0,
+		},
+		{
+			name: "Remove unnamed etcd member after the NodeRef startup grace period",
+			controlPlane: &pkg.ControlPlane{
+				KCP: &controlplanev1.KubeadmControlPlane{},
+				Machines: collections.Machines{
+					m1.Name: func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						conditions.Set(m, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyCondition, Status: metav1.ConditionTrue, Reason: controlplanev1.KubeadmControlPlaneMachineEtcdMemberHealthyReason})
+						return m
+					}(),
+					"m2": func() *clusterv1.Machine {
+						m := m1.DeepCopy()
+						m.Name = "m2"
+						m.Status.NodeRef.Name = "m2-node"
+						return m
+					}(),
+				},
+				Nodes: []*pkg.Node{
+					pkg.TransformNode(&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+						Name:              "m2-node",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-etcdMemberStartupGracePeriod - time.Second)),
+					}}),
+				},
+			},
+			etcdMembers: []*etcd.Member{
+				{Name: "m1-node"},
+				{Name: ""}, // Member on m2 machine does not have the name yet, even if NodeRef is already set.
+			},
+			wantResult:                 ctrl.Result{RequeueAfter: time.Second},
+			wantRemoveEtcdMemberCalled: 1,
+		},
+		{
 			name: "Do not remove additional etcd members when the target etcd cluster is not healthy",
 			controlPlane: &pkg.ControlPlane{
 				KCP: &controlplanev1.KubeadmControlPlane{},
@@ -3823,7 +3887,11 @@ func TestKubeadmControlPlaneReconciler_reconcileEtcdMembers(t *testing.T) {
 			tt.controlPlane.InjectTestManagementCluster(&fakeManagementCluster{
 				Workload: &workloadCluster,
 			})
-			tt.controlPlane.EtcdMembers = append(etcdMembers(tt.controlPlane.Machines), tt.additionalEtcdMembers...)
+			tt.controlPlane.EtcdMembers = append(tt.etcdMembers, tt.additionalEtcdMembers...)
+			if tt.etcdMembers == nil {
+				// If etcd members are not explicitly provided, infer them from machines with NodeRefs.
+				tt.controlPlane.EtcdMembers = append(tt.controlPlane.EtcdMembers, etcdMembers(tt.controlPlane.Machines)...)
+			}
 
 			r := &Reconciler{}
 			res, err := r.reconcileEtcdMembers(ctx, tt.controlPlane)


### PR DESCRIPTION
Kubelet can register a Node before kubeadm starts the local etcd static Pod. Keep an unnamed learner for a bounded startup grace period so KCP does not make the join fail with member not found.

<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->


Fixes #14197

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->