### PR TITLE
🐛 Compare kubelet and Machine versions ignoring provider build metadata

### DIFF
--- a/core/reconcilers/machine/machine_controller_status.go
+++ b/core/reconcilers/machine/machine_controller_status.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,7 @@ import (
 	contractapi "sigs.k8s.io/cluster-api/internal/contract/api"
 	"sigs.k8s.io/cluster-api/internal/util/inplace"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/version"
 )
 
 // updateStatus update Machine's status.
@@ -708,7 +710,7 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 		return
 	}
 
-	if m.Status.NodeInfo != nil && m.Status.NodeInfo.KubeletVersion != "" && m.Status.NodeInfo.KubeletVersion != m.Spec.Version {
+	if m.Status.NodeInfo != nil && m.Status.NodeInfo.KubeletVersion != "" && !kubeletVersionMatchesSpecVersion(m.Status.NodeInfo.KubeletVersion, m.Spec.Version) {
 		conditions.Set(m, metav1.Condition{
 			Type:   clusterv1.MachineUpToDateCondition,
 			Status: metav1.ConditionFalse,
@@ -724,6 +726,22 @@ func setUpToDateCondition(_ context.Context, m *clusterv1.Machine, ms *clusterv1
 		Status: metav1.ConditionTrue,
 		Reason: clusterv1.MachineUpToDateReason,
 	})
+}
+
+// kubeletVersionMatchesSpecVersion reports whether a Node's kubeletVersion refers to the same
+// Kubernetes version (major.minor.patch) as the Machine's spec.version, ignoring any provider-specific
+// pre-release or build metadata suffix (e.g. EKS reports "v1.36.3-eks-cb19647").
+// If either version cannot be parsed as a semantic version, it falls back to an exact string comparison.
+func kubeletVersionMatchesSpecVersion(kubeletVersion, specVersion string) bool {
+	kubelet, err := semver.ParseTolerant(kubeletVersion)
+	if err != nil {
+		return kubeletVersion == specVersion
+	}
+	spec, err := semver.ParseTolerant(specVersion)
+	if err != nil {
+		return kubeletVersion == specVersion
+	}
+	return version.Compare(kubelet, spec, version.WithoutPreReleases()) == 0
 }
 
 func setReadyCondition(ctx context.Context, machine *clusterv1.Machine) {

--- a/core/reconcilers/machine/machine_controller_status_test.go
+++ b/core/reconcilers/machine/machine_controller_status_test.go
@@ -1602,6 +1602,79 @@ func TestSetUpToDateCondition(t *testing.T) {
 			},
 		},
 		{
+			name: "kubeletVersion with provider suffix matches spec version",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version: "v1.31.0",
+				},
+				Status: clusterv1.MachineStatus{
+					NodeInfo: &corev1.NodeSystemInfo{
+						KubeletVersion: "v1.31.0-eks-cb19647",
+					},
+				},
+			},
+			expectCondition: &metav1.Condition{
+				Type:   clusterv1.MachineUpToDateCondition,
+				Status: metav1.ConditionTrue,
+				Reason: clusterv1.MachineUpToDateReason,
+			},
+		},
+		{
+			name: "kubeletVersion with provider suffix but different base version",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: "v1.31.0",
+						},
+					},
+				},
+			},
+			machine: &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version: "v1.31.0",
+				},
+				Status: clusterv1.MachineStatus{
+					NodeInfo: &corev1.NodeSystemInfo{
+						KubeletVersion: "v1.30.0-eks-cb19647",
+					},
+				},
+			},
+			expectCondition: &metav1.Condition{
+				Type:    clusterv1.MachineUpToDateCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  clusterv1.MachineUpToDateUpdatingReason,
+				Message: "* Node.status.nodeInfo.kubeletVersion v1.30.0-eks-cb19647, v1.31.0 required",
+			},
+		},
+		{
 			name: "updating (message from Updating)",
 			machineDeployment: &clusterv1.MachineDeployment{
 				Spec: clusterv1.MachineDeploymentSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

The Machine controller reports a Machine as not up to date when the Node's `kubeletVersion` differs from `Machine.spec.version` only by a provider-specific pre-release/build suffix. For example, EKS reports a node's kubelet version as `v1.36.3-eks-cb19647` while `Machine.spec.version` is `v1.36.3`. Because the comparison is a raw string equality check, the Machine is reported as upgrading (`UpToDate=False`, reason `Updating`) indefinitely, even though the workload cluster is healthy and fully available.

This change compares the versions semantically, ignoring pre-release and build metadata, so that:

- `v1.36.3-eks-cb19647` vs `v1.36.3` is considered up to date
- `v1.36.2` vs `v1.36.3` is still considered not up to date

If either version cannot be parsed as a semantic version, the previous exact string comparison is preserved as a fallback.

**Which issue(s) this PR fixes**:

Fixes #14219

**Release note**:

```release-note
Machine controller now compares the Node kubelet version against `Machine.spec.version` while ignoring provider-specific pre-release/build metadata suffixes, so Machines are no longer reported as upgrading when only the build suffix differs (e.g. EKS `v1.36.3-eks-cb19647`).
```
