### PR TITLE
🌱 Fix race conditions in KCP unit tests

### DIFF
--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	pkgerrors "github.com/pkg/errors"
@@ -274,7 +275,7 @@ func TestKubeadmControlPlaneReconciler_reconcileKubeconfig(t *testing.T) {
 }
 
 func TestCloneConfigsAndGenerateMachineAndSyncMachines(t *testing.T) {
-	setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+	setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 		t.Helper()
 
 		t.Log("Creating the namespace")
@@ -292,7 +293,7 @@ func TestCloneConfigsAndGenerateMachineAndSyncMachines(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	namespace := setup(t, g)
+	namespace := setupEnv(t, g)
 	defer teardown(t, g, namespace)
 
 	cluster := &clusterv1.Cluster{
@@ -320,6 +321,12 @@ func TestCloneConfigsAndGenerateMachineAndSyncMachines(t *testing.T) {
 		},
 	}
 	g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate)).To(Succeed())
+	// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+	// the regular cache in the manager is up-to-date.
+	g.Eventually(func(g Gomega) {
+		_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Second).To(Succeed())
 
 	namingTemplateKey := "-testkcp"
 	kcp := &controlplanev1.KubeadmControlPlane{

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/kubeadmcontrolplane_controller_test.go
@@ -1201,7 +1201,7 @@ func TestReconcileCertificateExpiries(t *testing.T) {
 }
 
 func TestReconcileInitializeControlPlane(t *testing.T) {
-	setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+	setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 		t.Helper()
 
 		t.Log("Creating the namespace")
@@ -1219,7 +1219,7 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	namespace := setup(t, g)
+	namespace := setupEnv(t, g)
 	defer teardown(t, g, namespace)
 
 	cluster := newCluster(&types.NamespacedName{Name: "foo", Namespace: namespace.Name})
@@ -1258,6 +1258,12 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 		},
 	}
 	g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate)).To(Succeed())
+	// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+	// the regular cache in the manager is up-to-date.
+	g.Eventually(func(g Gomega) {
+		_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Second).To(Succeed())
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1418,7 +1424,7 @@ kubernetesVersion: metav1.16.1
 }
 
 func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
-	setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+	setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 		t.Helper()
 
 		t.Log("Creating the namespace")
@@ -1436,7 +1442,7 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	namespace := setup(t, g)
+	namespace := setupEnv(t, g)
 	defer teardown(t, g, namespace)
 
 	cluster := newCluster(&types.NamespacedName{Name: "foo", Namespace: namespace.Name})
@@ -1500,6 +1506,12 @@ func TestReconcileInitializeControlPlane_withUserCA(t *testing.T) {
 		},
 	}
 	g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate)).To(Succeed())
+	// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+	// the regular cache in the manager is up-to-date.
+	g.Eventually(func(g Gomega) {
+		_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Second).To(Succeed())
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/scale_test.go
@@ -123,7 +123,7 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 
 func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 	t.Run("creates a control plane Machine if preflight checks pass", func(t *testing.T) {
-		setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+		setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 			t.Helper()
 
 			t.Log("Creating the namespace")
@@ -141,11 +141,18 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		namespace := setup(t, g)
+		namespace := setupEnv(t, g)
 		defer teardown(t, g, namespace)
 
 		cluster, kcp, genericInfrastructureMachineTemplate := createClusterWithControlPlane(namespace.Name)
 		g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate, client.FieldOwner("manager"))).To(Succeed())
+		// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+		// the regular cache in the manager is up-to-date.
+		g.Eventually(func(g Gomega) {
+			_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+			g.Expect(err).ToNot(HaveOccurred())
+		}).WithTimeout(5 * time.Second).To(Succeed())
+
 		kcp.UID = types.UID(util.RandomString(10))
 		setKCPHealthy(kcp)
 
@@ -269,7 +276,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		}
 	})
 	t.Run("scale up if preflight checks would fail but are not executed", func(t *testing.T) {
-		setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+		setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 			t.Helper()
 
 			t.Log("Creating the namespace")
@@ -287,11 +294,18 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		namespace := setup(t, g)
+		namespace := setupEnv(t, g)
 		defer teardown(t, g, namespace)
 
 		cluster, kcp, genericInfrastructureMachineTemplate := createClusterWithControlPlane(namespace.Name)
 		g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate, client.FieldOwner("manager"))).To(Succeed())
