### PR TITLE
Add MachineSet creation ceiling to prevent uncontrolled Machine creation

### DIFF
--- a/api/core/v1beta2/v1beta1_condition_consts.go
+++ b/api/core/v1beta2/v1beta1_condition_consts.go
@@ -277,6 +277,12 @@ const (
 	// generate a machine object.
 	MachineCreationFailedV1Beta1Reason = "MachineCreationFailed"
 
+	// MachineCreationBlockedV1Beta1Reason (Severity=Error) documents a MachineSet that stopped
+	// creating Machines because it already owns at least as many Machines as its desired replicas.
+	// This acts as a circuit-breaker against uncontrolled Machine creation, e.g. when owned Machines
+	// have drifted out of the MachineSet selector and are therefore no longer counted by the replica diff.
+	MachineCreationBlockedV1Beta1Reason = "MachineCreationBlocked"
+
 	// ResizedV1Beta1Condition documents a MachineSet is resizing the set of controlled machines.
 	ResizedV1Beta1Condition ConditionType = "Resized"
 

--- a/core/reconcilers/machineset/machineset_controller.go
+++ b/core/reconcilers/machineset/machineset_controller.go
@@ -809,6 +809,32 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 				return ctrl.Result{}, nil
 			}
 		}
+
+		// Circuit-breaker against uncontrolled Machine creation (see OCPBUGS-98066).
+		// The replica diff above is computed from Machines matching the MachineSet selector. If owned
+		// Machines drift out of the selector (e.g. their labels are mutated), they stop being counted
+		// and the diff keeps requesting new Machines, allowing a single MachineSet to create Machines
+		// without bound. Count Machines this MachineSet actually owns via ownerRef and never let that
+		// number exceed the desired replicas: if we already own enough (or more), halt creation and
+		// surface the reason instead of compounding the runaway.
+		ownedMachines, err := r.countOwnedMachines(ctx, ms)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		desiredReplicas := int(ptr.Deref(ms.Spec.Replicas, 0))
+		if ownedMachines >= desiredReplicas {
+			message := fmt.Sprintf("Machine creation blocked: MachineSet already owns %d Machines, which meets or exceeds the desired %d replicas; some owned Machines may have drifted out of the MachineSet selector", ownedMachines, desiredReplicas)
+			log.Info(message, "ownedMachines", ownedMachines, "desiredReplicas", desiredReplicas, "selectorMatchingMachines", len(machines))
+			s.scaleUpPreflightCheckErrMessages = append(s.scaleUpPreflightCheckErrMessages, message)
+			v1beta1conditions.MarkFalse(ms, clusterv1.MachinesCreatedV1Beta1Condition, clusterv1.MachineCreationBlockedV1Beta1Reason, clusterv1.ConditionSeverityError, "%s", message)
+			r.recorder.Eventf(ms, corev1.EventTypeWarning, "MachineCreationBlocked", "%s", message)
+			return ctrl.Result{}, nil
+		}
+		// Cap creation so the total number of owned Machines never exceeds the desired replicas, even
+		// when the selector-based diff would ask for more because of drifted (uncounted) Machines.
+		if machinesToAdd > desiredReplicas-ownedMachines {
+			machinesToAdd = desiredReplicas - ownedMachines
+		}
 		return r.createMachines(ctx, s, machinesToAdd)
 
 	case diff > 0:
