### PR TITLE
🌱 Improve KCP remediation annotation handling

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers.go
@@ -301,11 +301,12 @@ func (r *Reconciler) createMachine(ctx context.Context, kcp *controlplanev1.Kube
 		return err
 	}
 	r.controller.DeferNextReconcileUntilCacheUpToDate(kcp, capicontrollerutil.StructuredObject(clusterv1.GroupVersion, "Machine"), machine.ResourceVersion)
+
 	// Remove the annotation tracking that a remediation is in progress (the remediation completed when
 	// the replacement machine has been created above).
-	delete(kcp.Annotations, controlplanev1.RemediationInProgressAnnotation)
-
-	return nil
+	// Note: If this call fails we won't be removing the annotation immediately, but it will be cleaned up
+	// on next reconcile at the beginning of reconcileUnhealthyMachines.
+	return r.deleteRemediationInProgressAnnotation(ctx, kcp)
 }
 
 func (r *Reconciler) updateMachine(ctx context.Context, machine *clusterv1.Machine, kcp *controlplanev1.KubeadmControlPlane, cluster *clusterv1.Cluster) (*clusterv1.Machine, error) {

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller.go
@@ -477,7 +477,8 @@ func (r *Reconciler) reconcile(ctx context.Context, controlPlane *pkg.ControlPla
 		return ctrl.Result{}, pkgerrors.Wrap(err, "failed to sync Machines")
 	}
 	if stopReconcile {
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil // Explicitly requeue as we are not watching for changes to BootstrapConfig and InfraMachine objects.
+		// Explicitly requeue as we are not watching for changes to BootstrapConfig and InfraMachine objects.
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil // RequeueAfter should be at least 1s, because controller rate limiter is using 1s.
 	}
 
 	// Aggregate the operational state of all the machines; while aggregating we are adding the
@@ -1403,7 +1404,7 @@ func (r *Reconciler) reconcileEtcdMembers(ctx context.Context, controlPlane *pkg
 	log.Info("Etcd member without a corresponding Machine removed from the cluster", "member", etcdMemberToBeDeletedMsg)
 
 	// Force a new reconcile after removing an etcd member.
-	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	return ctrl.Result{RequeueAfter: 1 * time.Second}, nil // RequeueAfter should be at least 1s, because controller rate limiter is using 1s.
 }
 
 func (r *Reconciler) reconcilePreTerminateHook(ctx context.Context, controlPlane *pkg.ControlPlane) (ctrl.Result, error) {

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/remediation.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/remediation.go
@@ -100,19 +100,9 @@ func (r *Reconciler) reconcileUnhealthyMachines(ctx context.Context, controlPlan
 	// Check if the annotation is stale; this might happen in case there is a crash in the controller in between
 	// when a new Machine is created and the annotation is eventually removed from KCP via defer patch at the end
 	// of KCP reconcile.
-	if v, ok := controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation]; ok {
-		remediationData, err := RemediationDataFromAnnotation(v)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		for _, m := range controlPlane.Machines.UnsortedList() {
-			if m.CreationTimestamp.After(remediationData.Timestamp.Time) {
-				// Remove the annotation tracking that a remediation is in progress (the annotation is stale).
-				delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
-				break
-			}
-		}
+	if cleanedUpAnnotation, err := r.cleanupRemediationInProgressAnnotation(ctx, controlPlane); err != nil || cleanedUpAnnotation {
+		// Technically there is no need to requeue here. KCP patch above triggers reconciliation. But we have to return a non-zero Result so reconcile above returns.
+		return ctrl.Result{RequeueAfter: time.Second}, err // RequeueAfter should be at least 1s, because controller rate limiter is using 1s.
 	}
 
 	// Gets all machines that have `MachineHealthCheckSucceeded=False` (indicating a problem was detected on the machine)
@@ -373,11 +363,83 @@ func (r *Reconciler) reconcileUnhealthyMachines(ctx context.Context, controlPlan
 
 	// Set annotations tracking remediation details so they can be picked up by the machine
 	// that will be created as part of the scale up action that completes the remediation.
-	annotations.AddAnnotations(controlPlane.KCP, map[string]string{
-		controlplanev1.RemediationInProgressAnnotation: remediationInProgressValue,
-	})
+	// Note: If this call fails we won't be tracking remediation history correctly, but in any case KCP
+	// will wait for the deletion we triggered above to complete. As this should rarely happen, this is considered acceptable.
+	if err := r.addRemediationInProgressAnnotation(ctx, controlPlane.KCP, remediationInProgressValue); err != nil {
+		return ctrl.Result{}, err
+	}
 
-	return ctrl.Result{RequeueAfter: time.Millisecond}, nil // Technically there is no need to requeue here. Machine deletion above triggers reconciliation. But we have to return a non-zero Result so reconcile above returns.
+	// Technically there is no need to requeue here. Machine deletion above triggers reconciliation. But we have to return a non-zero Result so reconcile above returns.
+	return ctrl.Result{RequeueAfter: time.Second}, nil // RequeueAfter should be at least 1s, because controller rate limiter is using 1s.
+}
+
+func (r *Reconciler) cleanupRemediationInProgressAnnotation(ctx context.Context, controlPlane *pkg.ControlPlane) (bool, error) {
+	v, exists := controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation]
+	if !exists {
+		return false, nil
+	}
+
+	var annotationNeedsCleanup bool
+	if int32(len(controlPlane.Machines.Filter(collections.Not(collections.HasDeletionTimestamp)))) >= ptr.Deref(controlPlane.KCP.Spec.Replicas, 0) {
+		// If we already have enough non-deleting Machines we don't have to create another Machine to complete the remediation.
+		annotationNeedsCleanup = true
+	} else {
+		// If we already created a Machine after remediation, just the annotation removal failed after Machine creation
+		// and we have to clean up the annotation because it is stale.
+		remediationData, err := RemediationDataFromAnnotation(v)
+		if err != nil {
+			return false, err
+		}
+		for _, m := range controlPlane.Machines.UnsortedList() {
+			if m.CreationTimestamp.After(remediationData.Timestamp.Time) {
+				annotationNeedsCleanup = true
+			}
+		}
+	}
+
+	if !annotationNeedsCleanup {
+		return false, nil
+	}
+
+	// Note: If this call fails we won't be deleting the annotation immediately, but we'll return an
+	// error and retry on next reconcile.
+	if err := r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *Reconciler) deleteRemediationInProgressAnnotation(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error {
+	if _, exists := kcp.Annotations[controlplanev1.RemediationInProgressAnnotation]; !exists {
+		return nil
+	}
+
+	original := kcp.DeepCopy()
+	modified := original.DeepCopy()
+	delete(modified.Annotations, controlplanev1.RemediationInProgressAnnotation)
+	if err := r.Client.Patch(ctx, modified, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to remove %s annotation: %w", controlplanev1.RemediationInProgressAnnotation, err)
+	}
+	r.controller.DeferNextReconcileUntilCacheUpToDate(kcp, capicontrollerutil.StructuredObject(controlplanev1.GroupVersion, "KubeadmControlPlane"), modified.ResourceVersion)
+	return nil
+}
+
+func (r *Reconciler) addRemediationInProgressAnnotation(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, remediationInProgressValue string) error {
+	if currentValue, exists := kcp.Annotations[controlplanev1.RemediationInProgressAnnotation]; exists && currentValue == remediationInProgressValue {
+		return nil
+	}
+
+	original := kcp.DeepCopy()
+	modified := original.DeepCopy()
+	if modified.Annotations == nil {
+		modified.Annotations = map[string]string{}
+	}
+	modified.Annotations[controlplanev1.RemediationInProgressAnnotation] = remediationInProgressValue
+	if err := r.Client.Patch(ctx, modified, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to add %s annotation: %w", controlplanev1.RemediationInProgressAnnotation, err)
+	}
+	r.controller.DeferNextReconcileUntilCacheUpToDate(kcp, capicontrollerutil.StructuredObject(controlplanev1.GroupVersion, "KubeadmControlPlane"), modified.ResourceVersion)
+	return nil
 }
 
 // Gets the machine to be remediated, which is the "most broken" among the unhealthy machines, determined as the machine

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/remediation_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/remediation_test.go
@@ -32,8 +32,10 @@ import (
 	"k8s.io/client-go/tools/record"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	utilptr "k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/api/bootstrap/kubeadm/v1beta2"
 	controlplanev1 "sigs.k8s.io/cluster-api/api/controlplane/kubeadm/v1beta2"
@@ -142,10 +144,26 @@ func TestGetMachineToBeRemediated(t *testing.T) {
 func TestReconcileUnhealthyMachines(t *testing.T) {
 	g := NewWithT(t)
 
+	fc := capicontrollerutil.NewFakeController()
 	r := &Reconciler{
 		Client:     env.GetClient(),
-		controller: capicontrollerutil.NewFakeController(),
+		controller: fc,
 		recorder:   record.NewFakeRecorder(32),
+	}
+
+	machineTemplate := controlplanev1.KubeadmControlPlaneMachineTemplate{
+		Spec: controlplanev1.KubeadmControlPlaneMachineTemplateSpec{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				Kind:     builder.TestInfrastructureMachineTemplateKind,
+				APIGroup: builder.InfrastructureGroupVersion.Group,
+				Name:     "imt",
+			},
+		},
+	}
+	kcpSpec := controlplanev1.KubeadmControlPlaneSpec{
+		Version:         "v1.37.0",
+		Replicas:        new(int32(3)),
+		MachineTemplate: machineTemplate,
 	}
 
 	var err error
@@ -178,8 +196,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		}
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
 		g.Eventually(func() error {
 			if err := env.Get(ctx, client.ObjectKey{Namespace: m.Namespace, Name: m.Name}, m); err != nil {
@@ -208,8 +226,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		}
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 	})
 	t.Run("reconcileUnhealthyMachines return early if another remediation is in progress", func(t *testing.T) {
 		g := NewWithT(t)
@@ -226,22 +244,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 						}),
 					},
 				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas: new(int32(3)),
+				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m),
 		}
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 	})
-	t.Run("RemediationInProgressAnnotation is cleaned up when stale and there are no machines to be remediated", func(t *testing.T) {
+	t.Run("RemediationInProgressAnnotation is cleaned up when stale and there are no machines to be remediated (already enough replicas)", func(t *testing.T) {
 		g := NewWithT(t)
 
 		m := createMachine(ctx, g, ns.Name, "m1-healthy-")
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 					Annotations: map[string]string{
 						controlplanev1.RemediationInProgressAnnotation: MustMarshalRemediationData(&RemediationData{
 							Machine:    "foo",
@@ -250,15 +273,26 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 						}),
 					},
 				},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Version:         "v1.37.0",
+					Replicas:        new(int32(1)), // We already have 1 replicas, so we don't need to create a Machine to complete remediation
+					MachineTemplate: machineTemplate,
+				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+
+		// reconcileUnhealthyMachines cleans up the annotation.
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
-
-		g.Expect(ret.IsZero()).To(BeTrue())
+		g.Expect(ret).To(Equal(ctrl.Result{RequeueAfter: time.Second}))
 		g.Expect(err).ToNot(HaveOccurred())
+		// Verify next reconcile got deferred after the annotation was deleted.
+		g.Expect(fc.DeferralsUntilCacheUpToDate).To(HaveKey(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(controlPlane.KCP)}))
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		err = env.Get(ctx, client.ObjectKey{Namespace: m.Namespace, Name: m.Name}, m)
@@ -267,13 +301,15 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		g.Expect(env.Cleanup(ctx, m)).To(Succeed())
 	})
