### PR TITLE
🐛 cloudbuild: Bump machine to `highcpu-32`

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 7200s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@
 timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'E2_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'
 steps:
   # The latest image tag + sha can be found with:
   # crane ls registry.k8s.io/releng/gcb-docker-gcloud

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 7200s
+timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

This reverts commit 6505bf3.

Together with `-j 16`, this helps create more breathing room compared to
the current 8G restriction on `highcpu-8` with `-j 8`, while also
potentially speeding things up owing to the added core count. Note that
we are not changing GOMAXPROCS at this time, and letting it fallback to
its existing default behavior within the CI, mirroring the current core
count. This means that each of the 16 processes can span to 32
compilations in parallel at any given time. But I'm not entertaining
that idea at this time mostly to avoid pinning leading to unwanted
behavior on other variants / configurations, and more importantly, the
earlier `-j 8` on the 8-core variant could potentially span to 8
processes * 8 compilations, a 64-core request.

AMEND: There's possibly a better case that just occured to me. `-j 8` on
`highcpu-32` makes most sense since it helps avoid oversubscribing cores
way too much than what we have, but also, with `GOMAXPROCS` set to 32,
it still has enough work cut out for all cores almost all the time.
Going with this for now.

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->

/area ci

Fixes: #14193