@@ -848,6 +874,25 @@ func (r *Reconciler) syncReplicas(ctx context.Context, s *scope) (ctrl.Result, e
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// countOwnedMachines returns the number of Machines in the MachineSet's namespace that are
+// controlled by this MachineSet, regardless of whether they still match its selector. The normal
+// replica diff only counts selector-matching Machines; Machines whose labels have drifted out of the
+// selector are invisible to it but are still owned by (and were created by) this MachineSet. Counting
+// by ownerRef closes that gap and is what allows syncReplicas to cap uncontrolled Machine creation.
+func (r *Reconciler) countOwnedMachines(ctx context.Context, ms *clusterv1.MachineSet) (int, error) {
+	allMachines := &clusterv1.MachineList{}
+	if err := r.Client.List(ctx, allMachines, client.InNamespace(ms.Namespace)); err != nil {
+		return 0, pkgerrors.Wrap(err, "failed to list machines to enforce the Machine creation ceiling")
+	}
+	owned := 0
+	for i := range allMachines.Items {
+		if metav1.IsControlledBy(&allMachines.Items[i], ms) {
+			owned++
+		}
+	}
+	return owned, nil
 }
 
 func (r *Reconciler) cleanupOrphanedBootstrapConfigsInfraMachines(ctx context.Context, s *scope) error {

--- a/core/reconcilers/machineset/machineset_controller_test.go
+++ b/core/reconcilers/machineset/machineset_controller_test.go
@@ -2448,6 +2448,11 @@ func TestMachineSetReconciler_syncReplicas(t *testing.T) {
 		expectMachinesToDelete                    *int
 		expectedTargetMSName                      *string
 		expectedMachinesToMove                    *int
+		// ownedMachines are Machines controlled by the MachineSet via ownerRef. This can differ from
+		// machines (the selector-based scope view) when Machines drift out of the selector, which is
+		// what the creation ceiling guards against. When nil, owned Machines is treated as zero.
+		ownedMachines         []*clusterv1.Machine
+		expectCreationBlocked bool
 	}{
 		{
 			name: "no op when getAndAdoptMachinesForMachineSetSucceeded is false",
@@ -2544,6 +2549,48 @@ func TestMachineSetReconciler_syncReplicas(t *testing.T) {
 			expectedTargetMSName:   nil,
 			expectedMachinesToMove: nil,
 		},
+		{
+			name: "should cap creation to the ceiling when owned machines have drifted out of the selector",
+			getAndAdoptMachinesForMachineSetSucceeded: true,
+			machineSet: newMachineSet("ms1", "cluster1", 5),
+			// The selector-based view only sees 2 machines, so the diff asks for 3.
+			machines: []*clusterv1.Machine{
+				fakeMachine("m1"),
+				fakeMachine("m2"),
+			},
+			// But the MachineSet actually owns 4 machines via ownerRef (2 have drifted out of the
+			// selector). Creation must be capped to 5-4=1 so owned machines never exceed the replicas.
+			ownedMachines: []*clusterv1.Machine{
+				fakeMachine("m1", withOwnerMachineSet("ms1")),
+				fakeMachine("m2", withOwnerMachineSet("ms1")),
+				fakeMachine("drifted1", withOwnerMachineSet("ms1")),
+				fakeMachine("drifted2", withOwnerMachineSet("ms1")),
+			},
+			expectMachinesToAdd:    ptr.To(1),
+			expectMachinesToDelete: nil,
+			expectedTargetMSName:   nil,
+			expectedMachinesToMove: nil,
+		},
+		{
+			name: "should block creation when owned machines already meet the desired replicas",
+			getAndAdoptMachinesForMachineSetSucceeded: true,
+			machineSet: newMachineSet("ms1", "cluster1", 2),
+			// The selector-based view only sees 1 machine, so the diff asks for 1.
+			machines: []*clusterv1.Machine{
+				fakeMachine("m1"),
+			},
+			// But the MachineSet already owns 2 machines via ownerRef (1 has drifted out of the
+			// selector), which meets the desired replicas. Creation must be halted entirely.
+			ownedMachines: []*clusterv1.Machine{
+				fakeMachine("m1", withOwnerMachineSet("ms1")),
+				fakeMachine("drifted1", withOwnerMachineSet("ms1")),
+			},
+			expectMachinesToAdd:    nil,
+			expectMachinesToDelete: nil,
+			expectedTargetMSName:   nil,
+			expectedMachinesToMove: nil,
+			expectCreationBlocked:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2555,7 +2602,18 @@ func TestMachineSetReconciler_syncReplicas(t *testing.T) {
 				getAndAdoptMachinesForMachineSetSucceeded: tt.getAndAdoptMachinesForMachineSetSucceeded,
 			}
 
+			// Place the owned Machines in the MachineSet namespace so countOwnedMachines can list them.
+			ownedObjs := make([]client.Object, 0, len(tt.ownedMachines))
+			for _, m := range tt.ownedMachines {
+				if m.Namespace == "" {
+					m.Namespace = tt.machineSet.Namespace
+				}
+				ownedObjs = append(ownedObjs, m)
+			}
+
 			r := &Reconciler{
+				Client:   fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(ownedObjs...).Build(),
+				recorder: record.NewFakeRecorder(32),
 				overrideCleanupOrphanedBootstrapConfigsInfraMachines: func(_ context.Context, _ *scope) error {
 					return nil // Nothing to check in this test.
 				},
@@ -2580,6 +2638,14 @@ func TestMachineSetReconciler_syncReplicas(t *testing.T) {
 			res, err := r.syncReplicas(ctx, s)
 			g.Expect(err).ToNot(HaveOccurred(), "unexpected error when syncing replicas")
 			g.Expect(res.IsZero()).To(BeTrue(), "unexpected non zero result when syncing replicas")
+
+			if tt.expectCreationBlocked {
+				gotCond := v1beta1conditions.Get(tt.machineSet, clusterv1.MachinesCreatedV1Beta1Condition)
+				g.Expect(gotCond).ToNot(BeNil(), "expected MachinesCreated condition to be set when creation is blocked")
+				g.Expect(gotCond.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(gotCond.Reason).To(Equal(clusterv1.MachineCreationBlockedV1Beta1Reason))
+				g.Expect(s.scaleUpPreflightCheckErrMessages).ToNot(BeEmpty(), "expected the block to be surfaced on the ScalingUp condition")
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**

The MachineSet replica diff (`syncReplicas`) only counts Machines that match the MachineSet selector. If owned Machines drift out of the selector (e.g. their labels are mutated), they stop being counted by the diff, which then keeps requesting new Machines every reconcile — allowing a single MachineSet to create Machines without bound.

This PR adds a creation ceiling as defense-in-depth:

- A new `countOwnedMachines` helper counts Machines the MachineSet owns via `ownerRef`, independent of the selector.
- In the scale-up (`diff < 0`) branch, creation is capped so the number of owned Machines can never exceed the desired replicas.
- When owned Machines already meet or exceed the desired replicas, creation is halted entirely and surfaced via the `MachinesCreated` condition (new reason `MachineCreationBlocked`) and the `ScalingUp` condition, plus an event — instead of compounding the runaway.

Behavior is unchanged in the healthy case, where the owned count equals the selector-based count.

**Which issue(s) this PR fixes**

Fixes #14217

**Testing**

Added table-driven cases to `TestMachineSetReconciler_syncReplicas` covering (a) capping creation to the remaining headroom when Machines drift out of the selector, and (b) fully blocking creation when owned Machines already meet the desired replicas. Full `core/reconcilers/machineset` package tests pass.

/kind bug