-	t.Run("remediation in progress is ignored when stale", func(t *testing.T) {
+	t.Run("RemediationInProgressAnnotation is cleaned up when stale and there are no machines to be remediated (already Machine created after remediation)", func(t *testing.T) {
 		g := NewWithT(t)
 
-		m := createMachine(ctx, g, ns.Name, "m1-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer())
+		m := createMachine(ctx, g, ns.Name, "m1-healthy-")
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 					Annotations: map[string]string{
 						controlplanev1.RemediationInProgressAnnotation: MustMarshalRemediationData(&RemediationData{
 							Machine:    "foo",
@@ -282,15 +318,71 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 						}),
 					},
 				},
+				Spec: kcpSpec,
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+
+		// reconcileUnhealthyMachines cleans up the annotation.
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
+		g.Expect(ret.IsZero()).To(BeFalse())
 		g.Expect(err).ToNot(HaveOccurred())
+		// Verify next reconcile got deferred after the annotation was deleted.
+		g.Expect(fc.DeferralsUntilCacheUpToDate).To(HaveKey(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(controlPlane.KCP)}))
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
+		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
+
+		err = env.Get(ctx, client.ObjectKey{Namespace: m.Namespace, Name: m.Name}, m)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(m.ObjectMeta.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		g.Expect(env.Cleanup(ctx, m)).To(Succeed())
+	})
+	t.Run("RemediationInProgressAnnotation is cleaned up when stale and then a Machine is remediated in the next reconcile", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m := createMachine(ctx, g, ns.Name, "m1-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer())
+		controlPlane := &pkg.ControlPlane{
+			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+					Annotations: map[string]string{
+						controlplanev1.RemediationInProgressAnnotation: MustMarshalRemediationData(&RemediationData{
+							Machine:    "foo",
+							Timestamp:  metav1.Time{Time: time.Now().Add(-1 * time.Hour).UTC()},
+							RetryCount: 0,
+						}),
+					},
+				},
+				Spec: kcpSpec,
+			},
+			Cluster:  &clusterv1.Cluster{},
+			Machines: collections.FromMachines(m),
+		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+
+		// reconcileUnhealthyMachines cleans up the annotation.
+		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
+
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse())
+
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
+		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
+
+		// reconcileUnhealthyMachines remediates the Machine.
+		ret, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
+
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -312,16 +404,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		m := getDeletingMachine(ns.Name, "m1-unhealthy-deleting-", withMachineHealthCheckFailed())
 		controlPlane := &pkg.ControlPlane{
-			KCP:      &controlplanev1.KubeadmControlPlane{},
+			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
+				Spec: kcpSpec,
+			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m),
 		}
-		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
 
+		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue())
+
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 	})
 	t.Run("reconcileUnhealthyMachines return early if there is a pending topology upgrade", func(t *testing.T) {
 		utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)
@@ -363,8 +467,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		controlPlane.InjectTestManagementCluster(r.managementCluster)
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate while waiting for a version upgrade to v1.20.1 to be propagated from Cluster.spec.topology")
 		assertMachineCondition(ctx, g, m1, clusterv1.MachineOwnerRemediatedCondition, metav1.ConditionFalse, controlplanev1.KubeadmControlPlaneMachineRemediationDeferredReason, "KubeadmControlPlane can't remediate while waiting for a version upgrade to v1.20.1 to be propagated from Cluster.spec.topology")
@@ -388,17 +492,24 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
 					Remediation: controlplanev1.KubeadmControlPlaneRemediationSpec{
 						MaxRetry: utilptr.To[int32](3),
 					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -409,9 +520,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate this machine because the operation already failed 3 times (MaxRetry)")
@@ -437,17 +549,24 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
 					Remediation: controlplanev1.KubeadmControlPlaneRemediationSpec{
 						MaxRetry: utilptr.To[int32](3),
 					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -464,9 +583,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -498,6 +618,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
@@ -505,11 +629,14 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 						MaxRetry:                utilptr.To[int32](3),
 						MinHealthyPeriodSeconds: utilptr.To(minHealthyPeriod),
 					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -526,9 +653,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -558,6 +686,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
@@ -565,11 +697,14 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 						MaxRetry:           utilptr.To[int32](3),
 						RetryPeriodSeconds: utilptr.To(controlplanev1.DefaultMinHealthyPeriodSeconds), // RetryPeriodSeconds not yet expired.
 					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -580,9 +715,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate this machine because the operation already failed in the latest 1h0m0s (RetryPeriodSeconds)")
@@ -607,8 +743,13 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		m := createMachine(ctx, g, ns.Name, "m1-unhealthy-", withMachineHealthCheckFailed())
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](1),
+					Version:  "v1.37.0",
 					Rollout: controlplanev1.KubeadmControlPlaneRolloutSpec{
 						Strategy: controlplanev1.KubeadmControlPlaneRolloutStrategy{
 							RollingUpdate: controlplanev1.KubeadmControlPlaneRolloutStrategyRollingUpdate{
@@ -618,21 +759,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 							},
 						},
 					},
-				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
+
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate if current replicas are less or equal to 1")
@@ -648,23 +795,34 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		m3 := getDeletingMachine(ns.Name, "m3-deleting") // NB. This machine is not created, it gets only added to control plane
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](3),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.37.0",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
+
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane waiting for control plane machine deletion to complete before triggering remediation")
@@ -680,23 +838,34 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		m3 := createMachine(ctx, g, ns.Name, "m3-healthy-", withoutNodeRef()) // Provisioning
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To(int32(3)),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To(int32(3)),
+					Version:         "v1.37.0",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
+
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane waiting for control plane machine provisioning to complete before triggering remediation")
@@ -713,23 +882,34 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		m4 := createMachine(ctx, g, ns.Name, "m4-healthy-", withoutNodeRef()) // Provisioning
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To(int32(3)),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To(int32(3)),
+					Version:         "v1.37.0",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3, m4),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
+
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane waiting for control plane machine provisioning to complete before triggering remediation")
@@ -746,18 +926,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](3),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.37.0",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -769,9 +958,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate this Machine because this could result in loosing Kubernetes control plane components or in etcd quorum loss")
@@ -790,18 +980,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](5),
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](5),
+					Version:         "v1.37.0",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3, m4, m5),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -813,9 +1012,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).ToNot(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 
 		assertMachineV1beta1Condition(ctx, g, m1, clusterv1.MachineOwnerRemediatedV1Beta1Condition, corev1.ConditionFalse, clusterv1.WaitingForRemediationV1Beta1Reason, clusterv1.ConditionSeverityWarning, "KubeadmControlPlane can't remediate this Machine because this could result in loosing Kubernetes control plane components or in etcd quorum loss")
@@ -833,19 +1033,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](1),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(false),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](1),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(false),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -862,9 +1070,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -888,19 +1097,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](1),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(false),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](1),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(false),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		// First reconcile, remediate machine m1 for the first time
@@ -918,9 +1135,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -942,7 +1160,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			mi := createMachine(ctx, g, ns.Name, fmt.Sprintf("m%d-unhealthy-", i), withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
 
 			// Simulate KCP dropping RemediationInProgressAnnotation after creating the replacement machine.
-			delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+			g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+			g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 
 			controlPlane.Machines = collections.FromMachines(mi)
 			controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
@@ -954,6 +1173,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 			g.Expect(err).ToNot(HaveOccurred())
 
+			g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 			g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 			remediationData, err = RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 			g.Expect(err).ToNot(HaveOccurred())
@@ -982,20 +1202,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](2),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](1),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2),
 			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1012,9 +1240,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1040,20 +1269,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](3),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2, m3),
 			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1070,9 +1307,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1098,20 +1336,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To(int32(3)),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To(int32(3)),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2, m3),
 			EtcdLeader: &etcd.Member{Name: m2.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1128,9 +1374,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1157,20 +1404,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](4),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2, m3, m4),
 			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1187,9 +1442,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1216,20 +1472,28 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To(int32(4)),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To(int32(3)),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2, m3, m4),
 			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1246,9 +1510,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1274,19 +1539,27 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](1),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(false),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](1),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1, m2, m3),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(false),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		// First reconcile, remediate machine m1 for the first time