+		// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+		// the regular cache in the manager is up-to-date.
+		g.Eventually(func(g Gomega) {
+			_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+			g.Expect(err).ToNot(HaveOccurred())
+		}).WithTimeout(5 * time.Second).To(Succeed())
+
 		kcp.UID = types.UID(util.RandomString(10))
 		// Set KCP conditions in a way that preflight checks would fail, but the certificate check still passes.
 		conditions.Set(kcp, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthyCondition, Status: metav1.ConditionFalse})
@@ -339,7 +353,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		g.Expect(kubeadmConfig.Spec.ClusterConfiguration.FeatureGates).To(BeComparableTo(map[string]bool{desiredstate.ControlPlaneKubeletLocalMode: true}))
 	})
 	t.Run("does not create a control plane Machine if certificate are not available", func(t *testing.T) {
-		setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+		setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 			t.Helper()
 
 			t.Log("Creating the namespace")
@@ -357,11 +371,18 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		}
 
 		g := NewWithT(t)
-		namespace := setup(t, g)
+		namespace := setupEnv(t, g)
 		defer teardown(t, g, namespace)
 
 		cluster, kcp, genericInfrastructureMachineTemplate := createClusterWithControlPlane(namespace.Name)
 		g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate, client.FieldOwner("manager"))).To(Succeed())
+		// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+		// the regular cache in the manager is up-to-date.
+		g.Eventually(func(g Gomega) {
+			_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+			g.Expect(err).ToNot(HaveOccurred())
+		}).WithTimeout(5 * time.Second).To(Succeed())
+
 		kcp.UID = types.UID(util.RandomString(10))
 		// Set KCP conditions in a way that preflight checks pass but the certificate check fails.
 		conditions.Set(kcp, metav1.Condition{Type: controlplanev1.KubeadmControlPlaneControlPlaneComponentsHealthyCondition, Status: metav1.ConditionTrue})

--- a/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
+++ b/controlplane/kubeadm/reconcilers/kubeadmcontrolplane/update_test.go
@@ -57,7 +57,7 @@ const (
 )
 
 func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
-	setup := func(t *testing.T, g *WithT) *corev1.Namespace {
+	setupEnv := func(t *testing.T, g *WithT) *corev1.Namespace {
 		t.Helper()
 
 		t.Log("Creating the namespace")
@@ -75,13 +75,20 @@ func TestKubeadmControlPlaneReconciler_RolloutStrategy_ScaleUp(t *testing.T) {
 	}
 
 	g := NewWithT(t)
-	namespace := setup(t, g)
+	namespace := setupEnv(t, g)
 	defer teardown(t, g, namespace)
 
 	timeout := 30 * time.Second
 
 	cluster, kcp, genericInfrastructureMachineTemplate := createClusterWithControlPlane(namespace.Name)
 	g.Expect(env.CreateAndWait(ctx, genericInfrastructureMachineTemplate, client.FieldOwner("manager"))).To(Succeed())
+	// Note: Wait additionally until dynamicCache is up-to-date, CreateAndWait above only waits until
+	// the regular cache in the manager is up-to-date.
+	g.Eventually(func(g Gomega) {
+		_, err := dynamicCache.GetUnstructured(ctx, setup.DynamicCacheInfraMachineTemplateObjectType, genericInfrastructureMachineTemplate.GroupVersionKind().GroupKind(), client.ObjectKeyFromObject(genericInfrastructureMachineTemplate))
+		g.Expect(err).ToNot(HaveOccurred())
+	}).WithTimeout(5 * time.Second).To(Succeed())
+
 	cluster.UID = types.UID(util.RandomString(10))
 	cluster.Spec.ControlPlaneEndpoint.Host = Host
 	cluster.Spec.ControlPlaneEndpoint.Port = 6443


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
    1. If this is your first time, please read our contributor guidelines: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributing-a-patch and developer guide https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/developer/getting-started.md

    2. Please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones
    the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

**What this PR does / why we need it**:

e.g. https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-test-main/2096274669572198400

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- 
Please label this pull request according to what area(s) you are addressing. For reference on PR/issue labels, see: https://github.com/kubernetes-sigs/cluster-api/labels?q=area+

Area example:
/area runtime-sdk
-->