@@ -1303,9 +1576,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1327,7 +1601,8 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			mi := createMachine(ctx, g, ns.Name, fmt.Sprintf("m%d-unhealthy-", i), withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
 
 			// Simulate KCP dropping RemediationInProgressAnnotation after creating the replacement machine.
-			delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+			g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+			g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 			controlPlane.Machines = collections.FromMachines(mi, m2, m3)
 			controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
@@ -1339,6 +1614,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 			g.Expect(err).ToNot(HaveOccurred())
 
+			g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 			g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 			remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 			g.Expect(err).ToNot(HaveOccurred())
@@ -1369,14 +1645,14 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](3),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster: &clusterv1.Cluster{
@@ -1394,6 +1670,14 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			Machines:   collections.FromMachines(m1, m2, m3),
 			EtcdLeader: &etcd.Member{Name: m1.Status.NodeRef.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1409,9 +1693,10 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 		controlPlane.InjectTestManagementCluster(r.managementCluster)
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1438,6 +1723,16 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		g.Expect(patchHelper.Patch(ctx, m)).To(Succeed())
 	}
 
+	machineTemplate := controlplanev1.KubeadmControlPlaneMachineTemplate{
+		Spec: controlplanev1.KubeadmControlPlaneMachineTemplateSpec{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				Kind:     builder.TestInfrastructureMachineTemplateKind,
+				APIGroup: builder.InfrastructureGroupVersion.Group,
+				Name:     "imt",
+			},
+		},
+	}
+
 	t.Run("Remediates the first CP machine having problems to come up", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -1453,19 +1748,27 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
-				Spec: controlplanev1.KubeadmControlPlaneSpec{
-					Replicas: utilptr.To[int32](3),
-					Version:  "v1.19.1",
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
 				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(false),
-					},
+				Spec: controlplanev1.KubeadmControlPlaneSpec{
+					Replicas:        utilptr.To[int32](3),
+					Version:         "v1.19.1",
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:  &clusterv1.Cluster{},
 			Machines: collections.FromMachines(m1),
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(false),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1480,9 +1783,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1503,7 +1807,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		// NOTE: scale up also resets remediation in progress and remediation counts.
 
 		m2 := createMachine(ctx, g, ns.Name, "m2-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
-		delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+		g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 
 		// Control plane not initialized yet, Second CP is unhealthy and gets remediated (retry 2)
 
@@ -1513,9 +1818,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err = RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1536,7 +1842,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		// NOTE: scale up also resets remediation in progress and remediation counts.
 
 		m3 := createMachine(ctx, g, ns.Name, "m3-healthy-", withHealthyEtcdMember(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
-		delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+		g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 
 		g.Expect(env.Cleanup(ctx, m3)).To(Succeed())
 	})
@@ -1557,6 +1864,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
@@ -1569,17 +1880,21 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 							},
 						},
 					},
-				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2),
 			EtcdLeader: &etcd.Member{Name: m1.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1598,6 +1913,7 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1618,7 +1934,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		// NOTE: scale up also resets remediation in progress and remediation counts.
 
 		m3 := createMachine(ctx, g, ns.Name, "m3-unhealthy-", withMachineHealthCheckFailed(), withWaitBeforeDeleteFinalizer(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
-		delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+		g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 
 		// Control plane not initialized yet, Second CP is unhealthy and gets remediated (retry 2)
 
@@ -1629,9 +1946,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err = RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1652,7 +1970,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 		// NOTE: scale up also resets remediation in progress and remediation counts.
 
 		m4 := createMachine(ctx, g, ns.Name, "m4-healthy-", withHealthyEtcdMember(), withRemediateForAnnotation(MustMarshalRemediationData(remediationData)))
-		delete(controlPlane.KCP.Annotations, controlplanev1.RemediationInProgressAnnotation)
+		g.Expect(r.deleteRemediationInProgressAnnotation(ctx, controlPlane.KCP)).To(Succeed())
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 
 		g.Expect(env.Cleanup(ctx, m1, m4)).To(Succeed())
 	})
@@ -1674,6 +1993,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		controlPlane := &pkg.ControlPlane{
 			KCP: &controlplanev1.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kcp",
+					Namespace: ns.Name,
+				},
 				Spec: controlplanev1.KubeadmControlPlaneSpec{
 					Replicas: utilptr.To[int32](3),
 					Version:  "v1.19.1",
@@ -1686,17 +2009,21 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 							},
 						},
 					},
-				},
-				Status: controlplanev1.KubeadmControlPlaneStatus{
-					Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
-						ControlPlaneInitialized: utilptr.To(true),
-					},
+					MachineTemplate: machineTemplate,
 				},
 			},
 			Cluster:    &clusterv1.Cluster{},
 			Machines:   collections.FromMachines(m1, m2, m3),
 			EtcdLeader: &etcd.Member{Name: m1.Name},
 		}
+		g.Expect(env.CreateAndWait(ctx, controlPlane.KCP)).To(Succeed())
+		t.Cleanup(func() { g.Expect(env.DeleteAndWait(context.Background(), controlPlane.KCP)).To(Succeed()) })
+		controlPlane.KCP.Status = controlplanev1.KubeadmControlPlaneStatus{
+			Initialization: controlplanev1.KubeadmControlPlaneInitializationStatus{
+				ControlPlaneInitialized: utilptr.To(true),
+			},
+		}
+		g.Expect(env.Status().Update(ctx, controlPlane.KCP)).To(Succeed())
 		controlPlane.EtcdMembers = etcdMembers(controlPlane.Machines)
 
 		r := &Reconciler{
@@ -1712,9 +2039,10 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err := r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeFalse()) // Remediation completed, requeue
 
+		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(controlPlane.KCP), controlPlane.KCP)).To(Succeed())
 		g.Expect(controlPlane.KCP.Annotations).To(HaveKey(controlplanev1.RemediationInProgressAnnotation))
 		remediationData, err := RemediationDataFromAnnotation(controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation])
 		g.Expect(err).ToNot(HaveOccurred())
@@ -1742,8 +2070,8 @@ func TestReconcileUnhealthyMachinesSequences(t *testing.T) {
 
 		ret, err = r.reconcileUnhealthyMachines(ctx, controlPlane)
 
-		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ret.IsZero()).To(BeTrue()) // Remediation skipped
 
 		g.Expect(env.Cleanup(ctx, m1)).To(Succeed())
 	})

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update.go
@@ -133,6 +133,8 @@ func (r *Reconciler) rollingUpdate(
 	// Always scale up after we deleted an unhealthy Machine for remediation.
 	// If the remediation annotation is set here we have to create a new Machine to complete the
 	// remediation process (delete+create) before continuing with the rollout process.
+	// Note: The remediation annotation is cleaned up in reconcileUnhealthyMachines if a
+	// Machine creation is not needed to complete the remediation.
 	if _, ok := controlPlane.KCP.Annotations[controlplanev1.RemediationInProgressAnnotation]; ok {
 		return r.scaleUpControlPlane(ctx, controlPlane, true)
 	}

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
@@ -1008,7 +1008,10 @@ func Test_rollingUpdateSequences(t *testing.T) {
 				newMachine(machineAttr{Name: "machine-1", UpToDate: false, EligibleForInPlaceUpdate: true, CanUpdateMachine: true, AffectsAvailability: true}),
 				// one Machine got remediated (i.e. deleted)
 			},
-			skipVerifyMinMax: true, // As we first scale up after remediation we are intentionally violating the min/max range.
+			// As we first scale up after remediation we are intentionally violating the min/max range.
+			// Note: In reality this should never happen because reconcileUnhealthyMachines should clean up
+			// the remediation annotation in this case.
+			skipVerifyMinMax: true,
 			wantSequence: []string{
 				"machine-2 created",
 				"machine-0 deleted",

--- a/util/controller/controller_fake.go
+++ b/util/controller/controller_fake.go
@@ -28,7 +28,8 @@ import (
 
 func NewFakeController() *FakeController {
 	return &FakeController{
-		Deferrals: map[reconcile.Request]time.Time{},
+		Deferrals:                   map[reconcile.Request]time.Time{},
+		DeferralsUntilCacheUpToDate: map[reconcile.Request]bool{},
 	}
 }
 
@@ -36,7 +37,8 @@ var _ Controller = &FakeController{}
 
 type FakeController struct {
 	controller.Controller
-	Deferrals map[reconcile.Request]time.Time
+	Deferrals                   map[reconcile.Request]time.Time
+	DeferralsUntilCacheUpToDate map[reconcile.Request]bool
 }
 
 func (f *FakeController) DeferNextReconcile(req reconcile.Request, reconcileAfter time.Time) {
@@ -49,7 +51,10 @@ func (f *FakeController) DeferNextReconcileForObject(obj metav1.Object, reconcil
 	}] = reconcileAfter
 }
 
-func (f *FakeController) DeferNextReconcileUntilCacheUpToDate(_ metav1.Object, _ GroupVersionKindType, _ string) {
+func (f *FakeController) DeferNextReconcileUntilCacheUpToDate(obj metav1.Object, _ GroupVersionKindType, _ string) {
+	f.DeferralsUntilCacheUpToDate[reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()},
+	}] = true
 }
 
 func (f *FakeController) ClearConsistencyStore(_ client.ObjectKey, _ types.UID) {}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #10911
Part of #14160

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->